### PR TITLE
Make it possible to run w/o data without specifying additional CL args

### DIFF
--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -57,19 +57,19 @@ class Datagroups(object):
                         "name": g_name,
                         "group": g_name,
                         "filepaths": group["dataset"]["filepaths"],
-                        "xsec": None
+                        "xsec": group["dataset"]["xsec"],
                         })
-            else:
-                self.datasets = {x.name : x for x in datasets}
 
-            logger.debug(f"Getting these datasets: {self.datasets.keys()}")
-
-            if self.results:
                 self.data = [x for x in self.datasets.values() if x.is_data]
                 if self.data:
                     self.lumi = sum([self.results[x.name]["lumi"] for x in self.data if x.name in self.results])
                 else:
                     logger.warning("No data process was selected, normalizing MC to to 1/fb")
+
+            else:
+                self.datasets = {x.name : x for x in datasets}
+                
+            logger.debug(f"Getting these datasets: {self.datasets.keys()}")
 
         self.groups = {}
         self.nominalName = "nominal"

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -63,8 +63,9 @@ class Datagroups(object):
                 self.data = [x for x in self.datasets.values() if x.is_data]
                 if self.data:
                     self.lumi = sum([self.results[x.name]["lumi"] for x in self.data if x.name in self.results])
+                    logger.info(f"Integrated luminosity from data: {self.lumi}/fb")
                 else:
-                    logger.warning("No data process was selected, normalizing MC to to 1/fb")
+                    logger.warning("No data process was selected, normalizing MC to 1/fb")
 
             else:
                 self.datasets = {x.name : x for x in datasets}

--- a/wremnants/histmaker_tools.py
+++ b/wremnants/histmaker_tools.py
@@ -8,7 +8,11 @@ def scale_to_data(result_dict, data_name = "dataPostVFP"):
     # scale histograms by lumi*xsec/sum(gen weights)
     time0 = time.time()
 
-    lumi = result_dict[data_name]["lumi"]
+    if data_name in result_dict.keys():
+        lumi = result_dict[data_name]["lumi"]
+    else:
+        lumi = 1
+
     logger.debug(f"Scale histograms with lumi={lumi}")
     for d_name, result in result_dict.items():
         if result["dataset"]["is_data"]:
@@ -36,9 +40,12 @@ def aggregate_groups(datasets, result_dict, groups_to_aggregate):
     time0 = time.time()
 
     for group in groups_to_aggregate:
-        logger.debug(f"Aggregate group {group}")
 
         dataset_names = [d.name for d in datasets if d.group == group]
+        if len(dataset_names) == 0:
+            continue
+
+        logger.debug(f"Aggregate group {group}")
 
         resdict = None
         members = {}
@@ -60,17 +67,18 @@ def aggregate_groups(datasets, result_dict, groups_to_aggregate):
                     "n_members": 1,
                     "dataset": {
                         "name": group,
+                        "xsec": result["dataset"]["xsec"],
                         "filepaths": result["dataset"]["filepaths"],
                     },
                     "weight_sum": float(result["weight_sum"]),
                     "event_count": float(result["event_count"])
                 }
             else:
+                resdict["dataset"]["xsec"] += result["dataset"]["xsec"]
                 resdict["dataset"]["filepaths"] += result["dataset"]["filepaths"]
                 resdict["n_members"] += 1
                 resdict["weight_sum"] += float(result["weight_sum"])
                 resdict["event_count"] += float(result["event_count"])
-
 
             to_del.append(name)
 


### PR DESCRIPTION
In the current main to run the histmaker w/o data one needs to specify ```--noScaleToData```. This PR allows to run w/o this specification by simply assigning lumi=1 if no data is given.