### PR TITLE
Fix bug in envelope calculation 

### DIFF
--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -415,7 +415,7 @@ def syst_min_or_max_env_hist(h, proj_ax, syst_ax, indices, no_flow=[], do_min=Tr
     for ax in proj_ax:
         idx = names.index(ax)
         initial_order.append(idx)
-        names.insert(-2, names.pop(idx))
+        names.insert(-1, names.pop(idx))
         fullview = np.moveaxis(fullview, idx, -2)
     
     op = np.argmin if do_min else np.argmax


### PR DESCRIPTION
Names were not moved in the same way as indices. While in the `np.moveaxis` function -2 means second to last index, in `insert` function for a list -1 means second to last index. 
For some reason the previous code did not break but when the reco charge axis is removed then the code broke. 
Presumably, the gen V charge was used instead of the reco charge before, which has the same dimension.