### PR TITLE
Technical improvements

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,9 @@
-export PYTHONPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ):$PYTHONPATH"
-export PYTHONPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/narf:$PYTHONPATH"
+export WREM_BASE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-export WREM_BASE=""
-if [[ "$PWD" == *"/WRemnants"* ]]; then
-    WREM_BASE="$PWD"
-else
-    WREM_BASE="${PWD}/WRemnants"
-fi
+source ${WREM_BASE}/narf/setup.sh
+
+export PYTHONPATH="${WREM_BASE}:$PYTHONPATH"
+
 echo "Created environment variable WREM_BASE=${WREM_BASE}"
 
 # utility variables pointing to specific folders in the filesystem


### PR DESCRIPTION
Major robustness improvements to hdf5-based io, which unfortunately breaks backwards compatibility with hdf5 files produced using the initial version.  (but at least a sensible error message should be given since protocol versioning is being written to the files in all cases)

narf is now also silencing tensorflow warnings via environment variables set in the setup script.  In order for this to correctly take effect in WRemnants as well the setup script has been improved to call the narf setup script rather than adding it to the PYTHONPATH directly.

A bug was also fixed in setting the WREM_BASE environment variable when the setup script was being called from an external location.