### PR TITLE
Remove double charge axis from iso effStat tensor

### DIFF
--- a/scripts/combine/fitManager.py
+++ b/scripts/combine/fitManager.py
@@ -4,11 +4,11 @@
 #
 # charge combination
 #
-# python WRemnants/scripts/combine/fitManager.py -i /scratch/mciprian/CombineStudies/Wmass/abseta1p0/qcdScale_byPt/ --cf testChargeComb -c "plus,minus" --comb [--skip-fit-data]
+# python WRemnants/scripts/combine/fitManager.py -i /scratch/mciprian/CombineStudies/Wmass/abseta1p0/qcdScale_byPt/  --comb [--skip-fit-data]
 #
 # single charge (can select a single charge as -c plus, otherwise both are done in sequence)
 #
-# python WRemnants/scripts/combine/fitManager.py -i /scratch/mciprian/CombineStudies/Wmass/abseta1p0/qcdScale_byPt/ --cf testSingleCharge -c "plus,minus" --fit-single-charge [--skip-fit-data]
+# python WRemnants/scripts/combine/fitManager.py -i /scratch/mciprian/CombineStudies/Wmass/abseta1p0/qcdScale_byPt/  -c "plus,minus" --fit-single-charge [--skip-fit-data]
 
 import os, re, copy, math, array
 

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -212,7 +212,7 @@ def main(args):
                 splitGroupDict = {f"{groupName}_{x}" : f".*effSyst.*{x}" for x in list(effTypesNoIso + ["iso"])}
                 splitGroupDict[groupName] = ".*effSyst.*" # add also the group with everything
             else:
-                nameReplace = []# if any(x in name for x in chargeDependentSteps) else [("q0", ""), ("q1", "")]  # this part correlates nuisances between charges
+                nameReplace = [] if any(x in name for x in chargeDependentSteps) else [("q0", "qall")] # for iso charge the tag id with another sensible label
                 if args.binnedScaleFactors:
                     axes = ["SF eta", "nPtBins", "SF charge"]
                     axlabels = ["eta", "pt", "q"]

--- a/wremnants/include/muon_efficiencies_binned.h
+++ b/wremnants/include/muon_efficiencies_binned.h
@@ -225,7 +225,7 @@ namespace wrem {
     // this is now an independent class with respect to the previous one which only deals with nominal and statistical variations
     ////
     //// BASE CLASS FOR HELPER_STAT
-    template<int NEtaBins, int NPtBins, typename HIST_SF>
+    template<int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
     class muon_efficiency_binned_helper_stat_base {
     public:
 
@@ -233,7 +233,7 @@ namespace wrem {
             sf_type_(std::make_shared<const HIST_SF>(std::move(sf_type))) {}
 
         // number of eta bins, number of eigen variations for pt axis, then 2 charges
-        using stat_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtBins, 2>>;
+        using stat_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtBins, NCharges>>;
         
         int checkEffTypeInAxis(boost::histogram::axis::category<std::string> axis, const std::string& match = "match") {
             int ret = -1;
@@ -329,13 +329,13 @@ namespace wrem {
     ////
 
     // base template for one lepton case
-    template<bool do_other, int NEtaBins, int NPtBins, typename HIST_SF>
+    template<bool do_other, int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
     class muon_efficiency_binned_helper_stat :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF> {
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -347,13 +347,13 @@ namespace wrem {
     };
 
     // specialization for two-lepton case
-    template<int NEtaBins, int NPtBins, typename HIST_SF>
-    class muon_efficiency_binned_helper_stat<true, NEtaBins, NPtBins, HIST_SF> :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF> {
+    template<int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
+    class muon_efficiency_binned_helper_stat<true, NEtaBins, NPtBins, nCharges, HIST_SF> :
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;
@@ -377,13 +377,13 @@ namespace wrem {
     ////
 
     // base template for one lepton case
-    template<bool do_other, int NEtaBins, int NPtBins, typename HIST_SF>
+    template<bool do_other, int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
     class muon_efficiency_binned_helper_stat_iso :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF> {
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -396,13 +396,13 @@ namespace wrem {
     };
 
     // specialization for two-lepton case
-    template<int NEtaBins, int NPtBins, typename HIST_SF>
-    class muon_efficiency_binned_helper_stat_iso<true, NEtaBins, NPtBins, HIST_SF> :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF> {
+    template<int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
+    class muon_efficiency_binned_helper_stat_iso<true, NEtaBins, NPtBins, nCharges, HIST_SF> :
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;

--- a/wremnants/include/muon_efficiencies_binned.h
+++ b/wremnants/include/muon_efficiencies_binned.h
@@ -331,11 +331,11 @@ namespace wrem {
     // base template for one lepton case
     template<bool do_other, int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
     class muon_efficiency_binned_helper_stat :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -348,12 +348,12 @@ namespace wrem {
 
     // specialization for two-lepton case
     template<int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
-    class muon_efficiency_binned_helper_stat<true, NEtaBins, NPtBins, nCharges, HIST_SF> :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
+    class muon_efficiency_binned_helper_stat<true, NEtaBins, NPtBins, NCharges, HIST_SF> :
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;
@@ -379,11 +379,11 @@ namespace wrem {
     // base template for one lepton case
     template<bool do_other, int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
     class muon_efficiency_binned_helper_stat_iso :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -397,12 +397,12 @@ namespace wrem {
 
     // specialization for two-lepton case
     template<int NEtaBins, int NPtBins, int NCharges, typename HIST_SF>
-    class muon_efficiency_binned_helper_stat_iso<true, NEtaBins, NPtBins, nCharges, HIST_SF> :
-        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF> {
+    class muon_efficiency_binned_helper_stat_iso<true, NEtaBins, NPtBins, NCharges, HIST_SF> :
+        public muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, nCharges, HIST_SF>;
+        using stat_base_t = muon_efficiency_binned_helper_stat_base<NEtaBins, NPtBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;

--- a/wremnants/include/muon_efficiencies_smooth.h
+++ b/wremnants/include/muon_efficiencies_smooth.h
@@ -217,7 +217,7 @@ namespace wrem {
     // this is now an independent class with respect to the previous one which only deals with nominal and statistical variations
     ////
     //// BASE CLASS FOR HELPER_STAT
-    template<int NEtaBins, int NPtEigenBins, typename HIST_SF>
+    template<int NEtaBins, int NPtEigenBins, int NCharges, typename HIST_SF>
     class muon_efficiency_smooth_helper_stat_base {
     public:
 
@@ -225,7 +225,7 @@ namespace wrem {
             sf_type_(std::make_shared<const HIST_SF>(std::move(sf_type))) {}
 
         // number of eta bins, number of eigen variations for pt axis, then 2 charges and Up/Down shifts
-        using stat_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtEigenBins, 2, 2>>;
+        using stat_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtEigenBins, NCharges, 2>>;
         
         //using base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF>;        
         //muon_efficiency_smooth_helper_stat_base(const base_t &other) : base_t(other) {}
@@ -364,13 +364,13 @@ namespace wrem {
     ////
 
     // base template for one lepton case
-    template<bool do_other, int NEtaBins, int NPtEigenBins, typename HIST_SF>
+    template<bool do_other, int NEtaBins, int NPtEigenBins, int NCharges, typename HIST_SF>
     class muon_efficiency_smooth_helper_stat :
-        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF> {
+        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -382,13 +382,13 @@ namespace wrem {
     };
 
     // specialization for two-lepton case
-    template<int NEtaBins, int NPtEigenBins, typename HIST_SF>
-    class muon_efficiency_smooth_helper_stat<true, NEtaBins, NPtEigenBins, HIST_SF> :
-        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF> {
+    template<int NEtaBins, int NPtEigenBins, int NCharges, typename HIST_SF>
+    class muon_efficiency_smooth_helper_stat<true, NEtaBins, NPtEigenBins, NCharges, HIST_SF> :
+        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;
@@ -412,13 +412,13 @@ namespace wrem {
     ////
 
     // base template for one lepton case
-    template<bool do_other, int NEtaBins, int NPtEigenBins, typename HIST_SF>
+    template<bool do_other, int NEtaBins, int NPtEigenBins, int NCharges, typename HIST_SF>
     class muon_efficiency_smooth_helper_stat_iso :
-        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF> {
+        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF> {
         
     public:
         
-        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
   
         using stat_base_t::stat_base_t;
@@ -431,13 +431,13 @@ namespace wrem {
     };
 
     // specialization for two-lepton case
-    template<int NEtaBins, int NPtEigenBins, typename HIST_SF>
-    class muon_efficiency_smooth_helper_stat_iso<true, NEtaBins, NPtEigenBins, HIST_SF> :
-        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF> {
+    template<int NEtaBins, int NPtEigenBins, int NCharges, typename HIST_SF>
+    class muon_efficiency_smooth_helper_stat_iso<true, NEtaBins, NPtEigenBins, NCharges, HIST_SF> :
+        public muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF> {
 
     public:
 
-        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, HIST_SF>;
+        using stat_base_t = muon_efficiency_smooth_helper_stat_base<NEtaBins, NPtEigenBins, NCharges, HIST_SF>;
         using tensor_t = typename stat_base_t::stat_tensor_t;
 
         using stat_base_t::stat_base_t;

--- a/wremnants/muon_efficiencies_binned.py
+++ b/wremnants/muon_efficiencies_binned.py
@@ -34,6 +34,7 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
     # categorical axes in python bindings always have an overflow bin, so use a regular
     # axis for the charge
     axis_charge = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "SF charge")
+    axis_charge_inclusive = hist.axis.Regular(1, -2., 2., underflow=False, overflow=False, name = "SF charge") # for isolation and effStat only
     isoEff_types = ["iso", "isonotrig", "antiiso", "antiisonotrig"]
     allEff_types = ["reco", "tracking", "idip", "trigger"] + isoEff_types
     axis_allEff_type = hist.axis.StrCategory(allEff_types, name = "allEff_type")
@@ -121,22 +122,27 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
     ##############
     ## now the EFFSTAT    
     effStat_manager = {"sf_reco": {"nPtBins" : 0,
+                                   "nCharges" : 0,
                                    "axisLabels" : ["reco"],
                                    "boostHist" : None,
                                    "helper" : None},
                        "sf_tracking": {"nPtBins" : 0,
+                                       "nCharges" : 0,
                                        "axisLabels" : ["tracking"],
                                        "boostHist" : None,
                                        "helper" : None},
                        "sf_idip": {"nPtBins" : 0,
+                                   "nCharges" : 0,
                                    "axisLabels" : ["idip"],
                                    "boostHist" : None,
                                    "helper" : None},
                        "sf_trigger": {"nPtBins" : 0,
-                                   "axisLabels" : ["trigger"],
-                                   "boostHist" : None,
-                                   "helper" : None},
+                                     "nCharges" : 0,
+                                      "axisLabels" : ["trigger"],
+                                      "boostHist" : None,
+                                      "helper" : None},
                        "sf_iso": {"nPtBins" : 0,
+                                  "nCharges" : 0,
                                   "axisLabels" : ["iso", "isonotrig", "antiiso", "antiisonotrig"],
                                   "boostHist" : None,
                                   "helper" : None},
@@ -152,10 +158,17 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
 
     for effStatKey in effStat_manager.keys():
         axis_eff_type = None
+        axis_charge_def = None
         histPrefix = "effData" if "effData" in effStatKey else "effMC" if "effMC" in effStatKey else "SF"
         for charge, charge_tag in charges.items():
             for eff_type in effStat_manager[effStatKey]["axisLabels"]:
-                chargeTag = charge_tag if eff_type in chargeDependentSteps else "both"
+                if eff_type in chargeDependentSteps:
+                    axis_charge_def = axis_charge
+                    chargeTag = charge_tag
+                else:
+                    axis_charge_def = axis_charge_inclusive
+                    chargeTag = "both"                    
+                    if ic: continue # must continue after having set the charge axis
                 hist_name = f"{histPrefix}_{histNameTag}_{eratag}_{eff_type}_{chargeTag}"
                 hist_root = fin.Get(hist_name)
                 if hist_root is None:
@@ -170,14 +183,15 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
                     axis_eta_eff = hist_hist.axes[0]
                     axis_pt_eff = hist_hist.axes[1]
                     axis_eff_type = hist.axis.StrCategory(effStat_manager[effStatKey]["axisLabels"], name = f"{effStatKey}_eff_type")
+                    effStat_manager[effStatKey]["nCharges"] = 2 if eff_type in chargeDependentSteps else 1
                     effStat_manager[effStatKey]["boostHist"] = hist.Hist(axis_eta_eff,
                                                                          axis_pt_eff,
-                                                                         axis_charge,
+                                                                         axis_charge_def,
                                                                          axis_eff_type,
                                                                          name = effStatKey,
                                                                          storage = hist.storage.Weight())
                     
-                effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge.index(charge), axis_eff_type.index(eff_type)] = hist_hist.view(flow=True)[:,:]
+                effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge_def.index(charge), axis_eff_type.index(eff_type)] = hist_hist.view(flow=True)[:,:]
                 
         # set overflow and underflow equal to adjacent bins
         effStat_manager[effStatKey]["boostHist"].view(flow=True)[0, ...] = effStat_manager[effStatKey]["boostHist"].view(flow=True)[1, ...]
@@ -190,13 +204,13 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
         # this works because we are using the histogram after smoothing but with the original TnP pt binning 
         nptbins = np.count_nonzero(axis_pt_eff.edges < max_pt) if "tracking" not in effStatKey else axis_pt_eff.size
         logging.info(f"Using {nptbins} pt bins for {effStatKey}")
-
+        ncharges = effStat_manager[effStatKey]["nCharges"]
 
         sf_stat_pyroot = narf.hist_to_pyroot_boost(effStat_manager[effStatKey]["boostHist"])
         if "sf_iso" in effStatKey:
-            helper_stat = ROOT.wrem.muon_efficiency_binned_helper_stat_iso[str(is_w_like).lower(), netabins, nptbins, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
+            helper_stat = ROOT.wrem.muon_efficiency_binned_helper_stat_iso[str(is_w_like).lower(), netabins, nptbins, ncharges, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
         else:
-            helper_stat = ROOT.wrem.muon_efficiency_binned_helper_stat[str(is_w_like).lower(), netabins, nptbins, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
+            helper_stat = ROOT.wrem.muon_efficiency_binned_helper_stat[str(is_w_like).lower(), netabins, nptbins, ncharges, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
 
         # make new versions of these axes without overflow/underflow to index the tensor
         if isinstance(axis_eta_eff, bh.axis.Regular):
@@ -210,7 +224,7 @@ def make_muon_efficiency_helpers_binned(filename = data_dir + "/testMuonSF/allSm
             axis_pt_eff_tensor = hist.axis.Variable(axis_pt_eff.edges[:nptbins+1], name = "nPtBins", overflow = False, underflow = False)
 
         #print(f"{effStatKey} nPtBins-tensor = {axis_pt_eff_tensor.size}")
-        helper_stat.tensor_axes = [axis_eta_eff_tensor, axis_pt_eff_tensor, axis_charge]
+        helper_stat.tensor_axes = [axis_eta_eff_tensor, axis_pt_eff_tensor, axis_charge_def]
         effStat_manager[effStatKey]["helper"] = helper_stat
 
     fin.Close()

--- a/wremnants/muon_efficiencies_smooth.py
+++ b/wremnants/muon_efficiencies_smooth.py
@@ -27,6 +27,7 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
     # categorical axes in python bindings always have an overflow bin, so use a regular
     # axis for the charge
     axis_charge = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "SF charge")
+    axis_charge_inclusive = hist.axis.Regular(1, -2., 2., underflow=False, overflow=False, name = "SF charge") # for isolation and effStat only
     isoEff_types = ["iso", "isonotrig", "antiiso", "antiisonotrig"]
     allEff_types = ["reco", "tracking", "idip", "trigger"] + isoEff_types
     axis_allEff_type = hist.axis.StrCategory(allEff_types, name = "allEff_type")
@@ -106,33 +107,40 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
     # in this way the name of the (single) effType axis can be used to activate some internal behaviour as needed (for example trigger won't have variations for not triggering lepton)
     
     effStat_manager = {"sf_reco": {"nPtEigenBins" : 0,
+                                   "nCharges" : 0,
                                    "axisLabels" : ["reco"],
                                    "boostHist" : None,
                                    "helper" : None},
                        "sf_tracking": {"nPtEigenBins" : 0,
+                                       "nCharges" : 0,
                                        "axisLabels" : ["tracking"],
                                        "boostHist" : None,
                                        "helper" : None},
                        "sf_idip": {"nPtEigenBins" : 0,
+                                   "nCharges" : 0,
                                    "axisLabels" : ["idip"],
                                    "boostHist" : None,
                                    "helper" : None},
                        "sf_trigger": {"nPtEigenBins" : 0,
-                                   "axisLabels" : ["trigger"],
-                                   "boostHist" : None,
-                                   "helper" : None},
+                                      "nCharges" : 0,
+                                      "axisLabels" : ["trigger"],
+                                      "boostHist" : None,
+                                      "helper" : None},
                        }
     if directIsoSFsmoothing:
         effStat_manager["sf_iso"] = {"nPtEigenBins" : 0,
+                                     "nCharges" : 0,
                                      "axisLabels" : ["iso", "isonotrig", "antiiso", "antiisonotrig"],
                                      "boostHist" : None,
                                      "helper" : None}
     else:
         effStat_manager["sf_iso_effData"] =  {"nPtEigenBins" : 0,
+                                              "nCharges" : 0,
                                               "axisLabels" : ["iso", "isonotrig", "antiiso", "antiisonotrig"],
                                               "boostHist" : None,
                                               "helper" : None}
         effStat_manager["sf_iso_effMC"] = {"nPtEigenBins" : 0,
+                                           "nCharges" : 0,
                                            "axisLabels" : ["iso", "isonotrig", "antiiso", "antiisonotrig"],
                                            "boostHist" : None,
                                            "helper" : None}
@@ -140,14 +148,21 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
     for effStatKey in effStat_manager.keys():
         down_nom_up_effStat_axis = None
         axis_eff_type = None
-        for charge, charge_tag in charges.items():
+        axis_charge_def = None
+        for ic, (charge, charge_tag) in enumerate(charges.items()):
             for eff_type in effStat_manager[effStatKey]["axisLabels"]:
+                if eff_type in chargeDependentSteps:
+                    axis_charge_def = axis_charge
+                    chargeTag = charge_tag
+                else:
+                    axis_charge_def = axis_charge_inclusive
+                    chargeTag = "both"                    
+                    if ic: continue # must continue after having set the charge axis
                 nameTag = "nomiAndAlt"
                 if "effData" in effStatKey:
                     nameTag += "_onlyDataVar"
                 elif "effMC" in effStatKey:
                     nameTag += "_onlyMCVar"
-                chargeTag = charge_tag if eff_type in chargeDependentSteps else "both"
                 hist_name = f"SF_{nameTag}_{eratag}_{eff_type}_{chargeTag}"
                 hist_root = fin.Get(hist_name)
                 # print(f"stat: {effStatKey}|{eff_type} -> {hist_name}")
@@ -160,6 +175,7 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
                     # Z axis has nominal, 2*N effStat (first N up then N down) and one syst in the last bin
                     nPtEigenBins = int(int(hist_root.GetNbinsZ() - 2)/ 2)
                     effStat_manager[effStatKey]["nPtEigenBins"] = nPtEigenBins
+                    effStat_manager[effStatKey]["nCharges"] = 2 if eff_type in chargeDependentSteps else 1
                     down_nom_up_effStat_axis = hist.axis.Regular(int(1+2*nPtEigenBins), -0.5-nPtEigenBins, 0.5+nPtEigenBins, underflow=False, overflow=False, name = "downNomUpVar")
 
                 hist_hist = narf.root_to_hist(hist_root, axis_names = ["SF eta", "SF pt", "nomi-statUpDown-syst"])
@@ -168,22 +184,22 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
                     axis_eta_eff = hist_hist.axes[0]
                     axis_pt_eff = hist_hist.axes[1]
                     axis_eff_type = hist.axis.StrCategory(effStat_manager[effStatKey]["axisLabels"], name = f"{effStatKey}_eff_type")
-                    effStat_manager[effStatKey]["boostHist"] = hist.Hist(axis_eta_eff, axis_pt_eff, axis_charge,
+                    effStat_manager[effStatKey]["boostHist"] = hist.Hist(axis_eta_eff, axis_pt_eff, axis_charge_def,
                                                                          axis_eff_type,
                                                                          down_nom_up_effStat_axis,
                                                                          name = effStatKey,
                                                                          storage = hist.storage.Weight())
                     
                 # extract nominal (first bin that is not underflow)
-                effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(0)] = hist_hist.view(flow=True)[:,:,1]
+                effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge_def.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(0)] = hist_hist.view(flow=True)[:,:,1]
                 # now extract the stat variations
                 # note that for hist_hist the nominal bin of the third axis is number 1 when the underflow is active
                 for iup in range(1, 1 + nPtEigenBins):
                     # up variations
-                    effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(iup)] = hist_hist.view(flow=True)[:,:,1+iup]
+                    effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge_def.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(iup)] = hist_hist.view(flow=True)[:,:,1+iup]
                     # down variations
                     idown = -1 * iup
-                    effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(idown)] = hist_hist.view(flow=True)[:,:,1+iup+nPtEigenBins]
+                    effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, :, axis_charge_def.index(charge), axis_eff_type.index(eff_type), down_nom_up_effStat_axis.index(idown)] = hist_hist.view(flow=True)[:,:,1+iup+nPtEigenBins]
                 
         # set overflow and underflow equal to adjacent bins
         effStat_manager[effStatKey]["boostHist"].view(flow=True)[0, ...] = effStat_manager[effStatKey]["boostHist"].view(flow=True)[1, ...]
@@ -192,18 +208,19 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
         effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, axis_pt_eff.extent-1, ...] = effStat_manager[effStatKey]["boostHist"].view(flow=True)[:, axis_pt_eff.extent-2, ...]
 
         netabins = axis_eta_eff.size
+        ncharges = effStat_manager[effStatKey]["nCharges"]
         sf_stat_pyroot = narf.hist_to_pyroot_boost(effStat_manager[effStatKey]["boostHist"])
         if "sf_iso" in effStatKey:
-            helper_stat = ROOT.wrem.muon_efficiency_smooth_helper_stat_iso[str(is_w_like).lower(), netabins, nPtEigenBins, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
+            helper_stat = ROOT.wrem.muon_efficiency_smooth_helper_stat_iso[str(is_w_like).lower(), netabins, nPtEigenBins, ncharges, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
         else:
-            helper_stat = ROOT.wrem.muon_efficiency_smooth_helper_stat[str(is_w_like).lower(), netabins, nPtEigenBins, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
+            helper_stat = ROOT.wrem.muon_efficiency_smooth_helper_stat[str(is_w_like).lower(), netabins, nPtEigenBins, ncharges, type(sf_stat_pyroot)]( ROOT.std.move(sf_stat_pyroot) )
         # make new versions of these axes without overflow/underflow to index the tensor
         if isinstance(axis_eta_eff, bh.axis.Regular):
             axis_eta_eff_tensor = hist.axis.Regular(axis_eta_eff.size, axis_eta_eff.edges[0], axis_eta_eff.edges[-1], name = axis_eta_eff.name, overflow = False, underflow = False)
         elif isinstance(axis_eta_eff, bh.axis.Variable):
             axis_eta_eff_tensor = hist.axis.Variable(axis_eta_eff.edges, name = axis_eta_eff.name, overflow = False, underflow = False)
         axis_ptEigen_eff_tensor = hist.axis.Integer(0, effStat_manager[effStatKey]["nPtEigenBins"], underflow = False, overflow =False, name = "nPtEigenBins")    
-        helper_stat.tensor_axes = [axis_eta_eff_tensor, axis_ptEigen_eff_tensor, axis_charge, axis_down_up]
+        helper_stat.tensor_axes = [axis_eta_eff_tensor, axis_ptEigen_eff_tensor, axis_charge_def, axis_down_up]
         effStat_manager[effStatKey]["helper"] = helper_stat
 
     fin.Close()


### PR DESCRIPTION
The tensor for isolation (and isonotrig, etc...) is still built with the charge axis, but now it only has one bin from -2 to 2 (so reading with any charge will still get the only available bin). This allows for minimal modification of the helper classes (the number of charges is now a template parameters, like Neta or Npt), while also permitting reverting back to charge splitting quite easily at any moment if needed.

As a consequence, when running the cardmaker, only a single nuisance parameter will be created (for each eta-pt bin as usual), which is thus correlated between the two reco charge channels by definition, based on how setupCombineWmass.py and CardTool work (the name of nuisance parameters is set according to the existing syst tensor axes, with some labelling convention specified by the user in each call of CardTool.addSystematics). By default, the nuisance name for isolation would get "q0" label (the others would get q0 or q1 because there are two charge bins), which is actually replaced with "qall" using the existing replaceName functionality. In this way there is no ambiguity related to the fact that q0 is typically associated to charge minus.

At the moment, this PR still keeps the functionality provided by option --skipOtherChargeSyst to skip nuisances belonging to the opposite charge with respect to the one of the given channel (when the charge defines the Channel). The default is always not to skip, but using that option doesn't break anything.
This feature might be removed in the future, but for now it is the only way to run with the uncertainty on the fakes from the mT correction (because of its current implementation, which will be improved in a new PR).