### PR TITLE
Move to updated narf with safe version of Declare

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -33,11 +33,11 @@ for d in datasets: logger.info(f"Dataset {d.name}")
 
 # load lowPU specific libs
 #ROOT.gInterpreter.AddIncludePath(f"{pathlib.Path(__file__).parent}/include/")
-ROOT.gInterpreter.Declare('#include "lowpu_utils.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_efficiencies.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_prefire.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_rochester.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
+narf.clingutils.Declare('#include "lowpu_utils.h"')
+narf.clingutils.Declare('#include "lowpu_efficiencies.h"')
+narf.clingutils.Declare('#include "lowpu_prefire.h"')
+narf.clingutils.Declare('#include "lowpu_rochester.h"')
+narf.clingutils.Declare('#include "lowpu_recoil.h"')
 
 
 

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -32,11 +32,11 @@ for d in datasets: logging.info(f"Dataset {d.name}")
 
 # load lowPU specific libs
 #ROOT.gInterpreter.AddIncludePath(f"{pathlib.Path(__file__).parent}/include/")
-ROOT.gInterpreter.Declare('#include "lowpu_utils.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_efficiencies.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_prefire.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_rochester.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
+narf.clingutils.Declare('#include "lowpu_utils.h"')
+narf.clingutils.Declare('#include "lowpu_efficiencies.h"')
+narf.clingutils.Declare('#include "lowpu_prefire.h"')
+narf.clingutils.Declare('#include "lowpu_rochester.h"')
+narf.clingutils.Declare('#include "lowpu_recoil.h"')
 
 
 # standard regular axes

--- a/scripts/lowPU/recoilCorrection.py
+++ b/scripts/lowPU/recoilCorrection.py
@@ -21,7 +21,7 @@ from wremnants.datasets.datagroups import datagroups2016
 
 w = ROOT.RooWorkspace("w", "")
 
-ROOT.gInterpreter.Declare("""
+narf.clingutils.Declare("""
 
 void GaussianKernel(TH1D h, TH1D &h_sm, TH1D &h_pull, double sigma) {
 

--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -4,12 +4,12 @@ import pathlib
 
 ROOT.gInterpreter.AddIncludePath(f"{pathlib.Path(__file__).parent}/include/")
 
-ROOT.gInterpreter.Declare('#include "muonCorr.h"')
-ROOT.gInterpreter.Declare('#include "histoScaling.h"')
-ROOT.gInterpreter.Declare('#include "histHelpers.h"')
-ROOT.gInterpreter.Declare('#include "utils.h"')
-ROOT.gInterpreter.Declare('#include "csVariables.h"')
-ROOT.gInterpreter.Declare('#include "EtaPtCorrelatedEfficiency.h"')
+narf.clingutils.Declare('#include "muonCorr.h"')
+narf.clingutils.Declare('#include "histoScaling.h"')
+narf.clingutils.Declare('#include "histHelpers.h"')
+narf.clingutils.Declare('#include "utils.h"')
+narf.clingutils.Declare('#include "csVariables.h"')
+narf.clingutils.Declare('#include "EtaPtCorrelatedEfficiency.h"')
 
 from .datasets import datasets2016
 from .datasets import datasetsLowPU

--- a/wremnants/correctionsTensor_helper.py
+++ b/wremnants/correctionsTensor_helper.py
@@ -1,7 +1,7 @@
 import narf
 import ROOT
 
-ROOT.gInterpreter.Declare('#include "theory_corrections.h"')
+narf.clingutils.Declare('#include "theory_corrections.h"')
 
 def makeCorrectionsTensor(corrh, tensor, tensor_rank):
     corrhConv = narf.hist_to_pyroot_boost(corrh, tensor_rank=tensor_rank)

--- a/wremnants/include/muon_efficiencies_binned_vqt.h
+++ b/wremnants/include/muon_efficiencies_binned_vqt.h
@@ -68,7 +68,7 @@ namespace wrem_vqt {
                 if ((pt>=Ptbins[i])&&(pt<Ptbins[i+1])) {
                     for (unsigned int j=0; j!=ETASIZE; j++) {
                         if ((eta>=Etabins[j])&&(eta<Etabins[j+1])) {
-                            sf *= vector_[i*ETASIZE+j]->Eval(vqt);
+                            sf *= vector_[i*ETASIZE+j].Eval(vqt);
                         }
                     }
                 }

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -14,8 +14,8 @@ from functools import reduce
 
 logger = logging.child_logger(__name__)
 
-ROOT.gInterpreter.Declare('#include "muon_calibration.h"')
-ROOT.gInterpreter.Declare('#include "lowpu_utils.h"')
+narf.clingutils.Declare('#include "muon_calibration.h"')
+narf.clingutils.Declare('#include "lowpu_utils.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_efficiencies_binned.py
+++ b/wremnants/muon_efficiencies_binned.py
@@ -10,7 +10,7 @@ import lz4.frame
 
 from utilities import common
 
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_efficiencies_binned_vqt.py
+++ b/wremnants/muon_efficiencies_binned_vqt.py
@@ -10,8 +10,8 @@ import lz4.frame
 
 from utilities import common
 
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned.h"')
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned_vqt.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned_vqt.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_efficiencies_binned_vqt_integrated.py
+++ b/wremnants/muon_efficiencies_binned_vqt_integrated.py
@@ -10,8 +10,8 @@ import lz4.frame
 
 from utilities import common
 
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned.h"')
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned_vqt_integrated.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned_vqt_integrated.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_efficiencies_binned_vqt_real.py
+++ b/wremnants/muon_efficiencies_binned_vqt_real.py
@@ -10,8 +10,8 @@ import lz4.frame
 
 from utilities import common
 
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned.h"')
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_binned_vqt_real.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_binned_vqt_real.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_efficiencies_smooth.py
+++ b/wremnants/muon_efficiencies_smooth.py
@@ -10,7 +10,7 @@ import lz4.frame
 
 from utilities import common
 
-ROOT.gInterpreter.Declare('#include "muon_efficiencies_smooth.h"')
+narf.clingutils.Declare('#include "muon_efficiencies_smooth.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_prefiring.py
+++ b/wremnants/muon_prefiring.py
@@ -1,8 +1,9 @@
 import ROOT
 import pathlib
 import hist
+import narf.clingutils
 
-ROOT.gInterpreter.Declare('#include "muon_prefiring.h"')
+narf.clingutils.Declare('#include "muon_prefiring.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/muon_validation.py
+++ b/wremnants/muon_validation.py
@@ -6,7 +6,7 @@ import uproot
 from functools import reduce
 from utilities import common, logging
 
-ROOT.gInterpreter.Declare('#include "muon_validation.h"')
+narf.clingutils.Declare('#include "muon_validation.h"')
 
 logger = logging.child_logger(__name__)
 

--- a/wremnants/pileup.py
+++ b/wremnants/pileup.py
@@ -8,7 +8,7 @@ from utilities import common, logging
 
 logger = logging.child_logger(__name__)
 
-ROOT.gInterpreter.Declare('#include "pileup.h"')
+narf.clingutils.Declare('#include "pileup.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -9,8 +9,9 @@ import json
 import os
 import array
 from utilities import common as common
+import narf.clingutils
 
-ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
+narf.clingutils.Declare('#include "lowpu_recoil.h"')
 logger = logging.getLogger("wremnants").getChild(__name__.split(".")[-1])
 
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -5,9 +5,10 @@ import copy
 from utilities import boostHistHelpers as hh,common,logging
 from wremnants import theory_corrections
 from scipy import ndimage
+import narf.clingutils
 
 logger = logging.child_logger(__name__)
-ROOT.gInterpreter.Declare('#include "theoryTools.h"')
+narf.clingutils.Declare('#include "theoryTools.h"')
 
 # integer axis for -1 through 7
 axis_helicity = hist.axis.Integer(

--- a/wremnants/vertex.py
+++ b/wremnants/vertex.py
@@ -5,7 +5,7 @@ import narf
 import numpy as np
 import boost_histogram as bh
 
-ROOT.gInterpreter.Declare('#include "vertex.h"')
+narf.clingutils.Declare('#include "vertex.h"')
 
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 


### PR DESCRIPTION
New function ```narf.clingutils.Declare``` wraps ```ROOT.gInterpreter.Declare``` and checks the return code, raising an error if the compilation fails.  Previously compilation errors could go unnoticed and lead to crashes later on.