### PR TITLE
add features to addHists and fix possible bug in other functions

### DIFF
--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -119,7 +119,7 @@ def multiplyHists(h1, h2, allowBroadcast=True, createNew=True):
 
     return outh
 
-def addHists(h1, h2, allowBroadcast=True, createNew=True):
+def addHists(h1, h2, allowBroadcast=True, createNew=True, scale1=None, scale2=None):
     if allowBroadcast:
         h1 = broadcastSystHist(h1, h2)
         h2 = broadcastSystHist(h2, h1)

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -147,11 +147,11 @@ def addHists(h1, h2, allowBroadcast=True, createNew=True, scale1=None, scale2=No
     else:
         outvals = h1vals if h1.shape == outh.shape else h2vals
         np.add(h1vals, h2vals, out=outvals)
-        outh.values()[...] = outvals
+        outh.values(flow=True)[...] = outvals
         if hasWeights:
             outvars = h1vars if h1.shape == outh.shape else h2vars
             np.add(h1vars, h2vars, out=outvars)
-            outh.variances()[...] = outvars
+            outh.variances(flow=True)[...] = outvars
         return outh
 
 def sumHists(hists):


### PR DESCRIPTION
For addHists I am adding two parameters scale1 and scale2, to apply a multiplicative constant factor to any of the two inputs (one use case was to do x -y, scaling the second by -1, but I made it general).
I could have had a single argument accepting a pair, but I think this is simpler and easier for the user.

For the ratio, I just wanted to allow setting the value for special cases like 0/0, it was 1 so far, but if the ratio represents an efficiency the case 0/0 means no events at denominator, so the efficiency can be assumed to be 0.
About the condition for the cutoff, this currently assumes that the factors are expected to be positive, which may not always be the case. It was true for any use case I had so far, though.
Perhaps one may extend the condition to different configurations through more arguments.