### PR TITLE
Scale resumTNP nuisances in CardTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,12 @@ Make plot with mW impacts from a single fit result
 ```
 python scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py fitresults_123456789.root -o outputFolder/  --scaleToMeV --showTotal -x ".*eff_(stat|syst)_" [--postfix plotNamePostfix]
 ```
+
 Make plot with mW impacts comparing two fit results
 ```
 python scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py fitresults_123456789.root -o outputFolder/  --scaleToMeV --showTotal --compareFile fitresults_123456789_toCompare.root --printAltVal --legendEntries "Nominal" "Alternate" -x ".*eff_(stat|syst)_" [--postfix plotNamePostfix]
+```
+
 Print impacts without plotting (no need to specify output folder)
 ```
 python w_mass_13TeV/makeImpactsOnMW.py fitresults_123456789.root --scaleToMeV --showTotal --justPrint

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -66,7 +66,7 @@ def checkHistInFile(h, hname, fname, message=""):
 
 def safeGetObject(fileObject, objectName, quitOnFail=True, silent=False, detach=True):
     obj = fileObject.Get(objectName)
-    if obj == None:
+    if obj is None:
         if not silent:
             logger.error(f"Could not get {objectName} from file {fileObject.GetName()}")
         if quitOnFail:

--- a/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
+++ b/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
@@ -60,6 +60,11 @@ def sortParameters(params):
         params = sorted(params, key = lambda x: sortEffSyst(x))
     elif any(re.match('.*prefire.*',x) for x in params):
         params = sorted(params, key = lambda x: utilities.getNFromString(x,chooseIndex=0))
+    elif any(re.match('.*CMS_scale_m.*',x) for x in params):
+        params = sorted(params, key = lambda x: utilities.getNFromString(x,chooseIndex=0))
+    elif any(re.match('.*Z_nonClosure.*',x) for x in params):
+        params = sorted(params, key = lambda x: utilities.getNFromString(x,chooseIndex=0))
+        params = sorted(params, key = lambda x: 0 if "_A_" in x else 1)
 
     return params
 

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -63,7 +63,7 @@ def readNuisances(args, infile=None):
     hessfile = ROOT.TFile(infile,'read')
     impMat = hessfile.Get(th2name)
     if impMat == None:
-        error_msg = f"Cannot find the impact TH2 named {th2name} in input file. Maybe you didn't run --doImpacts?")
+        error_msg = f"Cannot find the impact TH2 named {th2name} in input file. Maybe you didn't run --doImpacts?"
         raise IOError(error_msg)
         
     matchKeep = re.compile(args.keepNuisgroups)

--- a/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
+++ b/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
@@ -133,7 +133,10 @@ def plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName, yAxisName,
     hMCstat = copy.deepcopy(den2D.Clone("hMCstat"))
     hMCstat.SetTitle("Sum of predicted processes")
     ROOT.wrem.makeHistStatUncertaintyRatio(hMCstat, den2D)
-    drawCorrelationPlot(hMCstat, xAxisName, yAxisName, "#sqrt{#sum w^{2}} / #sqrt{N}",
+    minyMCSum,maxyMCSum = getMinMaxHisto(hMCstat, sumError=False)
+    maxyMCSum = min(1.5,maxyMCSum)
+    minyMCSum = max(0.0, minyMCSum)
+    drawCorrelationPlot(hMCstat, xAxisName, yAxisName, "#sqrt{#sum w^{2}} / #sqrt{N}" + f"::{minyMCSum},{maxyMCSum}",
                         f"MCstatOverPoissonUncRatio_allProcs_{chargeLabel}", plotLabel="ForceTitle", outdir=outdir_dataMC,
                         palette=57, passCanvas=canvas, drawOption="COLZ0", skipLumi=True, zTitleOffSet=1.3)
     for h in hmc2D:
@@ -151,7 +154,7 @@ def plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName, yAxisName,
             minyFake,maxyFake = getMinMaxHisto(hMCstat_Fake, sumError=False)
             maxyFake = min(7.0,maxyFake)
             minyFake = max(0.0, minyFake)
-            drawCorrelationPlot(hMCstat_Fake, xAxisName, yAxisName, "#sqrt{#sum w^{2}} / #sqrt{N}"+f"::{minyFake},{maxyFake}",
+            drawCorrelationPlot(hMCstat_Fake, xAxisName, yAxisName, "#sqrt{#sum w^{2}} / #sqrt{N}" + f"::{minyFake},{maxyFake}",
                                 f"MCstatOverPoissonUncRatio_Fake_{chargeLabel}", plotLabel="ForceTitle", outdir=outdir_dataMC,
                                 palette=57, passCanvas=canvas, drawOption="COLZ0", skipLumi=True, zTitleOffSet=1.3)
     
@@ -256,19 +259,20 @@ if __name__ == "__main__":
     if not args.pseudodata:
         processes = ["Data"] + processes
     charges = ["plus", "minus"] if args.charges == "both" else [args.charges]
-
+    
     xAxisName = "Muon #eta"
     yAxisName = "Muon p_{T} (GeV)"
 
     colors = colors_plots_
     legEntries = legEntries_plots_
-    for charge in charges:
     
+    for charge in charges:
+
         # read histograms
         nomihists = {}
         infile = safeOpenFile(fname)
         for proc in processes:
-            nomihists[proc] = safeGetObject(infile, f"{proc}/x_{proc}_{charge}", detach=True) # process name as subfolder
+            nomihists[proc] = safeGetObject(infile, f"{proc}/nominal_{proc}_{charge}", detach=True) # process name as subfolder
         if args.pseudodata:
             nomihists["Data"] = safeGetObject(infile, f"{args.pseudodata}_{charge}", detach=True)
         infile.Close()
@@ -278,7 +282,7 @@ if __name__ == "__main__":
 
         outdir_dataMC = f"{outdir}dataMC_{charge}/"
         createPlotDirAndCopyPhp(outdir_dataMC)
-        
+
         plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName=xAxisName, yAxisName=yAxisName,
                              lumi=args.lumi, ptRangeProjection=args.ptRangeProjection, chargeLabel=charge,
                              canvas=canvas, canvasWide=cwide, canvas1D=canvas1D,

--- a/scripts/analysisTools/w_mass_13TeV/subMatrix.py
+++ b/scripts/analysisTools/w_mass_13TeV/subMatrix.py
@@ -91,7 +91,7 @@ def niceName(name):
             ncoeff = int(coeffnum[0].split("AngCoeff")[1]) - 1
             coeffText = f"A_{{{ncoeff}}}"
         scale = "#mu_{R}#mu_{F}" if "muRmuF" in name else "#mu_{R}" if "muR" in name else "#mu_{F}"
-        return f"{boson}{chargetext} {coeffText} {ptText} {scale}"
+        return f"{boson}{chargeText} {coeffText} {ptText} {scale}"
     elif "CMS_" in name:
         return name
     else:  

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -326,6 +326,7 @@ def setup(args,xnorm=False):
         propagate_to_fakes=to_fakes,
         np_model=args.npUnc,
         tnp_magnitude=args.tnpMagnitude,
+        tnp_scale = args.scaleTNP,
         mirror_tnp=True,
         pdf_from_corr=args.pdfUncFromCorr,
         scale_pdf_unc=args.scalePdf,

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -39,7 +39,7 @@ def make_parser(parser=None):
     parser.add_argument("--resumUnc", default="tnp", type=str, choices=["scale", "tnp", "none"], help="Include SCETlib uncertainties")
     parser.add_argument("--npUnc", default="Delta_Lambda", type=str, choices=combine_theory_helper.TheoryHelper.valid_np_models, help="Nonperturbative uncertainty model")
     parser.add_argument("--tnpMagnitude", default=1, type=float, help="Variation size for the TNP")
-    parser.add_argument("--scaleTNP", default=1, type=float, help="Scale the TNP uncertainties by this factor")
+    parser.add_argument("--scaleTNP", default=5, type=float, help="Scale the TNP uncertainties by this factor")
     parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--ewUnc", type=str, nargs="*", default=["winhacnloew"], choices=["horacenloew", "winhacnloew"], help="Include EW uncertainty")

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -36,6 +36,7 @@ class TheoryHelper(object):
     def configure(self, resumUnc, np_model,
             propagate_to_fakes=True, 
             tnp_magnitude=1,
+            tnp_scale=1.,
             mirror_tnp=True,
             pdf_from_corr=False,
             pdf_action=None,
@@ -47,6 +48,7 @@ class TheoryHelper(object):
         self.set_propagate_to_fakes(propagate_to_fakes)
 
         self.tnp_magnitude = tnp_magnitude
+        self.tnp_scale = tnp_scale
         self.mirror_tnp = mirror_tnp
         self.pdf_from_corr = pdf_from_corr
         self.pdf_action = pdf_action
@@ -55,7 +57,7 @@ class TheoryHelper(object):
 
     def add_all_theory_unc(self):
         self.add_nonpert_unc(model=self.np_model)
-        self.add_resum_unc(magnitude=self.tnp_magnitude, mirror=self.mirror_tnp)
+        self.add_resum_unc(magnitude=self.tnp_magnitude, mirror=self.mirror_tnp, scale=self.tnp_scale)
         self.add_pdf_uncertainty(from_corr=self.pdf_from_corr, action=self.pdf_action, scale=self.scale_pdf_unc)
 
     def set_resum_unc_type(self, resumUnc):


### PR DESCRIPTION
There was already option --scaleTNP to achieve that, but it was not propagated to the datacards. This PR implemented that.

The only relevant files that are modified are:
- **scripts/combine/setupCombineWMass.py**
- **wremnants/combine_theory_helper.py**

The rest is just a set of plotting scripts that don't affect the main analysis.
I checked that the scaling factor is correctly propagated to the datacards for the mW fit (default is 1, namely no scaling).
