### PR TITLE
Update datasets file for nanoV9

### DIFF
--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -35,10 +35,16 @@ parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdSca
 parser.add_argument("--muonCorrMag", default=1.e-4, type=float, help="Magnitude of dummy muon momentum calibration uncertainty")
 parser.add_argument("--muonCorrEtaBins", default=1, type=int, help="Number of eta bins for dummy muon momentum calibration uncertainty")
 parser.add_argument("-p", "--postfix", type=str, help="Postfix for output file name", default=None)
+parser.add_argument("--v9", action='store_true', help="Use NanoAODv9. Default is v8")
 args = parser.parse_args()
 
-filt = lambda x,filts=args.filterProcs: any([f in x.name for f in filts]) 
+filt = lambda x,filts=args.filterProcs: any([f in x.name for f in filts])
 datasets = wremnants.datasets2016.getDatasets(maxFiles=args.maxFiles, filt=filt if args.filterProcs else None)
+
+print('Use v9?', args.v9)
+
+if args.v9:
+    datasets = wremnants.datasets2016_v9.getDatasets(maxFiles=args.maxFiles, filt=filt if args.filterProcs else None)
 
 ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
 
@@ -97,11 +103,10 @@ calibration_helper, calibration_uncertainty_helper = wremnants.make_muon_calibra
 from wremnants import recoil_tools
 recoilHelper = recoil_tools.Recoil("highPU")
 
-
 #def add_plots_with_systematics
 
 def build_graph(df, dataset):
-    print("build graph")
+    print("build graph for dataset:", dataset.name)
     results = []
 
     if dataset.is_data:

--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -8,6 +8,7 @@ ROOT.gInterpreter.Declare('#include "utils.h"')
 ROOT.gInterpreter.Declare('#include "csVariables.h"')
 
 from .datasets import datasets2016
+from .datasets import datasets2016_v9
 from .datasets import datasetsLowPU
 
 from .muon_prefiring import make_muon_prefiring_helpers

--- a/wremnants/datasets/datasets2016_v9.py
+++ b/wremnants/datasets/datasets2016_v9.py
@@ -1,0 +1,164 @@
+import narf
+import logging
+import subprocess
+import glob
+import pathlib
+
+lumicsv = f"{pathlib.Path(__file__).parent.parent}/data/bylsoutput.csv"
+lumijson = f"{pathlib.Path(__file__).parent.parent}/data/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt"
+
+#TODO add the rest of the samples!
+def makeFilelist(paths, maxFiles=-1):
+    filelist = []
+    for path in paths:
+        filelist.extend(glob.glob(path) if path[:4] != "/eos" else buildXrdFileList(path, "eoscms.cern.ch"))
+    return filelist if maxFiles < 0 else filelist[:maxFiles]
+
+def getDatasets(maxFiles=-1, filt=None, mode=None):
+    dataPostVFP = narf.Dataset(name = "dataPostVFP",
+        filepaths = makeFilelist(["/scratch/shared/NanoAOD/TrackRefitv1/SingleMuon/Run2016F_postVFP_220223_222034/*/*.root",
+            "/scratch/shared/NanoAOD/TrackRefitv1/SingleMuon/Run2016G_220223_222128/*/*.root",
+            "/scratch/shared/NanoAOD/TrackRefitv1/SingleMuon/Run2016H_220223_222223/*/*.root",
+        ], maxFiles),
+        is_data = True,
+        lumi_csv = lumicsv,
+        lumi_json = lumijson
+    )
+
+    ZmmPostVFP = narf.Dataset(name = "ZmumuPostVFP",
+        filepaths = makeFilelist(
+            ["/scratch/shared/NanoAOD/TrackRefitv2/DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/*/*/*/*.root"], maxFiles),
+        is_data = False,
+        xsec = 2001.9,
+    )
+
+    BR_TAUToMU = 0.1739
+    BR_TAUToE = 0.1782
+    ZttPostVFP = narf.Dataset(name = "ZtautauPostVFP",
+        filepaths = makeFilelist(
+            ["/scratch/shared/NanoAOD/TrackRefitv1/DYJetsToTauTau_M-50_AtLeastOneEorMuDecay_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV8MCPostVFPWeightFix/*/*/*.root"], maxFiles),
+        is_data = False,
+        # At least one tau->e or mu decay, so everything that's not all other decays
+        xsec = ZmmPostVFP.xsec*(1.-(1. - BR_TAUToMU - BR_TAUToE)**2),
+    )
+
+    WpmunuPostVFP = narf.Dataset(name = "WplusmunuPostVFP",
+        filepaths = makeFilelist(
+            ["/scratch/shared/NanoAOD/TrackRefitv2/WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/*/*/*/*.root"], maxFiles),
+        is_data = False,
+        xsec = 11765.9,
+    )
+    
+    WmmunuPostVFP = narf.Dataset(name = "WminusmunuPostVFP",
+        filepaths = makeFilelist(
+            ["/scratch/shared/NanoAOD/TrackRefitv2/WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/*/*/*/*.root"], maxFiles),
+            is_data = False,
+            xsec = 8703.87,
+    )
+
+    WptaunuPostVFP = narf.Dataset(name = "WplustaunuPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/TrackRefitv1/WplusJetsToTauNu_TauToMu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV8MCPostVFPWeightFix/*/*/*.root"], maxFiles),
+            is_data = False,
+            xsec = BR_TAUToMU*WpmunuPostVFP.xsec,
+    )
+
+    WmtaunuPostVFP = narf.Dataset(name = "WminustaunuPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/TrackRefitv1/WminusJetsToTauNu_TauToMu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV8MCPostVFPWeightFix/*/*/*.root"], maxFiles),
+            is_data = False,
+            xsec = BR_TAUToMU*WmmunuPostVFP.xsec,
+    )
+
+    ttbarlnuPostVFP = narf.Dataset(name = "TTLeptonicPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 88.29,
+            group = "Top",
+    )
+
+    ttbarlqPostVFP = narf.Dataset(name = "TTSemileptonicPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 365.34,
+            group = "Top",
+    )
+
+    # TODO: these samples and cross sections are preliminary
+    singleTop_schanLepDecaysPostVFP = narf.Dataset(name = "SingleTschanLepDecaysPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 3.74,
+            group = "Top",
+    )
+
+    singleTop_tWAntitopPostVFP = narf.Dataset(name = "SingleTtWAntitopPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 19.55,
+            group = "Top",
+    )
+    singleTop_tchanAntitopPostVFP = narf.Dataset(name = "SingleTtchanAntitopPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 70.79,
+            group = "Top",
+    )
+    singleTop_tchanTopPostVFP = narf.Dataset(name = "SingleTtchanTopPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 119.71,
+            group = "Top",
+    )    
+
+    # TODO: should really use the specific decay channels
+    wwPostVFP = narf.Dataset(name = "WWPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/WW_TuneCP5_13TeV-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 75.8,
+            group = "Diboson",
+    )
+
+    wzPostVFP = narf.Dataset(name = "WZPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/WZ_TuneCP5_13TeV-pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 27.6,
+            group = "Diboson",
+    )
+
+    zz2l2nuPostVFP = narf.Dataset(name = "ZZ2l2nuPostVFP",
+        filepaths = makeFilelist(
+                ["/scratch/shared/NanoAOD/BKGV9/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/*.root"], maxFiles),
+            is_data = False,
+            xsec = 0.564,
+            group = "Diboson",
+    )
+
+    allPostVFP = [dataPostVFP,
+                  WpmunuPostVFP, WmmunuPostVFP, WptaunuPostVFP, WmtaunuPostVFP,
+                  ZmmPostVFP, ZttPostVFP,
+                  ttbarlnuPostVFP, ttbarlqPostVFP,
+                  singleTop_schanLepDecaysPostVFP, singleTop_tWAntitopPostVFP, singleTop_tchanAntitopPostVFP, singleTop_tchanTopPostVFP,
+                  wwPostVFP, wzPostVFP, zz2l2nuPostVFP]
+
+    allPostVFP_gen = allPostVFP[1:]
+
+    samples = allPostVFP if mode != "gen" else allPostVFP_gen
+    if filt:
+        return list(filter(filt, samples))
+    else:
+        return samples
+
+def buildXrdFileList(path, xrd):
+    xrdpath = path[path.find('/store'):]
+    logging.debug(f"Looking for path {xrdpath}")
+    f = subprocess.check_output(['xrdfs', f'root://{xrd}', 'ls', xrdpath]).decode(sys.stdout.encoding)
+    return filter(lambda x: "root" in x[-4:], f.split())

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -5,13 +5,15 @@ import copy
 import logging
 import sys
 import decimal
+import pathlib
 
 def drange(x, y, jump):
     while x < y:
         yield float(x)
         x += decimal.Decimal(jump)
         
-
+data_dir = f"{pathlib.Path(__file__).parent}/data/"
+        
 class Recoil:
 
     def __init__(self, type_):
@@ -19,7 +21,7 @@ class Recoil:
         if type_ == "highPU":
         
             self.recoil_qTbins = list(drange(0, 30, 0.5)) + list(range(30, 60, 2)) + list(range(60, 100, 5)) + list(range(100, 210, 10)) + [10000]
-            rInput_binned = "wremnants/data/recoil_fits_Z.root"
+            rInput_binned = data_dir + "recoil_fits_Z.root"
             rInput_parametric = ""
     
         elif type_ == "lowPU":
@@ -27,7 +29,7 @@ class Recoil:
             self.recoil_qTbins = list(drange(0, 30, 0.5)) + list(range(30, 60, 2)) + list(range(60, 100, 5)) + list(range(100, 210, 10)) + [10000]
             self.recoil_qTbins = list(range(0, 50, 5)) + list(range(50, 100, 10)) + list(range(100, 200, 25)) + [10000]
             print(self.recoil_qTbins)
-            rInput_binned = "wremnants/data/lowPU/recoil_fits_Z.root"
+            rInput_binned = data_dir + "lowPU/recoil_fits_Z.root"
             rInput_parametric = ""
             
         else: sys.exit("Recoil highPU or lowPU")


### PR DESCRIPTION
- Added a new dataset file for NanoV9  samples.
- Updated the wlike histomaker config to use the new samples. The option to pass is ```--v9```. Otherwise by default it will still run on the old sample.
- For now, there is a crash coming from the Recoill correction, so ran by masking the relevant lines in the config.
- Runs on both Pisa(dataset file not in this PR) and CERN server. 
### TODO
- XSECS of bkg samples need to be updated.
- W selection histomaker config needs to be updated