### PR TITLE
Update writing datacards

### DIFF
--- a/scripts/combine/Templates/WMass/main.txt
+++ b/scripts/combine/Templates/WMass/main.txt
@@ -2,8 +2,8 @@ imax 1
 jmax *
 kmax *
 ##----------------------------------
-shapes *  *  ${inputfile} $$PROCESS/${histName}_$$CHANNEL $$PROCESS/${histName}_$$SYSTEMATIC_$$CHANNEL
-shapes data_obs * ${inputfile} ${pseudodataHist}_$$CHANNEL 
+shapes *  *  ${inputfile} $$PROCESS/${histName}_$$PROCESS_$$CHANNEL $$PROCESS/${histName}_$$PROCESS_$$SYSTEMATIC_$$CHANNEL
+shapes data_obs * ${inputfile} Data/${pseudodataHist}_$$CHANNEL 
 ##----------------------------------
 bin   ${channel} 
 observation    -1

--- a/scripts/combine/Templates/WMass/main.txt
+++ b/scripts/combine/Templates/WMass/main.txt
@@ -2,7 +2,7 @@ imax 1
 jmax *
 kmax *
 ##----------------------------------
-shapes *  *  ${inputfile} ${histName}_$$PROCESS_$$CHANNEL ${histName}_$$PROCESS_$$SYSTEMATIC_$$CHANNEL
+shapes *  *  ${inputfile} $$PROCESS/${histName}_$$CHANNEL $$PROCESS/${histName}_$$SYSTEMATIC_$$CHANNEL
 shapes data_obs * ${inputfile} ${pseudodataHist}_$$CHANNEL 
 ##----------------------------------
 bin   ${channel} 

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -744,6 +744,9 @@ class CardTool(object):
                 "histName" : self.histName,
                 "pseudodataHist" : self.pseudoData+"_sum" if self.pseudoData else f"{self.histName}_{self.dataName}"
             }
+            # use the relative path because absolute paths are slow in text2hdf5.py conversion
+            args["inputfile"] = args["inputfile"].split("/")[-1]
+
             self.cardContent[chan] = output_tools.readTemplate(self.nominalTemplate, args)
             self.cardGroups[chan] = ""
             

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -395,11 +395,11 @@ class CardTool(object):
 
         return {name : var for name,var in zip(systInfo["outNames"], variations) if name}
 
-    def variationName(self, proc, name):
+    def variationName(self, name):
         if name == self.nominalName:
-            return f"{self.histName}_{proc}"
+            return f"{self.histName}"
         else:
-            return f"{self.histName}_{proc}_{name}"
+            return f"{self.histName}_{name}"
 
     def getBoostHistByCharge(self, h, q):
         return h[{"charge" : h.axes["charge"].index(q) if q != "sum" else hist.sum}]
@@ -552,7 +552,7 @@ class CardTool(object):
         # this is a big loop a bit slow, but it might be mainly the hist->root conversion and writing into the root file
         for name, var in var_map.items():
             if name != "":
-                self.writeHist(var, self.variationName(proc, name), setZeroStatUnc=setZeroStatUnc,
+                self.writeHist(var, proc, name, setZeroStatUnc=setZeroStatUnc,
                                decorrByBin=decorrelateByBin, hnomi=hnom)
         logger.debug("After self.writeHist(...)")
 
@@ -588,6 +588,7 @@ class CardTool(object):
             hvar = self.datagroups.groups[process].hists[label]
             if not hvar:
                 raise RuntimeError(f"Failed to load hist for process {process}, systematic {syst}")
+
             self.writeForProcess(hvar, process, syst)
         if syst != self.nominalName:
             self.fillCardWithSyst(syst)
@@ -609,6 +610,7 @@ class CardTool(object):
             procsToRead=self.datagroups.groups.keys(),
             label=self.nominalName, 
             scaleToNewLumi=self.lumiScale)
+        
         self.writeForProcesses(self.nominalName, processes=self.datagroups.groups.keys(), label=self.nominalName)
         self.loadNominalCard()
         if self.pseudoData and not self.xnorm:
@@ -742,7 +744,7 @@ class CardTool(object):
                 "inputfile" : self.outfile if type(self.outfile) == str  else self.outfile.GetName(),
                 "dataName" : self.dataName,
                 "histName" : self.histName,
-                "pseudodataHist" : self.pseudoData+"_sum" if self.pseudoData else f"{self.histName}_{self.dataName}"
+                "pseudodataHist" : self.pseudoData+"_sum" if self.pseudoData else f"{self.dataName}/{self.histName}"
             }
             # use the relative path because absolute paths are slow in text2hdf5.py conversion
             args["inputfile"] = args["inputfile"].split("/")[-1]
@@ -756,13 +758,13 @@ class CardTool(object):
             hout = narf.hist_to_root(self.getBoostHistByCharge(h, q))
             hout.SetName(name+f"_{charge}")
             hout.Write()
-
+        
     def writeHistWithCharges(self, h, name):
         hout = narf.hist_to_root(h)
         hout.SetName(f"{name}_{self.channels[0]}")
         hout.Write()
     
-    def writeHist(self, h, name, setZeroStatUnc=False, decorrByBin={}, hnomi=None):
+    def writeHist(self, h, proc, syst, setZeroStatUnc=False, decorrByBin={}, hnomi=None):
         if self.skipHist:
             return
         if self.project:
@@ -783,17 +785,25 @@ class CardTool(object):
                 raise ValueError("Cannot write hists with > 3 dimensions as combinetf does not accept THn")
 
         if h.ndim != self.nominalDim:
-            raise ValueError(f"Histogram {name} does not have the correct dimensions. Found {h.ndim}, expected {self.nominalDim}")
+            raise ValueError(f"Histogram {proc}/{syst} does not have the correct dimensions. Found {h.ndim}, expected {self.nominalDim}")
 
         if setZeroStatUnc:
             h.variances(flow=True)[...] = 0.
 
+
+        # make sub directories for each process or return existing sub directory
+        directory = self.outfile.mkdir(proc, proc, True)
+        directory.cd()
+
+        name = self.variationName(syst)
+
         hists = {name: h} # always keep original variation in output file for checks
         if decorrByBin:
-            hists.update(self.makeDecorrelatedSystHistograms(h, hnomi, name, decorrByBin))
+            hists.update(self.makeDecorrelatedSystHistograms(h, hnomi, syst, decorrByBin))
             
-        for hname,histo in hists.items():
+        for hname, histo in hists.items():
             if self.writeByCharge:
                 self.writeHistByCharge(histo, hname)
             else:
                 self.writeHistWithCharges(histo, hname)
+        self.outfile.cd()

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -395,11 +395,11 @@ class CardTool(object):
 
         return {name : var for name,var in zip(systInfo["outNames"], variations) if name}
 
-    def variationName(self, name):
+    def variationName(self, proc, name):
         if name == self.nominalName:
-            return f"{self.histName}"
+            return f"{self.histName}_{proc}"
         else:
-            return f"{self.histName}_{name}"
+            return f"{self.histName}_{proc}_{name}"
 
     def getBoostHistByCharge(self, h, q):
         return h[{"charge" : h.axes["charge"].index(q) if q != "sum" else hist.sum}]
@@ -581,7 +581,8 @@ class CardTool(object):
         for systAxName in ["systIdx", "tensor_axis_0", "vars"]:
             if systAxName in [ax.name for ax in hdata.axes]:
                 hdata = hdata[{systAxName : self.pseudoDataIdx }] 
-        self.writeHist(hdata, self.pseudoData+"_sum")
+
+        self.writeHist(hdata, self.dataName, self.pseudoData+"_sum")
 
     def writeForProcesses(self, syst, processes, label):
         for process in processes:
@@ -744,10 +745,10 @@ class CardTool(object):
                 "inputfile" : self.outfile if type(self.outfile) == str  else self.outfile.GetName(),
                 "dataName" : self.dataName,
                 "histName" : self.histName,
-                "pseudodataHist" : self.pseudoData+"_sum" if self.pseudoData else f"{self.dataName}/{self.histName}"
+                "pseudodataHist" : f"{self.histName}_{self.dataName}_{self.pseudoData}_sum" if self.pseudoData else f"{self.histName}_{self.dataName}"
             }
             # use the relative path because absolute paths are slow in text2hdf5.py conversion
-            args["inputfile"] = args["inputfile"].split("/")[-1]
+            args["inputfile"] = os.path.basename(args["inputfile"])
 
             self.cardContent[chan] = output_tools.readTemplate(self.nominalTemplate, args)
             self.cardGroups[chan] = ""
@@ -790,12 +791,11 @@ class CardTool(object):
         if setZeroStatUnc:
             h.variances(flow=True)[...] = 0.
 
-
         # make sub directories for each process or return existing sub directory
         directory = self.outfile.mkdir(proc, proc, True)
         directory.cd()
 
-        name = self.variationName(syst)
+        name = self.variationName(proc, syst)
 
         hists = {name: h} # always keep original variation in output file for checks
         if decorrByBin:


### PR DESCRIPTION
- Write relative paths in the text datacards instead of absolute paths (for better practical use)
- Write shapes into sub folders in root file, this speeds up the text2hdf5.py