### PR TITLE
Avoid conflicts between tensorflow and Eigen

### DIFF
--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -1,5 +1,4 @@
 import ROOT
-ROOT.ROOT.EnableThreadSafety()
 import narf
 import pathlib
 


### PR DESCRIPTION
There is a major conflict between tensorflow and Eigen:
The .so files which are loaded when calling ```import tensorflow``` export some symbols from Eigen which may not be of the same version or compiles with the same preprocessor directives as what is being jitted with cling.

In particular this concerns ```Eigen::internal::TensorBlockScratchAllocator<Eigen::DefaultDevice>::allocate``` which can lead to invalid calls to free (memory addresses mismatched from the corresponding malloc due to inconsistent alignment adjustments to the pointer address).

For the moment avoid importing tensorflow by default in narf, and add explicit protections such that a sensible error is printed rather than a segfault or other undefined behaviour.