### PR TITLE
Bug fixes and updates for histogram and card maker

### DIFF
--- a/scripts/combine/fitManager.py
+++ b/scripts/combine/fitManager.py
@@ -93,8 +93,6 @@ def prepareChargeFit(options, charges=["plus"]):
         
         txt2hdf5Cmd = 'text2hdf5.py {cf} --dataset {dn} --X-allow-no-signal'.format(cf=combinedCard, dn=options.dataname)
             
-        if not options.doSystematics:
-            txt2hdf5Cmd = txt2hdf5Cmd + " -S 0 "
         if len(postfix):
             txt2hdf5Cmd = txt2hdf5Cmd + " --postfix " + postfix
         if options.clipSystVariations > 0.0:
@@ -115,11 +113,9 @@ def prepareChargeFit(options, charges=["plus"]):
 
         bbboptions = " --binByBinStat "
         if not options.noCorrelateXsecStat: bbboptions += "--correlateXsecStat "
-        combineCmd = 'combinetf.py -t -1 {bbb} {metafile} --saveHists --computeHistErrors --doh5Output --POIMode none '.format(metafile=metafilename, bbb="" if options.noBBB else bbboptions)
+        combineCmd = 'combinetf.py -t -1 {bbb} {metafile} --doImpacts --saveHists --computeHistErrors --doh5Output --POIMode none '.format(metafile=metafilename, bbb="" if options.noBBB else bbboptions)
         if options.combinetfOption:
             combineCmd += " %s" % options.combinetfOption
-        if options.doSystematics and options.doImpactsOnMW:
-            combineCmd += " --doImpacts  "
 
         fitdir_data = "{od}/fit/data/".format(od=os.path.abspath(cardSubfolderFullName))
         fitdir_Asimov = fitdir_data.replace("/fit/data/", "/fit/hessian/")
@@ -178,7 +174,6 @@ if __name__ == "__main__":
     parser.add_argument(     '--postfix',    dest='postfix', type=str, default="", help="Postfix for .hdf5 file created with text2hdf5.py");
     parser.add_argument('--wlike', dest='isWlike', action="store_true", default=False, help="Make cards for the W-like analysis. Default is Wmass");
     # options for card maker and fit
-    parser.add_argument("-S",  "--doSystematics", type=int, default=1, help="enable systematics when running text2hdf5.py (-S 0 to disable them)")
     parser.add_argument(       "--clipSystVariations", type=float, default=-1.,  help="Clipping of syst variations, passed to text2hdf5.py")
     parser.add_argument(       "--clipSystVariationsSignal", type=float, default=-1.,  help="Clipping of signal syst variations, passed to text2hdf5.py")
     parser.add_argument(       '--no-bbb'  , dest='noBBB', default=False, action='store_true', help='Do not use bin-by-bin uncertainties')
@@ -190,8 +185,6 @@ if __name__ == "__main__":
     parser.add_argument(       '--no-combinetf'  , dest='skip_combinetf', default=False, action='store_true', help='skip running combinetf.py at the end, just print command (useful for tests)')
     parser.add_argument(       '--skip-fit-data', dest='skipFitData' , default=False, action='store_true', help='If True, fit only Asimov')
     parser.add_argument(       '--skip-fit-asimov', dest='skipFitAsimov' , default=False, action='store_true', help='If True, fit only data')
-    # --impacts-mW might not be needed or might not work, to be checked
-    parser.add_argument(      '--impacts-mW', dest='doImpactsOnMW', default=False, action='store_true', help='Set up cards to make impacts of nuisances on mW')
     parser.add_argument("-D", "--dataset",  dest="dataname", default="data_obs",  type=str,  help="Name of the observed dataset (pass name without x_ in the beginning). Useful to fit another pseudodata histogram")
     parser.add_argument("--combinetf-option",  dest="combinetfOption", default="",  type=str,  help="Pass other options to combinetf (TODO: some are already activated with other options, might move them here)")
     parser.add_argument("-t",  "--toys", type=int, default=0, help="Run combinetf for N toys if argument N is positive")

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -140,7 +140,7 @@ if not args.noEfficiencyUnc:
         ## TODO: this merged implementation for the effstat makes it very cumbersome to do things differently for iso and trigidip!!
         ## the problem is that I would need custom actions inside based on actual nuisance names, which needs to be commanded from outside, and this is not straightforward
         axes = ["idiptrig-iso"] if num == 2 else ["SF eta", "SF pt", "SF charge", "idiptrig-iso"]
-        axlabels = ["IDIPTrig"] if num == 2 else ["eta", "pt", "q", "Trig"]
+        axlabels = ["Trig"] if num == 2 else ["eta", "pt", "q", "Trig"]  # WARNING: Trig0/Trig1 actually stands for trigger/isolation, the axis name was intended to indicate the order "axis_idiptrig_iso"
         cardTool.addSystematic(name, 
             mirror=True,
             group="muon_eff_syst" if "Syst" in name else "muon_eff_stat", # TODO: for now better checking them separately
@@ -149,8 +149,8 @@ if not args.noEfficiencyUnc:
             baseName=name+"_",
             processes=cardTool.allMCProcesses(),
             passToFakes=passSystToFakes,
-            systNameReplace=[("q0Trig0", "Trig0"), ("q1Trig0", "Trig0")] if args.correlateEffStatIsoByCharge else [],
-            scale=1.0 if "Syst" in name  else {".*effStatTnP.*Trig0" : "1.414", ".*effStatTnP.*Trig1" : "1.0"} if not args.correlateEffStatIsoByCharge else 1.0 # only for iso, scale up by sqrt(2) when decorrelating between charges and efficiencies were derivied inclusively
+            systNameReplace=[("Trig0", "IDIPTrig"), ("q0Trig1", "Iso"), ("q1Trig1", "Iso")] if args.correlateEffStatIsoByCharge else [("Trig0", "IDIPTrig"), ("Trig1", "Iso")], # replace with better names
+            scale=1.0 if "Syst" in name  else {".*effStatTnP.*Iso" : "1.414", ".*effStatTnP.*IDIPTrig" : "1.0"} if not args.correlateEffStatIsoByCharge else 1.0 # only for iso, scale up by sqrt(2) when decorrelating between charges and efficiencies were derived inclusively
         )
 
 inclusiveScale = args.qcdScale == "integrated"

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -209,7 +209,7 @@ def build_graph(df, dataset):
         muonL1PrefireSyst = df.HistoBoost("muonL1PrefireSyst", nominal_axes, [*nominal_cols, "muonL1PrefireSyst_tensor"], tensor_axes = [down_up_axis])
         results.append(muonL1PrefireSyst)
 
-        df = df.Define("ecalL1Prefire_tensor", f"wrem::twoPointScaling(nominal_weight, L1PreFiringWeight_ECAL_Dn, L1PreFiringWeight_ECAL_Up, L1PreFiringWeight_ECAL_Nom)")
+        df = df.Define("ecalL1Prefire_tensor", f"wrem::twoPointScaling(nominal_weight/L1PreFiringWeight_ECAL_Nom, L1PreFiringWeight_ECAL_Dn, L1PreFiringWeight_ECAL_Up)")
         ecalL1Prefire = df.HistoBoost("ecalL1Prefire", nominal_axes, [*nominal_cols, "ecalL1Prefire_tensor"], tensor_axes = [down_up_axis])
         results.append(ecalL1Prefire)
         

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -254,7 +254,7 @@ def build_graph(df, dataset):
         muonL1PrefireSyst = df.HistoBoost("muonL1PrefireSyst", nominal_axes, [*nominal_cols, "muonL1PrefireSyst_tensor"], tensor_axes = [down_up_axis])
         results.append(muonL1PrefireSyst)
 
-        df = df.Define("ecalL1Prefire_tensor", f"wrem::twoPointScaling(nominal_weight, L1PreFiringWeight_ECAL_Dn, L1PreFiringWeight_ECAL_Up, L1PreFiringWeight_ECAL_Nom)")
+        df = df.Define("ecalL1Prefire_tensor", f"wrem::twoPointScaling(nominal_weight/L1PreFiringWeight_ECAL_Nom, L1PreFiringWeight_ECAL_Dn, L1PreFiringWeight_ECAL_Up)")
         ecalL1Prefire = df.HistoBoost("ecalL1Prefire", nominal_axes, [*nominal_cols, "ecalL1Prefire_tensor"], tensor_axes = [down_up_axis])
         results.append(ecalL1Prefire)
         # n.b. this is the W analysis so mass weights shouldn't be propagated

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -155,6 +155,8 @@ def build_graph(df, dataset):
     df = df.Filter("Sum(vetoElectrons) == 0")
 
     df = df.Define("goodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_pt,TrigObj_l1pt,TrigObj_l2pt,TrigObj_filterBits)")
+    # TODO: when new SF are available move to the following trigger matching
+    #df = df.Define("goodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_filterBits)")
     df = df.Filter("wrem::hasTriggerMatch(TrigMuon_eta,TrigMuon_phi,TrigObj_eta[goodTrigObjs],TrigObj_phi[goodTrigObjs])")
     df = df.Filter("Flag_globalSuperTightHalo2016Filter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_goodVertices && Flag_HBHENoiseIsoFilter && Flag_HBHENoiseFilter && Flag_BadPFMuonFilter")
 
@@ -182,7 +184,7 @@ def build_graph(df, dataset):
         df = df.Define("weight_fullMuonSF_withTrackingReco", muon_efficiency_helper, ["TrigMuon_pt", "TrigMuon_eta", "TrigMuon_charge", "NonTrigMuon_pt", "NonTrigMuon_eta", "NonTrigMuon_charge"])
         df = df.Define("weight_newMuonPrefiringSF", muon_prefiring_helper, ["Muon_correctedEta", "Muon_correctedPt", "Muon_correctedPhi", "Muon_looseId"])
 
-        weight_expr = "weight*weight_pu*weight_fullMuonSF_withTrackingReco*weight_newMuonPrefiringSF"
+        weight_expr = "weight*weight_pu*weight_fullMuonSF_withTrackingReco*weight_newMuonPrefiringSF*L1PreFiringWeight_ECAL_Nom"
         df = theory_tools.define_weights_and_corrs(df, weight_expr, dataset.name, corr_helpers, args)
     else:
         df = df.DefinePerSample("nominal_weight", "1.0")
@@ -252,6 +254,9 @@ def build_graph(df, dataset):
         muonL1PrefireSyst = df.HistoBoost("muonL1PrefireSyst", nominal_axes, [*nominal_cols, "muonL1PrefireSyst_tensor"], tensor_axes = [down_up_axis])
         results.append(muonL1PrefireSyst)
 
+        df = df.Define("ecalL1Prefire_tensor", f"wrem::twoPointScaling(nominal_weight, L1PreFiringWeight_ECAL_Dn, L1PreFiringWeight_ECAL_Up, L1PreFiringWeight_ECAL_Nom)")
+        ecalL1Prefire = df.HistoBoost("ecalL1Prefire", nominal_axes, [*nominal_cols, "ecalL1Prefire_tensor"], tensor_axes = [down_up_axis])
+        results.append(ecalL1Prefire)
         # n.b. this is the W analysis so mass weights shouldn't be propagated
         # on the Z samples (but can still use it for dummy muon scale)
         if isW or isZ:

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -43,7 +43,7 @@ dataDictV9 = {
     
     'WmtaunuPostVFP' : { 'name' : "WminustaunuPostVFP",
                          'filepaths' : 
-                         ["/scratch/shared/NanoAOD/TrackRefitv2_GenPartPrecision/WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP/220729_152430/*/*.root"],
+                         ["/scratch/shared/NanoAOD/TrackRefitv2_GenPartPrecision/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP/220823_073247/*/*.root"],
                          'xsec' : BR_TAUToMU*xsec_WmmunuPostVFP,
     },
     'ttbarlnuPostVFP' : { 'name' : "TTLeptonicPostVFP",

--- a/wremnants/include/histoScaling.h
+++ b/wremnants/include/histoScaling.h
@@ -16,13 +16,13 @@ namespace wrem {
         
     }
 
-    Eigen::TensorFixedSize<double, Eigen::Sizes<2>> twoPointScaling(double nominal_weight, double scaleDown, double scaleUp, double scaleCentral = 1.0) {
+    Eigen::TensorFixedSize<double, Eigen::Sizes<2>> twoPointScaling(double nominal_weight, double scaleDown, double scaleUp) {
 
         Eigen::TensorFixedSize<double, Eigen::Sizes<2>> outWeights;
             
-        // Down weight, then up weight, scaleCentral might generally be 1.0 in case it was not already included in nominal_weight for all histograms
-        outWeights(0) = nominal_weight * scaleDown / scaleCentral;
-        outWeights(1) = nominal_weight * scaleUp   / scaleCentral;
+        // Down weight, then up weight, nominal_weight should not already include a centralScale weight if any
+        outWeights(0) = nominal_weight * scaleDown;
+        outWeights(1) = nominal_weight * scaleUp;
         return outWeights;
         
     }

--- a/wremnants/include/histoScaling.h
+++ b/wremnants/include/histoScaling.h
@@ -5,14 +5,24 @@
 
 namespace wrem {
 
-    Eigen::TensorFixedSize<double, Eigen::Sizes<2>> dummyScaling(double nominal_weight, double scale) {
+    Eigen::TensorFixedSize<double, Eigen::Sizes<2>> constantScaling(double nominal_weight, double scale) {
 
         Eigen::TensorFixedSize<double, Eigen::Sizes<2>> outWeights;
-        outWeights.setConstant(nominal_weight);
             
         // Down weight, then up weight
-        outWeights(0) = (1./scale) * nominal_weight;
-        outWeights(1) = scale      * nominal_weight;
+        outWeights(0) = nominal_weight / scale;
+        outWeights(1) = nominal_weight * scale;
+        return outWeights;
+        
+    }
+
+    Eigen::TensorFixedSize<double, Eigen::Sizes<2>> twoPointScaling(double nominal_weight, double scaleDown, double scaleUp, double scaleCentral = 1.0) {
+
+        Eigen::TensorFixedSize<double, Eigen::Sizes<2>> outWeights;
+            
+        // Down weight, then up weight, scaleCentral might generally be 1.0 in case it was not already included in nominal_weight for all histograms
+        outWeights(0) = nominal_weight * scaleDown / scaleCentral;
+        outWeights(1) = nominal_weight * scaleUp   / scaleCentral;
         return outWeights;
         
     }

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -123,6 +123,16 @@ bool hasTriggerMatch(const float& eta, const float& phi, const Vec_f& TrigObj_et
 
 }
 
+bool hasMatchDR2(const float& eta, const float& phi, const Vec_f& vec_eta, const Vec_f& vec_phi, const float dr2 = 0.09) {
+
+  for (unsigned int jvec = 0; jvec < vec_eta.size(); ++jvec) {
+    if (deltaR2(eta, phi, vec_eta[jvec], vec_phi[jvec]) < dr2) return true;
+  }
+  return false;
+
+}
+
+    
 template<std::ptrdiff_t N, typename V>
 auto vec_to_tensor(const V &vec, std::size_t start = 0) {
   Eigen::TensorFixedSize<typename V::value_type, Eigen::Sizes<N>> res;

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -164,9 +164,10 @@ def define_and_make_pdf_hists(df, axes, cols, dataset, pdfset="nnpdf31", storeUn
 
 
     df = df.Define(tensorASName, "Eigen::TensorFixedSize<double, Eigen::Sizes<2>> res; "
-            f"res(0) = {pdfInfo['alphas'][0]}; "
-            f"res(1) = {pdfInfo['alphas'][1]}; "
-            "return wrem::clip_tensor(res, 10.)")
+            f"res(0) = nominal_weight * {pdfInfo['alphas'][0]}; "
+            f"res(1) = nominal_weight * {pdfInfo['alphas'][1]}; "
+            "res (nominal_weight/nominal_pdf_cen) * wrem::clip_tensor(res, 10.);"
+            "return res;")
     if cols:
         pdfHist = df.HistoBoost(pdfName if hname=="" else f"{hname}_{pdfName}", axes, [*cols, tensorName])
         alphaSHist = df.HistoBoost(f"alphaS002{pdfName}" if hname=="" else f"{hname}_alphaS002{pdfName}", axes, [*cols, tensorASName])


### PR DESCRIPTION
**mw_with_mu_eta_pt.py**
    - add gen match for top background (only W for now)
    - add ECAL prefiring weights and corresponding syst hists
**setupCombineWmas.py** and **CardTool.py**
    - add QCD scales and other signal systs to tau
    - add stat unc on fakes (was default but removed by mistake)
    - fix removal of systs from fakes (was mistakenly modifying input list of processes on which to apply the syst)
    - add groups of nuisances to card for charge plus (was being written only for charge minus)
    - add ECAL prefiring weights and related syst
    - improve naming of effStat nuisance parameters and fix wrong scaling by sqrt(2) (it was scaling trigger rather than isolation)
**wremnants/theory_tools.py**
    - fix alphaS histogram, was missing nominal event weight

**TODO**:
    - add missing QCD scales for Z when doing Wmass and other way around
    - fix derivation of QCD scales histogram on fakes
