### PR TITLE
New script to browse an hdf5 file to check its content

### DIFF
--- a/scripts/utilities/browse_hdf5.py
+++ b/scripts/utilities/browse_hdf5.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+import lz4.frame
+import pickle
+import hist
+from utilities import boostHistHelpers as hh, logging
+#import wremnants
+import hdf5plugin
+import h5py
+import narf
+from narf import ioutils
+import ROOT
+
+logger = logging.child_logger(__name__)
+
+if __name__ == "__main__":    
+
+     parser = argparse.ArgumentParser()
+     parser.add_argument("inputfile", type=str, nargs=1, help="Input file")
+     parser.add_argument("-w", "--what", type=str, default="all",
+                         choices=["all", "procs", "hists", "axes"],
+                         help="What to print")
+     parser.add_argument("-p", "--process", type=str, default=None,
+                         help="Process to print")
+     parser.add_argument("-n", "--histo", type=str, default=None,
+                         help="Select specific histogram, and printout will have more information")
+     args = parser.parse_args()
+
+     h5file = h5py.File(args.inputfile[0], "r")
+     results = narf.ioutils.pickle_load_h5py(h5file["results"])
+
+     if args.what == "all":
+          print(results)
+     else:
+          if args.what == "procs":
+               print(results.keys())
+          elif args.what in ["hists", "axes"]:               
+               print("="*30)
+               print("GOING TO PRINT HISTOGRAMS")
+               print("="*30)
+               #print(results.keys())
+               for p in results.keys():
+                    if p == "meta_info":
+                         continue
+                    if args.process and p != args.process:
+                         continue
+                    print("-"*30)
+                    print(f"Process {p}")
+                    space = " "*5
+                    for k in results[p]["output"].keys():
+                         if args.histo and k != args.histo:
+                              continue
+                         print(f"{space}{k}")                         
+                         if args.what == "axes":
+                              print(f"{space}  Axes = {results[p]['output'][k].axes.name}")
+                              if k == args.histo:
+                                   for n in results[p]['output'][k].axes:
+                                        print(f"{space}{space} {n}")

--- a/scripts/utilities/browse_hdf5.py
+++ b/scripts/utilities/browse_hdf5.py
@@ -56,7 +56,10 @@ if __name__ == "__main__":
                               continue
                          print(f"{space}{k}")                         
                          if args.what == "axes":
-                              print(f"{space}  Axes = {results[p]['output'][k].axes.name}")
+                              histObj = results[p]['output'][k]
+                              if isinstance(histObj, ioutils.H5PickleProxy):
+                                   histObj = histObj.get()
+                              print(f"{space}  Axes = {histObj.axes.name}")
                               if k == args.histo:
-                                   for n in results[p]['output'][k].axes:
+                                   for n in histObj.axes:
                                         print(f"{space}{space} {n}")


### PR DESCRIPTION
Some people including myself expressed the interest in having a simple interface to browse an hdf5 file to explore its content, given that it's not as trivial as opening a root file and doing ".ls".
I hope it helps.

Example command: 
"python scripts/utilities/browse_hdf5.py file.hdf5 [-w <whatToPrint> -p <processName> -n <histogramName>]"

-w procs will print only the process names
-w hists will print the histogram names for each process found.
-w axes will print the axis details for all axes for anything that is found (better used in conjunction with -p <processName> and/or -n <histogramName> to select a single process or histogram)

-p <processName> will print info only for the selected process (could be extended to accept a list, for now it is only one)
-n <histogramName> picks a single histogram with this name

For example:
python scripts/utilities/browse_hdf5.py file.hdf5 -w axes -p ZmumuPostVFP -n nominal