### PR TITLE
Some fixes and new features for card maker

### DIFF
--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO)
 scriptdir = f"{pathlib.Path(__file__).parent}"
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-o", "--outfolder", type=str, default="/scratch/kelong/CombineStudies")
+parser.add_argument("-o", "--outfolder", type=str, default="/scratch/kelong/CombineStudies", help="Main output folder, with the root file storing all histograms and datacards for single charge")
 parser.add_argument("-i", "--inputFile", type=str, required=True)
 parser.add_argument("--qcdScale", choices=["byHelicityPtAndByPt", "byHelicityPt", "byHelicityCharge", "byPt", "byCharge", "integrated",], default="byHelicityPt", 
         help="Decorrelation for QCDscale (additionally always by charge). With 'byHelicityPtAndByPt' two independent histograms are stored, split and not split by helicities (for tests)")
@@ -34,16 +34,23 @@ parser.add_argument("--skipSignalSystOnFakes", dest="skipSignalSystOnFakes" , ac
 parser.add_argument("--scaleMuonCorr", type=float, default=1.0, help="Scale up/down dummy muon scale uncertainty by this factor")
 parser.add_argument("--correlateEffStatIsoByCharge", action='store_true', help="Correlate isolation efficiency uncertanties between the two charges (by default they are decorrelated)")
 parser.add_argument("--doStatOnly", action="store_true", default=False, help="Set up fit to get stat-only uncertainty (currently combinetf with -S 0 doesn't work)")
+parser.add_argument("--noHist", action='store_true', help="Skip the making of 2D histograms (root file is left untouched if existing")
 args = parser.parse_args()
 
 if not os.path.isdir(args.outfolder):
     os.makedirs(args.outfolder)
 
+if args.noHist and args.noStatUncFakes:
+    logging.warning("Option --noHist would override --noStatUncFakes. Please select only one of them")
+    quit()
+    
 datagroups = datagroups2016(args.inputFile, wlike=args.wlike)
 templateDir = f"{scriptdir}/Templates/WMass"
 name = "WMass" if not args.wlike else "ZMassWLike"
 cardTool = CardTool.CardTool(f"{args.outfolder}/{name}_{{chan}}.txt")
 cardTool.setNominalTemplate(f"{templateDir}/main.txt")
+if args.noHist:
+    cardTool.skipHistograms()
 cardTool.setOutfile(os.path.abspath(f"{args.outfolder}/{name}CombineInput.root"))
 cardTool.setDatagroups(datagroups)
 cardTool.setFakeName(args.qcdProcessName)

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -101,10 +101,10 @@ def addSystAxis(h, size=1, offset=0):
     hnew[...] = np.stack((newvals, newvars), axis=-1)
     return hnew
 
-def clipNegativeVals(h):
+def clipNegativeVals(h, clipValue=0):
     hnew = hist.Hist(*h.axes, storage=hist.storage.Weight())
     vals = h.values(flow=True)
-    vals[vals<0] = 0
+    vals[vals<0] = clipValue
     hnew[...] = np.stack((vals, h.variances(flow=True)), axis=-1)
     return hnew
 

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -18,6 +18,8 @@ def notImplemented(operation="Unknown"):
 
 class CardTool(object):
     def __init__(self, cardName="card.txt"):
+        self.skipHist = False # don't produce/write histograms, file with them already exists
+        self.outfile = None
         self.cardName = cardName
         self.systematics = {}
         self.lnNSystematics = {}
@@ -47,6 +49,11 @@ class CardTool(object):
         self.chargeIdDict = {"minus" : {"val" : -1, "id" : "q0", "badId" : None},
                              "plus"  : {"val" : 1., "id" : "q1", "badId" : None}
                              }
+
+    def skipHistograms(self):
+        self.skipHist = True
+        if len(self.noStatUncProcesses):
+            logging.info("Attention: histograms are not saved according to input options, thus statistical uncertainty won't be zeroed")
         
     def setSkipOtherChargeSyst(self):
         self.keepOtherChargeSyst = False
@@ -54,6 +61,8 @@ class CardTool(object):
         self.chargeIdDict["minus"]["badId"] = "q1"
 
     def setProcsNoStatUnc(self, procs, resetList=True):
+        if self.skipHist:
+            logging.info("Attention: trying to set statistical uncertainty to 0 for some processes, but histograms won't be saved according to input options")
         if resetList:
             self.noStatUncProcesses = []
         if isinstance(procs, str):
@@ -61,7 +70,7 @@ class CardTool(object):
         elif isinstance(procs, list):
             self.noStatUncProcesses.extend(procs)
         else:
-            raise ValueError("In setNoStatUncForProcs(): expecting string or list argument")            
+            raise ValueError("In setNoStatUncForProcs(): expecting string or list argument")
 
     def getProcsNoStatUnc(self):
         return self.noStatUncProcesses
@@ -275,10 +284,12 @@ class CardTool(object):
                 f"process {proc}, syst {syst}. Found {len(var_names)} names and {len(variations)} variations.")
         setZeroStatUnc = False
         if proc in self.noStatUncProcesses:
+            logging.info(f"Zeroing statistical uncertainty for process {proc}")
             setZeroStatUnc = True
-        for name, var in zip(var_names, variations):
-            if name != "":
-                self.writeHist(var, self.variationName(proc, name), setZeroStatUnc=setZeroStatUnc)
+        if not self.skipHist:
+            for name, var in zip(var_names, variations):
+                if name != "":
+                    self.writeHist(var, self.variationName(proc, name), setZeroStatUnc=setZeroStatUnc)
 
     def addPseudodata(self, processes):
         self.datagroups.loadHistsForDatagroups(
@@ -290,7 +301,8 @@ class CardTool(object):
         for systAxName in ["systIdx", "tensor_axis_0"]:
             if systAxName in [ax.name for ax in hdata.axes]:
                 hdata = hdata[{systAxName : 0 }] 
-        self.writeHist(hdata, self.pseudoData+"_sum")
+        if not self.skipHist:
+            self.writeHist(hdata, self.pseudoData+"_sum")
 
     def writeForProcesses(self, syst, processes, label):
         for process in processes:
@@ -303,8 +315,10 @@ class CardTool(object):
 
     def setOutfile(self, outfile):
         if type(outfile) == str:
-            self.outfile = ROOT.TFile(outfile, "recreate")
-            #self.outfile = uproot.recreate(outfile)
+            if self.skipHist:
+                self.outfile = outfile # only store name, file will not be used and doesn't need to be opened
+            else:
+                self.outfile = ROOT.TFile(outfile, "recreate")
         else:
             self.outfile = outfile
 
@@ -319,6 +333,7 @@ class CardTool(object):
 
         self.writeLnNSystematics()
         for syst in self.systematics.keys():
+            if self.isExcludedNuisance(syst): continue
             processes=self.systematics[syst]["processes"]
             self.datagroups.loadHistsForDatagroups(self.histName, syst, label="syst",
                                                    procsToRead=processes, forceNonzero=syst != "qcdScaleByHelicity")
@@ -421,8 +436,7 @@ class CardTool(object):
                 "labels" : "".join([str(x).ljust(self.spacing) for x in self.processLabels()]),
                 # Could write out the proper normalizations pretty easily
                 "rates" : "-1".ljust(self.spacing)*nprocs,
-                #"inputfile" : self.outfile.file_path,
-                "inputfile" : self.outfile.GetName(),
+                "inputfile" : self.outfile if type(self.outfile) == str  else self.outfile.GetName(),
                 "dataName" : self.dataName,
                 "histName" : self.histName,
                 "pseudodataHist" : self.pseudoData+"_sum" if self.pseudoData else f"{self.histName}_{self.dataName}"
@@ -440,7 +454,6 @@ class CardTool(object):
 
     def writeHistWithCharges(self, h, name):
         hout = narf.hist_to_root(h)
-        #self.outfile[name] = h
         hout.SetName(f"{name}_{self.channels[0]}")
         hout.Write()
     

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -286,10 +286,9 @@ class CardTool(object):
         if proc in self.noStatUncProcesses:
             logging.info(f"Zeroing statistical uncertainty for process {proc}")
             setZeroStatUnc = True
-        if not self.skipHist:
-            for name, var in zip(var_names, variations):
-                if name != "":
-                    self.writeHist(var, self.variationName(proc, name), setZeroStatUnc=setZeroStatUnc)
+        for name, var in zip(var_names, variations):
+            if name != "":
+                self.writeHist(var, self.variationName(proc, name), setZeroStatUnc=setZeroStatUnc)
 
     def addPseudodata(self, processes):
         self.datagroups.loadHistsForDatagroups(
@@ -301,8 +300,7 @@ class CardTool(object):
         for systAxName in ["systIdx", "tensor_axis_0"]:
             if systAxName in [ax.name for ax in hdata.axes]:
                 hdata = hdata[{systAxName : 0 }] 
-        if not self.skipHist:
-            self.writeHist(hdata, self.pseudoData+"_sum")
+        self.writeHist(hdata, self.pseudoData+"_sum")
 
     def writeForProcesses(self, syst, processes, label):
         for process in processes:
@@ -458,6 +456,9 @@ class CardTool(object):
         hout.Write()
     
     def writeHist(self, h, name, setZeroStatUnc=False):
+        if self.skipHist:
+            logging.info("Histograms will not be written because 'skipHist' flag is set to True")
+            return
         if setZeroStatUnc:
             hist_no_error = h.copy()
             hist_no_error.variances(flow=True)[...] = 0.

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -337,8 +337,11 @@ class CardTool(object):
                                                    procsToRead=processes, forceNonzero=syst != "qcdScaleByHelicity")
             self.writeForProcesses(syst, label="syst", processes=processes)
         
+        if self.skipHist:
+            logging.info("Histograms will not be written because 'skipHist' flag is set to True")
         self.writeCard()
 
+        
     def writeCard(self):
         for chan in self.channels:
             with open(self.cardName.format(chan=chan), "w") as card:
@@ -457,7 +460,6 @@ class CardTool(object):
     
     def writeHist(self, h, name, setZeroStatUnc=False):
         if self.skipHist:
-            logging.info("Histograms will not be written because 'skipHist' flag is set to True")
             return
         if setZeroStatUnc:
             hist_no_error = h.copy()

--- a/wremnants/pileup.py
+++ b/wremnants/pileup.py
@@ -55,11 +55,16 @@ def make_pileup_helper(era = None, cropHighWeight = 5.,
     for i in range(puweights.GetNbinsX() + 2):
         if mchist.GetBinContent(i) == 0.:
             puweights.SetBinContent(i, 1.)
-        mchist.SetBinContent(i, min(puweights.GetBinContent(i), cropHighWeight))
+        puweights.SetBinContent(i, min(puweights.GetBinContent(i), cropHighWeight))
 
     puweights.SetName(f"pileup_weights_{era}")
     puweights.SetTitle("")
-
+    print("")
+    print(f"PU weights for era {era}")
+    print([puweights.GetBinContent(i) for i in range(1,puweights.GetNbinsX()+1)])
+    print("")
+    print("")
+    
     helper = ROOT.wrem.pileup_helper(puweights)
 
     return helper


### PR DESCRIPTION
- fixing small bug for PU weights (clipping of large weight was not applied, but had no effect for postVFP since weights are never very large)

**setupCombineWmass.py**
- add option --noHist to skip saving 2D histograms in file (it makes sense only if the file already exists and for some reason one doesn't want to fill it again), which might make the code slightly faster, although the slowest part is about reading boost histograms for the pickle file and this can't be avoided, because systs to write in the card are somehow derived from those.
- augment domain of option --excludeNuisances, allowing to skip the reading of some boost histograms, e.g. with -x ".*pdf.*" to skip the pdf histogram entirely. 