### PR TITLE
Fix mix up of prefsr lepton definition; fix sample path

### DIFF
--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -96,11 +96,11 @@ def build_graph(df, dataset):
 
     if args.singleLeptonHists and isW or isZ:
         if isW:
-            df = df.Define('ptPrefsrLep', 'genlanti.pt()')
-            df = df.Define('etaPrefsrLep', 'genlanti.eta()')
-        else:
             df = df.Define('ptPrefsrLep', 'genl.pt()')
             df = df.Define('etaPrefsrLep', 'genl.eta()')
+        else:
+            df = df.Define('ptPrefsrLep', 'genlanti.pt()')
+            df = df.Define('etaPrefsrLep', 'genlanti.eta()')
         results.append(df.HistoBoost("nominal_genlep", lep_axes, [*lep_cols, "nominal_weight"]))
 
     if not args.skipEWHists and (isW or isZ):

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -151,14 +151,14 @@ dataDictV9 = {
     },
     'ZZTo2Q2LPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/*.root"],
+        ["{BASE_PATH}/BKGV9/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/*/*.root"],
         'xsec' : 5.1,
         'group' : "Diboson",
     },
     'QCDmuEnrichPt15PostVFP' : { 
-                                'filepaths' : 
-                                ["{BASE_PATH}/BKGV9/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/*/*.root"],
-                                'xsec' : 238800,
-                                'group' : "QCD",
+        'filepaths' : 
+        ["{BASE_PATH}/BKGV9/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/*/*.root"],
+        'xsec' : 238800,
+        'group' : "QCD",
     }
 }

--- a/wremnants/include/csVariables.h
+++ b/wremnants/include/csVariables.h
@@ -42,9 +42,9 @@ struct CSVars {
 
 };
 
-CSVars csSineCosThetaPhi(const PtEtaPhiMVector& lplus, const PtEtaPhiMVector& lminus) {
-    PxPyPzEVector lplusv(lplus);
-    PxPyPzEVector dilepton = lplusv + PxPyPzEVector(lminus);
+CSVars csSineCosThetaPhi(const PtEtaPhiMVector& antilepton, const PtEtaPhiMVector& lepton) {
+    PxPyPzEVector antilepton_v(antilepton);
+    PxPyPzEVector dilepton = antilepton_v + PxPyPzEVector(lepton);
     const int zsign = std::copysign(1.0, dilepton.z());
     const double energy = 6500.;
     PxPyPzEVector proton1(0., 0., zsign*energy, energy);
@@ -55,17 +55,17 @@ CSVars csSineCosThetaPhi(const PtEtaPhiMVector& lplus, const PtEtaPhiMVector& lm
 
     auto pro1boost = unitBoostedVector(dilepCMBoost, proton1);
     auto pro2boost = unitBoostedVector(dilepCMBoost, proton2);
-    auto lplusboost = unitBoostedVector(dilepCMBoost, lplusv);
+    auto antilepton_boost = unitBoostedVector(dilepCMBoost, antilepton_v);
     auto csFrame = (pro1boost-pro2boost).Unit();
     auto csYaxis = cross(pro1boost, pro2boost).Unit();
     auto csXaxis = cross(csYaxis, csFrame).Unit();
 
-    double costheta = dot(csFrame, lplusboost);
-    auto csCross = cross(csFrame, lplusboost);
-    double sintheta = csCross.R()/(csFrame.R()*lplusboost.R());
+    double costheta = dot(csFrame, antilepton_boost);
+    auto csCross = cross(csFrame, antilepton_boost);
+    double sintheta = csCross.R()/(csFrame.R()*antilepton_boost.R());
 
-    double sinphi = dot(csYaxis, lplusboost)/sintheta;
-    double cosphi = dot(csXaxis, lplusboost)/sintheta;
+    double sinphi = dot(csYaxis, antilepton_boost)/sintheta;
+    double cosphi = dot(csXaxis, antilepton_boost)/sintheta;
 
     CSVars angles = {sintheta, costheta, sinphi, cosphi};
     return angles;

--- a/wremnants/include/theoryTools.h
+++ b/wremnants/include/theoryTools.h
@@ -74,8 +74,8 @@ Eigen::TensorFixedSize<int, Eigen::Sizes<2>> prefsrLeptons(const ROOT::VecOps::R
   std::array<int, 2> selected_pdgids = { pdgId[selected_idxs[0]], pdgId[selected_idxs[1]] };
   const bool partIdx = selected_pdgids[0] > 0;
   Eigen::TensorFixedSize<int, Eigen::Sizes<2>> out;
-  out(0) = selected_idxs[partIdx];
-  out(1) = selected_idxs[!partIdx];
+  out(0) = selected_idxs[!partIdx];
+  out(1) = selected_idxs[partIdx];
   return out;
 
 }

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -136,7 +136,7 @@ def define_prefsr_vars(df):
     df = df.Define("phiVgen", "genV.Phi()")
     df = df.Define("absYVgen", "std::fabs(yVgen)")
     df = df.Define("chargeVgen", "GenPart_pdgId[prefsrLeps[0]] + GenPart_pdgId[prefsrLeps[1]]")
-    df = df.Define("csSineCosThetaPhi", "wrem::csSineCosThetaPhi(genl, genlanti)")
+    df = df.Define("csSineCosThetaPhi", "wrem::csSineCosThetaPhi(genlanti, genl)")
     return df
 
 def define_scale_tensor(df):


### PR DESCRIPTION
- The lepton and anti lepton were interchanged in the prefsr definition. At other places, they were interchanged a second time, I hope I found all occurrences, but please check.
- Sample path for one of the new samples was missing one "/*" as seen by the warnings 