### PR TITLE
fix for space between process name in datacard

### DIFF
--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -735,7 +735,7 @@ class CardTool(object):
             args = {
                 "channel" :  chan,
                 "channelPerProc" : chan.ljust(self.procColumnsSpacing)*nprocs,
-                "processes" : "".join([x.ljust(self.procColumnsSpacing) for x in procs]),
+                "processes" : " ".join([x.ljust(self.procColumnsSpacing) for x in procs]),
                 "labels" : "".join([str(x).ljust(self.procColumnsSpacing) for x in self.processLabels()]),
                 # Could write out the proper normalizations pretty easily
                 "rates" : "-1".ljust(self.procColumnsSpacing)*nprocs,


### PR DESCRIPTION
As for the title, this PR ensures that there is always 1 space between process names in datacard.
 
Before, the space allotted for each process was configured, but since we can't predict the length of process names we were forced to use unnaturally large spacing, which may have still not been sufficient (it happened to some of us). 

This also allows us to keep the available space for each process name to a reasonable minimum, to avoid having absurd datacard with fields separated by enormous white spaces when not necessary.