### PR TITLE
Fix nasty bug where nominal cols were accidentally modified

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ env:
   MAX_FILES: 10
   LUMI_SCALE: 100
   NTHREADS: 16
+  WEB_DIR: ~/www/WMassAnalysis/PRValidation
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -89,7 +90,13 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_with_mu_eta_pt.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --forceDefaultName
 
       - name: wmass plotting
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta -p ~/www/WMassAnalysis/PRValidation -f $PLOT_DIR -a W $OUTFILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+
+      - name: wmass plot mtAndMet
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mtAndMET --hists mt met -p $WEB_DIR -f $PLOT_DIR 
+
+      - name: wmass plot massShift
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py  python3 scripts/plotting/makeDataMCStackPlot.py -a 'massVariation' --yscale '1.2' --hist 'pt' --baseName 'nominal' -r '0.95' '1.05' -p $WEB_DIR -f $PLOT_DIR $OUTFILE variation --varName 'massWeight' --selectEntries massShift100MeVUp massShift100MeVDown --varLabel '$m_{W}\pm100\,MeV$' "" --selectAxis massShift --color grey grey
 
       - name: lowpu w analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_lowPU.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4
@@ -101,7 +108,7 @@ jobs:
         run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ WMass_eta_pt/WMass_plus.txt WMass_eta_pt/WMass_minus.txt 
 
       - name: wmass combine impacts
-        run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh WMass_eta_pt/fitresults_123456789.root ~/www/WMassAnalysis/PRValidation/$PLOT_DIR/impactsW.html
+        run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh WMass_eta_pt/fitresults_123456789.root $WEB_DIR/$PLOT_DIR/impactsW.html
 
         #TODO: test low pu combine and combined fit
           #- name: lowpu w combine
@@ -143,7 +150,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_wlike_with_mu_eta_pt.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --theoryCorr scetlib_dyturbo --forceDefaultName
 
       - name: wlike plotting
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists pt eta -p ~/www/WMassAnalysis/PRValidation -f $PLOT_DIR -a wlike $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists pt eta pt-eta -p $WEB_DIR -f $(date +%Y_%m_%d)/PR$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }') -a wlike $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: wlike combine setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombineWMass.py -i $OUTFILE --verbose 4 --lumiScale $LUMI_SCALE
@@ -152,7 +159,7 @@ jobs:
         run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ ZMassWLike_eta_pt/ZMassWLike_plus.txt ZMassWLike_eta_pt/ZMassWLike_minus.txt 
 
       - name: wlike combine impacts
-        run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh ZMassWLike_eta_pt/fitresults_123456789.root ~/www/WMassAnalysis/PRValidation/$PLOT_DIR/impactsWlike.html
+        run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh ZMassWLike_eta_pt/fitresults_123456789.root $WEB_DIR/$PLOT_DIR/impactsWlike.html
 
       - name: lowpu z analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_lowPU.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --forceDefaultName
@@ -196,13 +203,13 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_dilepton.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4  --theoryCorr scetlib_dyturbo --axes ptll --forceDefaultName
 
       - name: dilepton plotting ptll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists ptll -p ~/www/WMassAnalysis/PRValidation -f $PLOT_DIR -a z $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists ptll -p $WEB_DIR -f $PLOT_DIR -a z $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal_mll --hists mll -p ~/www/WMassAnalysis/PRValidation -f $PLOT_DIR -a z $OUTFILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal_mll --hists mll -p $WEB_DIR -f $PLOT_DIR -a z $OUTFILE
 
       - name: dilepton plotting yll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal_yll --nominalRef nominal_yll --hists yll -p ~/www/WMassAnalysis/PRValidation -f $PLOT_DIR -a z $OUTFILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal_yll --nominalRef nominal_yll --hists yll -p $WEB_DIR -f $PLOT_DIR -a z $OUTFILE
 
       - name: dilepton combine ptll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombineWMass.py -i $OUTFILE --fitvar ptll --constrainMass --lumiScale $LUMI_SCALE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mtAndMET --hists mt met -p $WEB_DIR -f $PLOT_DIR $OUTFILE
 
       - name: wmass plot massShift
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -a massVariation --yscale 1.2 --hist pt --baseName nominal -r 0.98 1.02 -p $WEB_DIR -f $PLOT_DIR $OUTFILE variation --varName massWeight --selectEntries massShift100MeVUp massShift100MeVDown --varLabel '$m_{W}\pm100\,MeV$' "" --selectAxis massShift --color grey grey
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -a massVariation --yscale 1.2 --hist pt --baseName nominal -r 0.98 1.02 -p $WEB_DIR -f $PLOT_DIR $OUTFILE variation --varName massWeight --selectEntries massShift100MeVUp massShift100MeVDown --varLabel '$m_{W}\pm100\,MeV$' ' ' --selectAxis massShift --color grey grey
 
       - name: lowpu w analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_lowPU.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4
@@ -150,7 +150,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_wlike_with_mu_eta_pt.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --theoryCorr scetlib_dyturbo --forceDefaultName
 
       - name: wlike plotting
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists pt eta pt-eta -p $WEB_DIR -f $(date +%Y_%m_%d)/PR$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }') -a wlike $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a wlike $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: wlike combine setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombineWMass.py -i $OUTFILE --verbose 4 --lumiScale $LUMI_SCALE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
   MAX_FILES: 10
   LUMI_SCALE: 100
   NTHREADS: 16
-  WEB_DIR: ~/www/WMassAnalysis/PRValidation
+  WEB_DIR: /home/c/cmsmwbot/www/WMassAnalysis/PRValidation
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -90,13 +90,13 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_with_mu_eta_pt.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --forceDefaultName
 
       - name: wmass plotting
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $OUTFILE
 
       - name: wmass plot mtAndMet
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mtAndMET --hists mt met -p $WEB_DIR -f $PLOT_DIR 
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mtAndMET --hists mt met -p $WEB_DIR -f $PLOT_DIR $OUTFILE
 
       - name: wmass plot massShift
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py  python3 scripts/plotting/makeDataMCStackPlot.py -a 'massVariation' --yscale '1.2' --hist 'pt' --baseName 'nominal' -r '0.95' '1.05' -p $WEB_DIR -f $PLOT_DIR $OUTFILE variation --varName 'massWeight' --selectEntries massShift100MeVUp massShift100MeVDown --varLabel '$m_{W}\pm100\,MeV$' "" --selectAxis massShift --color grey grey
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -a massVariation --yscale 1.2 --hist pt --baseName nominal -r 0.98 1.02 -p $WEB_DIR -f $PLOT_DIR $OUTFILE variation --varName massWeight --selectEntries massShift100MeVUp massShift100MeVDown --varLabel '$m_{W}\pm100\,MeV$' "" --selectAxis massShift --color grey grey
 
       - name: lowpu w analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_lowPU.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4

--- a/scripts/combine/pullsAndImpacts.py
+++ b/scripts/combine/pullsAndImpacts.py
@@ -153,8 +153,7 @@ def readFitInfoFromFile(filename, group=False, sort=None, ascending=True, stat=0
 
 def parseArgs():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--inputFile", 
-        default="/Users/kenneth/cernbox/CombineStudies/WGen/etal_ptl_smear_unrolled_scetlib/fitresults_123456789.root", 
+    parser.add_argument("-f", "--inputFile", type=str, required=True,
         help="fitresults output ROOT file from combinetf")
     parser.add_argument("-s", "--sort", default="impact", type=str, choices=["label", "pull", "constraint", "impact"], help="Sort mode for nuisances")
     parser.add_argument("--stat", default=0.0, type=float, help="Overwrite stat. uncertainty with this value")

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -21,6 +21,7 @@ xlabels = {
     "costhetastarll" : r"$\cos{\phi^{\star}_{\ell\ell}}$",
     "phistarll" : r"$\phi^{\star}_{\ell\ell}$",
     "MET_pt" : r"p$_{\mathrm{T}}^{miss}$ (GeV)",
+    "met" : r"p$_{\mathrm{T}}^{miss}$ (GeV)",
     "mt" : r"m$_{T}^{\ell\nu}$ (GeV)",
     "etaSum":r"$\eta^{\ell(+)} + \eta^{\ell(-)}$",
     "etaDiff":r"$\eta^{\ell(+)} - \eta^{\ell(-)}$",
@@ -69,6 +70,7 @@ variation.add_argument("--varLabel", type=str, nargs='+', required=True, help="L
 variation.add_argument("--selectAxis", type=str, nargs='+', help="If you need to select a variation axis")
 variation.add_argument("--selectEntries", type=str, nargs='+', help="entries to read from the selected axis")
 variation.add_argument("--colors", type=str, nargs='+', help="Variation colors")
+variation.add_argument("--linestyle", type=str, default=[], nargs='+', help="Linestyle for variations")
 variation.add_argument("--doubleColors", action='store_true', help="Auto generate colors in pairs (useful for systematics)")
 variation.add_argument("--transform", action='store_true', help="Apply variation-specific transformation")
 variation.add_argument("--fillBetween", action='store_true', help="Fill between uncertainty hists in ratio")
@@ -195,7 +197,7 @@ for h in args.hists:
             xlabel=xlabels[h], ylabel="Events/bin", rrange=args.rrange, binwnorm=1.0, lumi=groups.lumi,
             ratio_to_data=args.ratioToData, rlabel="Pred./Data" if args.ratioToData else "Data/Pred.",
             xlim=args.xlim, no_fill=args.noFill, cms_decor="Preliminary" if not args.noData else "Simulation Preliminary",
-            legtext_size=20*args.scaleleg)
+            legtext_size=20*args.scaleleg, unstacked_linestyles=args.linestyle if hasattr(args, "linestyle") else [])
 
     fitresultstring=""
     if args.fitresult:

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -94,8 +94,8 @@ if addVariation and (args.selectAxis or args.selectEntries):
                          f" found selectEntries={len(args.selectEntries)} and varLabel={len(args.varLabel)}")
     if len(args.varName) < len(args.selectEntries):
         args.varName = padArray(args.varName, args.selectEntries)
-    axes = padArray(args.selectAxis, args.varLabel)
-    entries = padArray(args.selectEntries, args.varLabel)
+    axes = padArray(args.selectAxis, args.varName)
+    entries = padArray(args.selectEntries, args.varName)
 
 outdir = plot_tools.make_plot_dir(args.outpath, args.outfolder)
 

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -62,7 +62,6 @@ colors = [[cmap(i)]*3 for i in range(len(args.pdfs))]
 outdir = plot_tools.make_plot_dir(args.outpath, args.outfolder)
 
 for obs in args.obs:
-    print("Obs is", obs)
     for name,color,labels,hists in zip(args.pdfs,colors, names, uncHists):
         # This is the reference
         action = sel.unrolledHist if obs == "unrolled" else lambda x: x.project(obs) 

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -476,6 +476,9 @@ def transport_smearing_weights_to_reco(
     procs = ['WplusmunuPostVFP', 'WminusmunuPostVFP', 'ZmumuPostVFP'],
 ):
     for proc in procs:
+        if proc not in resultdict:
+            logger.warning(f"Proc {proc} not found in output. Skipping smearing weights")
+            continue
         proc_hist = resultdict[proc]['output']
         nominal_reco = proc_hist['nominal'].get()
 
@@ -516,8 +519,8 @@ def muon_scale_variation_from_manual_shift(
 
 def make_alt_reco_and_gen_hists(df, results, nominal_axes, nominal_columns, matched_reco_sel = "goodMuons"):
 
-    nominal_cols_gen = nominal_columns
-    nominal_cols_gen_smeared = nominal_columns
+    nominal_cols_gen = nominal_columns[:]
+    nominal_cols_gen_smeared = nominal_columns[:]
 
     for col in ("pt", "eta", "charge"):
         idx = [i for i, x in enumerate(nominal_columns) if f"_{col}0" in x]

--- a/wremnants/plot_tools.py
+++ b/wremnants/plot_tools.py
@@ -93,7 +93,7 @@ def makeStackPlotWithRatio(
     binwnorm=None, select={},  action = (lambda x: x), extra_text=None, extra_text_loc=(0.8, 0.7), grid = False, 
     plot_title = None, title_padding = 0, yscale=None,
     fill_between=False, skip_fill=0, ratio_to_data=False, baseline=True, legtext_size=20, cms_decor="Preliminary", lumi=16.8,
-    no_fill=False, bin_density=300, 
+    no_fill=False, bin_density=300, unstacked_linestyles=[],
 ):
     stack = [action(histInfo[k][histName])[select] for k in stackedProcs if histInfo[k][histName]]
     colors = [histInfo[k]["color"] for k in stackedProcs if histInfo[k][histName]]
@@ -155,6 +155,7 @@ def makeStackPlotWithRatio(
         )
 
     if unstacked:
+        linestyles = unstacked_linestyles+['solid']*(len(unstacked)-len(unstacked_linestyles))
         if type(unstacked) == str: 
             unstacked = unstacked.split(",")
         ratio_ref = data_hist if data_hist else sum(stack) 
@@ -169,9 +170,11 @@ def makeStackPlotWithRatio(
                 linewidth=2,
             )
 
-        for proc in unstacked:
+        for proc,style in zip(unstacked, linestyles):
             logger.debug(f"Plotting proc {proc}")
             unstack = action(histInfo[proc][histName][select])
+            if proc == "Data":
+                style = "None"
             hep.histplot(
                 unstack,
                 yerr=True if proc == "Data" else False,
@@ -179,7 +182,8 @@ def makeStackPlotWithRatio(
                 color=histInfo[proc]["color"],
                 label=histInfo[proc]["label"],
                 ax=ax1,
-                alpha=0.7 if not proc == "Data" else 1.,
+                alpha=0.7 if proc != "Data" else 1.,
+                linestyle=style,
                 binwnorm=binwnorm,
             )
             # TODO: Add option to leave data off ratio, I guess
@@ -192,6 +196,7 @@ def makeStackPlotWithRatio(
                 label=histInfo[proc]["label"],
                 yerr=True if (proc == "Data" and not data_hist) else False,
                 linewidth=2,
+                linestyle=style,
                 ax=ax2
             )
 


### PR DESCRIPTION
This was screwing up a subset of the systematics hists, notably the mass shift, which totally screws up the impacts.

Originally introduced in #183 so any studies done in the meantime should be repeated.

Also added a bit more to the CI, including plots of the mass variation, to catch such mistakes