### PR TITLE
Updates on EW uncertainties from winhac

### DIFF
--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -315,7 +315,7 @@ def setup(args,xnorm=False):
             group="theory_ew",
             systAxes=["systIdx"],
             labelsByAxis=[f"{ewUnc}nloewCorr"],
-            skipEntries=[(0, -1), (2, -1)],
+            skipEntries=[(0, -1), (1, -1)],
             passToFakes=passSystToFakes,
         )
 

--- a/scripts/corrections/make_theory_corr_ew.py
+++ b/scripts/corrections/make_theory_corr_ew.py
@@ -16,12 +16,10 @@ import h5py
 import narf
 import pdb
 
-generator_choices = ["horace-nlo", "horace-lo-photos", "horace-qed", "horace-lo", "winhac-nlo", "winhac-lo-photos", "winhac-lo", "MiNNLO"]
-
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--input", nargs="+", type=str, default=["w_z_gen_dists_scetlib_dyturboCorr_ewinput.hdf5"], help="File containing EW hists")
-parser.add_argument("--nums", nargs="+", type=str, default=["horace-nlo"], choices=generator_choices, help="Numerators")
-parser.add_argument("--den", type=str, default="horace-lo-photos", choices=generator_choices, help="Denominatos")
+parser.add_argument("--nums", nargs="+", type=str, default=["horace-nlo"], help="Numerators")
+parser.add_argument("--den", type=str, default="horace-lo-photos", help="Denominatos")
 parser.add_argument("--normalize", action="store_true", default=False, help="Normalize distributions before computing ratio")
 parser.add_argument("--noSmoothing", action="store_true", default=False, help="Disable smoothing of corrections")
 parser.add_argument("--debug", action='store_true', help="Print debug output")
@@ -54,27 +52,10 @@ text_dict = {
 project = args.project
 
 # file created with `python WRemnants/scripts/histmakers/w_z_gen_dists.py --skipAngularCoeffs --filter horace -p ewinput`
-res = {}
-meta = {}
-for inpt in args.input:
-    logger.info(f"Load {inpt}")
-    f = h5py.File(inpt, 'r')
-    res.update(narf.ioutils.pickle_load_h5py(f["results"]))
 
-    try:
-        meta.update(input_tools.get_metadata(inpt))
-    except ValueError as e:
-        logger.warning(f"No meta data found for file {inpt}")
-        pass
-
+res, meta, _ = input_tools.read_infile(args.input)
 
 corrh = {}
-
-try:
-    meta = input_tools.get_metadata(args.input)
-except ValueError as e:
-    logger.warning(f"No meta data found for file {args.input}")
-    pass
 
 labels = {
     "ewMll": "$m_{\ell\ell}$", 
@@ -147,10 +128,10 @@ def make_plot_2d(h, name, proc, plot_error=False, cmin=None, cmax=None, flow=Tru
     if log:
         plot_name += "_log"
     plot_tools.save_pdf_and_png(args.plotdir, plot_name)
-    plot_tools.write_index_and_log(args.plotdir, plot_name, args=args, analysis_meta_info=meta)
+    plot_tools.write_index_and_log(args.plotdir, plot_name, args=args, analysis_meta_info=meta[0])
 
-def make_plot_1d(hists, name, proc, axis, ratio=False, normalize=False, ymin=None, ymax=None, flow=True, density=False):
-    logger.info(f"Make 1D plot for {name} with axes {axis}")
+def make_plot_1d(hists, name, proc, axis, ratio=False, normalize=False, xmin=None, xmax=None, ymin=None, ymax=None, flow=True, density=False):
+    logger.info(f"Make 1D plot for {name} with axis {axis}")
 
     if not isinstance(hists, list):
         hists = [hists]
@@ -214,12 +195,15 @@ def make_plot_1d(hists, name, proc, axis, ratio=False, normalize=False, ymin=Non
 
         # outname += f"_{name[i]}"
 
+    if xmin is not None:
+        ax.set_xlim(xmin, xmax)
+
     ax.text(1.0, 1.003, text_dict[proc], transform=ax.transAxes, fontsize=30,
             verticalalignment='bottom', horizontalalignment="right")
-    plot_tools.addLegend(ax, text_size=16)
+    plot_tools.addLegend(ax, ncols=2, text_size=12)
 
     output_tools.make_plot_dir(*args.plotdir.rsplit("/", 1))
-    plot_name = f"hist{outname}_{axis}_{proc}"
+    plot_name = f"hist{outname}_{axis}_{proc}_{name[-1]}"
     if ratio:
         plot_name += "_div"
     if args.noSmoothing and "_div_" in name[0]:
@@ -227,7 +211,7 @@ def make_plot_1d(hists, name, proc, axis, ratio=False, normalize=False, ymin=Non
     if args.normalize:
         plot_name += "_normalize"
     plot_tools.save_pdf_and_png(args.plotdir, plot_name)
-    plot_tools.write_index_and_log(args.plotdir, plot_name, args=args, analysis_meta_info=meta)
+    plot_tools.write_index_and_log(args.plotdir, plot_name, args=args, analysis_meta_info=meta[0])
 
 for proc in procs:
 
@@ -336,15 +320,20 @@ for proc in procs:
         logger.info("Make 1D control plots")
 
         for ax in project:
-            if ax in ["ewMll", "ewMlly"]:
+            # xmin, xmax = 60, 120
+            xmin, xmax = None, None
+
+            if ax in ["ewMll", "Mll"]:
+                ymin, ymax = 0.95, 1.05
+            elif ax in ["ewMlly", "Mlly"]:
                 ymin, ymax = 0.8, 1.2
             else:
                 ymin, ymax = 0, 2
 
             hratios1D = [hh.divideHists(hnum.project(ax), hden.project(ax)) for hnum in hnums]
 
-            make_plot_1d(hratios1D, [f"{n}_div_{args.den}" for n in nums], proc, ax, ymin=ymin, ymax=ymax, ratio=True)
-            make_plot_1d([*hnums, hden], [*nums, args.den], proc, ax, ymin=0, density=False)
+            make_plot_1d([*hnums, hden], [*nums, args.den], proc, ax, xmin=xmin, xmax=xmax, ymin=0, density=False)
+            make_plot_1d(hratios1D, [f"{n}_div_{args.den}" for n in nums], proc, ax, xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, ratio=True)
 
 for num, corrh in corrhs.items():
     outname = num.replace('-', '') + 'ew'

--- a/utilities/input_tools.py
+++ b/utilities/input_tools.py
@@ -395,7 +395,6 @@ def args_from_metadata(card_tool, arg):
     return meta_data["args"][arg]
 
 def get_metadata(infile):
-    import narf
     results = None
     if infile.endswith(".pkl.lz4"):
         with lz4.frame.open(infile) as f:
@@ -405,7 +404,7 @@ def get_metadata(infile):
             results = pickle.load(f)
     elif infile.endswith(".hdf5"):
         h5file = h5py.File(infile, "r")
-        results = narf.ioutils.pickle_load_h5py(h5file["results"])
+        results = ioutils.pickle_load_h5py(h5file["results"])
 
     if not results:
         raise ValueError("Failed to find results dict. Note that only pkl, hdf5, and pkl.lz4 file types are supported")
@@ -432,7 +431,7 @@ def read_infile(input):
     elif input.endswith(".hdf5"):
         h5file = h5py.File(input, "r")
         infiles = [h5file]
-        result = load_results(h5file["results"])
+        result = ioutils.pickle_load_h5py(h5file["results"])
     else:
         raise ValueError("Unsupported file type")
 

--- a/utilities/input_tools.py
+++ b/utilities/input_tools.py
@@ -411,3 +411,31 @@ def get_metadata(infile):
         raise ValueError("Failed to find results dict. Note that only pkl, hdf5, and pkl.lz4 file types are supported")
 
     return results["meta_info"] if "meta_info" in results else results["meta_data"]
+
+def read_infile(input):
+    # read histogramer input file(s)
+    result = {}
+    meta = []
+    infiles = []
+    if isinstance(input, list):
+        for inpt in input:
+            r, m, h = read_infile(inpt)
+            result.update(r)
+            meta += m
+            infiles += h
+        return result, meta, infiles
+    
+    logger.info(f"Load {input}")
+    if input.endswith(".pkl.lz4"):
+        with lz4.frame.open(input) as f:
+            result = pickle.load(f)
+    elif input.endswith(".hdf5"):
+        h5file = h5py.File(input, "r")
+        infiles = [h5file]
+        result = load_results(h5file["results"])
+    else:
+        raise ValueError("Unsupported file type")
+
+    meta = result["meta_info"] if "meta_info" in result else result["meta_data"]
+
+    return result, [meta], [infiles]

--- a/wremnants/datasets/datasetDict_gen.py
+++ b/wremnants/datasets/datasetDict_gen.py
@@ -1,5 +1,11 @@
 from wremnants.datasets.datasetDict_v9 import xsec_ZmmPostVFP,xsec_WpmunuPostVFP,xsec_WmmunuPostVFP
 
+# winhac cross sections from: https://gitlab.cern.ch/cms-wmass/private/issue-tracking/-/issues/34#note_7052239
+xsec_winhac_WminusToMuNu_LO = 7.57405974
+xsec_winhac_WminusToMuNu_NLOEW = 7.58516621
+xsec_winhac_WplusToMuNu_LO = 10.10450380
+xsec_winhac_WplusToMuNu_NLOEW = 10.11709477
+
 horace_v1 = False
 horace_v2 = False
 horace_v3 = False
@@ -56,19 +62,19 @@ genDataDict = {
     'WplusToMuNu_winhac-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8-photospp/*/*.root"],
-                   'xsec' : xsec_WpmunuPostVFP,
+                   'xsec' : xsec_winhac_WplusToMuNu_LO,
                     'group': "Wmunu",
     },
     'WplusToMuNu_winhac-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
-                   'xsec' : xsec_WpmunuPostVFP,
+                   'xsec' : xsec_winhac_WplusToMuNu_LO,
                     'group': "Wmunu",
     },
     'WplusToMuNu_winhac-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_NLOEW_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
-                   'xsec' : xsec_WpmunuPostVFP,
+                   'xsec' : xsec_winhac_WplusToMuNu_NLOEW,
                     'group': "Wmunu",
     },
     'WminusToMuNu_horace-lo-photos' : { 
@@ -92,19 +98,19 @@ genDataDict = {
     'WminusToMuNu_winhac-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8-photospp/*/*.root"],
-                   'xsec' : xsec_WmmunuPostVFP,
+                   'xsec' : xsec_winhac_WminusToMuNu_LO,
                     'group': "Wmunu",
     },
     'WminusToMuNu_winhac-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
-                   'xsec' : xsec_WmmunuPostVFP,
+                   'xsec' : xsec_winhac_WminusToMuNu_LO,
                     'group': "Wmunu",
     },
     'WminusToMuNu_winhac-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_NLOEW_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
-                   'xsec' : xsec_WmmunuPostVFP,
+                   'xsec' : xsec_winhac_WminusToMuNu_NLOEW,
                     'group': "Wmunu",
     },
 }

--- a/wremnants/datasets/datasetDict_gen.py
+++ b/wremnants/datasets/datasetDict_gen.py
@@ -1,5 +1,7 @@
 from wremnants.datasets.datasetDict_v9 import xsec_ZmmPostVFP,xsec_WpmunuPostVFP,xsec_WmmunuPostVFP
 
+horace_v1 = False
+horace_v2 = False
 horace_v3 = False
 
 genDataDict = {
@@ -7,134 +9,228 @@ genDataDict = {
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsToMuMu_TuneCP5_13TeV-powheg-NNLOPS-pythia8-photos/RunIISummer15wmLHEGS/221121_114507/000*/*.root"],
                    'xsec' : 1863.,
+                   'group': "Zmumu",
     },
     'ZmumuNNLOPS' : { 
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsToMuMu_TuneCP5_13TeV-powheg-NNLOPS-pythia8-photos/RunIISummer15wmLHEGS/221121_114507/000*/*.root"],
                    'xsec' : 1863.,
+                   'group': "Zmumu",
     },
     'ZToMuMu_horace-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsToMuMu_LO_TuneCP5_13TeV-horace-pythia8-photospp/*/*.root"],
                    'xsec' : xsec_ZmmPostVFP,
+                   'group': "Zmumu",
     },
     'ZToMuMu_horace-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsJetsToMuMu_LO_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_ZmmPostVFP,
+                   'group': "Zmumu",
     },
     'ZToMuMu_horace-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsToMuMu_NLOEW_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_ZmmPostVFP,
+                   'group': "Zmumu",
     },
     'WplusToMuNu_horace-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-horace-pythia8-photospp/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WplusToMuNu_horace-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WplusToMuNu_horace-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_NLOEW_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WplusToMuNu_winhac-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8-photospp/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WplusToMuNu_winhac-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WplusToMuNu_winhac-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WplusJetsToMuNu_NLOEW_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
                    'xsec' : xsec_WpmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_horace-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-horace-pythia8-photospp/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_horace-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_horace-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_NLOEW_TuneCP5_13TeV-horace-pythia8/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_winhac-lo-photos' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8-photospp/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_winhac-lo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
     'WminusToMuNu_winhac-nlo' : { 
                    'filepaths' :
                     ["{BASE_PATH}/WminusJetsToMuNu_NLOEW_TuneCP5_13TeV-winhac-pythia8/*/*.root"],
                    'xsec' : xsec_WmmunuPostVFP,
+                    'group': "Wmunu",
     },
 }
 
+if horace_v1:
+    genDataDict.update({
+        'ZToMuMu_horace-v1-alpha-old-fsr-off-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-alpha-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-born-fsr-photos-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photos-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-born-fsr-photoslow-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photoslow-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-born-fsr-photosnopair-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photosnopair-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-born-fsr-pythia-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-pythia-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-exp-fsr-off-isr-off' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-exp-fsr-off-isr-off/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v1-exp-old-fsr-off-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v1/ZToMuMu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+    })
+
+if horace_v2:
+    genDataDict.update({
+        'ZToMuMu_horace-v2-born-fsr-photos_nopair-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v2/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v2-exp-new-fsr-off-isr-off' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v2/ZToMuMu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+        'ZToMuMu_horace-v2-exp-old-fsr-off-isr-pythia' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v2/ZToMuMu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
+        },
+    })
+
 if horace_v3:
     genDataDict.update({
-        'ZToMuMu_horace-lo-photos' : { 
+        'ZToMuMu_horace-v3-lo-photos' : { 
                 'filepaths' :
-                ["{BASE_PATH}/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
                 'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
         },
-        'ZToMuMu_horace-qed' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
-                    'xsec' : xsec_ZmmPostVFP,
+        'ZToMuMu_horace-v3-qed' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
         },
-        'ZToMuMu_horace-nlo' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
-                    'xsec' : xsec_ZmmPostVFP,
+        'ZToMuMu_horace-v3-nlo' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/ZToMuMu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
+                'xsec' : xsec_ZmmPostVFP,
+                'group': "Zmumu",
         },
-        'WplusToMuNu_horace-lo-photos' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
-                    'xsec' : xsec_WpmunuPostVFP,
+        'WplusToMuNu_horace-v3-lo-photos' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
+                'xsec' : xsec_WpmunuPostVFP,
+                'group': "Wmunu",
         },
-        'WplusToMuNu_horace-qed' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
-                    'xsec' : xsec_WpmunuPostVFP,
+        'WplusToMuNu_horace-v3-qed' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_WpmunuPostVFP,
+                'group': "Wmunu",
         },
-        'WplusToMuNu_horace-nlo' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
-                    'xsec' : xsec_WpmunuPostVFP,
+        'WplusToMuNu_horace-v3-nlo' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WplusToMuNu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
+                'xsec' : xsec_WpmunuPostVFP,
+                'group': "Wmunu",
         },
-        'WminusToMuNu_horace-lo-photos' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
-                    'xsec' : xsec_WmmunuPostVFP,
+        'WminusToMuNu_horace-v3-lo-photos' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-born-fsr-photos_nopair-isr-pythia/job*.root"],
+                'xsec' : xsec_WmmunuPostVFP,
+                'group': "Wmunu",
         },
-        'WminusToMuNu_horace-qed' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
-                    'xsec' : xsec_WmmunuPostVFP,
+        'WminusToMuNu_horace-v3-qed' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-exp-old-fsr-off-isr-pythia/job*.root"],
+                'xsec' : xsec_WmmunuPostVFP,
+                'group': "Wmunu",
         },
-        'WminusToMuNu_horace-nlo' : { 
-                    'filepaths' :
-                        ["{BASE_PATH}/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
-                    'xsec' : xsec_WmmunuPostVFP,
+        'WminusToMuNu_horace-v3-nlo' : { 
+                'filepaths' :
+                ["/eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoGen/Horace_v3/WminusToMuNu_TuneCP5_13TeV-horace-exp-new-fsr-off-isr-off/job*.root"],
+                'xsec' : xsec_WmmunuPostVFP,
+                'group': "Wmunu",
         }
     })


### PR DESCRIPTION
Now 200% of the variation from NLO/LO EW winhac are taken as an uncertainty. 
A couple of updates on the scripts to make those corrections and corresponding plots are added. Also the reference to the older horace samples (on eos) are added, while they are disabled by default. 
I would also update the wremnants-data once the new winhac file is merged, which contains the normalization effect of the variation.  