### PR TITLE
Add helpers for calibration workflows and bump narf for fitter improvements

### DIFF
--- a/wremnants/include/muon_calibration.h
+++ b/wremnants/include/muon_calibration.h
@@ -37,7 +37,7 @@ template <std::ptrdiff_t NJac = 3, std::ptrdiff_t NReplicas = 0>
 class CVHCorrectorSingle {
 public:
 
-  using V = ROOT::Math::PtEtaPhiM4D<double>;
+  using V = ROOT::Math::PtEtaPhiMVector;
 
   CVHCorrectorSingle(const std::string &filename) {
     TFile *fcor = TFile::Open(filename.c_str());

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -385,7 +385,7 @@ def make_hists_for_smearing_weights(df, nominal_axes, nominal_cols, results):
     results.append(smearing_weights_down)
     results.append(smearing_weights_up)
 
-def define_jpsi_corrections(df, helper):
+def define_lbl_corrections_jpsi_calibration_ntuples(df, helper):
     df = df.DefinePerSample("Muplus_charge", "1")
     df = df.DefinePerSample("Muminus_charge", "-1")
 
@@ -412,7 +412,7 @@ def define_jpsi_corrections(df, helper):
 
     return df
 
-def define_jpsi_corrections_passthrough(df):
+def define_passthrough_corrections_jpsi_calibration_ntuples(df):
     df = df.DefinePerSample("Muplus_charge", "1")
     df = df.DefinePerSample("Muminus_charge", "-1")
 


### PR DESCRIPTION
Add some helpers used in muon calibration-related scripts (to be added in later PRs)

Bump narf mainly for improvements to the tensorflow fitter
@jeyserma this should now give the correct uncertainties for nll fits with weighted events (as long as the variance is consistently present in the histogram)