### PR TITLE
Theory fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
 
     env:
       OUTFILE: "mw_with_mu_eta_pt.hdf5"
+      OUTFILE_DILEPTON: "mz_dilepton.hdf5"
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -89,6 +90,9 @@ jobs:
       - name: wmass analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_with_mu_eta_pt.py -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --forceDefaultName
 
+      - name: dilepton analysis
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_dilepton.py --axes ptll yll -j $NTHREADS --maxFiles $MAX_FILES --verbose 4 --forceDefaultName
+
       - name: wmass plotting
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $OUTFILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
@@ -104,8 +108,14 @@ jobs:
       - name: wmass combine setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombineWMass.py -i $OUTFILE --verbose 4 --lumiScale $LUMI_SCALE
 
+      - name: dilepton combine setup
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombineWMass.py -i $OUTFILE_DILEPTON --fitvar ptll-yll --verbose 4 --lumiScale $LUMI_SCALE
+
+      - name: aggregate combine inputs
+        run: cp -p ZMassDilepton_ptll_yll/* WMass_pt_eta/
+
       - name: wmass combine fit 
-        run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ mass WMass_pt_eta WMass_plus.txt WMass_minus.txt 
+        run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ mass WMass_pt_eta WMass_plus.txt WMass_minus.txt ZMassDilepton_minus.txt ZMassDilepton_plus.txt
 
       - name: wmass combine impacts
         run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh WMass_pt_eta/fitresults_123456789.root $WEB_DIR/$PLOT_DIR/impactsW.html

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -287,8 +287,9 @@ def main(args,xnorm=False):
     if wmass and not xnorm:
         combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, single_v_nonsig_samples, to_fakes, name_append=scale_name_Z, resum=args.resumUnc)
 
-    common_np_samples = signal_samples_inctau + single_v_nonsig_samples if wmass else signal_samples_inctau
-    combine_helpers.add_common_np_uncertainties(cardTool, common_np_samples, to_fakes)
+    if resum != "none":
+        common_np_samples = signal_samples_inctau + single_v_nonsig_samples if wmass else signal_samples_inctau
+        combine_helpers.add_common_np_uncertainties(cardTool, common_np_samples, to_fakes)
 
     if not xnorm:
         msv_config_dict = {

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -282,7 +282,7 @@ def main(args,xnorm=False):
     combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, signal_samples_inctau, to_fakes, resum=args.resumUnc)
     # for Z background in W mass case (W background for Wlike is essentially 0, useless to apply QCD scales there)
     if wmass and not xnorm:
-        combine_helpers.add_scale_uncertainty(cardTool, "integrated", single_v_nonsig_samples, False, name_append="Z", resum=args.resumUnc)
+        combine_helpers.add_scale_uncertainty(cardTool, "integrated", single_v_nonsig_samples, False, name_append="Z", resum="none")
 
     if not xnorm:
         msv_config_dict = {

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -287,7 +287,7 @@ def main(args,xnorm=False):
     if wmass and not xnorm:
         combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, single_v_nonsig_samples, to_fakes, name_append=scale_name_Z, resum=args.resumUnc)
 
-    if resum != "none":
+    if args.resumUnc != "none":
         common_np_samples = signal_samples_inctau + single_v_nonsig_samples if wmass else signal_samples_inctau
         combine_helpers.add_common_np_uncertainties(cardTool, common_np_samples, to_fakes)
 

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -279,10 +279,16 @@ def main(args,xnorm=False):
 
     to_fakes = passSystToFakes and not args.noQCDscaleFakes and not xnorm
     combine_helpers.add_pdf_uncertainty(cardTool, single_v_samples, passSystToFakes, from_corr=args.pdfUncFromCorr)
-    combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, signal_samples_inctau, to_fakes, resum=args.resumUnc)
+    scale_name_W = "W"
+    scale_name_Z = "Z"
+    scale_name = scale_name_W if wmass else scale_name_Z
+    combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, signal_samples_inctau, to_fakes, resum=args.resumUnc, name_append = scale_name)
     # for Z background in W mass case (W background for Wlike is essentially 0, useless to apply QCD scales there)
     if wmass and not xnorm:
-        combine_helpers.add_scale_uncertainty(cardTool, "integrated", single_v_nonsig_samples, False, name_append="Z", resum="none")
+        combine_helpers.add_scale_uncertainty(cardTool, args.minnloScaleUnc, single_v_nonsig_samples, to_fakes, name_append=scale_name_Z, resum=args.resumUnc)
+
+    common_np_samples = signal_samples_inctau + single_v_nonsig_samples if wmass else signal_samples_inctau
+    combine_helpers.add_common_np_uncertainties(cardTool, common_np_samples, to_fakes)
 
     if not xnorm:
         msv_config_dict = {

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -310,7 +310,7 @@ def build_graph(df, dataset):
 
         if apply_theory_corr:
             results.extend(theory_tools.make_theory_corr_hists(df, "nominal", axes, cols, 
-                corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+                corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly, isW = isW)
             )
         if args.muonScaleVariation == 'smearingWeights' and (isW or isZ): 
             nominal_cols_gen, nominal_cols_gen_smeared = muon_calibration.make_alt_reco_and_gen_hists(df, results, axes, cols, reco_sel_GF)

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -32,8 +32,8 @@ era = args.era
 # available axes for dilepton validation plots
 all_axes = {
     "mll": hist.axis.Regular(60, 60., 120., name = "mll", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
-    "yll": hist.axis.Regular(25, -2.5, 2.5, name = "yll"),
-    "absYll": hist.axis.Regular(25, 0., 2.5, name = "absYll", underflow=False),
+    "yll": hist.axis.Regular(20, -2.5, 2.5, name = "yll"),
+    "absYll": hist.axis.Regular(10, 0., 2.5, name = "absYll", underflow=False),
     "ptll": hist.axis.Variable(common.ptV_binning if not args.finePtBinning else range(60), name = "ptll", underflow=False),
     "etaPlus": hist.axis.Regular(int(args.eta[0]), args.eta[1], args.eta[2], name = "etaPlus"),
     "etaMinus": hist.axis.Regular(int(args.eta[0]), args.eta[1], args.eta[2], name = "etaMinus"),

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -83,8 +83,8 @@ def build_graph(df, dataset):
     print("build graph")
     results = []
 
-    isW = dataset.name in common.wprocs
-    isZ = dataset.name in common.zprocs
+    isW = dataset.name in common.wprocs_lowpu
+    isZ = dataset.name in common.zprocs_lowpu
 
     if dataset.is_data: df = df.DefinePerSample("weight", "1.0")
     else: df = df.Define("weight", "std::copysign(1.0, genWeight)")
@@ -320,7 +320,7 @@ def build_graph(df, dataset):
 
     if apply_theory_corr:
         results.extend(theory_tools.make_theory_corr_hists(df, "reco_mT", axes=gen_reco_mll_axes, cols=gen_reco_mt_cols, 
-            helpers=corr_helpers[dataset.name], generators=args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+            helpers=corr_helpers[dataset.name], generators=args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly, isW=isW)
         )
 
     if dataset.name in sigProcs:

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -83,6 +83,9 @@ def build_graph(df, dataset):
     print("build graph")
     results = []
 
+    isW = dataset.name in common.wprocs
+    isZ = dataset.name in common.zprocs
+
     if dataset.is_data: df = df.DefinePerSample("weight", "1.0")
     else: df = df.Define("weight", "std::copysign(1.0, genWeight)")
   
@@ -110,7 +113,7 @@ def build_graph(df, dataset):
      
         if apply_theory_corr:
             results.extend(theory_tools.make_theory_corr_hists(df_xnorm, "xnorm", axes=axes_xnorm, cols=cols_xnorm, 
-                helpers=corr_helpers[dataset.name], generators=args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+                helpers=corr_helpers[dataset.name], generators=args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly, isW=isW)
             )
   
     if flavor == "mumu":

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -130,11 +130,11 @@ def build_graph(df, dataset):
 
     if args.theoryCorr and dataset.name in corr_helpers:
         results.extend(theory_tools.make_theory_corr_hists(df, "nominal_gen", nominal_axes, nominal_cols,
-            corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+            corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly, isW=isW)
         )
         if args.singleLeptonHists:
             results.extend(theory_tools.make_theory_corr_hists(df, "nominal_genlep", lep_axes, lep_cols, 
-                corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+                corr_helpers[dataset.name], args.theoryCorr, modify_central_weight=not args.theoryCorrAltOnly, isW=isW)
             )
 
     if "MEParamWeight" in df.GetColumnNames():

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -199,7 +199,7 @@ def scaleHist(h, scale, createNew=True):
             hnew = hist.Hist(*h.axes)
         else:
             hnew = hist.Hist(*h.axes, storage=hist.storage.Weight())
-            hnew.variances(flow=True)[...] = scale * h.variances(flow=True)
+            hnew.variances(flow=True)[...] = scale*scale * h.variances(flow=True)
 
         hnew.values(flow=True)[...] = scale * h.values(flow=True)
 
@@ -207,7 +207,7 @@ def scaleHist(h, scale, createNew=True):
     else:
         h.values(flow=True)[...] *= scale
         if h._storage_type() == hist.storage.Weight():
-            h.variances(flow=True)[...] *= scale
+            h.variances(flow=True)[...] *= scale*scale
         return h
     
 def normalize(h, scale=1e6, createNew=True):

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -156,7 +156,7 @@ def common_parser_combine():
     parser.add_argument("--wlike", action='store_true', help="Run W-like analysis of mZ")
     parser.add_argument("-o", "--outfolder", type=str, default=".", help="Output folder with the root file storing all histograms and datacards for single charge (subfolder WMass or ZMassWLike is created automatically inside)")
     parser.add_argument("-i", "--inputFile", type=str)
-    parser.add_argument("--minnloScaleUnc", choices=["byHelicityPt", "byHelicityPtCharge", "byHelicityCharge", "byPtCharge", "byPt", "byCharge", "integrated",], default="byPtCharge", 
+    parser.add_argument("--minnloScaleUnc", choices=["byHelicityPt", "byHelicityPtCharge", "byHelicityCharge", "byPtCharge", "byPt", "byCharge", "integrated",], default="byHelicityPt",
             help="Decorrelation for QCDscale")
     parser.add_argument("--rebinPtV", type=float, nargs='*', help="Rebin axis with gen boson pt by this value (default does nothing)")
     parser.add_argument("--resumUnc", default="tnp", type=str, choices=["scale", "tnp", "none"], help="Include SCETlib uncertainties")

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -206,7 +206,7 @@ class CardTool(object):
                       baseName="", mirror=False, mirrorDownVarEqualToUp=False, mirrorDownVarEqualToNomi=False,
                       scale=1, processes=None, group=None, noConstraint=False,
                       action=None, doActionBeforeMirror=False, actionArgs={}, actionMap={},
-                      systNameReplace=[], groupFilter=None, passToFakes=False,
+                      systNameReplace=[], systNamePrepend=None, groupFilter=None, passToFakes=False,
                       rename=None, splitGroup={}, decorrelateByBin={},
                       ):
         # note: setting Up=Down seems to be pathological for the moment, it might be due to the interpolation in the fit
@@ -260,6 +260,7 @@ class CardTool(object):
                 "skipEntries" : [] if not skipEntries else skipEntries,
                 "name" : name,
                 "decorrByBin": decorrelateByBin,
+                "systNamePrepend" : systNamePrepend,
             }
         })
         
@@ -376,6 +377,8 @@ class CardTool(object):
                     if "systNameReplace" in systInfo and systInfo["systNameReplace"]:
                         for rep in systInfo["systNameReplace"]:
                             name = name.replace(*rep)
+                    if name and "systNamePrepend" in systInfo and systInfo["systNamePrepend"]:
+                        name = systInfo["systNamePrepend"]+name
                     # Obviously there is a nicer way to do this...
                     if "Up" in name:
                         name = name.replace("Up", "")+"Up"

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -6,6 +6,7 @@ import re
 logger = logging.child_logger(__name__)
 
 def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append="", resum=None, use_hel_hist=False, rebin_pt=None):
+
     if not len(samples):
         logger.warning(f"Skipping QCD scale syst '{scale_type}', no process to apply it to")
         return
@@ -135,8 +136,8 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
                 group="resumNonpert",
                 systAxes=["downUpVar"],
                 passToFakes=to_fakes,
-                actionMap={s : lambda h: hh.syst_min_and_max_env_hist(h, obs, "vars", 
-                    [x for x in h.axes["vars"] if re.match(f"^{np_nuisance}-*\d+", x)]) for s in expanded_samples},
+                actionMap={s : lambda h,np=np_nuisance: hh.syst_min_and_max_env_hist(h, obs, "vars",
+                    [x for x in h.axes["vars"] if re.match(f"^{np}-*\d+", x)]) for s in expanded_samples},
                 outNames=[f"{nuisance_name}Up", f"{nuisance_name}Down"],
                 rename=nuisance_name, 
             )

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -141,7 +141,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
             card_tool.addSystematic(name=f"scetlib_dyturboOmega",
                 processes=samples,
                 group="resumNonpert",
-                systAxes=["absYVgen", "chargeVgen", "downUpVar"],
+                systAxes=["absYVgenNP", "chargeVgenNP", "downUpVar"],
                 # labelsByAxis=["AbsYVBin", "genQ", "DownUp"],
                 passToFakes=to_fakes,
                 actionMap={s : lambda h,np=np_nuisance: hh.syst_min_and_max_env_hist(syst_tools.hist_to_variations(h), obs, "vars",

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -104,7 +104,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
                 passToFakes=to_fakes,
                 systNameReplace=[("central", ""), ("pdf0", ""), ("+1", "Up"), ("-1", "Down"), ("-0.5", "Down"), ("+0.5", "Up"), ("up", "Up"), ("down", "Down")],
                 skipEntries=[{syst_ax : x} for x in both_exclude+scale_nuisances],
-                rename=f"resumTNP", 
+                rename=f"resumTNP{name_append}",
             )
         else:
             # Exclude the tnp uncertainty nuisances
@@ -117,7 +117,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
                 actionMap={s : lambda h: hh.syst_min_and_max_env_hist(h, obs, "vars", 
                     [x for x in h.axes["vars"] if any(re.match(y, x) for y in resumscale_nuisances)]) for s in expanded_samples},
                 outNames=["scetlibResumScaleUp", "scetlibResumScaleDown"],
-                rename=f"resumScale", 
+                rename=f"resumScale{name_append}",
             )
             card_tool.addSystematic(name=theory_unc,
                 processes=samples,
@@ -126,7 +126,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
                 systAxes=["vars"],
                 actionMap={s : lambda h: h[{"vars" : ["kappaFO0.5-kappaf2.", "kappaFO2.-kappaf0.5", "mufdown", "mufup",]}] for s in expanded_samples},
                 outNames=["scetlib_kappaUp", "scetlib_kappaDown", "scetlib_muFUp", "scetlib_muFDown"],
-                rename=f"resumFOScale", 
+                rename=f"resumFOScale{name_append}",
             )
 
         for np_nuisance in ["c_nu", "omega_nu", "Omega"]:
@@ -139,7 +139,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
                 actionMap={s : lambda h,np=np_nuisance: hh.syst_min_and_max_env_hist(h, obs, "vars",
                     [x for x in h.axes["vars"] if re.match(f"^{np}-*\d+", x)]) for s in expanded_samples},
                 outNames=[f"{nuisance_name}Up", f"{nuisance_name}Down"],
-                rename=nuisance_name, 
+                rename=nuisance_name + name_append,
             )
         card_tool.addSystematic(name=theory_unc,
             processes=samples,
@@ -150,7 +150,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
             actionMap={s : lambda h: hh.syst_min_and_max_env_hist(h, obs, "vars", 
                 [x for x in h.axes["vars"] if "transition_point" in x]) for s in expanded_samples},
             outNames=["resumTransitionUp", "resumTransitionDown"],
-            rename=f"scetlibResumTransition", 
+            rename=f"scetlibResumTransition{name_append}",
         )
 
     if helicity:
@@ -158,7 +158,7 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
         skip_entries.extend([{"helicity" : complex(0, i)} for i in (5,6,7)])
 
     # Skip MiNNLO unc. 
-    if resum and not (pt_binned or helicity):
+    if resum != "none" and not (pt_binned or helicity):
         logger.warning("Without pT or helicity splitting, only the SCETlib uncertainty will be applied!")
     else:
         group_name += f"MiNNLO"

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -67,14 +67,15 @@ def add_scale_uncertainty(card_tool, scale_type, samples, to_fakes, name_append=
         action_args["rebinPtV"] = rebin_pt
 
     if resum != "none":
-        if pt_binned:
-            binning = np.array(common.ptV_10quantiles_binning)
-            pt30_idx = np.argmax(binning > 30)
+        binning = np.array(common.ptV_10quantiles_binning)
+        pt30_idx = np.argmax(binning > 30)
+        if helicity:
+            # Drop the uncertainties for < 30 for sigma_-1
+            skip_entries.extend([{"helicity" : -1.j, "ptVgen" : complex(0, x)} for x in binning[:pt30_idx-1]])
+        elif pt_binned:
             # Drop the uncertainties for < 30
             skip_entries.extend([{"ptVgen" : complex(0, x)} for x in binning[:pt30_idx-1]])
-        if helicity:
-            skip_entries.append({"helicity" : -1.j})
-        
+
         obs = card_tool.project[:]
         if not obs:
             raise ValueError("Failed to find the observable names for the resummation uncertainties")

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -195,7 +195,7 @@ def add_common_np_uncertainties(card_tool, samples, to_fakes):
         logger.error("Can not add resummation uncertainties. No theory correction was applied!")
     theory_unc = theory_unc[0]+"Corr"
     if theory_unc != "scetlib_dyturboCorr":
-        raise ValueError(f"The theory uncertainty hist {theory_unc} doesn't have the resummation {resum} uncertainty implemented")
+        raise ValueError(f"The theory uncertainty hist {theory_unc} doesn't have the resummation uncertainty implemented")
 
     # NOTE: The map needs to be keyed on the base procs not the group names, which is
     # admittedly a bit nasty
@@ -204,8 +204,6 @@ def add_common_np_uncertainties(card_tool, samples, to_fakes):
     obs = card_tool.project[:]
     if not obs:
         raise ValueError("Failed to find the observable names for the resummation uncertainties")
-
-    print("theory_unc", theory_unc)
 
     for np_nuisance in ["c_nu", "omega_nu"]:
         nuisance_name = f"scetlibNP{np_nuisance}"

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -196,7 +196,7 @@ def hist_to_variations(hist_in):
 
     s = hist.tag.Slicer()
 
-    genAxes = ["absYVgen", "chargeVgen"]
+    genAxes = ["absYVgenNP", "chargeVgenNP"]
 
     nom_hist = hist_in[{"vars" : "pdf0"}]
     nom_hist_sum = nom_hist[{genAxis : s[::hist.sum] for genAxis in genAxes}]

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -187,8 +187,6 @@ def scale_helicity_hist_to_variations(scale_hist, sum_axes=[], rebinPtV=None):
 
 def hist_to_variations(hist_in):
 
-    print("hist_in", hist_in.name, hist_in)
-
     if hist_in.name is None:
         out_name = "hist_variations"
     else:
@@ -200,13 +198,6 @@ def hist_to_variations(hist_in):
 
     nom_hist = hist_in[{"vars" : "pdf0"}]
     nom_hist_sum = nom_hist[{genAxis : s[::hist.sum] for genAxis in genAxes}]
-
-    print("nom_hist", nom_hist.name, nom_hist)
-    print("nom_hist_sum", nom_hist_sum.name, nom_hist_sum)
-
-    # print("hist", hist)
-    # print("nom_hist", nom_hist)
-    # systhist = hist.view(flow=True) - nom_hist.view(flow=True)
 
     variation_data = hist_in.view(flow=True) - nom_hist.view(flow=True)[...,None] + nom_hist_sum.view(flow=True)[..., None, None, None]
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -26,15 +26,15 @@ axis_muFfact = hist.axis.Variable(
 axis_absYVgen = hist.axis.Variable(
     # [0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4, 4.25, 4.5, 4.75, 5, 10],
     [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
-    name = "absYVgen", underflow=False
+    name = "absYVgenNP", underflow=False
 )
 
 axis_chargeWgen = hist.axis.Regular(
-    2, -2, 2, name="chargeVgen", underflow=False, overflow=False
+    2, -2, 2, name="chargeVgenNP", underflow=False, overflow=False
 )
 
 axis_chargeZgen = hist.axis.Integer(
-    0, 1, name="chargeVgen", underflow=False, overflow=False
+    0, 1, name="chargeVgenNP", underflow=False, overflow=False
 )
 
 scale_tensor_axes = (axis_muRfact, axis_muFfact)


### PR DESCRIPTION
Some fixes for the current theory implementation such that the NP and scetlib uncertainties are (probably) consistently propagated to both the mw and wlike fits.

The pt-helicity decorrelated scale variations have also been made the default, with the overlaps ~properly removed with respect to the scetlib uncertainties (sigma_-1 is varied only at high pt, and all the other helicity components are varied over the full pt range)