### PR TITLE
Change name of effSyst nuisance, fix for QCD scales, and update my script to manage fit

### DIFF
--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -17,6 +17,7 @@ parser.add_argument("-o", "--outfolder", type=str, default="/scratch/kelong/Comb
 parser.add_argument("-i", "--inputFile", type=str, required=True)
 parser.add_argument("--qcdScale", choices=["byHelicityPt", "byPt", "byCharge", "integrated",], default="byHelicityPt", 
         help="Decorrelation for QCDscale (additionally always by charge)")
+parser.add_argument("--rebinPtV", type=int, default=0, help="Rebin axis with gen boson pt by this value (default does nothing)")
 parser.add_argument("--wlike", action='store_true', help="Run W-like analysis of mZ")
 parser.add_argument("--noEfficiencyUnc", action='store_true', help="Skip efficiency uncertainty (useful for tests, because it's slow)")
 parser.add_argument("--pdf", type=str, default="nnpdf31", choices=theory_tools.pdfMap.keys(), help="PDF to use")
@@ -132,7 +133,8 @@ if not inclusiveScale:
 # TODO: reuse some code here
 if "Pt" in args.qcdScale:
     scale_action = None
-    scaleActionArgs = {"sum_helicity" : True}
+    if args.rebinPtV:
+        scale_action = lambda h: h[{"ptVgen" : hist.rebin(args.rebinPtV)}]
     scaleGroupName += "ByPtV"
     scaleSystAxes.insert(0, "ptVgen")
     scaleLabelsByAxis.insert(0, "genPtV")
@@ -141,7 +143,7 @@ if "Pt" in args.qcdScale:
 if helicity:
     scale_hist = "qcdScaleByHelicity"
     scale_action = syst_tools.scale_helicity_hist_to_variations 
-    scaleActionArgs.pop("sum_helicity")
+    scaleActionArgs = {"rebinPtV" : args.rebinPtV}
     scaleGroupName += "ByHelicity"
     scaleSystAxes.insert(0, "helicity")
     scaleLabelsByAxis.insert(0, "Coeff")

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -99,7 +99,7 @@ cardTool.addSystematic(f"alphaS002{pdfName}",
     passToFakes=passSystToFakes,
 )
 if not args.noEfficiencyUnc:
-    for name,num in zip(["effSystIsoTnP", "effStatTnP",], [2, 624*4]):
+    for name,num in zip(["effSystTnP", "effStatTnP",], [2, 624*4]):
         axes = ["idiptrig-iso"] if num == 2 else ["SF eta", "SF pt", "SF charge", "idiptrig-iso"]
         axlabels = ["IDIPTrig"] if num == 2 else ["eta", "pt", "q", "Trig"]
         cardTool.addSystematic(name, 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -205,10 +205,10 @@ def build_graph(df, dataset):
         effStatTnP = df.HistoBoost("effStatTnP", nominal_axes, [*nominal_cols, "effStatTnP_tensor"], tensor_axes = muon_efficiency_helper_stat.tensor_axes)
         results.append(effStatTnP)
 
-        df = df.Define("effSystIsoTnP_weight", muon_efficiency_helper_syst, ["goodMuons_pt0", "goodMuons_eta0", "goodMuons_charge0", "passIso", "nominal_weight"])
+        df = df.Define("effSystTnP_weight", muon_efficiency_helper_syst, ["goodMuons_pt0", "goodMuons_eta0", "goodMuons_charge0", "passIso", "nominal_weight"])
 
-        effSystIsoTnP = df.HistoBoost("effSystIsoTnP", nominal_axes, [*nominal_cols, "effSystIsoTnP_weight"], tensor_axes = muon_efficiency_helper_syst.tensor_axes)
-        results.append(effSystIsoTnP)
+        effSystTnP = df.HistoBoost("effSystTnP", nominal_axes, [*nominal_cols, "effSystTnP_weight"], tensor_axes = muon_efficiency_helper_syst.tensor_axes)
+        results.append(effSystTnP)
 
         #FIXME skipping EffTrackingRecoTnP_ since it's not consistently defined yet
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -226,10 +226,10 @@ def build_graph(df, dataset):
         effStatTnP = df.HistoBoost("effStatTnP", nominal_axes, [*nominal_cols, "effStatTnP_tensor"], tensor_axes = muon_efficiency_helper_stat.tensor_axes)
         results.append(effStatTnP)
 
-        df = df.Define("effSystIsoTnP_weight", muon_efficiency_helper_syst, ["TrigMuon_pt", "TrigMuon_eta", "TrigMuon_charge", "NonTrigMuon_pt", "NonTrigMuon_eta", "NonTrigMuon_charge", "nominal_weight"])
+        df = df.Define("effSystTnP_weight", muon_efficiency_helper_syst, ["TrigMuon_pt", "TrigMuon_eta", "TrigMuon_charge", "NonTrigMuon_pt", "NonTrigMuon_eta", "NonTrigMuon_charge", "nominal_weight"])
 
-        effSystIsoTnP = df.HistoBoost("effSystIsoTnP", nominal_axes, [*nominal_cols, "effSystIsoTnP_weight"], tensor_axes = muon_efficiency_helper_syst.tensor_axes)
-        results.append(effSystIsoTnP)
+        effSystTnP = df.HistoBoost("effSystTnP", nominal_axes, [*nominal_cols, "effSystTnP_weight"], tensor_axes = muon_efficiency_helper_syst.tensor_axes)
+        results.append(effSystTnP)
 
         #FIXME skipping EffTrackingRecoTnP_ since it's not consistently defined yet
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1,7 +1,7 @@
 import hist
 import numpy as np
 
-def scale_helicity_hist_to_variations(scale_hist, sum_helicity=False, sum_ptV=False):
+def scale_helicity_hist_to_variations(scale_hist, sum_helicity=False, sum_ptV=False, rebinPtV=0):
 
     s = hist.tag.Slicer()
     # select nominal QCD scales, but keep the sliced axis at size 1 for broadcasting
@@ -10,6 +10,10 @@ def scale_helicity_hist_to_variations(scale_hist, sum_helicity=False, sum_ptV=Fa
     # select nominal QCD scales and project down to nominal axes
     nom_hist = nom_scale_hist[{"ptVgen" : s[::hist.sum], "chargeVgen" : s[::hist.sum], "helicity" : s[::hist.sum], "muRfact" : s[1.j], "muFfact" : s[1.j] }]
 
+    if rebinPtV > 0:
+        scale_hist = scale_hist[{"ptVgen" : s[::hist.rebin(rebinPtV)]}]
+        nom_scale_hist = nom_scale_hist[{"ptVgen" : s[::hist.rebin(rebinPtV)]}]
+    
     if sum_helicity:
         scale_hist = scale_hist[{"helicity" : s[::hist.sum]}]
         nom_scale_hist = nom_scale_hist[{"helicity" : s[::hist.sum]}]


### PR DESCRIPTION
Remove "Iso" from effSystIsoTnp_xxx nuisance, since iso or not iso depends on the xxx part of the name, this also makes it consistent with effStatTnP.

The rest is just an update for my script to manage card combination and fit (but I would invite people to use it too if they like)

Small fixes for QCD scales binned by pt (mainly remove unnecessary arguments used when the input histogram was still the one with helicity splitting).
Add possibility to rebin the axis with gen Vpt when setting up the cards.


