### PR TITLE
Add width uncertainty on W and Z

### DIFF
--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -193,6 +193,8 @@ def main(args,xnorm=False):
     constrainedZ = constrainMass and not wmass
     label = 'W' if wmass else 'Z'
     massSkip = [(f"^massShift[W|Z]{i}MeV.*",) for i in range(0, 110 if constrainedZ else 100, 10)]
+    widthSkipZ = [("widthZ2p49333GeV",), ("widthZ2p49493GeV",), ("widthZ2p4952GeV",)] 
+    widthSkipW = [("widthW2p09053GeV",), ("widthW2p09173GeV",), ("widthW2p085GeV",)]
     if wmass and not xnorm:
         cardTool.addSystematic(f"massWeightZ",
                                 processes=single_v_nonsig_samples,
@@ -206,9 +208,8 @@ def main(args,xnorm=False):
         cardTool.addSystematic(f"widthWeightZ",
                                 processes=single_v_nonsig_samples,
                                 group=f"widthZ",
-                                skipEntries=[(0,), (1,)],
+                                skipEntries=widthSkipZ[:],
                                 mirror=False,
-                                noConstraint=False,
                                 systAxes=["width"],
                                 passToFakes=passSystToFakes,
         )
@@ -228,11 +229,10 @@ def main(args,xnorm=False):
     )
     cardTool.addSystematic(f"widthWeight{label}",
                             processes=signal_samples_inctau,
-                            skipEntries=[(0,), (1,)],
+                            skipEntries=widthSkipZ[:] if label=="Z" else widthSkipW[:],
                             group=f"width{label}",
                             mirror=False,
                             #TODO: Name this
-                            noConstraint=not constrainMass,
                             systAxes=["width"],
                             passToFakes=passSystToFakes,
     )

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -197,8 +197,6 @@ def main(args,xnorm=False):
     constrainedZ = constrainMass and not wmass
     label = 'W' if wmass else 'Z'
     massSkip = [(f"^massShift[W|Z]{i}MeV.*",) for i in range(0, 110 if constrainedZ else 100, 10)]
-    widthSkipZ = [("widthZ2p49333GeV",), ("widthZ2p49493GeV",), ("widthZ2p4952GeV",)] 
-    widthSkipW = [("widthW2p09053GeV",), ("widthW2p09173GeV",), ("widthW2p085GeV",)]
     if wmass and not xnorm:
         cardTool.addSystematic(f"massWeightZ",
                                 processes=single_v_nonsig_samples,
@@ -232,6 +230,8 @@ def main(args,xnorm=False):
         return
     
     if args.widthUnc:
+        widthSkipZ = [("widthZ2p49333GeV",), ("widthZ2p49493GeV",), ("widthZ2p4952GeV",)] 
+        widthSkipW = [("widthW2p09053GeV",), ("widthW2p09173GeV",), ("widthW2p085GeV",)]
         if wmass and not xnorm:
             cardTool.addSystematic(f"widthWeightZ",
                                     processes=single_v_nonsig_samples,

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -203,6 +203,15 @@ def main(args,xnorm=False):
                                 systAxes=["massShift"],
                                 passToFakes=passSystToFakes,
         )
+        cardTool.addSystematic(f"widthWeightZ",
+                                processes=single_v_nonsig_samples,
+                                group=f"widthZ",
+                                skipEntries=[(0,), (1,)],
+                                mirror=False,
+                                noConstraint=False,
+                                systAxes=["width"],
+                                passToFakes=passSystToFakes,
+        )
 
     if not (constrainMass or wmass):
         massSkip.append(("^massShift.*2p1MeV.*",))
@@ -217,7 +226,17 @@ def main(args,xnorm=False):
                             systAxes=["massShift"],
                             passToFakes=passSystToFakes,
     )
-    
+    cardTool.addSystematic(f"widthWeight{label}",
+                            processes=signal_samples_inctau,
+                            skipEntries=[(0,), (1,)],
+                            group=f"width{label}",
+                            mirror=False,
+                            #TODO: Name this
+                            noConstraint=not constrainMass,
+                            systAxes=["width"],
+                            passToFakes=passSystToFakes,
+    )
+
     if args.doStatOnly:
         # print a card with only mass weights and a dummy syst
         cardTool.addLnNSystematic("dummy", processes=["Top", "Diboson"] if wmass else ["Other"], size=1.001, group="dummy")

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -21,6 +21,7 @@ def make_parser(parser=None):
     parser.add_argument("--fitvar", nargs="+", help="Variable to fit", default=["pt", "eta"])
     parser.add_argument("--noEfficiencyUnc", action='store_true', help="Skip efficiency uncertainty (useful for tests, because it's slow). Equivalent to --excludeNuisances '.*effSystTnP|.*effStatTnP' ")
     parser.add_argument("--ewUnc", action='store_true', help="Include EW uncertainty")
+    parser.add_argument("--widthUnc", action='store_true', help="Include uncertainty on W and Z width")
     parser.add_argument("--pseudoData", type=str, help="Hist to use as pseudodata")
     parser.add_argument("--pseudoDataIdx", type=str, default="0", help="Variation index to use as pseudodata")
     parser.add_argument("--pseudoDataFile", type=str, help="Input file for pseudodata (if it should be read from a different file)", default=None)
@@ -208,14 +209,6 @@ def main(args,xnorm=False):
                                 systAxes=["massShift"],
                                 passToFakes=passSystToFakes,
         )
-        cardTool.addSystematic(f"widthWeightZ",
-                                processes=single_v_nonsig_samples,
-                                group=f"widthZ",
-                                skipEntries=widthSkipZ[:],
-                                mirror=False,
-                                systAxes=["width"],
-                                passToFakes=passSystToFakes,
-        )
 
     if not (constrainMass or wmass):
         massSkip.append(("^massShift.*2p1MeV.*",))
@@ -230,15 +223,6 @@ def main(args,xnorm=False):
                             systAxes=["massShift"],
                             passToFakes=passSystToFakes,
     )
-    cardTool.addSystematic(f"widthWeight{label}",
-                            processes=signal_samples_inctau,
-                            skipEntries=widthSkipZ[:] if label=="Z" else widthSkipW[:],
-                            group=f"width{label}",
-                            mirror=False,
-                            #TODO: Name this
-                            systAxes=["width"],
-                            passToFakes=passSystToFakes,
-    )
 
     if args.doStatOnly:
         # print a card with only mass weights, no longer need a dummy syst since combinetf is fixed now
@@ -246,6 +230,26 @@ def main(args,xnorm=False):
         cardTool.writeOutput(args=args, xnorm=xnorm)
         logger.info("Using option --doStatOnly: the card was created with only mass nuisance parameter")
         return
+    
+    if args.widthUnc:
+        if wmass and not xnorm:
+            cardTool.addSystematic(f"widthWeightZ",
+                                    processes=single_v_nonsig_samples,
+                                    group=f"widthZ",
+                                    skipEntries=widthSkipZ[:],
+                                    mirror=False,
+                                    systAxes=["width"],
+                                    passToFakes=passSystToFakes,
+            )
+        cardTool.addSystematic(f"widthWeight{label}",
+                                processes=signal_samples_inctau,
+                                skipEntries=widthSkipZ[:] if label=="Z" else widthSkipW[:],
+                                group=f"width{label}",
+                                mirror=False,
+                                #TODO: Name this
+                                systAxes=["width"],
+                                passToFakes=passSystToFakes,
+        )
 
     if not xnorm:
         if wmass:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -99,6 +99,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--theoryCorr", nargs="*", default=["scetlib_dyturbo"], choices=theory_corrections.valid_theory_corrections(),
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
+    parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")   
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--eta", nargs=3, type=float, help="Eta binning as 'nbins min max' (only uniform for now)", default=[48,-2.4,2.4])
     parser.add_argument("--pt", nargs=3, type=float, help="Pt binning as 'nbins,min,max' (only uniform for now)", default=[29,26.,55.])

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -6,7 +6,6 @@ from wremnants import theory_tools
 from wremnants.datasets.datagroups import Datagroups
 import re
 import collections.abc
-from decimal import Decimal
 
 logger = logging.child_logger(__name__)
 
@@ -245,11 +244,6 @@ def define_width_weights(df, proc):
     nweights = 5
     df = df.Define("widthWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(MEParamWeightAltSet1)")
     df = df.Define("widthWeight_tensor_wnom", "auto res = widthWeight_tensor; res = nominal_weight*res; return res;")
-
-    # df = df.Define("widthWeight_nominal", "widthWeight_tensor[3]")
-    # df = df.Define("widthWeight_down", "widthWeight_tensor[2]/widthWeight_nominal")
-    # df = df.Define("widthWeight_up", "widthWeight_tensor[4]/widthWeight_nominal")
-
     return df
 
 def add_widthweights_hist(results, df, axes, cols, base_name="nominal", proc=""):
@@ -261,7 +255,6 @@ def add_widthweights_hist(results, df, axes, cols, base_name="nominal", proc="")
 
 def widthWeightNames(matches=None, proc=""):
     central=3
-
     if proc[0] == "Z":
         widths=(2.49333, 2.49493, 2.4929, 2.4952, 2.4975)
     elif proc[0] == "W":

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -268,9 +268,9 @@ def widthWeightNames(matches=None, proc=""):
         widths=(2.09053, 2.09173, 2.043, 2.085, 2.127) 
     else:
         raise RuntimeError(f"No width found for process {proc}")
-    # 0 and 1 are for reference
+    # 0 and 1 are Up, Down from mass uncertainty EW fit (already accounted for in mass variations)
     names = [f"width{proc[0]}{str(widths[i]).replace('.','p')}GeV" for i in (0, 1)]
-    # 2, 3, and 4 are Down, Central, Up
+    # 2, 3, and 4 are PDG width Down, Central, Up
     names.append(f"widthShift{proc[0]}{str(2.3 if proc[0] == 'Z' else 42).replace('.','p')}MeVDown")
     names.append(f"width{proc[0]}{str(widths[central]).replace('.','p')}GeV")
     names.append(f"widthShift{proc[0]}{str(2.3 if proc[0] == 'Z' else 42).replace('.','p')}MeVUp")
@@ -461,7 +461,8 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
     df = theory_tools.define_scale_tensor(df)
     df = define_mass_weights(df, dataset_name)
-    df = define_width_weights(df, dataset_name)
+    if args.widthVariations:
+        df = define_width_weights(df, dataset_name)
 
     add_pdf_hists(results, df, dataset_name, axes, cols, args.pdfs, base_name=base_name)
     add_qcdScale_hist(results, df, scale_axes, scale_cols, base_name=base_name)
@@ -482,6 +483,7 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
         # TODO: Should have consistent order here with the scetlib correction function
         add_massweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
-        add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
+        if args.widthVariations:
+            add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
 
     return df

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -236,6 +236,37 @@ def massWeightNames(matches=None, proc=""):
     # If name is "" it won't be stored
     return [x if not matches or any(y in x for y in matches) else "" for x in names]
 
+def define_width_weights(df, proc):
+    if "widthWeight_tensor" in df.GetColumnNames():
+        logger.debug("widthWeight_tensor already defined, do nothing here.")
+        return df
+    nweights = 5
+    df = df.Define("widthWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(MEParamWeightAltSet1)")
+    df = df.Define("widthWeight_tensor_wnom", "auto res = widthWeight_tensor; res = nominal_weight*res; return res;")
+
+    return df
+
+def add_widthweights_hist(results, df, axes, cols, base_name="nominal", proc=""):
+    name = Datagroups.histName(base_name, syst="widthWeight"+(proc[0] if len(proc) else proc))
+    widthWeight = df.HistoBoost(name, axes, [*cols, "widthWeight_tensor_wnom"], 
+                    tensor_axes=[hist.axis.StrCategory(widthWeightNames(proc=proc), name="width")], 
+                    storage=hist.storage.Double())
+    results.append(widthWeight)
+
+def widthWeightNames(matches=None, proc=""):
+    central=3
+    nweights=5
+    if proc[0] == "Z":
+        widths=(2.49333, 2.49493, 2.4929, 2.4952, 2.4975) 
+    elif proc[0] == "W":
+        widths=(2.09053, 2.09173, 2.043, 2.085, 2.127) 
+    else:
+        raise RuntimeError(f"No width found for process {proc}")
+    
+    names = [f"width{proc[0]}{str(widths[i]).replace('.','p')}MeV{'' if i == central else ('Down' if widths[i] < widths[central] else 'Up')}" for i in range(nweights)]
+    return [x if not matches or any(y in x for y in matches) else "" for x in names]
+
+
 def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal"):
     for pdf in pdfs:
         try:
@@ -391,6 +422,7 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
     df = theory_tools.define_scale_tensor(df)
     df = define_mass_weights(df, dataset_name)
+    df = define_width_weights(df, dataset_name)
 
     add_pdf_hists(results, df, dataset_name, axes, cols, args.pdfs, base_name=base_name)
     add_qcdScale_hist(results, df, scale_axes, scale_cols, base_name=base_name)
@@ -411,5 +443,6 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
         # TODO: Should have consistent order here with the scetlib correction function
         add_massweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
+        add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
 
     return df


### PR DESCRIPTION
Weights for different W or Z boson widths are stored in the ntuples (branch "MEParamWeightAltSet1"). In this PR the weights are propagated in the histmaker and cardmaker to assess the corresponding uncertainty.