### PR TITLE
Fix canvas popup, and silent warning messages from efficiency histograms in CardTool

### DIFF
--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -2,15 +2,15 @@
 
 import re, sys, os, os.path, subprocess, json, ROOT, copy, math
 import numpy as np
-import logging
-logging.basicConfig(level=logging.INFO)
-
+from utilities import common, logging
 from functools import partial
 
 from array import array
 import shutil
 #sys.path.append(os.getcwd() + "/plotUtils/")
 from scripts.analysisTools.plotUtils.CMS_lumi import *
+
+logger = logging.child_logger(__name__)
 
 _canvas_pull = ROOT.TCanvas("_canvas_pull","",800,800)
 
@@ -168,7 +168,7 @@ def getMinMaxHisto(h, excludeEmpty=True, sumError=True,
     elif dim == 2: nbins = (h.GetNbinsX() + 2) * (h.GetNbinsY() + 2)
     elif dim == 3: nbins = (h.GetNbinsX() + 2) * (h.GetNbinsY() + 2) * (h.GetNbinsZ() + 2)
     else:
-        logging.error("In getMaxHisto(): dim = %d is not supported. Exit" % dim)
+        logger.error("In getMaxHisto(): dim = %d is not supported. Exit" % dim)
         quit()
 
     nBinMin = 0
@@ -192,7 +192,7 @@ def getMinMaxHisto(h, excludeEmpty=True, sumError=True,
         if excludeMin != None and tmpmin <= excludeMin: continue
         if excludeMax != None and tmpmax >= excludeMax: continue
         if firstValidBin < 0: 
-            logging.debug("ibin %d:   tmpmin,tmpmax = %.2f, %.2f" % (ibin,tmpmin,tmpmax))
+            logger.debug("ibin %d:   tmpmin,tmpmax = %.2f, %.2f" % (ibin,tmpmin,tmpmax))
             firstValidBin = ibin
         if sumError:
             tmpmin -= h.GetBinError(ibin)
@@ -201,11 +201,11 @@ def getMinMaxHisto(h, excludeEmpty=True, sumError=True,
             #the first time we pick a non empty bin, we set min and max to the histogram content in that bin
             minval = tmpmin
             maxval = tmpmax
-            logging.debug("#### ibin %d:   min,max = %.2f, %.2f" % (ibin,minval,maxval))
+            logger.debug("#### ibin %d:   min,max = %.2f, %.2f" % (ibin,minval,maxval))
         else:
             minval = min(minval,tmpmin)
             maxval = max(maxval,tmpmax)
-        logging.debug("ibin %d:   min,max = %.2f, %.2f" % (ibin,minval,maxval))
+        logger.debug("ibin %d:   min,max = %.2f, %.2f" % (ibin,minval,maxval))
     
     return minval,maxval
 
@@ -1533,7 +1533,7 @@ def drawNTH1(hists=[],
     # where x1 and y1 are the coordinates the first line, and ypass is how much below y1 the second line is (and so on for following lines)
 
     if len(hists) != len(legEntries):
-        logging.warning("In drawNTH1: #(hists) != #(legEntries). Abort")
+        logger.warning("In drawNTH1: #(hists) != #(legEntries). Abort")
         quit()
 
     if (rebinFactorX): 
@@ -2392,9 +2392,9 @@ def drawTH1dataMCstack(h1, thestack,
     if hErrStack != None:
         stackErr = copy.deepcopy(hErrStack.Clone("stackErr"))
 
-    # logging.info("drawTH1dataMCstack():  integral(data):  " + str(h1.Integral()))
-    # logging.info("drawTH1dataMCstack():  integral(stack): " + str(stackCopy.Integral()))
-    # logging.info("drawTH1dataMCstack():  integral(herr):  " + str(stackErr.Integral()))
+    # logger.info("drawTH1dataMCstack():  integral(data):  " + str(h1.Integral()))
+    # logger.info("drawTH1dataMCstack():  integral(stack): " + str(stackCopy.Integral()))
+    # logger.info("drawTH1dataMCstack():  integral(herr):  " + str(stackErr.Integral()))
 
     h1.SetStats(0)
     titleBackup = h1.GetTitle()
@@ -3537,8 +3537,8 @@ def getArrayParsingString(inputString, verbose=False, makeFloat=False):
     tmp = inputString.replace('[','').replace(']','')
     tmp = tmp.split(',')
     if verbose:
-        logging.info("Input: %s" % inputString)
-        logging.info("Output: %s" % tmp)
+        logger.info("Input: %s" % inputString)
+        logger.info("Output: %s" % tmp)
     if makeFloat:
         ret = [float(x) for x in tmp]
     else:
@@ -3612,7 +3612,7 @@ def getEtaPtBinning(inputBins, whichBins="reco"):
     # whichBins can be reco or gen
     # actually, gen was needed only for 2D xsec, might not be used anymore
     if whichBins not in ["reco", "gen"]:
-        logging.error("In function getEtaPtBinning(): whichBins must be 'reco' or 'gen'. Exit")
+        logger.error("In function getEtaPtBinning(): whichBins must be 'reco' or 'gen'. Exit")
         exit()
 
     # case in which we are passing a file containing the binning and not directly the binning itself

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -12,8 +12,6 @@ from scripts.analysisTools.plotUtils.CMS_lumi import *
 
 logger = logging.child_logger(__name__)
 
-_canvas_pull = ROOT.TCanvas("_canvas_pull","",800,800)
-
 #########################################################################
 colors_plots_ = {"Wmunu"      : ROOT.kRed+2,
                  "Zmumu"      : ROOT.kAzure+2,
@@ -2570,6 +2568,7 @@ def drawTH1dataMCstack(h1, thestack,
   
     if "unrolled" in canvasName:
 
+        _canvas_pull = ROOT.TCanvas("_canvas_pull","",800,800)
         _canvas_pull.SetTickx(1)
         _canvas_pull.SetTicky(1)
         _canvas_pull.SetGridx(1)

--- a/scripts/analysisTools/tests/testFakesVsMt.py
+++ b/scripts/analysisTools/tests/testFakesVsMt.py
@@ -19,7 +19,7 @@ import lz4.frame, pickle
 from wremnants.datasets.datagroups import datagroups2016
 from wremnants import histselections as sel
 
-from utilities import boostHistHelpers as hh,common
+from utilities import boostHistHelpers as hh, common, logging
 
 ## safe batch mode                                 
 import sys
@@ -510,7 +510,7 @@ if __name__ == "__main__":
     parser.add_argument(     '--use-qcd-mc', dest='useQCDMC' , action='store_true',   help='Make study using QCD MC instead of data-driven fakes, as a cross check')
     args = parser.parse_args()
     
-    logger = common.setup_color_logger(os.path.basename(__file__), args.verbose)
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     if args.doAbsEta:
         logger.error("Option --absolute-eta not implemented correctly yet. Abort")
         quit()

--- a/scripts/analysisTools/tests/testQCDisoMtCorr.py
+++ b/scripts/analysisTools/tests/testQCDisoMtCorr.py
@@ -11,7 +11,7 @@ import lz4.frame, pickle
 from wremnants.datasets.datagroups import datagroups2016
 from wremnants import histselections as sel
 
-from utilities import boostHistHelpers as hh,common
+from utilities import boostHistHelpers as hh, common, logging
 
 ## safe batch mode                                 
 import sys
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     args = parser.parse_args()
     
-    logger = common.setup_color_logger(os.path.basename(__file__), args.verbose)
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     
     ROOT.TH1.SetDefaultSumw2()
 

--- a/scripts/analysisTools/tests/testShapesIsoMtRegions.py
+++ b/scripts/analysisTools/tests/testShapesIsoMtRegions.py
@@ -4,7 +4,8 @@
 from wremnants.datasets.datagroups import datagroups2016
 from wremnants import histselections as sel
 #from wremnants import plot_tools,theory_tools,syst_tools
-from utilities import boostHistHelpers as hh,common
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
 
 import narf
 import wremnants
@@ -19,7 +20,6 @@ import lz4.frame
 import argparse
 import os
 import shutil
-import logging
 import re
 
 ## safe batch mode
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     parser.add_argument("--isoMtRegion", type=int, nargs='+', default=[0,1,2,3], choices=[0,1,2,3], help="Integer index for iso-Mt regions to plot (conversion is index = passIso * 1 + passMT * 2 as in common.getIsoMtRegionFromID)");
     args = parser.parse_args()
 
-    logger = common.setup_color_logger(os.path.basename(__file__), args.verbose)
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose, True)
     # if 0:
     #     logger.critical("TEST LOGGER CRITICAL")
     #     logger.error("TEST LOGGER ERROR")

--- a/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
+++ b/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
@@ -9,7 +9,6 @@
 
 import re
 import os, os.path
-import logging
 import argparse
 import shutil
 
@@ -28,13 +27,11 @@ from scripts.analysisTools.plotUtils.utility import *
 
 sys.path.append(os.getcwd())
 
-logging.basicConfig(level=logging.INFO)
-
 def plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName, yAxisName,
                          lumi="", ptRangeProjection=(0,-1), chargeLabel="",
                          canvas=None, canvasWide=None, canvas1D=None,
                          colors=None, legEntries=None, isPseudoData=False,
-                         ratioRange=(0.92,1.08)):
+                         ratioRange=None):
 
     #TODO: make colors and legEntries a single dictionary
 
@@ -83,7 +80,10 @@ def plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName, yAxisName,
         lowPtbin = 1
         highPtbin = hdata2D.GetNbinsY()
 
-    ratioRangeStr = f"::{args.ratioRange[0]},{args.ratioRange[1]}"
+    ratioRangeStr = ""
+    if ratioRange:
+        ratioRangeStr = f"::{ratioRange[0]},{ratioRange[1]}"
+    
         
     hdata_eta = hdata2D.ProjectionX("data_eta",lowPtbin,highPtbin,"e")
     hdata_pt  = hdata2D.ProjectionY("data_pt",1,hdata2D.GetNbinsX(),"e")

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -215,7 +215,7 @@ def main(args):
                 splitGroupDict = {f"{groupName}_{x}" : f".*effSyst.*{x}" for x in list(effTypesNoIso + ["iso"])}
                 splitGroupDict[groupName] = ".*effSyst.*" # add also the group with everything
             else:
-                nameReplace = [] if any(x in name for x in chargeDependentSteps) else [("q0", ""), ("q1", "")]  # this part correlates nuisances between charges
+                nameReplace = []# if any(x in name for x in chargeDependentSteps) else [("q0", ""), ("q1", "")]  # this part correlates nuisances between charges
                 if args.binnedScaleFactors:
                     axes = ["SF eta", "nPtBins", "SF charge"]
                     axlabels = ["eta", "pt", "q"]

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -232,8 +232,17 @@ def main(args):
                 splitGroupDict[groupName] = ".*effStat.*" # add also the group with everything
             if args.effStatLumiScale and "Syst" not in name:
                 scale /= math.sqrt(args.effStatLumiScale)
-
-            cardTool.addSystematic(name, 
+            silentCheckOtherCharge = False
+            if wmass or (wlike and "trigger" in name):
+                # For wmass the histograms associated to the wrong reco charge are present but equal to nominal one.
+                # To avoid annoying warnings of this expected behaviour we silent the related check in cardtool.
+                # This also has to happen for effStat trigger in the wlike case
+                # Note: should be the case also for trigger effSyst, but since it is packed with the other steps we can't
+                # silent it only for that from here (in any case we can live with a single unnecessary warning)
+                silentCheckOtherCharge = True
+                
+            cardTool.addSystematic(
+                name, 
                 mirror=mirror,
                 group=groupName,
                 systAxes=axes,
@@ -243,7 +252,8 @@ def main(args):
                 passToFakes=passSystToFakes,
                 systNameReplace=nameReplace,
                 scale=scale,
-                splitGroup=splitGroupDict
+                splitGroup=splitGroupDict,
+                silentCheckOtherCharge=silentCheckOtherCharge
             )
 
     to_fakes = passSystToFakes and not args.noQCDscaleFakes

--- a/utilities/input_tools.py
+++ b/utilities/input_tools.py
@@ -8,6 +8,7 @@ import os
 import hdf5plugin
 import h5py
 from narf import ioutils
+import ROOT
 
 logger = logging.child_logger(__name__)
 

--- a/utilities/input_tools.py
+++ b/utilities/input_tools.py
@@ -280,3 +280,35 @@ def read_matched_scetlib_dyturbo_hist(scetlib_resum, scetlib_fo_sing, dyturbo_fo
         logger.warning("Did not find variation for nonsingular! Assuming nominal for all variations!")
         hnonsing = hnonsing[{"vars" : 0}]
     return hh.addHists(hsing, hnonsing)
+
+def safeGetRootObject(fileObject, objectName, quitOnFail=True, silent=False, detach=True):
+    obj = fileObject.Get(objectName)
+    if obj == None:
+        if not silent:
+            print(f"Error getting {objectName} from file {fileObject.GetName()}")
+        if quitOnFail:
+            quit()
+        return None
+    else:
+        if detach:
+            obj.SetDirectory(0)
+        return obj
+        
+def safeOpenRootFile(fileName, quitOnFail=True, silent=False, mode="READ"):
+    fileObject = ROOT.TFile.Open(fileName, mode)
+    if not fileObject or fileObject.IsZombie():
+        if not silent:
+            print(f"Error when opening file {fileName}")
+        if quitOnFail:
+            quit()
+        else:
+            return None
+    elif not fileObject.IsOpen():
+        if not silent:
+            print(f"File {fileName} was not opened")
+        if quitOnFail:
+            quit()
+        else:
+            return None
+    else:
+        return fileObject

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -395,7 +395,7 @@ class CardTool(object):
         # so there is some customization based on what one expects to silent some noisy warnings
         for name in sorted(var_names):
             for chan in self.channels:
-                if self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
+                if chan in self.chargeIdDict .keys() and self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
                     if silentCheckOtherCharge:
                         continue
                 if chan in ["plus", "minus"]:

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -398,7 +398,6 @@ class CardTool(object):
                 if self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
                     if self.datagroups.wmass or silentCheckOtherCharge:
                         continue
-                    logger.error(self.datagroups.wmass)
                 if chan in ["plus", "minus"]:
                     q = self.chargeIdDict[chan]["val"]
                     hnom = self.getBoostHistByCharge(hnom3D, q)

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -53,8 +53,8 @@ class CardTool(object):
         self.lumiScale = 1.
         self.project = None
         self.keepOtherChargeSyst = True
-        self.chargeIdDict = {"minus" : {"val" : -1, "id" : "q0", "badId" : None},
-                             "plus"  : {"val" : 1., "id" : "q1", "badId" : None},
+        self.chargeIdDict = {"minus" : {"val" : -1, "id" : "q0", "badId" : "q1"},
+                             "plus"  : {"val" : 1., "id" : "q1", "badId" : "q0"},
                              "inclusive" : {"val" : "sum", "id" : "none", "badId" : None}, # for this channel there is no bad id, currently using random string to make sure it doesn't match
                              }
 
@@ -221,7 +221,8 @@ class CardTool(object):
                       baseName="", mirror=False, scale=1, processes=None, group=None, noConstraint=False,
                       action=None, doActionBeforeMirror=False, actionArgs={}, actionMap={},
                       systNameReplace=[], groupFilter=None, passToFakes=False,
-                      rename=None, splitGroup={}, decorrelateByCharge=False, decorrelateByBin={}):
+                      rename=None, splitGroup={}, decorrelateByCharge=False, decorrelateByBin={},
+                      silentCheckOtherCharge=False):
 
         # Need to make an explicit copy of the array before appending
         procs_to_add = [x for x in (self.allMCProcesses() if processes is None else processes)]
@@ -261,7 +262,8 @@ class CardTool(object):
                 "skipEntries" : [] if not skipEntries else skipEntries,
                 "name" : name,
                 "decorrCharge" : decorrelateByCharge,
-                "decorrByBin": decorrelateByBin
+                "decorrByBin": decorrelateByBin,
+                "silentCheckOtherCharge" : silentCheckOtherCharge
             }
         })
         
@@ -382,16 +384,21 @@ class CardTool(object):
     def getBoostHistByCharge(self, h, q):
         return h[{"charge" : h.axes["charge"].index(q) if q != "sum" else hist.sum}]
         
-    def checkSysts(self, hnom3D, var_map, proc, thresh=0.25):
+    def checkSysts(self, hnom3D, var_map, proc, thresh=0.25, silentCheckOtherCharge=False):
         #if self.check_variations:
         var_names = set([name.replace("Up", "").replace("Down", "") for name in var_map.keys() if name])
         if len(var_names) != len(var_map.keys())/2:
             raise ValueError(f"Invalid syst names for process {proc}! Expected an up/down variation for each syst. "
                 f"Found systs {var_names} and outNames {var_map.keys()}")
-        for name in var_names:
+        # for wmass some systs are only expected to affect a reco charge, but the syst for other charge might still exist and be used
+        # although one expects it to be same as nominal. The following check would trigger on this case with spurious warnings
+        # so there is some customization based on what one expects to silent some noisy warnings
+        for name in sorted(var_names):
             for chan in self.channels:
-                if not self.keepOtherChargeSyst and self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
-                    continue
+                if self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
+                    if self.datagroups.wmass or silentCheckOtherCharge:
+                        continue
+                    logger.error(self.datagroups.wmass)
                 if chan in ["plus", "minus"]:
                     q = self.chargeIdDict[chan]["val"]
                     hnom = self.getBoostHistByCharge(hnom3D, q)
@@ -441,7 +448,7 @@ class CardTool(object):
         var_map = self.systHists(h, syst) 
         # TODO: Make this optional
         if syst != self.nominalName:
-            self.checkSysts(self.procDict[proc][self.nominalName], var_map, proc)
+            self.checkSysts(self.procDict[proc][self.nominalName], var_map, proc, silentCheckOtherCharge=systInfo["silentCheckOtherCharge"])
         setZeroStatUnc = False
         if proc in self.noStatUncProcesses:
             logger.info(f"Zeroing statistical uncertainty for process {proc}")

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -396,7 +396,7 @@ class CardTool(object):
         for name in sorted(var_names):
             for chan in self.channels:
                 if self.chargeIdDict[chan]["badId"] is not None and self.chargeIdDict[chan]["badId"] in name:
-                    if self.datagroups.wmass or silentCheckOtherCharge:
+                    if silentCheckOtherCharge:
                         continue
                 if chan in ["plus", "minus"]:
                     q = self.chargeIdDict[chan]["val"]

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -1,7 +1,7 @@
 from utilities import boostHistHelpers as hh
 import hist
 import numpy as np
-from scripts.analysisTools.plotUtils.utility import safeOpenFile, safeGetObject
+from utilities.input_tools import safeOpenRootFile, safeGetRootObject
 import narf
 import ROOT
 
@@ -82,8 +82,8 @@ def applyCorrection(h, scale=1.0, offsetCorr=0.0, corrFile=None, corrHist=None, 
         ## TDirectory.TContext() should restore the ROOT current directory to whatever it was before a new ROOT file was opened
         ## but it doesn't work at the moment, apparently the class miss the __enter__ member and the usage with "with" fails
         #with ROOT.TDirectory.TContext():
-        f = safeOpenFile(corrFile, mode="READ")
-        corr = safeGetObject(f, corrHist, detach=True)
+        f = safeOpenRootFile(corrFile, mode="READ")
+        corr = safeGetRootObject(f, corrHist, detach=True)
         if offsetCorr:
             offsetHist = corr.Clone("offsetHist")
             ROOT.wrem.initializeRootHistogram(offsetHist, offsetCorr)


### PR DESCRIPTION
The canvas popup was related to importing some functions from script/analysisTools/plotUtils/utility.py, where a leftover canvas was defined in the global scope.
The canvas creation has now be moved in a local scope, but also the imported functions are now moved to utilities/input_tools.py
They are safeOpenRootFile and safeGetRootObject, which are used to read the mT correction for fakes from a root file in CardTool.py

Also, this PR removes the annoying warning messages appearing in CardTool.py when doing efficiency histograms for Wmass for the wrong reco charge. There is a check to warn when the histogram ratio var/nomi is exactly 1, but this is expected to happen for efficiency histograms, since the tensor also has the reco charge.
CardTool.addSystematics now has a "silentCheckOtherCharge" item to skip the check when the wrong reco charge is identified in the variation histogram's name. This is currently set to True only for Wmass efficiency histograms or effStat_trigger for Wlike, since also there the variation applies to a single charge only.

**NOTE**: this PR still does NOT fix the implementation of the proper charge correlation for effStat_iso nuisances. At the moment the nuisance parameters will be named with a charge label (q0 or q1 for minus and plus), so the fit will treat them as uncorrelated between charges, which is not what we want.
The proper fix requires removing the charge axis from the tensor of iso step, and will require everyone to rerun everything from scratch.
Another ad hoc fix (which I have already implemented but not in this PR) modifies the name at card level through a setting of CardTool.addSystematics, but this solution was discarded by many people.