### PR TITLE
adding deltaPhi(mu,met) also for Wlike using wlikeMET

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -24,7 +24,6 @@ parser.add_argument("--vqtTestIntegrated", action="store_true", help="Test of is
 parser.add_argument("--vqtTestReal", action="store_true", help="Test of isolation SFs dependence on V q_T projection, using 3D SFs directly (instead of the Vqt fits)")
 parser.add_argument("--vqtTestIncludeTrigger", action="store_true", help="Test of isolation SFs dependence on V q_T projection. Including trigger")
 parser.add_argument("--noGenMatchMC", action='store_true', help="Don't use gen match filter for prompt muons with MC samples (note: QCD MC never has it anyway)")
-parser.add_argument("--dphiMuonMetCut", type=float, help="Threshold to cut |deltaPhi| > thr*np.pi between muon and met", default=0.25)
 args = parser.parse_args()
 
 if args.vqtTestIntegrated:

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -292,7 +292,7 @@ def build_graph(df, dataset):
     results.append(df.HistoBoost("yZ", [axis_yll], ["yZ", "nominal_weight"]))
     results.append(df.HistoBoost("ptZ", [axis_ptll], ["ptZ", "nominal_weight"]))
     
-    df = df.Define("mT_wlike", f"wrem::mt_wlike_nano(TrigMuon_pt, TrigMuon_phi, NonTrigMuon_pt, NonTrigMuon_phi, MET_corr_rec_pt, MET_corr_rec_phi)")
+    df = df.Define("mT_wlike", f"wrem::get_mt_wlike(TrigMuon_pt, TrigMuon_phi, NonTrigMuon_pt, NonTrigMuon_phi, MET_corr_rec_pt, MET_corr_rec_phi)")
     results.append(df.HistoBoost("mT_wlike", [axis_mt], ["mT_wlike", "nominal_weight"]))
     
     results.append(df.HistoBoost("lep_pT", [axis_pt], ["TrigMuon_pt", "nominal_weight"]))

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -165,10 +165,10 @@ def build_graph(df, dataset):
     ###########
     met_vars = ("MET_corr_rec_pt", "MET_corr_rec_phi")
     df = df.Define("met_wlike_TV2", f"wrem::get_met_wlike(nonTrigMuons_pt0, nonTrigMuons_phi0, {', '.join(met_vars)})")
-    df = df.Define("met_wlike_TV2_pt", "met_wlike_TV2.Mod()")
     df = df.Define("transverseMass", "wrem::get_mt_wlike(trigMuons_pt0, trigMuons_phi0, met_wlike_TV2)")
     results.append(df.HistoBoost("transverseMass", [axis_mt], ["transverseMass", "nominal_weight"]))
     results.append(df.HistoBoost("MET", [hist.axis.Regular(20, 0, 100, name="MET")], ["MET_corr_rec_pt", "nominal_weight"]))
+    df = df.Define("met_wlike_TV2_pt", "met_wlike_TV2.Mod()")
     results.append(df.HistoBoost("WlikeMET", [hist.axis.Regular(20, 0, 100, name="Wlike-MET")], ["met_wlike_TV2_pt", "nominal_weight"]))
     ###########
 
@@ -176,7 +176,6 @@ def build_graph(df, dataset):
     df = df.Define("deltaPhiMuonMet", "std::abs(wrem::deltaPhi(trigMuons_phi0,met_wlike_TV2.Phi()))")
     df = df.Filter(f"deltaPhiMuonMet > {args.dphiMuonMetCut*np.pi}")
     df = df.Filter("transverseMass >= 45.") # 40 for Wmass, thus be 45 here (roughly half the boson mass)
-
                    
     nominal_cols = ["trigMuons_eta0", "trigMuons_pt0", "trigMuons_charge0"]
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -10,6 +10,7 @@ import lz4.frame
 import math
 import time
 import os
+import numpy as np
 
 parser = common.set_parser_default(parser, "pt", [34, 26, 60])
 
@@ -159,17 +160,24 @@ def build_graph(df, dataset):
     # utility plots of transverse mass, with or without recoil corrections
     ###########
     met_vars = ("MET_pt", "MET_phi")
-    df = df.Define("transverseMass_uncorr", f"wrem::mt_wlike_nano(trigMuons_pt0, trigMuons_phi0, nonTrigMuons_pt0, nonTrigMuons_phi0, {', '.join(met_vars)})")
+    df = df.Define("transverseMass_uncorr", f"wrem::get_mt_wlike(trigMuons_pt0, trigMuons_phi0, nonTrigMuons_pt0, nonTrigMuons_phi0, {', '.join(met_vars)})")
     results.append(df.HistoBoost("transverseMass_uncorr", [axis_mt], ["transverseMass_uncorr", "nominal_weight"]))
     ###########
     met_vars = ("MET_corr_rec_pt", "MET_corr_rec_phi")
-    df = df.Define("transverseMass", f"wrem::mt_wlike_nano(trigMuons_pt0, trigMuons_phi0, nonTrigMuons_pt0, nonTrigMuons_phi0, {', '.join(met_vars)})")
+    df = df.Define("met_wlike_TV2", f"wrem::get_met_wlike(nonTrigMuons_pt0, nonTrigMuons_phi0, {', '.join(met_vars)})")
+    df = df.Define("met_wlike_TV2_pt", "met_wlike_TV2.Mod()")
+    df = df.Define("transverseMass", "wrem::get_mt_wlike(trigMuons_pt0, trigMuons_phi0, met_wlike_TV2)")
     results.append(df.HistoBoost("transverseMass", [axis_mt], ["transverseMass", "nominal_weight"]))
     results.append(df.HistoBoost("MET", [hist.axis.Regular(20, 0, 100, name="MET")], ["MET_corr_rec_pt", "nominal_weight"]))
+    results.append(df.HistoBoost("WlikeMET", [hist.axis.Regular(20, 0, 100, name="Wlike-MET")], ["met_wlike_TV2_pt", "nominal_weight"]))
     ###########
-    
+
+    # cutting after storing mt distributions for plotting, since the cut is only on corrected met
+    df = df.Define("deltaPhiMuonMet", "std::abs(wrem::deltaPhi(trigMuons_phi0,met_wlike_TV2.Phi()))")
+    df = df.Filter(f"deltaPhiMuonMet > {args.dphiMuonMetCut*np.pi}")
     df = df.Filter("transverseMass >= 45.") # 40 for Wmass, thus be 45 here (roughly half the boson mass)
-    
+
+                   
     nominal_cols = ["trigMuons_eta0", "trigMuons_pt0", "trigMuons_charge0"]
 
     if unfold:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -119,6 +119,7 @@ def common_parser(for_reco_highPU=False):
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)
+        parser.add_argument("--dphiMuonMetCut", type=float, help="Threshold to cut |deltaPhi| > thr*np.pi between muon and met", default=0.25)
         parser.add_argument("--muonCorrMC", type=str, default="idealMC_lbltruth", 
             choices=["none", "trackfit_only", "trackfit_only_idealMC", "lbl", "idealMC_lbltruth", "idealMC_massfit", "idealMC_lbltruth_massfit"], 
             help="Type of correction to apply to the muons in simulation")

--- a/wremnants/include/muon_efficiencies_smooth.h
+++ b/wremnants/include/muon_efficiencies_smooth.h
@@ -196,7 +196,7 @@ namespace wrem {
             constexpr bool pass_iso = true;
             const tensor_t variation_trig = base_t::sf_syst_var(trig_pt, trig_eta, trig_sapt, trig_saeta, trig_charge, pass_iso, with_trigger);
             const tensor_t variation_nontrig = base_t::sf_syst_var(nontrig_pt, nontrig_eta, nontrig_sapt, nontrig_saeta, nontrig_charge, pass_iso, without_trigger);
-            return nominal_weight*variation_trig*variation_nontrig;
+            return nominal_weight * variation_trig * variation_nontrig;
         }
 
     };

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -44,20 +44,18 @@ TVector2 get_met_wlike(float ptOther, float phiOther, float met, float phimet) {
   
 }
 
+float get_mt_wlike(float pt, float phi, const TVector2& met_wlike) {
+
+    return mt_2(pt, phi, met_wlike.Mod(), met_wlike.Phi());
+
+}
     
 float get_mt_wlike(float pt, float phi, float ptOther, float phiOther, float met, float phimet) {
 
-    TVector2 met_wlike = get_met_wlike(ptOther, phiOther, met, phimet);
-    return std::sqrt(2*pt*met_wlike.Mod()*(1-std::cos(phi-met_wlike.Phi())));
+    const TVector2 met_wlike = get_met_wlike(ptOther, phiOther, met, phimet);
+    return get_mt_wlike(pt, phi, met_wlike);
 
 }
-
-float get_mt_wlike(float pt, float phi, TVector2 met_wlike) {
-
-    return std::sqrt(2*pt*met_wlike.Mod()*(1-std::cos(phi-met_wlike.Phi())));
-
-}
-
     
 double deltaPhi(float phi1, float phi2) {
     double result = phi1 - phi2;

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -31,7 +31,7 @@ float mt_2(float pt1, float phi1, float pt2, float phi2) {
     return std::sqrt(2*pt1*pt2*(1-std::cos(phi1-phi2)));
 }
 
-float mt_wlike_nano(float pt, float phi, float ptOther, float phiOther, float met, float phimet) {
+TVector2 get_met_wlike(float ptOther, float phiOther, float met, float phimet) {
 
   TVector2 pl = TVector2();
   pl.SetMagPhi(ptOther,phiOther);
@@ -40,10 +40,25 @@ float mt_wlike_nano(float pt, float phi, float ptOther, float phiOther, float me
   met_wlike.SetMagPhi(met,phimet);
   met_wlike = pl + met_wlike;
 
-  return std::sqrt(2*pt*met_wlike.Mod()*(1-std::cos(phi-met_wlike.Phi())));
+  return met_wlike;
+  
+}
+
+    
+float get_mt_wlike(float pt, float phi, float ptOther, float phiOther, float met, float phimet) {
+
+    TVector2 met_wlike = get_met_wlike(ptOther, phiOther, met, phimet);
+    return std::sqrt(2*pt*met_wlike.Mod()*(1-std::cos(phi-met_wlike.Phi())));
 
 }
 
+float get_mt_wlike(float pt, float phi, TVector2 met_wlike) {
+
+    return std::sqrt(2*pt*met_wlike.Mod()*(1-std::cos(phi-met_wlike.Phi())));
+
+}
+
+    
 double deltaPhi(float phi1, float phi2) {
     double result = phi1 - phi2;
     while (result > M_PI) result -= 2.0*M_PI;

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -522,9 +522,9 @@ class Recoil:
         self.df = self.df.Define("recoil_corr_xy_perp", "recoil_corr_xy[2]")
         
         # transverse mass
-        self.df = self.df.Define("mT_uncorr", f"wrem::mt_wlike_nano({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_uncorr_pt, MET_uncorr_phi)")
-        self.df = self.df.Define("mT_corr_lep", f"wrem::mt_wlike_nano({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_lep_pt, MET_corr_lep_phi)")
-        self.df = self.df.Define("mT_corr_xy", f"wrem::mt_wlike_nano({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_xy_pt, MET_corr_xy_phi)")
+        self.df = self.df.Define("mT_uncorr", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_uncorr_pt, MET_uncorr_phi)")
+        self.df = self.df.Define("mT_corr_lep", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_lep_pt, MET_corr_lep_phi)")
+        self.df = self.df.Define("mT_corr_xy", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_xy_pt, MET_corr_xy_phi)")
         
         self.df = self.df.Define("RawMET_sumEt_sqrt", "sqrt(RawMET_sumEt)")
    
@@ -687,7 +687,7 @@ class Recoil:
         self.df = self.df.Define("MET_corr_rec_xy_dPhi", "wrem::deltaPhi(MET_corr_rec_phi, MET_corr_xy_phi)")
         self.df = self.df.Define("METx_corr_rec", "MET_corr_rec_pt*cos(MET_corr_rec_phi)")
         self.df = self.df.Define("METy_corr_rec", "MET_corr_rec_pt*sin(MET_corr_rec_phi)")
-        self.df = self.df.Define("mT_corr_rec", f"wrem::mt_wlike_nano({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_rec_pt, MET_corr_rec_phi)")
+        self.df = self.df.Define("mT_corr_rec", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_rec_pt, MET_corr_rec_phi)")
         
         if not self.storeHists: 
             return


### PR DESCRIPTION
For consistency, this is now also implemented for the high PU wlike analysis.
I didn't add it to low PU analysis flows because I am not sure we want the same cut, or with the same threshold.
The threshold is configurable with the same option that was in the mw histmaker, now moved to utilities/common.py to be used also for the mz_wlike histmaker

I also renamed the function to compute the wlike transverse mass with a more sensible name, and changed that everywhere. There are also a couple of new function to create the wlike met, which can then be reused directly (also for mT but not only).