### PR TITLE
Fakerate based on lepton pt eta charge

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -8,8 +8,6 @@ parser.add_argument("--flavor", type=str, choices=["e", "mu"], help="Flavor (e o
 
 parser = common.set_parser_default(parser, "genVars", ["ptVGen"])
 parser = common.set_parser_default(parser, "theoryCorr", ["scetlib_dyturbo", "winhacnloew"])
-parser = common.set_parser_default(parser, "pt", [10,26.,56.])
-parser = common.set_parser_default(parser, "eta", [12,-2.4,2.4])
 args = parser.parse_args()
 
 
@@ -55,6 +53,9 @@ ROOT.gInterpreter.Declare('#include "lowpu_rochester.h"')
 ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
 ROOT.gInterpreter.Declare('#include "electron_selections.h"')
 
+# axes used in fakerate calculation
+axis_fakerate_pt = hist.axis.Variable([26., 27., 28., 29., 30., 32., 34., 37., 40., 44., 49., 56.], name = "pt", underflow=False)
+axis_fakerate_eta = hist.axis.Regular(12, -2.4, 2.4, name = "eta", underflow=False, overflow=False)
 
 # standard regular axes
 axis_eta = hist.axis.Regular(args.eta[0], args.eta[1], args.eta[2], name = "eta", underflow=False, overflow=False)
@@ -86,7 +87,7 @@ if args.unfolding:
 
 # axes for final cards/fitting
 nominal_axes = [
-    axis_pt, axis_eta, axis_charge, 
+    axis_fakerate_pt, axis_fakerate_eta, axis_charge, 
     hist.axis.Variable([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 75, 90, 150], name = "ptll", underflow=False, overflow=True),    
     axis_passIso, axis_passMT]
 
@@ -97,7 +98,7 @@ nominal_cols = ["lep_pt", "lep_eta", "lep_charge", "ptll", "passIso",  "passMT"]
 axis_mT = hist.axis.Variable([0] + list(range(40, 110, 1)) + [110, 112, 114, 116, 118, 120, 125, 130, 140, 160, 180, 200], name = "mt",underflow=False, overflow=True)
 axis_mT = hist.axis.Regular(100, 0, 200, name = "mt", underflow=False)
 
-axes_mT = [axis_pt, axis_eta, axis_charge, axis_mT, axis_passIso]
+axes_mT = [axis_fakerate_pt, axis_fakerate_eta, axis_charge, axis_mT, axis_passIso]
 cols_mT = ["lep_pt", "lep_eta", "lep_charge", "transverseMass",  "passIso"]
 
 # reco_mT_axes = [common.axis_recoil_reco_ptW_lowpu, common.axis_mt_lowpu, axis_charge, axis_passMT, axis_passIso]

--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -7,6 +7,9 @@ parser.add_argument("--lumiUncertainty", type=float, help="Uncertainty for lumin
 parser.add_argument("--flavor", type=str, choices=["e", "mu"], help="Flavor (e or mu)", default="mu")
 
 parser = common.set_parser_default(parser, "genVars", ["ptVGen"])
+parser = common.set_parser_default(parser, "theoryCorr", ["scetlib_dyturbo", "winhacnloew"])
+parser = common.set_parser_default(parser, "pt", [10,26.,56.])
+parser = common.set_parser_default(parser, "eta", [12,-2.4,2.4])
 args = parser.parse_args()
 
 
@@ -54,7 +57,7 @@ ROOT.gInterpreter.Declare('#include "electron_selections.h"')
 
 
 # standard regular axes
-axis_eta = hist.axis.Regular(24, -2.4, 2.4, name = "eta", underflow=False, overflow=False)
+axis_eta = hist.axis.Regular(args.eta[0], args.eta[1], args.eta[2], name = "eta", underflow=False, overflow=False)
 axis_pt = hist.axis.Regular(args.pt[0], args.pt[1], args.pt[2], name = "pt", underflow=False)
 axis_phi = hist.axis.Regular(50, -4, 4, name = "phi")
 axis_charge = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "charge")
@@ -83,18 +86,19 @@ if args.unfolding:
 
 # axes for final cards/fitting
 nominal_axes = [
-    hist.axis.Variable([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 75, 90, 150], name = "ptll", underflow=False, overflow=True),
-    axis_charge, axis_passMT, axis_passIso]
+    axis_pt, axis_eta, axis_charge, 
+    hist.axis.Variable([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 75, 90, 150], name = "ptll", underflow=False, overflow=True),    
+    axis_passIso, axis_passMT]
 
 # corresponding columns
-nominal_cols = ["ptll", "lep_charge", "passMT", "passIso"]
+nominal_cols = ["lep_pt", "lep_eta", "lep_charge", "ptll", "passIso",  "passMT"]
 
 # mt final cards/fitting
 axis_mT = hist.axis.Variable([0] + list(range(40, 110, 1)) + [110, 112, 114, 116, 118, 120, 125, 130, 140, 160, 180, 200], name = "mt",underflow=False, overflow=True)
 axis_mT = hist.axis.Regular(100, 0, 200, name = "mt", underflow=False)
 
-axes_mT = [axis_mT, axis_charge, axis_passMT, axis_passIso]
-cols_mT = ["transverseMass", "lep_charge", "passMT", "passIso"]
+axes_mT = [axis_pt, axis_eta, axis_charge, axis_mT, axis_passIso]
+cols_mT = ["lep_pt", "lep_eta", "lep_charge", "transverseMass",  "passIso"]
 
 # reco_mT_axes = [common.axis_recoil_reco_ptW_lowpu, common.axis_mt_lowpu, axis_charge, axis_passMT, axis_passIso]
 # gen_reco_mT_axes = [common.axis_recoil_gen_ptW_lowpu, common.axis_recoil_reco_ptW_lowpu, common.axis_mt_lowpu, axis_charge, axis_passMT, axis_passIso]
@@ -268,7 +272,6 @@ def build_graph(df, dataset):
     results.append(df.HistoBoost("lep_pt", [axis_pt, axis_charge, axis_passMT, axis_passIso], ["lep_pt", "lep_charge", "passMT", "passIso", "nominal_weight"]))
     results.append(df.HistoBoost("lep_eta", [axis_eta, axis_charge, axis_passMT, axis_passIso], ["lep_eta", "lep_charge", "passMT", "passIso", "nominal_weight"]))
     results.append(df.HistoBoost("lep_phi", [axis_phi, axis_charge, axis_passMT, axis_passIso], ["lep_phi", "lep_charge", "passMT", "passIso", "nominal_weight"]))
-    results.append(df.HistoBoost("lep_pt", [axis_pt, axis_charge, axis_passMT, axis_passIso], ["lep_pt", "lep_charge", "passMT", "passIso", "nominal_weight"]))
     results.append(df.HistoBoost("lep_iso", [axis_iso], ["lep_iso", "nominal_weight"]))
    
     # results.append(df.HistoBoost("qcd_space", [axis_pt, axis_eta, axis_iso, axis_charge, axis_mT], ["lep_pt", "lep_eta", "lep_iso", "lep_charge", "transverseMass", "nominal_weight"]))  

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -131,11 +131,13 @@ else:
 if not args.nominalRef:
     nominalName = args.baseName.rsplit("_", 1)[0]
     groups.setNominalName(nominalName)
-    groups.loadHistsForDatagroups(args.baseName, syst="", procsToRead=datasets, applySelection=applySelection)
+    groups.loadHistsForDatagroups(args.baseName, syst="", procsToRead=datasets, applySelection=applySelection, 
+        fakerateIntegrationAxes=list(set([x for h in args.hists for x in h.split("-") if x not in ["pt", "eta", "charge"]])))
 else:
     nominalName = args.nominalRef
     groups.setNominalName(nominalName)
-    groups.loadHistsForDatagroups(nominalName, syst=args.baseName, procsToRead=datasets, applySelection=applySelection)
+    groups.loadHistsForDatagroups(nominalName, syst=args.baseName, procsToRead=datasets, applySelection=applySelection,
+        fakerateIntegrationAxes=list(set([x for h in args.hists for x in h.split("-") if x not in ["pt", "eta", "charge"]])))
 
 exclude = ["Data"] 
 unstack = exclude[:]

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -14,26 +14,17 @@ def broadcastSystHist(h1, h2):
     if h1.ndim > h2.ndim or h1.shape == h2.shape:
         return h1
 
-    a1 = h1.view(flow=True)
-    a2 = h2.view(flow=True)
+    s1 = h1.view(flow=True).shape
+    s2 = h2.view(flow=True).shape
 
-    # the additional axes have to be trailing, if they ar not, they must be moved
-    moves = []
-    offset = 0
-    for i, a in enumerate(h1.axes.name):
-        b = h2.axes.name[i+offset]
-        if a != b:
-            idx = h2.axes.name.index(b)
-            moves.append(idx)
-            a2 = np.moveaxis(a2, idx, -1)
-            offset += 1
+    # the additional axes have to be broadcasted as leading
+    moves = {i: e for i, (e, n2) in enumerate(zip(s2, h2.axes.name)) if n2 not in h1.axes.name}
+    broadcast_shape = list(moves.values()) + list(s1)
 
-    # Transpose because we keep syst axis last, but numpy broadcasts from the front
-    new_vals = np.broadcast_to(a1.T, a2.T.shape).T
+    new_vals = np.broadcast_to(h1.view(flow=True), broadcast_shape)
 
-    # move back to original order, in reversed order
-    for idx in moves[::-1]:
-        new_vals = np.moveaxis(new_vals, -1, idx)
+    # move back to original order
+    new_vals = np.moveaxis(new_vals, np.arange(len(moves)), list(moves.keys()))
 
     return hist.Hist(*h2.axes, data=new_vals, storage=h1.storage_type())
 

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -100,6 +100,10 @@ class CardTool(object):
             
     def setProjectionAxes(self, project):
         self.project = project
+        self.setFakerateAxes(fakerate_integration_axes=project)
+
+    def setFakerateAxes(self, fakerate_axes=["pt", "eta", "charge"], fakerate_integration_axes=[]):
+        self.fakerateIntegrationAxes = [x for x in fakerate_integration_axes if x not in fakerate_axes]
 
     def setProcsNoStatUnc(self, procs, resetList=True):
         if self.skipHist:
@@ -305,7 +309,8 @@ class CardTool(object):
         self.datagroups.loadHistsForDatagroups(
             baseName=self.nominalName, syst=syst, label="syst",
             procsToRead=[proc],
-            scaleToNewLumi=self.lumiScale)
+            scaleToNewLumi=self.lumiScale, 
+            fakerateIntegrationAxes=self.fakerateIntegrationAxes)
         return self.datagroups.getDatagroups()[proc].hists["syst"]
         
     def setMirrorForSyst(self, syst, mirror=True):
@@ -603,7 +608,8 @@ class CardTool(object):
         datagroups.loadHistsForDatagroups(
             baseName=self.nominalName, syst=self.pseudoData, label=self.pseudoData,
             procsToRead=processes,
-            scaleToNewLumi=self.lumiScale)
+            scaleToNewLumi=self.lumiScale, 
+            fakerateIntegrationAxes=self.fakerateIntegrationAxes)
         procDict = datagroups.getDatagroups()
         hists = [procDict[proc].hists[self.pseudoData] for proc in processes if proc not in processesFromNomi]
         # now add possible processes from nominal
@@ -614,7 +620,8 @@ class CardTool(object):
             datagroupsFromNomi.loadHistsForDatagroups(
                 baseName=self.pseudoData, syst=self.nominalName, label=self.pseudoData,
                 procsToRead=processesFromNomi,
-                scaleToNewLumi=self.lumiScale)
+                scaleToNewLumi=self.lumiScale,
+                fakerateIntegrationAxes=self.fakerateIntegrationAxes)
             procDictFromNomi = datagroupsFromNomi.getDatagroups()
             hists.extend([procDictFromNomi[proc].hists[self.pseudoData] for proc in processesFromNomi])
         # done, now sum all histograms
@@ -684,7 +691,8 @@ class CardTool(object):
             procsToRead=self.datagroups.groups.keys(),
             label=self.nominalName, 
             scaleToNewLumi=self.lumiScale, 
-            forceNonzero=forceNonzero)
+            forceNonzero=forceNonzero,
+            fakerateIntegrationAxes=self.fakerateIntegrationAxes)
         if simultaneousABCD and not self.xnorm:
             setSimultaneousABCD(self)
         self.writeForProcesses(self.nominalName, processes=self.datagroups.groups.keys(), label=self.nominalName, check_systs=check_systs)
@@ -708,6 +716,7 @@ class CardTool(object):
                 forceToNominal=[x for x in self.datagroups.getProcNames() if x not in 
                                 self.datagroups.getProcNames([p for g in processes for p in self.expandProcesses(g) if p != "Fake"])],
                 scaleToNewLumi=self.lumiScale,
+                fakerateIntegrationAxes=self.fakerateIntegrationAxes,
             )
             self.writeForProcesses(syst, label="syst", processes=processes, check_systs=check_systs)
 

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -220,7 +220,7 @@ class Datagroups(object):
     ## procName are grouped into datagroups
     ## baseName takes values such as "nominal"
     def setHists(self, baseName, syst, procsToRead=None, label=None, nominalIfMissing=True, 
-                 applySelection=True, forceNonzero=True, preOpMap=None, preOpArgs=None, scaleToNewLumi=1, 
+                 applySelection=True, fakerateIntegrationAxes=[], forceNonzero=True, preOpMap=None, preOpArgs=None, scaleToNewLumi=1, 
                  excludeProcs=None, forceToNominal=[]):
         if not label:
             label = syst if syst else baseName
@@ -375,7 +375,11 @@ class Datagroups(object):
                     logger.warning(f"Selection requested for process {procName} but applySelection=False, thus it will be ignored")
                 elif label in group.hists.keys():
                     logger.debug(f"Apply selection for process {procName}")
-                    group.hists[label] = group.selectOp(group.hists[label], **group.selectOpArgs)
+                    if procName == nameFake and "fakerate_integration_axes" not in group.selectOpArgs:
+                        opArgs = {**group.selectOpArgs, "fakerate_integration_axes": fakerateIntegrationAxes}
+                    else:
+                        opArgs = group.selectOpArgs
+                    group.hists[label] = group.selectOp(group.hists[label], **opArgs)
 
         # Avoid situation where the nominal is read for all processes for this syst
         if not foundExact:
@@ -419,7 +423,7 @@ class Datagroups(object):
 
     def loadHistsForDatagroups(
         self, baseName, syst, procsToRead=None, excluded_procs=None, channel="", label="",
-        nominalIfMissing=True, applySelection=True, forceNonzero=True, pseudodata=False,
+        nominalIfMissing=True, applySelection=True, fakerateIntegrationAxes=[], forceNonzero=True, pseudodata=False,
         preOpMap={}, preOpArgs={}, scaleToNewLumi=1, forceToNominal=[]
     ):
         logger.debug("Calling loadHistsForDatagroups()")
@@ -428,9 +432,9 @@ class Datagroups(object):
         if self.rtfile and self.combine:
             self.setHistsCombine(baseName, syst, channel, procsToRead, excluded_procs, label)
         else:
-            self.setHists(baseName, syst, procsToRead, label, nominalIfMissing, applySelection,
+            self.setHists(baseName, syst, procsToRead, label, nominalIfMissing, applySelection, fakerateIntegrationAxes,
                           forceNonzero, preOpMap, preOpArgs,
-                          scaleToNewLumi=scaleToNewLumi, 
+                          scaleToNewLumi=scaleToNewLumi,  
                           excludeProcs=excluded_procs, forceToNominal=forceToNominal)
 
     def getDatagroups(self):

--- a/wremnants/datasets/datagroupsLowPU.py
+++ b/wremnants/datasets/datagroupsLowPU.py
@@ -10,7 +10,7 @@ def make_datagroups_lowPU(dg, combine=False, excludeGroups=None, filterGroups=No
 
     if dg.wmass and applySelection:
         sigOp = sel.signalHistWmass
-        fakeOp = lambda x: sel.fakeHistABCD(x, low_PU=True)
+        fakeOp = lambda x: sel.fakeHistABCD(x)
     else:
         sigOp = None
         fakeOp = None

--- a/wremnants/datasets/datagroupsLowPU.py
+++ b/wremnants/datasets/datagroupsLowPU.py
@@ -10,7 +10,7 @@ def make_datagroups_lowPU(dg, combine=False, excludeGroups=None, filterGroups=No
 
     if dg.wmass and applySelection:
         sigOp = sel.signalHistWmass
-        fakeOp = lambda x: sel.fakeHistABCD(x)
+        fakeOp = sel.fakeHistABCD
     else:
         sigOp = None
         fakeOp = None

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -17,7 +17,7 @@ hist_map = {
     "ptll_mll" : "nominal",
 }
 
-def fakeHistABCD(h, thresholdMT=40.0, fakerate_integration_axes=["ptll"], axis_name_mt="mt", integrateMT=False):
+def fakeHistABCD(h, thresholdMT=40.0, fakerate_integration_axes=[], axis_name_mt="mt", integrateMT=False):
     # integrateMT=False keeps the mT axis in the returned histogram (can be used to have fakes vs mT)
 
     if axis_name_mt in h.axes.name:

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -2,7 +2,7 @@ import hist
 import numpy as np
 from utilities.input_tools import safeOpenRootFile, safeGetRootObject
 from utilities import boostHistHelpers as hh
-from utilities.common import passMT, failMT, passIso, failIso
+from utilities import common
 import narf
 import ROOT
 
@@ -15,39 +15,35 @@ hist_map = {
     "ptll_mll" : "nominal",
 }
 
-def fakeHistABCD(h, low_PU=False,
-                 boolMT=True, thresholdMT=40.0, axisNameMT="mt", integrateMT=True):
+def fakeHistABCD(h, thresholdMT=40.0, fakerate_integration_axes=["ptll"], axis_name_mt="mt", integrateMT=False):
     # boolMT=False generalizes the method when mT is a real axis (i.e. no need for passMT)
     # integrateMT=False keeps the mT axis in the returned histogram (can be used to have fakes vs mT)
-    if low_PU and "mt" in [ax.name for ax in h.axes]:
-        return h[{**failIso, **passMT}]*h[{**passIso, **failMT}].sum().value / h[{**failIso, **failMT}].sum().value
 
-    elif boolMT:
-        return hh.multiplyHists(
-            hh.divideHists(h[{**passIso, **failMT}],
-                           h[{**failIso, **failMT}],
-                           cutoff=1,
-                           createNew=True,
-                           ),
-            #where=h[{"passIso" : False, "passMT" : True}].values(flow=True)>1),
-            h[{"passIso" : False, "passMT" : True}],
-        )
-    else:
+    if axis_name_mt in h.axes.name:
         s = hist.tag.Slicer()
-        hFRF = hh.divideHists(h[{**passIso,  axisNameMT : s[0:complex(0,thresholdMT):hist.sum]}], 
-                              h[{**failIso, axisNameMT : s[0:complex(0,thresholdMT):hist.sum]}],
-                              cutoff=1,
-                              createNew=True,
-                              )
+        low = hist.underflow if h.axes["mt"].traits.underflow else 0
+        failMT = {axis_name_mt : s[low:complex(0,thresholdMT):hist.sum]}
         if integrateMT:
-            return hh.multiplyHists(hFRF,
-                                    h[{**failIso, axisNameMT : s[complex(0,thresholdMT):hist.overflow:hist.sum]}]
-                                    )
+            passMT = {axis_name_mt : s[complex(0,thresholdMT):hist.overflow:hist.sum]}
         else:
-            return hh.multiplyHists(hFRF,
-                                    h[{**failIso, axisNameMT : s[complex(0,thresholdMT):hist.overflow]}],
-                                    )
-        
+            passMT = {axis_name_mt : s[complex(0,thresholdMT):hist.overflow]}
+        fakerate_integration_axes.append(axis_name_mt)        
+    else:
+        failMT = common.failMT
+        passMT = common.passMT
+        fakerate_integration_axes.append(common.passMTName)
+
+    if any(a in h.axes.name for a in fakerate_integration_axes):
+        fakerate_axes = [n for n in h.axes.name if n not in [*fakerate_integration_axes, common.passIsoName]]
+        hPassIsoFailMT = h[{**common.passIso, **failMT}].project(*fakerate_axes)
+        hFailIsoFailMT = h[{**common.failIso, **failMT}].project(*fakerate_axes)
+    else:
+        hPassIsoFailMT = h[{**common.passIso, **failMT}]
+        hFailIsoFailMT = h[{**common.failIso, **failMT}]
+
+    fakerate = hh.divideHists(hPassIsoFailMT, hFailIsoFailMT, cutoff=1, createNew=True)
+    return hh.multiplyHists(fakerate, h[{**common.failIso, **passMT}])
+    
 def fakeHistIsoRegion(h, scale=1.):
     #return h[{"iso" : 0.3j, "mt" : hist.rebin(10)}]*scale
     return h[{"iso" : 4}]*scale
@@ -60,9 +56,16 @@ def fakeHistIsoRegionIntGen(h, scale=1.):
     print("Slicing")
     return h[{"iso" : 0, "qTgen" : s[::hist.sum]}]
 
-def signalHistWmass(h, charge=None, passIso=passIso, passMT=passMT, genBin=None):
+def signalHistWmass(h, thresholdMT=40.0, charge=None, passIso=common.passIso, passMT=common.passMT, axis_name_mt="mt", integrateMT=False, genBin=None):
     if genBin != None:
         h = h[{"recoil_gen" : genBin}]
+
+    if axis_name_mt in h.axes.name:
+        s = hist.tag.Slicer()
+        if integrateMT:
+            passMT = {axis_name_mt : s[complex(0,thresholdMT):hist.overflow:hist.sum]}
+        else:
+            passMT = {axis_name_mt : s[complex(0,thresholdMT):hist.overflow]}
 
     sel = {**passIso, **passMT}
     if charge in [-1, 1]:
@@ -77,16 +80,16 @@ def signalHistWmass(h, charge=None, passIso=passIso, passMT=passMT, genBin=None)
 
 # the following are utility wrapper functions for signalHistWmass with proper region selection
 def histWmass_failMT_passIso(h, charge=None):
-    return signalHistWmass(h, charge, passIso, failMT)
+    return signalHistWmass(h, charge, common.passIso, common.failMT)
 
 def histWmass_failMT_failIso(h, charge=None):
-    return signalHistWmass(h, charge, failIso, failMT)
+    return signalHistWmass(h, charge, common.failIso, common.failMT)
 
 def histWmass_passMT_failIso(h, charge=None):
-    return signalHistWmass(h, charge, failIso, passMT)
+    return signalHistWmass(h, charge, common.failIso, common.passMT)
 
 def histWmass_passMT_passIso(h, charge=None):
-    return signalHistWmass(h, charge, passIso, passMT)
+    return signalHistWmass(h, charge, common.passIso, common.passMT)
 
 # TODO: Not all hists are made with these axes
 def signalHistLowPileupW(h):


### PR DESCRIPTION
Axes to be integrated in the fakerate computation can be specified. Mainly to improve the fakerate estimation for mtW and ptll in lowPU. The histogram broadcasting needed to be adjusted to be able to deal with missing inner dimensions since the fakerate may not have missing inner dimensions when systematics are computed.