### PR TITLE
Add new shape systs for fakes, and a bug fix for CardTool.py

### DIFF
--- a/scripts/combine/fitManager.py
+++ b/scripts/combine/fitManager.py
@@ -207,11 +207,6 @@ if __name__ == "__main__":
         args.inputdir += "/"
             
     if args.cardFolder:
-        testName = args.cardFolder.rstrip("/")
-        if testName in ["plus", "minus"]:
-            # these names are already used, they contain the configurations used to make histograms
-            print("Warning: folder specified with --card-folder cannot be named as plus|minus/ (you used %s)" % args.cardFolder)
-            quit()
         if not args.cardFolder.endswith("/"):
             args.cardFolder += "/"
         cardFolderFullName = args.inputdir + args.cardFolder

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -145,6 +145,7 @@ cardTool.addSystematic(f"alphaS002{pdfName}",
     scale=0.75, # TODO: this depends on the set, should be provided in theory_tools.py
     passToFakes=passSystToFakes,
 )
+
 if not args.noEfficiencyUnc:
     for name,num in zip(["effSystTnP", "effStatTnP",], [2, 624*4]):
         ## TODO: this merged implementation for the effstat makes it very cumbersome to do things differently for iso and trigidip!!
@@ -310,9 +311,20 @@ cardTool.addSystematic("ecalL1Prefire",
 )
 
 if not args.wlike:
-    cardTool.addLnNSystematic("CMS_Fakes", processes=[args.qcdProcessName], size=1.05)
+    cardTool.addLnNSystematic("CMS_Fakes", processes=[args.qcdProcessName], size=1.05, group="MultijetBkg")
     cardTool.addLnNSystematic("CMS_Top", processes=["Top"], size=1.06)
     cardTool.addLnNSystematic("CMS_VV", processes=["Diboson"], size=1.16)
+
+    # FIXME: it doesn't really make sense to mirror this one since the systematic goes only in one direction
+    cardTool.addSystematic(f"qcdJetPt45", 
+                           processes=["Fake"],
+                           mirror=True,
+                           group="MultijetBkg",
+                           systAxes=[],
+                           outNames=["qcdJetPt45Down", "qcdJetPt45Up"],
+                           passToFakes=passSystToFakes,
+    )
+
 else:
     cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15)
 

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -172,9 +172,12 @@ scaleGroupName = "QCDscale"
 scaleSkipEntries = [(1, 1), (0, 2), (2, 0)]
 # This is hacky but it's the best idea I have for now...
 systNameReplaceVec = [("muR2muF2", "muRmuFUp"), ("muR0muF0", "muRmuFDown"), ("muR2muF1", "muRUp"), 
-                      ("muR0muF1", "muRDown"), ("muR1muF0", "muFDown"), ("muR1muF2", "muFUp"),
-                      ("genQ0", "genVminus"), ("genQ1", "genVplus")]
-
+                      ("muR0muF1", "muRDown"), ("muR1muF0", "muFDown"), ("muR1muF2", "muFUp")]
+if args.wlike:
+    systNameReplaceVec.extend( [("genQ0", "")] )
+else :
+    systNameReplaceVec.extend( [ ("genQ0", "genVminus"), ("genQ1", "genVplus")] )
+    
 # for Z background in W mass case (W background for Wlike is essentially 0, useless to apply QCD scales there)
 if not args.wlike:
     cardTool.addSystematic("inclusive_qcdScale",
@@ -291,11 +294,10 @@ cardTool.addSystematic("muonL1PrefireSyst",
     labelsByAxis=["downUpVar"],
     passToFakes=passSystToFakes,
 )
-# TODO: Allow to be appended to previous group ## FIXME: doesn't it do it already?
 cardTool.addSystematic("muonL1PrefireStat", 
     processes=cardTool.allMCProcesses(),
     group="muonPrefire",
-    baseName="CMS_prefire_stat_m",
+    baseName="CMS_prefire_stat_m_",
     systAxes=["downUpVar", "etaPhiRegion"],
     labelsByAxis=["downUpVar", "etaPhiReg"],
     passToFakes=passSystToFakes,
@@ -316,14 +318,31 @@ if not args.wlike:
     cardTool.addLnNSystematic("CMS_VV", processes=["Diboson"], size=1.16)
 
     # FIXME: it doesn't really make sense to mirror this one since the systematic goes only in one direction
+    # cardTool.addSystematic(f"qcdJetPt45", 
+    #                        processes=["Fake"],
+    #                        mirror=True,
+    #                        group="MultijetBkg",
+    #                        systAxes=[],
+    #                        outNames=["qcdJetPt45Down", "qcdJetPt45Up"],
+    #                        passToFakes=passSystToFakes,
+    # )
     cardTool.addSystematic(f"qcdJetPt45", 
                            processes=["Fake"],
-                           mirror=True,
+                           mirror=False,
                            group="MultijetBkg",
                            systAxes=[],
-                           outNames=["qcdJetPt45Down", "qcdJetPt45Up"],
+                           outNames=["qcdJetPt45Up"],
                            passToFakes=passSystToFakes,
     )
+    cardTool.addSystematic(f"qcdJetPt20", 
+                           processes=["Fake"],
+                           mirror=False,
+                           group="MultijetBkg",
+                           systAxes=[],
+                           outNames=["qcdJetPt20Down"],
+                           passToFakes=passSystToFakes,
+    )
+
 
 else:
     cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -147,6 +147,7 @@ def build_graph(df, dataset):
     df = df.Filter("Sum(vetoElectrons) == 0")
 
     df = df.Define("goodCleanJets", "Jet_jetId >= 6 && (Jet_pt > 50 || Jet_puId >= 4) && Jet_pt > 30 && abs(Jet_eta) < 2.4 && wrem::cleanJetsFromLeptons(Jet_eta,Jet_phi,Muon_correctedEta[vetoMuons],Muon_correctedPhi[vetoMuons],Electron_eta[vetoElectrons],Electron_phi[vetoElectrons])")
+    df = df.Define("goodCleanJetsPt45", "goodCleanJets && Jet_pt > 45")
 
     df = df.Define("passMT", "transverseMass >= 40.0")
     df = df.Filter("passMT || Sum(goodCleanJets)>=1")
@@ -169,6 +170,10 @@ def build_graph(df, dataset):
         nominal = df.HistoBoost("nominal", nominal_axes, nominal_cols)
         results.append(nominal)
 
+        dQCDbkGVar = df.Filter("passMT || Sum(goodCleanJetsPt45)>=1")
+        qcdJetPt45 = dQCDbkGVar.HistoBoost("qcdJetPt45", nominal_axes, nominal_cols)
+        results.append(qcdJetPt45)
+        
     else:
         df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
         df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
@@ -191,6 +196,11 @@ def build_graph(df, dataset):
         nominal = df.HistoBoost("nominal", nominal_axes, [*nominal_cols, "nominal_weight"])
         results.append(nominal)
 
+        dQCDbkGVar = df.Filter("passMT || Sum(goodCleanJetsPt45)>=1")
+        qcdJetPt45 = dQCDbkGVar.HistoBoost("qcdJetPt45", nominal_axes, [*nominal_cols, "nominal_weight"])
+        results.append(qcdJetPt45)
+
+        
         df = df.Define("effStatTnP_tensor", muon_efficiency_helper_stat, ["goodMuons_pt0", "goodMuons_eta0", "goodMuons_charge0", "passIso", "nominal_weight"])
 
         effStatTnP = df.HistoBoost("effStatTnP", nominal_axes, [*nominal_cols, "effStatTnP_tensor"], tensor_axes = muon_efficiency_helper_stat.tensor_axes)

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -409,7 +409,7 @@ class CardTool(object):
             for chan in self.channels:
                 # do not write systs which should only apply to other charge, to simplify card
                 if self.keepOtherChargeSyst or self.chargeIdDict[chan]["badId"] not in systname:
-                    self.cardContent[chan] += f"{systname.ljust(self.spacing)}{shape.ljust(self.spacing)}{''.join(include)}\n"
+                    self.cardContent[chan] += f"{systname.ljust(self.spacing)} {shape.ljust(self.spacing)}{''.join(include)}\n"
         # unlike for LnN systs, here it is simpler to act on the list of these systs to form groups, rather than doing it syst by syst 
         if group:
             for chan in self.channels:

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -204,7 +204,7 @@ class CardTool(object):
 
     def systLabelForAxis(self, axLabel, entry):
         if axLabel == "mirror" or axLabel == "downUpVar":
-            return 'Up' if entry else 'Down'
+            return 'Up' if entry else 'Down'  # note, the first entry is the original, might want to call it Up if it was defined by an actual scaling up of something (e.g. efficiencies)
         if "{i}" in axLabel:
             return axLabel.format(i=entry)
         return axLabel+str(entry)

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -76,7 +76,7 @@ class datagroups(object):
 
                 group[label] = h if not group[label] else hh.addHists(h, group[label])
 
-            if selectSignal and group[label]:
+            if selectSignal and group[label] and "signalOp" in group and group["signalOp"]:
                 group[label] = group["signalOp"](group[label])
         # Avoid situation where the nominal is read for all processes for this syst
         if not foundExact:

--- a/wremnants/include/vertex.h
+++ b/wremnants/include/vertex.h
@@ -10,21 +10,18 @@ class vertex_helper {
 public:
 
   vertex_helper(const TH2D &weights) :
-    vertexweights_(make_shared_TH1<const TH2D>(weights)),
-        nBinsX_(make_shared<const int>(weights.GetNbinsX())),
-        nBinsY_(make_shared<const int>(weights.GetNbinsY())) {}
+    vertexweights_(make_shared_TH1<const TH2D>(weights)) {}
 
     // returns the vertex weight
     double operator() (float genVtx_z, float nTrueInt) const {
-        int xbin = std::clamp(vertexweights_->GetXaxis()->FindFixBin(genVtx_z), 1, *nBinsX_);
-        int ybin = std::clamp(vertexweights_->GetYaxis()->FindFixBin(nTrueInt), 1, *nBinsY_);
+        int xbin = std::clamp(vertexweights_->GetXaxis()->FindFixBin(genVtx_z), 1, vertexweights_->GetNbinsX());
+        int ybin = std::clamp(vertexweights_->GetYaxis()->FindFixBin(nTrueInt), 1, vertexweights_->GetNbinsY());
         return vertexweights_->GetBinContent(xbin, ybin);
     }
 
 
 private:
     std::shared_ptr<const TH2D> vertexweights_;
-    std::shared_ptr<const int> nBinsX_, nBinsY_;
 };
 
 }


### PR DESCRIPTION
Adding syst for fakes, obtained varying the awayJet pt from the nominal 30 GeV to 45. The new histogram is added in the hist maker, and in setupCombineWmass.py it is mirrored to define a shape uncertainty (actually the mirroring doesn't make much sense for this syst, because it is one way by definition, so it should be changed).
The effect is mostly flat vs eta, but with a shape variation vs pt for the QCD template, from +20% of nominal at low pt down to few % at high pt.

Also implementing a fix for CardTool.py,  adding a space before the "shape" keyword in the datacard, otherwise when a syst has a very long name the syst name and the keyword were chained with no separation, causing error when trying to run the fit or combine cards.