### PR TITLE
fix for fakes and missing argument in the runner script

### DIFF
--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -38,7 +38,7 @@ signal_samples_inctau = list(filter(lambda x: x[0] == ("Z" if args.wlike else "W
 print("Single V samples", single_v_samples)
 print("Single Vmu samples", single_vmu_samples)
 print("signal samples", signal_samples)
-print("single_c_fake_samples", single_v_and_fake_samples)
+print("single_v_fake_samples", single_v_and_fake_samples)
 
 pdfName = theory_tools.pdfMap[args.pdf]["name"]
 cardTool.addSystematic(pdfName, 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -209,7 +209,7 @@ def build_graph(df, dataset):
             qcdScaleByHelicityUnc = df.HistoBoost("qcdScaleByHelicity", [*nominal_axes, axis_absYVgen, axis_ptVgen, axis_chargeVgen], [*nominal_cols, "absYVgen", "ptVgen", "chargeVgen", "helicityWeight_tensor"], tensor_axes=helicity_helper.tensor_axes)
             results.append(qcdScaleByHelicityUnc)
 
-            results.extend(theory_tools.define_and_make_pdf_hists(df, nominal_axes, nominal_cols))
+            results.extend(theory_tools.define_and_make_pdf_hists(df, nominal_axes, nominal_cols, dataset))
 
             nweights = 21 if isW else 23
             df = df.Define("massWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(MEParamWeight)")

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -5,11 +5,11 @@ import numpy as np
 def fakeHistABCD(h):
     return hh.multiplyHists(
         hh.divideHists(h[{"passIso" : True, "passMT" : False}], 
-            h[{"passIso" : False, "passMT" : True}],
+            h[{"passIso" : False, "passMT" : False}],
                 cutoff=1
             ),
                 #where=h[{"passIso" : False, "passMT" : True}].values(flow=True)>1),
-        h[{"passIso" : False, "passMT" : False}], 
+        h[{"passIso" : False, "passMT" : True}], 
     )
 
 def fakeHistIsoRegion(h, scale=1.):


### PR DESCRIPTION
 To compute the histogram for fakes one needs to compute (passIso_failMt / failIso_failMt) * failIso_passMt, but we were inverting failMt and passMt when the isolation is failed in fakeHistABCD.
After this fix the QCD histogram is much more compatible with what we had from CMGTools, residual difference is <1%, mainly at high pt, and could be due to clipping of negative bin contents to 0 before making ratios (by default CMGTools was not doing it so far)

 Also adding a missing argument with dataset name in a function to include pdf variations in the mW runner script.