### PR TITLE
DeepMET recoil calibration with uncertainties

### DIFF
--- a/scripts/combine/fitManager.py
+++ b/scripts/combine/fitManager.py
@@ -132,7 +132,7 @@ def prepareChargeFit(options, charges=["plus"]):
             
         bbboptions = " --binByBinStat "
         if not options.noCorrelateXsecStat: bbboptions += "--correlateXsecStat "
-        combineCmd = 'combinetf.py -t -1 {bbb} {metafile} --doImpacts --saveHists --computeHistErrors --doh5Output '.format(metafile=metafilename, bbb="" if options.noBBB else bbboptions)
+        combineCmd = 'combinetf.py -t -1 {bbb} {metafile} --doImpacts --saveHists --computeHistErrors '.format(metafile=metafilename, bbb="" if options.noBBB else bbboptions)
         if options.combinetfOption:
             combineCmd += " %s" % options.combinetfOption
         if args.theoryAgnostic:

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -247,7 +247,7 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=1)
-    df = muon_selections.select_good_muons(df, nMuons=1, use_trackerMuons=args.trackerMuons, use_isolation=False)
+    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, nMuons=1, use_trackerMuons=args.trackerMuons, use_isolation=False)
 
     # the corrected RECO muon kinematics, which is intended to be used as the nominal
     df = muon_calibration.define_corrected_reco_muon_kinematics(df)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -341,7 +341,7 @@ def build_graph(df, dataset):
     
     if not args.noRecoil:
         lep_cols = ["goodMuons_pt0", "goodMuons_phi0", "goodMuons_charge0", "Muon_pt[goodMuons][0]"]
-        df = recoilHelper.recoil_W(df, results, dataset, common.vprocs, lep_cols) # produces corrected MET as MET_corr_rec_pt/phi  vprocs_lowpu wprocs_recoil_lowpu
+        df = recoilHelper.recoil_W(df, results, dataset, common.vprocs, lep_cols, cols_fakerate=nominal_cols, axes_fakerate=nominal_axes, mtw_min=mtw_min) # produces corrected MET as MET_corr_rec_pt/phi
     else:
         df = df.Alias("MET_corr_rec_pt", "MET_pt")
         df = df.Alias("MET_corr_rec_phi", "MET_phi")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -400,7 +400,7 @@ def build_graph(df, dataset):
             results.append(yieldsForWeffMC)
         # df = df.Filter(f"wrem::printVar(nominal_weight)")
             
-        if not args.noRecoil:
+        if not args.noRecoil and args.recoilUnc:
             df = recoilHelper.add_recoil_unc_W(df, results, dataset, cols, axes, "nominal")
         if apply_theory_corr:
             results.extend(theory_tools.make_theory_corr_hists(df, "nominal", axes, cols, 

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -182,12 +182,12 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True)
+    df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True)
 
     # for dilepton analysis we will call trigMuons (nonTrigMuons) those with charge plus (minus). In fact both might be triggering, naming scheme might be improved
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
-    df = muon_selections.select_z_candidate(df, args.pt[1], args.pt[2], mass_min, mass_max)
+    df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -146,11 +146,11 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True)
+    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True)
 
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
-    df = muon_selections.select_z_candidate(df, template_minpt, template_maxpt, mass_min, mass_max)
+    df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
     df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -212,7 +212,7 @@ def build_graph(df, dataset):
     nominal = df.HistoBoost("nominal", axes, [*cols, "nominal_weight"])
     results.append(nominal)
 
-    if not args.noRecoil:
+    if not args.noRecoil and args.recoilUnc:
         df = recoilHelper.add_recoil_unc_Z(df, results, dataset, cols, axes, "nominal")
 
     if not dataset.is_data and not args.onlyMainHistograms:

--- a/scripts/lowPU/MET_xy_correction.py
+++ b/scripts/lowPU/MET_xy_correction.py
@@ -15,7 +15,7 @@ import pickle
 import narf
 import numpy as np
 
-import wremnants.datasets.datagroups as datagroups
+from wremnants.datasets import datagroups
 
 
 def makePlot(hist_data, hist_mc, fOut, xLabel, npv, outDir_):

--- a/scripts/lowPU/MET_xy_correction.py
+++ b/scripts/lowPU/MET_xy_correction.py
@@ -15,15 +15,7 @@ import pickle
 import narf
 import numpy as np
 
-from wremnants.datasets.datagroupsLowPU import datagroupsLowPU
-from wremnants.datasets.datagroups import datagroups2016
-
-def readProc(datagroups, hName, procName):
-
-    label = "%s_%s" % (hName, procName)
-    datagroups.setHists(hName, "", label=label, procsToRead=[procName], selectSignal=False)
-    bhist = datagroups.groups[procName][label]
-    return bhist 
+import wremnants.datasets.datagroups as datagroups
 
 
 def makePlot(hist_data, hist_mc, fOut, xLabel, npv, outDir_):
@@ -168,8 +160,8 @@ def METxyCorrection(direction = "x", corrType="uncorr", polyOrderData=-1, polyOr
     functions.prepareDir(outDir_, False)
 
     
-    b_data = functions.readBoostHistProc(datagroups, "MET%s_%s_npv" % (direction, corrType), [data])
-    b_mc = functions.readBoostHistProc(datagroups, "MET%s_%s_npv" % (direction, corrType), procs)
+    b_data = functions.readBoostHistProc(groups, "MET%s_%s_npv" % (direction, corrType), [data])
+    b_mc = functions.readBoostHistProc(groups, "MET%s_%s_npv" % (direction, corrType), procs)
 
     h_data = narf.hist_to_root(b_data)
     h_mc = narf.hist_to_root(b_mc)
@@ -294,17 +286,17 @@ def METxyCorrection(direction = "x", corrType="uncorr", polyOrderData=-1, polyOr
 if __name__ == "__main__":
 
     met = "DeepMETReso" # PFMET, RawPFMET DeepMETReso
-    flavor = "mu" # mu, e, mumu, ee
+    flavor = "mumu" # mu, e, mumu, ee
     lowPU = False
 
     # DATA For electron channels!
-    
+
     ####################################################################
     if lowPU:
         npv_max, npv_fit_min, npv_fit_max = 10, 0, 10
         lumi_header = "199 pb^{#minus1} (13 TeV)"
         
-        datagroups = datagroupsLowPU("lowPU_%s_%s.pkl.lz4" % (flavor, met), flavor=flavor)
+        groups = datagroupsLowPU("lowPU_%s_%s.pkl.lz4" % (flavor, met), flavor=flavor)
         procs = ['EWK', 'Top', 'Zmumu'] 
         data = "SingleMuon" if "mu" in flavor else "SingleElectron"
 
@@ -335,7 +327,7 @@ if __name__ == "__main__":
             npv_max, npv_fit_min, npv_fit_max = 60, 5, 55
             polyOrderDataX, polyOrderMCX = 3, 3
             polyOrderDataY, polyOrderMCY = 3, 3
-            datagroups = datagroups2016(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+            groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
             procs = ["Zmumu", "Ztautau", "Other"]
             data = "Data"
         else:
@@ -350,8 +342,9 @@ if __name__ == "__main__":
                 datagroups.groups[g]['selectOp'] = None
             
 
-        outDir = "/eos/user/j/jaeyserm/www/wmass/highPU/METxy_correction/METxy_%s_%s/" % (flavor, met)
-        fOut = "wremnants/data/recoil/highPU/%s_%s/met_xy_correction.json" % (flavor, met)
+        #outDir = "/eos/user/j/jaeyserm/www/wmass/highPU/METxy_correction/METxy_%s_%s/" % (flavor, met)
+        outDir = f"/home/submit/jaeyserm/public_html/wmass/highPU/METxy_correction/METxy_{flavor}_{met}/"
+        fOut = "wremnants-data/data/recoil/highPU/%s_%s/met_xy_correction.json" % (flavor, met)
         functions.prepareDir(outDir, True)
         
         dictout = {}

--- a/scripts/lowPU/functions.py
+++ b/scripts/lowPU/functions.py
@@ -102,21 +102,17 @@ def drange(x, y, jump):
         x += jump
         
         
-def readBoostHistProc(datagroups, hName, procNames, charge=None):
+def readBoostHistProc(groups, hName, procs, charge=None):
 
-    label = "%s_tmp" % (hName)
-    datagroups.setHists(hName, "", label=label, procsToRead=procNames)
-    bhist = None
-    for procName in procNames:
-        h = datagroups.groups[procName][label]
-        if bhist == None: bhist = h
-        else: bhist = bhist + h
-      
+    groups.setNominalName(hName)
+    groups.loadHistsForDatagroups(hName, syst="")
+    bhist = sum([groups.groups[p].hists[hName] for p in procs])
+
     axes = [ax.name for ax in bhist.axes]
     if "charge" in axes:
         s = hist.tag.Slicer()
         if charge and charge == "combined": bhist = bhist[{"charge" : s[::hist.sum]}]
         elif charge and charge == "plus": bhist = bhist[{"charge" : bhist.axes["charge"].index(+1)}]
         elif charge and charge == "minus": bhist = bhist[{"charge" : bhist.axes["charge"].index(-1)}]
-        
+
     return bhist 

--- a/scripts/lowPU/makePlots.py
+++ b/scripts/lowPU/makePlots.py
@@ -1,0 +1,932 @@
+import sys,array,math,os,copy,fnmatch
+from collections import OrderedDict
+
+import ROOT
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetOptTitle(0)
+
+import hist
+from utilities import boostHistHelpers as hh
+import numpy as np
+
+
+import plotter
+import functions
+
+import lz4.frame
+import pickle
+import narf
+
+import wremnants.datasets.datagroups as datagroups
+#from wremnants.datasets.datagroups2016 import make_datagroups_2016
+#from wremnants.datasets.datagroupsLowPU import make_datagroups_lowPU
+#from wremnants.datasets.datagroupsLowPU import datagroupsLowPU
+#from wremnants.datasets.datagroups import datagroups2016
+from wremnants import histselections as sel
+
+
+def parseHist(h, norm=1, rebin=1): # parse 1D histogram
+
+    h = functions.Rebin(h, rebin)
+    h.Scale(norm)
+
+    # overflow
+    n = h.GetNbinsX()
+    h.SetBinContent(1, h.GetBinContent(0) + h.GetBinContent(1))
+    h.SetBinContent(n, h.GetBinContent(n+1) + h.GetBinContent(n))
+    h.SetBinError(1, math.hypot(h.GetBinError(0), h.GetBinError(1)))
+    h.SetBinError(n, math.hypot(h.GetBinError(n+1), h.GetBinError(n)))
+    h.SetBinContent(0, 0)
+    h.SetBinContent(n+1, 0)
+    h.SetBinContent(0, 0)
+    h.SetBinContent(n+1, 0)
+
+    return h
+
+
+
+def addUnc(hTarget, hNom, hUp, hDw=None):
+
+    for k in range(1, hTarget.GetNbinsX()+1):
+
+        #if hDw != None: sigma = 0.5*abs(abs(hUp.GetBinContent(k)-hNom.GetBinContent(k)) + abs(hDw.GetBinContent(k)-hNom.GetBinContent(k)))
+        if hDw != None: sigma = 0.5*abs(hUp.GetBinContent(k)-hDw.GetBinContent(k))
+        else: sigma = abs(hUp.GetBinContent(k)-hNom.GetBinContent(k))
+        hTarget.SetBinError(k, math.sqrt(sigma*sigma + hTarget.GetBinError(k)*hTarget.GetBinError(k)))
+
+
+
+
+def parseProc_Z(histCfg, procName, syst="", rebin=1):
+
+    axis = histCfg['axis']
+    hName = histCfg['name']
+
+    label = "%s_%s" % (hName, procName)
+    bhist = functions.readBoostHistProc(groups, hName, [procName])
+    rhist = narf.hist_to_root(bhist)
+    rhist = functions.Rebin(rhist, rebin)
+    rhist.SetName(label)
+    rhist = doOverlow(rhist)
+
+    if procName == "SingleMuon" or procName == "SingleElectron": pass
+    else: rhist.Scale(MC_SF)
+
+    print("Get histogram %s, yield=%.2f" % (label, rhist.Integral()))
+    return rhist
+
+def getHist(histCfg, procName, syst="", boost=False):
+    axis = histCfg['axis']
+    hName = histCfg['name']
+    charge = histCfg['charge'] if 'charge' in histCfg else False
+
+    if syst != "":
+        hName += f"_{syst}"
+    #label = "%s_%s" % (hName, procName)
+    #groups.setHists(hName, "", label=label, procsToRead=[procName])
+    #bhist = groups.groups[procName].hists[label]
+
+    groups.setNominalName(hName)
+    groups.loadHistsForDatagroups(hName, syst="", procsToRead=[procName]) #, procsToRead=datasets, applySelection=applySelection)
+    hists = groups.getDatagroups()
+    bhist = groups.groups[procName].hists[hName]
+    
+    s = hist.tag.Slicer()
+    axes = [ax.name for ax in bhist.axes]
+    if "eta" in axes and "pt" in axes:
+        bhist = bhist[{"eta" : s[::hist.sum], "pt" : s[::hist.sum]}]
+
+    if charge and charge == "combined": bhist = bhist[{"charge" : s[::hist.sum]}]
+    elif charge and charge == "plus": bhist = bhist[{"charge" : bhist.axes["charge"].index(+1)}]
+    elif charge and charge == "minus": bhist = bhist[{"charge" : bhist.axes["charge"].index(-1)}]
+
+    if boost:
+        return bhist
+    rhist = narf.hist_to_root(bhist)
+    rhist.SetName(f"{procName}_{hName}")
+    return rhist
+
+
+def doRecoilStatSyst(histCfg, procName, hNom, h_syst, rebin):
+    tags = ["target_para", "target_perp", "source_para", "source_perp", "target_para_bkg", "target_perp_bkg"]
+    tags = ["para", "perp"]
+    doubleSide = False
+    for tag in tags:
+        try:
+            bhist_pert = getHist(histCfg, procName, syst=f"recoilUnc_{tag}", boost=True)
+        except:
+            continue
+        ax_entries = list(bhist_pert.axes[1])
+        s = hist.tag.Slicer()
+        print(f"Include {tag} recoil uncertainty for process {procName} and histogram {histCfg['name']}")
+        if doubleSide:
+            for i in range(int(len(ax_entries)/2)):
+
+                hDw = bhist_pert[{"recoilVar" : 2*(i-1)-1}]
+                hUp = bhist_pert[{"recoilVar" : 2*i-1}]
+
+                hDw = narf.hist_to_root(hDw)
+                hUp = narf.hist_to_root(hUp)
+
+                hUp = parseHist(hUp, rebin=rebin)
+                hDw = parseHist(hDw, rebin=rebin)
+                print(f" variation {i}, nom={hNom.Integral()}, up={hUp.Integral()}, dw={hDw.Integral()}")
+                #if tag == "target_para" and i == 3:
+                #    for k in range(0, hNom.GetNbinsX()): print(" ", tag, i, hNom.GetBinCenter(k), hNom.GetBinContent(k), hUp.GetBinContent(k), hDw.GetBinContent(k), hNom.GetBinContent(k)/hUp.GetBinContent(k) if hUp.GetBinContent(k) > 0 else 1)
+                addUnc(h_syst, hNom, hUp, hDw)
+        else:
+            for i in range(int(len(ax_entries))):
+                hUp = bhist_pert[{"recoilVar" : i}]
+                hUp = narf.hist_to_root(hUp)
+                hUp = parseHist(hUp, rebin=rebin)
+                #print(f" variation {i}, nom={hNom.Integral()}, up={hUp.Integral()}")
+                #if tag == "target_para" and i == 3:
+                #    for k in range(0, hNom.GetNbinsX()): print(" ", tag, i, hNom.GetBinCenter(k), hNom.GetBinContent(k), hUp.GetBinContent(k), hDw.GetBinContent(k), hNom.GetBinContent(k)/hUp.GetBinContent(k) if hUp.GetBinContent(k) > 0 else 1)
+                addUnc(h_syst, hNom, hUp)
+
+
+def parseHists(histCfg, leg, rebin=1, noData=False):
+
+    h_data = getHist(histCfg, data)
+    h_data = parseHist(h_data, rebin=rebin)
+    leg.AddEntry(h_data, groups.groups[data].label, "PE")
+
+    st = ROOT.THStack()
+    st.SetName("stack")
+    h_bkg = h_data.Clone("bkg_nominal")
+    h_bkg.Reset("ACE")
+    bkg_hists = {}
+    normMC = 0
+    for i,proc in enumerate(procs):
+
+        hist = getHist(histCfg, proc)
+        hist = parseHist(hist, rebin=rebin)
+        hist.SetFillColor(ROOT.TColor.GetColor(groups.groups[proc].color))
+        hist.SetLineColor(ROOT.kBlack)
+        hist.SetLineWidth(1)
+        hist.SetLineStyle(1)
+        bkg_hists[proc] = hist
+        if proc != dataNormProc:
+            normMC += hist.Integral()
+
+    if dataNormProc != "":
+        bkg_hists[dataNormProc].Scale((h_data.Integral()-normMC)/bkg_hists[dataNormProc].Integral())
+    for i,proc in enumerate(procs):
+        leg.AddEntry(bkg_hists[proc], groups.groups[proc].label if proc != "WJetsToMuNu" else "W^{{#{q}}} #rightarrow #mu^{{#{q}}}#nu".format(q=charge if charge != "combined" else "pm"), "F")
+        st.Add(bkg_hists[proc])
+        h_bkg.Add(bkg_hists[proc])
+
+
+    h_bkg.SetLineColor(ROOT.kBlack)
+    h_bkg.SetFillColor(0)
+    h_bkg.SetLineWidth(2)
+
+    h_data.SetLineColor(ROOT.kBlack)
+    h_data.SetMarkerStyle(20)
+    h_data.SetMarkerColor(ROOT.kBlack)
+    h_data.SetLineColor(ROOT.kBlack)
+
+    h_err = h_bkg.Clone("syst")
+    h_err.SetFillColor(ROOT.kBlack)
+    h_err.SetMarkerSize(0)
+    h_err.SetLineWidth(0)
+    h_err.SetFillStyle(3004)
+    leg.AddEntry(h_err, "Stat. Unc." if not doSyst else "Stat. + Syst. Unc.", "F")
+
+    h_syst = h_bkg.Clone("syst_group%d" % i)
+    h_syst.SetFillColor(ROOT.kBlack)
+    h_syst.SetFillColorAlpha(ROOT.kBlack, 1)
+    h_syst.SetMarkerSize(0)
+    h_syst.SetLineWidth(0)
+    h_syst.SetFillStyle(3004)
+    for iBin in range(0, h_syst.GetNbinsX()+1): h_syst.SetBinError(iBin, 0) # reset errors for non-stat ones
+
+    systs = {}
+
+    # do systematics
+    for i,proc in enumerate(procs):
+
+        if not doSyst:
+            continue
+
+        hNom = getHist(histCfg, proc)
+        hNom = parseHist(hNom, rebin=rebin)
+        hPert = doRecoilStatSyst(histCfg, proc, hNom, h_err, rebin)
+
+
+
+
+    # ratios (bands)
+    h_bkg_ratio = h_bkg.Clone("h_bkg_ratio") # nominal point, need to remove stat. error
+    h_err_ratio = h_err.Clone("syst_ratio")
+    h_err_ratio.Divide(h_bkg_ratio)
+
+
+    # Data/MC ratio (the error bars represent the data uncertainty)
+    h_ratio = h_data.Clone("h_ratio")
+    for i in range(h_bkg .GetNbinsX()+1): h_bkg.SetBinError(i, 0) # set MC errors to zero
+    h_ratio.Divide(h_bkg)
+    h_ratio.SetMarkerStyle(20)
+    h_ratio.SetMarkerSize(0.7)
+    h_ratio.SetMarkerColor(ROOT.kBlack)
+    h_ratio.SetLineColor(ROOT.kBlack)
+    h_ratio.SetLineWidth(1)
+
+    return h_data, st, h_bkg, h_ratio, h_err, h_err_ratio
+
+
+
+def singlePlot(histCfg, fOut, xMin, xMax, yMin, yMax, xLabel, yLabel, logY=True, rebin=1, legPos=[], yRatio = 1.3, dataNorm=False):
+
+    # default cfg
+    cfg = {
+
+        'logy'              : True,
+        'logx'              : False,
+
+        'xmin'              : 60,
+        'xmax'              : 120,
+        'ymin'              : 1e1,
+        'ymax'              : 1e5, # 3e6
+
+        'xtitle'            : "m(#mu,#mu) (GeV)",
+        'ytitle'            : "Events",
+
+        'topRight'          : lumi_header,
+        'topLeft'           : "#bf{CMS} #scale[0.7]{#it{Preliminary}}",
+
+        'ratiofraction'     : 0.3,
+        'ytitleR'           : "Data/MC",
+
+        'yminR'             : 1-(yRatio-1), # 0.7
+        'ymaxR'             : yRatio, # 1.3
+    }
+
+
+
+
+    leg = ROOT.TLegend(.50, 0.88-(len(procs)+2)*0.05, .8, .88)
+    leg.SetBorderSize(0)
+    leg.SetFillStyle(0)
+    leg.SetTextSize(0.040)
+
+
+    h_data, st, h_bkg, h_ratio, h_err, h_err_ratio = parseHists(histCfg, leg, rebin)
+
+    if dataNorm:
+        for i in range(0, h_data.GetNbinsX()+1):
+            h_data.SetBinContent(i, h_bkg.GetBinContent(i))
+            h_ratio.SetBinContent(i, 1)
+
+    cfg['logy'] = logY
+    cfg['xmin'] = xMin
+    cfg['xmax'] = xMax
+    cfg['ymin'] = yMin
+    cfg['ymax'] = yMax
+
+    cfg['xtitle'] = xLabel
+    cfg['ytitle'] = yLabel
+
+    if not logY:
+        ROOT.TGaxis.SetMaxDigits(3)
+        ROOT.TGaxis.SetExponentOffset(-0.075, 0.01, "y")
+
+
+    plotter.cfg = cfg
+    canvas, padT, padB = plotter.canvasRatio()
+    dummyT, dummyB, dummyL = plotter.dummyRatio()
+
+    ## top panel
+    canvas.cd()
+    padT.Draw()
+    padT.cd()
+    padT.SetGrid()
+    dummyT.Draw("HIST")
+
+    st.Draw("HIST SAME")
+
+    h_err.Draw("E2 SAME")
+    h_bkg.Draw("HIST SAME")
+    h_data.Draw("PE SAME")
+    leg.Draw("SAME")
+
+    plotter.auxRatio()
+    ROOT.gPad.SetTickx()
+    ROOT.gPad.SetTicky()
+    ROOT.gPad.RedrawAxis()
+
+
+    ## bottom panel
+    canvas.cd()
+    padB.Draw()
+    padB.SetFillStyle(0)
+    padB.cd()
+    dummyB.Draw("HIST")
+    dummyL.Draw("SAME")
+
+    h_ratio.Draw("PE0 SAME") # E2 SAME
+    h_err_ratio.Draw("E2 SAME")
+
+    ROOT.gPad.SetTickx()
+    ROOT.gPad.SetTicky()
+    ROOT.gPad.RedrawAxis()
+
+    canvas.SaveAs("%s/%s.png" % (outDir, fOut))
+    canvas.SaveAs("%s/%s.pdf" % (outDir, fOut))
+    canvas.Close()
+
+
+
+def singlePlot_noData(hName, fOut, xMin, xMax, yMin, yMax, xLabel, yLabel, logY=True, rebin=1, legPos=[], projectionx=[]):
+
+    # default cfg
+    cfg = {
+
+        'logy'              : True,
+        'logx'              : False,
+
+        'xmin'              : 60,
+        'xmax'              : 120,
+        'ymin'              : 1e1,
+        'ymax'              : 1e5, # 3e6
+
+        'xtitle'            : "m(#mu,#mu) (GeV)",
+        'ytitle'            : "Events",
+
+        'topRight'          : lumi_header,
+        'topLeft'           : "#bf{CMS} #scale[0.7]{#it{Preliminary}}",
+
+    }
+
+
+    leg = ROOT.TLegend(.20, 0.90-(len(bkgs)+1)*0.05, .55, .90)
+    leg.SetBorderSize(0)
+    leg.SetFillStyle(0)
+    leg.SetTextSize(0.040)
+
+    h_data, st, h_bkg, sysHists, h_ratio, sysHists_ratio = parseHists(hName, leg, rebin, projectionx=projectionx, noData=True)
+    #h_data, st, h_bkg, h_bkg_err, h_ratio, h_bkg_err_ratio = parseHists(hName, leg, rebin)
+
+    cfg['logy'] = logY
+    cfg['xmin'] = xMin
+    cfg['xmax'] = xMax
+    cfg['ymin'] = yMin
+    cfg['ymax'] = yMax
+
+    cfg['xtitle'] = xLabel
+    cfg['ytitle'] = yLabel
+
+
+    plotter.cfg = cfg
+    canvas = plotter.canvas()
+    dummy = plotter.dummy()
+
+
+    canvas.SetGrid()
+    dummy.Draw("HIST")
+
+    st.Draw("HIST SAME")
+
+    #for h in sysHists: h.Draw("E2 SAME")
+    sysHists[0].Draw("E2 SAME")
+    h_bkg.Draw("HIST SAME")
+    leg.Draw("SAME")
+
+    plotter.aux(canvas)
+    ROOT.gPad.SetTickx()
+    ROOT.gPad.SetTicky()
+    ROOT.gPad.RedrawAxis()
+
+
+
+    canvas.SaveAs("%s/%s.png" % (outDir, fOut))
+    canvas.SaveAs("%s/%s.pdf" % (outDir, fOut))
+    canvas.Close()
+
+
+def MET2d(type_="ratio"):
+
+    histCfg = {"name": "recoil_corr_rec_para_perp_2d", "axis": "recoil_perp" }
+    h_data = parseProc(histCfg, data)
+    hist_mc = None
+    for i,proc in enumerate(procs):
+
+        hist = parseProc(histCfg, proc)
+        if hist_mc == None: hist_mc = hist
+        else: hist_mc.Add(hist)
+
+    h_ratio = h_data.Clone("ratio")
+    h_ratio.Divide(hist_mc)
+
+    '''
+    for i in range(1, h_data.GetNbinsX()+1):
+        for j in range(1, h_data.GetNbinsX()+1):
+
+            val = h_data.GetBinContent(i, j)
+            if val >= 1 and val < 1.05: newval = 1.025
+            elif val >= 1.05 and val < 1.1: newval = 1.075
+            elif val >= 1.1 and val < 1.15: newval = 1.125
+            elif val >= 1.15 and val < 1.2: newval = 1.175
+            elif val >= 1.2: newval = 1.3
+            elif val <= 1 and val > 0.95: newval = 0.975
+            elif val <= 0.95 and val > 0.9: newval = 0.925
+            elif val <= 0.9 and val > 0.85: newval = 0.875
+            elif val <= 0.85 and val > 0.8: newval = 0.825
+            elif val <= 0.8: newval = 0.7
+            h_data.SetBinContent(i, j, newval)
+            #print("%.3f " % h_data.GetBinContent(i, j), end="")
+    '''
+
+    cfg = {
+
+        'logy'              : False,
+        'logx'              : False,
+
+        'xmin'              : -10,
+        'xmax'              : 10,
+        'ymin'              : -10,
+        'ymax'              : 10,
+
+        'xtitle'            : "Recoil parallel",
+        'ytitle'            : "Recoil perp",
+
+        'topRight'          : lumi_header,
+        'topLeft'           : "#bf{CMS} #scale[0.7]{#it{Preliminary}}",
+    }
+
+
+
+    #ROOT.gStyle.SetPalette(6, [ROOT.kRed+2, ROOT.kOrange+2 , ROOT.kGreen +2 , ROOT.kGreen +2 , ROOT.kAzure +2, ROOT.kBlue  +2])
+    #ROOT.gStyle.SetNumberContours(6)
+    #ROOT.gStyle.SetPalette(ROOT.kVisibleSpectrum)
+
+
+    plotter.cfg = cfg
+    canvas = plotter.canvas()
+    canvas.SetRightMargin(0.12)
+    #canvas.SetLogz()
+    dummy = plotter.dummy()
+    canvas.cd()
+    dummy.Draw("HIST")
+
+    ROOT.gStyle.SetPaintTextFormat("4.3f")
+    h_data.SetMarkerSize(0.4)
+
+    if type_ == "data":
+        #h_data.GetZaxis().SetRangeUser(0.8, 1.2)
+        #h_data.Draw("SAME COLZ TEXTE")
+        h_data.Draw("SAME COLZ")
+    elif type_ == "mc":
+        #h_mc.GetZaxis().SetRangeUser(0.8, 1.2)
+        #h_data.Draw("SAME COLZ TEXTE")
+        hist_mc.Draw("SAME COLZ")
+    else:
+        #h_ratio.GetZaxis().SetRangeUser(0.8, 1.2)
+        #h_data.Draw("SAME COLZ TEXTE")
+        h_ratio.Draw("SAME COLZ")
+
+    ells = []
+    for r in [1, 2, 3]:
+        met1 = ROOT.TEllipse(0., 0., r, r)
+        met1.SetFillStyle(4000)
+        met1.SetLineWidth(1)
+        met1.Draw("SAME")
+        ells.append(met1)
+
+
+    plotter.aux(canvas)
+
+    canvas.Modify()
+    canvas.Update()
+    canvas.Draw()
+    canvas.RedrawAxis()
+    canvas.SaveAs("%s/MET_2d_%s.png" % (outDir, type_))
+    canvas.SaveAs("%s/MET_2d_%s.pdf" % (outDir, type_))
+    canvas.Delete()
+
+    for i in range(1, h_data.GetNbinsX()+1):
+        for j in range(1, h_data.GetNbinsX()+1):
+
+            print("%.3f " % h_data.GetBinContent(i, j), end="")
+        print()
+
+        #hx = h_data.ProjectionX("x", i, i)
+        #hy = h_data.ProjectionY("y", i, i)
+
+        #print(hx.Integral()/hx.GetNbinsX(), hy.Integral()/hy.GetNbinsX())
+
+def doYields_Z(hName):
+
+    with open("%s/yields.txt" % outDir, 'w') as f:
+        sys.stdout = f
+
+        formatted_row = '{:<15} {:<25}'
+        print(formatted_row.format(*(["Process", "Yields"])))
+        print(formatted_row.format(*(["---------------"]+["-----------------------"]*3)))
+        for proc in procs+[data]:
+            row = [proc]
+            h = getHist({"name": hName, "axis": ""}, proc, boost=True)
+            
+            yield_, err = sum(h.values()), math.sqrt(sum(h.variances()))
+            row.append("%.3e +/- %.3e" % (yield_, err))
+            print(formatted_row.format(*row))
+    sys.stdout = sys.__stdout__
+
+def doYields_W(hName):
+
+    with open("%s/yields.txt" % outDir, 'w') as f:
+        sys.stdout = f
+
+        formatted_row = '{:<15} {:<25} {:<25} {:<25}'
+        print(formatted_row.format(*(["Process", "Yields plus", "Yields minus", "Yields combined"])))
+        print(formatted_row.format(*(["---------------"]+["-----------------------"]*3)))
+        for proc in procs+[data]:
+            row = [proc]
+            for q in ["plus", "minus", "combined"]:
+                h = getHist({"name": hName, "axis": "", "charge": q}, proc, boost=True)
+                
+                #s = hist.tag.Slicer()
+                #h = h[{"mt": s[complex(0,40):complex(0,120)]}]
+                #print(h)
+                #print(h.values())
+                #print(h.variances())
+                #print(h.values())
+                yield_, err = sum(h.values()), math.sqrt(sum(h.variances()))
+                row.append("%.3e +/- %.3e" % (yield_, err))
+            print(formatted_row.format(*row))
+    sys.stdout = sys.__stdout__
+
+
+
+
+def lowPU_Z():
+
+    doYields_Z("mZ")
+    singlePlot({"name": "mZ", "axis": "mll" }, "mZ", 60, 120, 1e0, 1e7, "m(l, l) (GeV)", "Events", yRatio=1.15)
+
+    ## recoil plots
+    bins_recoil_para_perp = [-100, -80, -70, -60, -50, -46, -42, -38, -34] + list(range(-30, 30, 2)) + [30, 34, 38, 42, 46, 50, 60, 70, 80, 100]
+    bins_recoil_magn = list(range(0, 50, 5)) + list(range(50, 100, 5)) + [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+    singlePlot({"name": "recoil_uncorr_para", "axis": "recoil_perp" }, "recoil_uncorr_para", -100, 100, 1e-1, 1e7, "U_{#parallel} (GeV) (uncorrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_uncorr_perp", "axis": "recoil_perp" }, "recoil_uncorr_perp", -100, 100, 1e-1, 1e7, "U_{#perp}  (GeV) (uncorrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_uncorr_magn", "axis": "recoil_magn" }, "recoil_uncorr_magn", 0, 200, 1e-1, 1e7, "|U| (GeV) (uncorrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_lep_para", "axis": "recoil_perp" }, "recoil_corr_lep_para", -100, 100, 1e-1, 1e7, "U_{#parallel} (GeV) (lepton corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_lep_perp", "axis": "recoil_perp" }, "recoil_corr_lep_perp", -100, 100, 1e-1, 1e7, "U_{#perp}   (GeV) (lepton corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_lep_magn", "axis": "recoil_magn" }, "recoil_corr_lep_magn", 0, 200, 1e-1, 1e7, "|U| (GeV) (lepton corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_xy_para", "axis": "recoil_perp" }, "recoil_corr_xy_para", -100, 100, 1e-1, 1e7, "U_{#parallel} (GeV) (XY corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_xy_perp", "axis": "recoil_perp" }, "recoil_corr_xy_perp", -100, 100, 1e-1, 1e7, "U_{#perp}   (GeV) (XY corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_xy_magn", "axis": "recoil_magn" }, "recoil_corr_xy_magn", 0, 200, 1e-1, 1e7, "|U| (GeV) (XY corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_rec_para", "axis": "recoil_para_qT" }, "recoil_corr_rec_para", -100, 100, 1e-1, 1e7, "U_{#parallel} (GeV) (recoil corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qTrw", "axis": "recoil_para_qT" }, "recoil_corr_rec_para_qTrw", -100, 100, 1e-1, 1e7, "U_{#parallel} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_rec_perp", "axis": "recoil_perp" }, "recoil_corr_rec_perp", -100, 100, 1e-1, 1e7, "U_{#perp}   (GeV) (recoil corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_perp_qTrw", "axis": "recoil_perp" }, "recoil_corr_rec_perp_qTrw", -100, 100, 1e-1, 1e7, "U_{#perp}   (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_rec_magn", "axis": "recoil_magn" }, "recoil_corr_rec_magn", 0, 200, 1e-1, 1e7, "|U| (GeV) (recoil corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_magn_qTrw", "axis": "recoil_magn_qTrw" }, "recoil_corr_rec_magn_qTrw", 0, 200, 1e-1, 1e7, "|U| (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+
+    singlePlot({"name": "recoil_corr_xy_para_qT", "axis": "recoil_para" }, "recoil_corr_xy_para_qT", -200, 100, 1e-1, 1e7, "U_{#parallel} #minus q_{T} (GeV)", "Events", rebin=5, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qT", "axis": "recoil_para" }, "recoil_corr_rec_para_qT", -200, 100, 1e-1, 1e7, "U_{#parallel} #minus q_{T} (GeV) (recoil corrected)", "Events", rebin=5, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qT_qTrw", "axis": "recoil_para_qTrw" }, "recoil_corr_rec_para_qT_qTrw", -200, 100, 1e-1, 1e7, "U_{#parallel} #minus q_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=5, yRatio=1.15)
+
+
+    ##### MET PLOTS
+    bins_MET = list(range(0, 50, 2)) + list(range(50, 70, 4)) + [70, 80, 90, 100] # was 2 before
+    bins_MET = [0, 0.5, 1, 1.5] + list(range(2, 20, 1)) + list(range(20, 50, 2)) + list(range(50, 70, 4)) + [70, 80, 90, 100] # was 2 before
+    bins_MET = list(range(0, 20, 2)) + list(range(20, 50, 5)) + [50, 60, 70, 80, 90, 100] # was 2 before
+    singlePlot({"name": "MET_uncorr_pt", "axis": "MET_pt" }, "MET_uncorr_pt", 0, 100, 1, 1e5, "MET p_{T} (uncorrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_lep_pt", "axis": "MET_pt" }, "MET_corr_lep_pt", 0, 100, 1, 1e5, "MET p_{T} (lepton corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_xy_pt", "axis": "MET_pt" }, "MET_corr_xy_pt", 0, 100, 1, 1e5, "MET p_{T} (XY corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_pt", "axis": "MET_pt" }, "MET_corr_rec_pt", 0, 100, 1, 1e5, "MET p_{T} (recoil corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_pt_qTrw", "axis": "MET_pt" }, "MET_corr_rec_pt_qTrw", 0, 100, 1, 1e5, "MET p_{T} (recoil corrected, q_{T} rw)", "Events", rebin=bins_MET, yRatio=1.15)
+
+    singlePlot({"name": "MET_uncorr_phi", "axis": "recoil_MET_phi" }, "MET_uncorr_phi", -4, 4, 1e1, 1e7, "MET #phi (uncorrected)", "Events", rebin=1, yRatio=1.15)
+    singlePlot({"name": "MET_corr_lep_phi", "axis": "recoil_MET_phi" }, "MET_corr_lep_phi", -4, 4, 1e1, 1e7, "MET #phi (lepton corrected)", "Events", rebin=1, yRatio=1.15)
+    singlePlot({"name": "MET_corr_xy_phi", "axis": "recoil_MET_phi" }, "MET_corr_xy_phi", -4, 4, 1e1, 1e7, "MET #phi (XY corrected)", "Events", rebin=1, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_phi", "axis": "recoil_MET_phi" }, "MET_corr_rec_phi", -4, 4, 1e1, 1e7, "MET #phi (recoil corrected)", "Events", rebin=1, yRatio=1.15)
+
+    mT_bins = [0, 10, 15, 20, 25, 30, 35,] + list(range(40, 100, 2)) + [100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 140, 160, 200]
+    singlePlot({"name": "mT_uncorr", "axis": "mt" }, "mT_uncorr", 0, 200, 1e-1, 1e6, "m_{T} (GeV) (uncorrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_lep", "axis": "mt" }, "mT_corr_lep", 0, 200, 1e-1, 1e6, "m_{T} (GeV) (lepton corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_xy", "axis": "mt" }, "mT_corr_xy", 0, 200, 1e-1, 1e6, "m_{T} (GeV) (XY corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_rec", "axis": "mt" }, "mT_corr_rec", 0, 200, 1e-1, 1e6, "m_{T} (GeV)  (recoil corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_rec_qTrw", "axis": "mt" }, "mT_corr_rec_qTrw", 0, 200, 1e-1, 1e6, "m_{T} (GeV)  (recoil corrected, q_{T} rw)", "Events", rebin=mT_bins, yRatio=1.15)
+
+
+
+    recoil_qTbins = list(range(0, 30, 1)) + list(range(30, 50, 2)) + list(range(50, 70, 5)) + list(range(70, 100, 10)) + [100]
+    recoil_qTbins = list(range(0, 30, 1)) + list(range(30, 50, 2)) + list(range(50, 70, 5)) + list(range(70, 120, 10)) + [120, 150]
+    singlePlot({"name": "qT", "axis": "qT" }, "qT", 0, 100, 0.1, 1e6, "q_{T} (GeV)", "Events", rebin=recoil_qTbins, yRatio=1.15)
+    singlePlot({"name": "qT_qTrw", "axis": "qT" }, "qT_qTrw", 0, 100, 0.1, 1e6, "q_{T} (GeV) (q_{T} rw)", "Events", rebin=recoil_qTbins, yRatio=1.15)
+
+    singlePlot({"name": "METx_uncorr", "axis": "MET_xy" }, "METx_uncorr", -100, 100, 1e1, 1e6, "MET x (uncorrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_uncorr", "axis": "MET_xy" }, "METy_uncorr", -100, 100, 1e1, 1e6, "MET y (uncorrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_lep", "axis": "MET_xy" }, "METx_corr_lep", -100, 100, 1e1, 1e6, "MET x (lepton corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_lep", "axis": "MET_xy" }, "METy_corr_lep", -100, 100, 1e1, 1e6, "MET y (lepton corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_xy", "axis": "MET_xy" }, "METx_corr_xy", -100, 100, 1e1, 1e6, "MET x (XY corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_xy", "axis": "MET_xy" }, "METy_corr_xy", -100, 100, 1e1, 1e6, "MET y (XY corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_rec", "axis": "MET_xy" }, "METx_corr_rec", -100, 100, 1e1, 1e6, "MET x (recoil corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_rec", "axis": "MET_xy" }, "METy_corr_rec", -100, 100, 1e1, 1e6, "MET y (recoil corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "MET_corr_lep_ll_dPhi", "axis": "recoil_MET_phi" }, "MET_corr_lep_ll_dPhi", -4, 4, 1e1, 1e6, "#Delta#phi(MET lep corr, ll) (lepton corrected)", "Events", rebin=1)
+    singlePlot({"name": "MET_corr_xy_ll_dPhi", "axis": "recoil_MET_phi" }, "MET_corr_xy_ll_dPhi", -4, 4, 1e1, 1e6, "#Delta#phi(MET xy corr, ll) (lepton corrected)", "Events", rebin=1)
+    singlePlot({"name": "MET_corr_rec_ll_dPhi", "axis": "recoil_MET_phi" }, "MET_corr_rec_ll_dPhi", -4, 4, 1e1, 1e6, "#Delta#phi(MET rec corr, ll) (lepton corrected)", "Events", rebin=1)
+    #singlePlot({"name": "ll_phi", "axis": "recoil_MET_phi" }, "ll_phi", -4, 4, 1e1, 1e6, "ll #phi (lepton corrected)", "Events", rebin=1)
+    #singlePlot({"name": "MET_corr_rec_xy_dPhi", "axis": "recoil_MET_phi" }, "MET_corr_rec_xy_dPhi", -4, 4, 1e1, 1e6, "#phi(MET rec corr) - #phi(MET xy corr)", "Events", rebin=1)
+
+    singlePlot({"name": "npv", "axis": "recoil_npv" }, "npv", 0, 15, 1e1, 1e7, "Number of primary vertices", "Events", rebin=1, yRatio=1.8)
+
+def highPU_Z():
+    #mT_bins = [0, 10, 15, 20, 25, 30, 35,] + list(range(40, 100, 2)) + [100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 140, 160, 200]
+    #singlePlot({"name": "mT_corr_rec", "axis": "mt" }, "mT_corr_rec", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    #singlePlot({"name": "mT_corr_rec_qTrw", "axis": "mt" }, "mT_corr_rec_qTrw", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil corrected, q_{T} rw)", "Events", rebin=mT_bins, yRatio=1.15)
+    #quit()
+    doYields_Z("mT_corr_lep")
+    #quit()
+    bins_recoil_para_perp = [-150, -120, -110, -100, -90, -80, -70, -60, -50, -46, -42, -38, -34] + list(range(-30, 30, 2)) + [30, 34, 38, 42, 46, 50, 60, 70, 80, 90, 100, 110, 120, 150]
+    bins_recoil_magn = list(range(0, 100, 4)) + [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+    singlePlot({"name": "recoil_uncorr_para", "axis": "recoil_para" }, "recoil_uncorr_para", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (uncorrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+    singlePlot({"name": "recoil_uncorr_perp", "axis": "recoil_perp" }, "recoil_uncorr_perp", -150, 150, 1e0, 1e8, "U_{#perp}  (GeV) (uncorrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_uncorr_magn", "axis": "recoil_magn" }, "recoil_uncorr_magn", 0, 200, 1e0, 1e8, "|U| (GeV) (uncorrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_lep_para", "axis": "recoil_para" }, "recoil_corr_lep_para", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (lepton corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_lep_perp", "axis": "recoil_perp" }, "recoil_corr_lep_perp", -150, 150, 1e0, 1e8, "U_{#perp}  (GeV) (lepton corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_lep_magn", "axis": "recoil_magn" }, "recoil_corr_lep_magn", 0, 200, 1e0, 1e8, "|U| (GeV) (lepton corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+
+    singlePlot({"name": "recoil_corr_xy_para", "axis": "recoil_para" }, "recoil_corr_xy_para", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (XY corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_xy_perp", "axis": "recoil_perp" }, "recoil_corr_xy_perp", -150, 150, 1e0, 1e8, "U_{#perp}  (GeV) (XY corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_xy_magn", "axis": "recoil_magn" }, "recoil_corr_xy_magn", 0, 200, 1e0, 1e8, "|U| (GeV) (XY corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+
+
+    singlePlot({"name": "recoil_corr_rec_para", "axis": "recoil_para" }, "recoil_corr_rec_para", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (recoil corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qTrw", "axis": "recoil_para_qT" }, "recoil_corr_rec_para_qTrw", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_rec_perp", "axis": "recoil_perp" }, "recoil_corr_rec_perp", -150, 150, 1e0, 1e8, "U_{#perp}  (GeV) (recoil corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_perp_qTrw", "axis": "recoil_perp" }, "recoil_corr_rec_perp_qTrw", -150, 150, 1e0, 1e8, "U_{#perp}  (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+
+    singlePlot({"name": "recoil_corr_rec_magn", "axis": "recoil_magn" }, "recoil_corr_rec_magn", 0, 200, 1e0, 1e8, "|U| (GeV) (recoil corrected)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_magn_qTrw", "axis": "recoil_magn" }, "recoil_corr_rec_magn_qTrw", 0, 200, 1e0, 1e8, "|U| (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_recoil_magn, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_xy_para_qT", "axis": "recoil_para" }, "recoil_corr_xy_para_qT", -200, 100, 1e0, 1e8, "U_{#parallel} #minus q_{T} (GeV) (XY corrected)", "Events", rebin=5, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qT", "axis": "recoil_para" }, "recoil_corr_rec_para_qT", -200, 100, 1e0, 1e8, "U_{#parallel} #minus q_{T} (GeV) (recoil corrected)", "Events", rebin=5, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_para_qT_qTrw", "axis": "recoil_para_qTrw" }, "recoil_corr_rec_para_qT_qTrw", -200, 100, 1e0, 1e8, "U_{#parallel} #minus q_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=5, yRatio=1.15)
+
+
+
+    ##### MET PLOTS
+    bins_MET = list(range(0, 20, 2)) + list(range(20, 50, 2)) + list(range(50, 70, 4)) + [70, 80, 90, 110, 130, 150] # was 2 before
+    singlePlot({"name": "MET_uncorr_pt", "axis": "recoil_MET_pt" }, "MET_uncorr_pt", 0, 150, 10, 1e8, "MET p_{T} (uncorrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_lep_pt", "axis": "recoil_MET_pt" }, "MET_corr_lep_pt", 0, 150, 10, 1e8, "MET p_{T} (lepton corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_xy_pt", "axis": "recoil_MET_pt" }, "MET_corr_xy_pt", 0, 150, 10, 1e8, "MET p_{T} (XY corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_pt", "axis": "recoil_MET_pt" }, "MET_corr_rec_pt", 0, 150, 10, 1e8, "MET p_{T} (recoil corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_pt_qTrw", "axis": "recoil_MET_pt" }, "MET_corr_rec_pt_qTrw", 0, 150, 10, 1e8, "MET p_{T} (recoil corrected, q_{T} rw)", "Events", rebin=bins_MET, yRatio=1.15)
+
+
+    singlePlot({"name": "MET_uncorr_phi", "axis": "recoil_MET_phi" }, "MET_uncorr_phi", -4, 4, 1e3, 1e9, "MET #phi (uncorrected)", "Events", rebin=1)
+    singlePlot({"name": "MET_corr_lep_phi", "axis": "recoil_MET_phi" }, "MET_corr_lep_phi", -4, 4, 1e3, 1e9, "MET #phi (lepton corrected)", "Events", rebin=1)
+    singlePlot({"name": "MET_corr_xy_phi", "axis": "recoil_MET_phi" }, "MET_corr_xy_phi", -4, 4, 1e3, 1e9, "MET #phi (XY corrected)", "Events", rebin=1, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_phi", "axis": "recoil_MET_phi" }, "MET_corr_rec_phi", -4, 4, 1e3, 1e9, "MET #phi (recoil corrected)", "Events", rebin=1, yRatio=1.15)
+
+
+
+
+
+    recoil_qTbins = list(range(0, 50, 1)) + list(range(50, 80, 2)) + list(range(80, 120, 5)) + list(range(120, 160, 10)) + list(range(160, 200, 20)) + [200]
+    singlePlot({"name": "qT", "axis": "qT" }, "qT", 0, 120, 10, 1e9, "q_{T} (GeV)", "Events", rebin=recoil_qTbins, yRatio=1.15)
+    singlePlot({"name": "qT_qTrw", "axis": "qT" }, "qT_qTrw", 0, 120, 10, 1e9, "q_{T} (GeV), (q_{T} rw)", "Events", rebin=recoil_qTbins, yRatio=1.15)
+
+    singlePlot({"name": "METx_uncorr", "axis": "MET_xy" }, "METx_uncorr", -100, 100, 1e1, 1e8, "MET x (uncorrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_uncorr", "axis": "MET_xy" }, "METy_uncorr", -100, 100, 1e1, 1e8, "MET y (uncorrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_lep", "axis": "MET_xy" }, "METx_corr_lep", -100, 100, 1e1, 1e8, "MET x (lepton corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_lep", "axis": "MET_xy" }, "METy_corr_lep", -100, 100, 1e1, 1e8, "MET y (lepton corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_xy", "axis": "MET_xy" }, "METx_corr_xy", -100, 100, 1e1, 1e8, "MET x (XY corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_xy", "axis": "MET_xy" }, "METy_corr_xy", -100, 100, 1e1, 1e8, "MET y (XY corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "METx_corr_rec", "axis": "MET_xy" }, "METx_corr_rec", -100, 100, 1e1, 1e8, "MET x (recoil corrected)", "Events", rebin=1)
+    singlePlot({"name": "METy_corr_rec", "axis": "MET_xy" }, "METy_corr_rec", -100, 100, 1e1, 1e8, "MET y (recoil corrected)", "Events", rebin=1)
+
+    singlePlot({"name": "npv", "axis": "recoil_npv" }, "npv", 0, 50, 1e2, 1e8, "Number of primary vertices", "Events", rebin=1)
+    singlePlot({"name": "njets", "axis": "recoil_njets" }, "njets", 0, 20, 1e3, 1e8, "Number of jets", "Events", rebin=1)
+    singlePlot({"name": "RawMET_sumEt", "axis": "recoil_sumEt" }, "RawMET_sumEt", 0, 3000, 10, 1e6, "RawMET sumEt", "Events", rebin=2)
+
+    mT_bins = [0, 10, 15, 20, 25, 30, 35,] + list(range(40, 100, 2)) + [100, 102, 104, 106, 108, 110, 115, 120, 125, 130, 140, 160, 200]
+    singlePlot({"name": "mT_uncorr", "axis": "mt" }, "mT_uncorr", 0, 200, 1e0, 1e8, "m_{T} (GeV) (uncorrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_lep", "axis": "mt" }, "mT_corr_lep", 0, 200, 1e0, 1e8, "m_{T} (GeV) (lepton corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_xy", "axis": "mt" }, "mT_corr_xy", 0, 200, 1e0, 1e8, "m_{T} (GeV) (XY corrected)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_rec", "axis": "mt" }, "mT_corr_rec", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil corrected)", "Events", rebin=mT_bins, yRatio=1.06)
+    singlePlot({"name": "mT_corr_rec_qTrw", "axis": "mt" }, "mT_corr_rec_qTrw", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil corrected, q_{T} rw)", "Events", rebin=mT_bins, yRatio=1.06)
+    
+    # response corrected profiles
+    singlePlot({"name": "mT_corr_rec_resp_qTrw", "axis": "mt" }, "mT_corr_rec_resp_qTrw", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil, resp. corrected, q_{T} rw)", "Events", rebin=mT_bins, yRatio=1.15)
+    singlePlot({"name": "mT_corr_rec_resp_qTrw", "axis": "mt" }, "mT_corr_rec_resp_qTrw", 0, 200, 1e0, 1e8, "m_{T} (GeV)  (recoil, resp. corrected, q_{T} rw)", "Events", rebin=mT_bins, yRatio=1.15)
+    
+    singlePlot({"name": "MET_corr_rec_resp_pt", "axis": "recoil_MET_pt" }, "MET_corr_rec_resp_pt", 0, 150, 10, 1e8, "MET p_{T} (recoil, resp. corrected)", "Events", rebin=bins_MET, yRatio=1.15)
+    singlePlot({"name": "MET_corr_rec_resp_pt_qTrw", "axis": "recoil_MET_pt" }, "MET_corr_rec_resp_pt_qTrw", 0, 150, 10, 1e8, "MET p_{T} (recoil, resp. corrected, q_{T} rw)", "Events", rebin=bins_MET, yRatio=1.15)
+
+    singlePlot({"name": "recoil_corr_rec_resp_para", "axis": "recoil_para" }, "recoil_corr_rec_resp_para", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (recoil, resp. corrected)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+    singlePlot({"name": "recoil_corr_rec_resp_para_qTrw", "axis": "recoil_para_qT" }, "recoil_corr_rec_resp_para_qTrw", -150, 150, 1e0, 1e8, "U_{#parallel} (GeV) (recoil, resp. corrected, q_{T} rw)", "Events", rebin=bins_recoil_para_perp, yRatio=1.15)
+
+def lowPU_W():
+
+    doYields_W("mT_corr_rec")
+    yRatio = 1.15
+
+    # lepton
+    singlePlot({"name": "lep_pt", "axis": "", "charge": charge }, "lep_pt", 25, 100, 1e1, 1e6, "Lepton p_{T} (GeV)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "lep_eta", "axis": "", "charge": charge }, "lep_eta", -2.5, 2.5, 1e4, 1e7, "Lepton #eta (GeV)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "lep_phi", "axis": "", "charge": charge }, "lep_phi", -4, 4, 1e4, 1e7, "Lepton #phi (GeV)", "Events", rebin=1, yRatio=yRatio)
+
+    # mT
+    bins_mT = list(range(40, 110, 1)) + [110, 112, 114, 116, 118, 120, 125, 130, 140, 160, 180, 200]
+    singlePlot({"name": "mT_corr_rec", "axis": "mt", "charge": charge }, "mT_corr_rec", 40, 200, 1e0, 1e7, "m_{T} (GeV) (recoil corrected)", "Events", rebin=bins_mT, yRatio=yRatio)
+    singlePlot({"name": "mT_corr_xy", "axis": "mt", "charge": charge }, "mT_corr_xy", 40, 200, 1e0, 1e7, "m_{T} (GeV) (XY corrected)", "Events", rebin=bins_mT, yRatio=yRatio)
+    singlePlot({"name": "mT_corr_rec_qTrw", "axis": "mt", "charge": charge }, "mT_corr_rec_qTrw", 40, 200, 1e0, 1e7, "m_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_mT, yRatio=yRatio)
+
+    # MET
+    bins_MET = list(range(0, 10, 2)) + list(range(10, 70, 1)) + list(range(70, 120, 2)) + list(range(120, 150, 5)) + list(range(150, 200, 10))  + [200]
+    singlePlot({"name": "MET_corr_rec_pt", "axis": "MET_pt", "charge": charge }, "MET_corr_rec_pt", 0, 200, 1e0, 1e7, "MET p_{T} (GeV) (recoil corrected)", "Events", rebin=bins_MET, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_xy_pt", "axis": "MET_pt", "charge": charge }, "MET_corr_xy_pt", 0, 200, 1e0, 1e7, "MET p_{T} (GeV) (XY corrected)", "Events", rebin=bins_MET, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_rec_pt_qTrw", "axis": "MET_pt", "charge": charge }, "MET_corr_rec_pt_qTrw", 0, 200, 1e0, 1e7, "MET p_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_MET, yRatio=yRatio)
+
+    singlePlot({"name": "MET_corr_lep_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_lep_phi", -4, 4, 1e4, 1e7, "MET #phi (lepton corrected)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_xy_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_xy_phi", -4, 4, 1e4, 1e7, "MET #phi (XY corrected)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_rec_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_rec_phi", -4, 4, 1e4, 1e7, "MET #phi (recoil corrected)", "Events", rebin=1, yRatio=yRatio)
+
+
+    # recoil
+    bins_recoil_magn = list(range(0, 100, 2)) + list(range(100, 150, 5)) + [150, 160, 170, 180, 190, 200]
+    singlePlot({"name": "recoil_corr_rec_magn", "axis": "recoil_magn", "charge": charge  }, "recoil_corr_rec_magn", 0, 200, 1e0, 1e7, "Recoil |U| (GeV)", "Events", rebin=bins_recoil_magn, dataNorm=True, yRatio=yRatio) # blind!
+    singlePlot({"name": "recoil_corr_rec_magn_qTrw", "axis": "recoil_magn", "charge": charge  }, "recoil_corr_rec_magn_qTrw", 0, 200, 1e0, 1e7, "Recoil |U| (GeV)", "Events", rebin=bins_recoil_magn, yRatio=yRatio)
+
+def highPU_W():
+
+    doYields_W("mT_corr_lep")
+    #quit()
+    yRatio = 1.15
+    # mT
+    bins_mT = list(range(40, 110, 1)) + [110, 112, 114, 116, 118, 120, 125, 130, 140, 160, 180, 200]
+    singlePlot({"name": "mT_corr_lep", "axis": "mt", "charge": charge }, "mT_corr_lep", 40, 200, 1e2, 1e9, "m_{T} (GeV) (lepton corrected)", "Events", rebin=bins_mT, yRatio=yRatio)
+    singlePlot({"name": "mT_corr_rec", "axis": "mt", "charge": charge }, "mT_corr_rec", 40, 200, 1e2, 1e9, "m_{T} (GeV) (recoil corrected)", "Events", rebin=bins_mT, yRatio=1.06)
+    singlePlot({"name": "mT_corr_xy", "axis": "mt", "charge": charge }, "mT_corr_xy", 40, 200, 1e2, 1e9, "m_{T} (GeV) (XY corrected)", "Events", rebin=bins_mT, yRatio=yRatio)
+    singlePlot({"name": "mT_corr_xy", "axis": "mt", "charge": charge }, "mT_corr_xy_noLogY", 40, 140, 0, 5e6, "m_{T} (GeV) (XY corrected)", "Events", rebin=bins_mT, yRatio=yRatio, logY=False)
+    singlePlot({"name": "mT_corr_rec_qTrw", "axis": "mt", "charge": charge }, "mT_corr_rec_qTrw", 40, 200, 1e2, 1e9, "m_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_mT, yRatio=1.06)
+    singlePlot({"name": "mT_corr_rec", "axis": "mt", "charge": charge }, "mT_corr_rec_noLogY", 40, 140, 0, 5e6, "m_{T} (GeV) (recoil corrected)", "Events", rebin=bins_mT, yRatio=1.06, logY=False)
+
+    # MET
+    bins_MET = list(range(0, 10, 2)) + list(range(10, 70, 1)) + list(range(70, 120, 2)) + list(range(120, 150, 5)) + list(range(150, 200, 10))  + [200]
+    singlePlot({"name": "MET_corr_lep_pt", "axis": "MET_pt", "charge": charge }, "MET_corr_lep_pt", 0, 200, 1e2, 1e9, "MET p_{T} (GeV) (lepton corrected)", "Events", rebin=bins_MET, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_rec_pt", "axis": "MET_pt", "charge": charge }, "MET_corr_rec_pt", 0, 200, 1e2, 1e9, "MET p_{T} (GeV) (recoil corrected)", "Events", rebin=bins_MET, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_xy_pt", "axis": "MET_pt", "charge": charge }, "MET_corr_xy_pt", 0, 200, 1e2, 1e9, "MET p_{T} (GeV) (XY corrected)", "Events", rebin=bins_MET, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_rec_pt_qTrw", "axis": "MET_pt", "charge": charge }, "MET_corr_rec_pt_qTrw", 0, 200, 1e2, 1e9, "MET p_{T} (GeV) (recoil corrected, q_{T} rw)", "Events", rebin=bins_MET, yRatio=yRatio)
+
+
+    singlePlot({"name": "MET_corr_lep_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_lep_phi", -4, 4, 1e5, 1e9, "MET #phi (lepton corrected)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_xy_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_xy_phi", -4, 4, 1e5, 1e9, "MET #phi (XY corrected)", "Events", rebin=1, yRatio=yRatio)
+    singlePlot({"name": "MET_corr_rec_phi", "axis": "recoil_MET_phi", "charge": charge }, "MET_corr_rec_phi", -4, 4, 1e5, 1e9, "MET #phi (recoil corrected)", "Events", rebin=1, yRatio=yRatio)
+
+
+    # recoil
+    bins_recoil_magn = list(range(0, 100, 2)) + list(range(100, 150, 5)) + [150, 160, 170, 180, 190, 200]
+    singlePlot({"name": "recoil_corr_rec_magn", "axis": "recoil_magn", "charge": charge  }, "recoil_corr_rec_magn", 0, 200, 1e2, 1e9, "Recoil |U| (GeV)", "Events", rebin=bins_recoil_magn, dataNorm=True, yRatio=yRatio) # blind!
+    singlePlot({"name": "recoil_corr_rec_magn_qTrw", "axis": "recoil_magn", "charge": charge  }, "recoil_corr_rec_magn_qTrw", 0, 200, 1e2, 1e9, "Recoil |U| (GeV)", "Events", rebin=bins_recoil_magn, yRatio=yRatio)
+
+
+if __name__ == "__main__":
+
+    print("Start")
+    flavor = "mumu"
+    met = "DeepMETReso" # DeepMETReso RawPFMET
+    charge = "combined" # combined plus minus
+    lowPU = False
+    doSyst = False
+
+    suffix = "scetlib_dyturbo"
+    #suffix = ""
+    #suffix = "_scetlibCorr"
+
+    if lowPU:
+
+        lumi_header = "199 pb^{#minus1} (13 TeV)"
+        groups = datagroupsLowPU(f"lowPU_{flavor}_{met}.hdf5", flavor=flavor)
+
+        if flavor == "mumu":
+            procs, data = ['EWK', 'Top', 'Zmumu'], 'SingleMuon'
+            outDir = f"/eos/user/j/jaeyserm/www/wmass/lowPU/Z{flavor}_{met}/plots{suffix}/"
+            dataNormProc = 'Zmumu'
+            functions.prepareDir(outDir, remove=True)
+            lowPU_Z()
+        elif flavor == "mu":
+            procs, data = ['EWK', 'Top', 'Fake', 'WJetsToMuNu'], 'SingleMuon'
+            outDir = f"/eos/user/j/jaeyserm/www/wmass/lowPU/W{flavor}_{met}/plots_{charge}{suffix}/"
+            dataNormProc = 'WJetsToMuNu'
+            #dataNormProc = ''
+            label = "W^{#%s}, %s" % (charge if charge != "combined" else "pm", met)
+            functions.prepareDir(outDir, remove=True)
+            lowPU_W()
+        elif flavor == "ee":
+            procs, data = ['EWK', 'TTbar', 'DYee'], 'SingleElectron'
+
+
+
+    else:
+        lumi_header = "16.8 fb^{#minus1} (13 TeV)"
+
+        def fakeHistABCD(h):
+
+            axes = [ax.name for ax in h.axes]
+            if "mt" in axes:
+                s = hist.tag.Slicer()
+                sf = h[{"passIso" : True, "passMT" : False}].sum().value / h[{"passIso" : False, "passMT" : False}].sum().value
+                return h[{"passIso" : False, "passMT" : True}]*sf
+
+            ret = hh.multiplyHists(
+                hh.divideHists(h[{"passIso" : True, "passMT" : False}],
+                    h[{"passIso" : False, "passMT" : False}],
+                        cutoff=1
+                    ),
+                        #where=h[{"passIso" : False, "passMT" : True}].values(flow=True)>1),
+                h[{"passIso" : False, "passMT" : True}],
+            )
+            return ret
+
+
+        
+
+        if flavor == "mumu":
+            #groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+            groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_scetlib_dyturboCorr.hdf5")
+            
+            groups.groups['Zmumu'].color = "#F8CE68"
+            groups.groups['Zmumu'].label = "DY #rightarrow #mu^{#plus}#mu^{#minus} (MiNNLO)"
+            
+            groups.addGroup("Top",
+                members = list(filter(lambda y: y.group == "Top", groups.datasets.values())),
+                label = "Top",
+                color = "#DE5A6A",
+                selectOp = sel.signalHistWmass if flavor == "mu" else None,
+            )
+        else:
+            groups = datagroups.Datagroups(f"mw_with_mu_eta_pt_{met}.hdf5")
+            #groups = datagroups.Datagroups(f"mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5")
+            
+            groups.groups['Fake'].selectOp = fakeHistABCD
+            groups.groups['Fake'].color = "#A9A9A9"
+            groups.groups['Wmunu'].color = "#F8CE68"
+            groups.groups['Wmunu'].label = "W^{#pm} #rightarrow #mu^{#pm}#nu"
+            groups.groups['Top'].color = "#DE5A6A"
+
+
+        groups.addGroup("EWK_Z",
+            members = [x for x in groups.datasets.values() if not x.is_data and x.group not in ["Zmumu", "Top"] and x.group != "QCD"],
+            label = r"EWK (#tau^{#plus}#tau^{#minus}, VV)",
+            color = "#64C0E8",
+            selectOp = sel.signalHistWmass if flavor == "mu" else None,
+        )
+        
+        groups.addGroup("EWK_W",
+            members = [x for x in groups.datasets.values() if not x.is_data and x.group not in ["Wmunu", "Top"] and x.group != "QCD"],
+            label = r"EWK (#tau^{#plus}#tau^{#minus}, VV)",
+            color = "#64C0E8",
+            selectOp = sel.signalHistWmass if flavor == "mu" else None,
+        )
+
+        groups.addGroup("Topa",
+            members = list(filter(lambda y: y.group == "Top", groups.datasets.values())),
+            label = "Top",
+            color = "#DE5A6A",
+            selectOp = sel.signalHistWmass if flavor == "mu" else None,
+        )
+
+        if flavor == "mumu":
+            procs, data = ['EWK_Z', 'Top', 'Zmumu'], 'Data'
+            #procs, data = ['Ztautau', 'Other', 'Zmumu'], 'Data'
+            #outDir = f"/eos/user/j/jaeyserm/www/wmass/highPU/Z{flavor}_{met}/plots{suffix}/"
+            outDir = f"/home/submit/jaeyserm/public_html/wmass/highPU/Z{flavor}_{met}/plots{suffix}/"
+            dataNormProc = 'Zmumu'
+            functions.prepareDir(outDir, remove=True)
+            highPU_Z()
+
+        if flavor == "mu":
+            procs, data = ['EWK_W', 'Top', 'Fake', 'Wmunu'], 'Data'
+            outDir = f"/home/submit/jaeyserm/public_html/wmass/highPU/W{flavor}_{met}/plots{suffix}/"
+            dataNormProc = 'Wmunu'
+            #dataNormProc = ''
+            functions.prepareDir(outDir, remove=True)
+            highPU_W()
+
+
+

--- a/scripts/lowPU/makePlots.py
+++ b/scripts/lowPU/makePlots.py
@@ -812,10 +812,10 @@ if __name__ == "__main__":
     met = "DeepMETReso" # DeepMETReso RawPFMET
     charge = "combined" # combined plus minus
     lowPU = False
-    doSyst = False
+    doSyst = True
 
     suffix = "scetlib_dyturbo"
-    #suffix = ""
+    suffix = ""
     #suffix = "_scetlibCorr"
 
     if lowPU:
@@ -867,8 +867,8 @@ if __name__ == "__main__":
         
 
         if flavor == "mumu":
-            #groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
-            groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_scetlib_dyturboCorr.hdf5")
+            groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+            #groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_scetlib_dyturboCorr.hdf5")
             
             groups.groups['Zmumu'].color = "#F8CE68"
             groups.groups['Zmumu'].label = "DY #rightarrow #mu^{#plus}#mu^{#minus} (MiNNLO)"

--- a/scripts/lowPU/qT_reweighting.py
+++ b/scripts/lowPU/qT_reweighting.py
@@ -15,7 +15,7 @@ import pickle
 import narf
 import numpy as np
 
-from wremnants.datasets.datagroups import Datagroups
+import wremnants.datasets.datagroups as datagroups
 
 
 
@@ -24,10 +24,8 @@ if __name__ == "__main__":
 
     met = "DeepMETReso" # PFMET, RawPFMET DeepMETReso
     flavor = "mumu" # mu, e, mumu, ee
-    pdf = "nnpdf31"
     lowPU = False
 
-    
     ####################################################################
     if lowPU:
         recoil_qTbins = list(range(0, 30, 1)) + list(range(30, 50, 2)) + list(range(50, 70, 5)) + list(range(70, 120, 10)) + [120, 150, 300]
@@ -63,15 +61,18 @@ if __name__ == "__main__":
 
     else:
         recoil_qTbins = list(range(0, 50, 1)) + list(range(50, 80, 2)) + list(range(80, 120, 5)) + list(range(120, 160, 10)) + list(range(160, 300, 20)) + [500]
+        recoil_qTbins = list(range(0, 201, 1))
         
-        datagroups = Datagroups("mz_wlike_with_mu_eta_pt_%s_%s.pkl.lz4" % (met, pdf), wlike=True)
+        #groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+        groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_DeepMETReso_nnpdf31_noPTcut.hdf5")
+        
         sig = "Zmumu"
         data = "Data"
         bkgs = ['Ztautau', 'Other']
 
-        h_sig = narf.hist_to_root(functions.readBoostHistProc(datagroups, "qT", [sig]))
-        h_data = narf.hist_to_root(functions.readBoostHistProc(datagroups, "qT", [data]))
-        h_bkgs = narf.hist_to_root(functions.readBoostHistProc(datagroups, "qT", bkgs))
+        h_sig = narf.hist_to_root(functions.readBoostHistProc(groups, "qT", [sig]))
+        h_data = narf.hist_to_root(functions.readBoostHistProc(groups, "qT", [data]))
+        h_bkgs = narf.hist_to_root(functions.readBoostHistProc(groups, "qT", bkgs))
         
         h_sig = functions.Rebin(h_sig, recoil_qTbins)
         h_data = functions.Rebin(h_data, recoil_qTbins)
@@ -84,13 +85,13 @@ if __name__ == "__main__":
         
         weights = []
         for i in range(1, h_sig.GetNbinsX()+1):
-            w = h_data.GetBinContent(i)/h_sig.GetBinContent(i)
+            w = h_data.GetBinContent(i)/h_sig.GetBinContent(i) if h_sig.GetBinContent(i) > 0 and h_data.GetBinContent(i) else 1
             weights.append(w)
             print(h_data.GetBinLowEdge(i), h_data.GetBinLowEdge(i+1), w)
 
         outDict = {}
         outDict['qT_bins'] = recoil_qTbins
         outDict['weights'] = weights
-        functions.writeJSON("wremnants/data/recoil/highPU/%s_%s/qT_reweighting.json" % (flavor, met), outDict)
+        functions.writeJSON("wremnants-data/data/recoil/highPU/%s_%s/qT_reweighting.json" % (flavor, met), outDict)
 
 

--- a/scripts/lowPU/qT_reweighting.py
+++ b/scripts/lowPU/qT_reweighting.py
@@ -15,7 +15,7 @@ import pickle
 import narf
 import numpy as np
 
-import wremnants.datasets.datagroups as datagroups
+from wremnants.datasets import datagroups
 
 
 

--- a/scripts/lowPU/response_mt.py
+++ b/scripts/lowPU/response_mt.py
@@ -1,0 +1,138 @@
+
+import sys,array,math,os,copy,json
+import numpy as np
+
+import ROOT
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetOptTitle(0)
+
+import functions
+import plotter
+
+import lz4.frame
+import pickle
+import narf
+import numpy as np
+
+import wremnants.datasets.datagroups as datagroups
+
+
+def makePlot(xMin=0, xMax=200, yMin=1, yMax=1e5):
+
+    b_resp = functions.readBoostHistProc(groups, "mT_corr_rec_qTrw", [proc])
+    b_no_resp = functions.readBoostHistProc(groups, "mT_corr_rec_resp_qTrw", [proc])
+
+    h_resp = narf.hist_to_root(b_resp)
+    h_no_resp = narf.hist_to_root(b_no_resp)
+
+    h_resp.SetLineColor(ROOT.kBlue)
+    h_resp.SetLineWidth(2)
+
+    h_no_resp.SetLineColor(ROOT.kRed)
+    h_no_resp.SetLineWidth(2)
+
+    cfg = {
+
+        'logy'              : False,
+        'logx'              : False,
+
+        'xmin'              : xMin,
+        'xmax'              : xMax,
+        'ymin'              : yMin,
+        'ymax'              : yMax,
+
+        'xtitle'            : "m_{T} (GeV)",
+        'ytitle'            : "Events",
+
+        'topRight'          : lumi_header, 
+        'topLeft'           : "#bf{CMS} #scale[0.7]{#it{Preliminary}}",
+
+    }
+
+    leg = ROOT.TLegend(.60, 0.75, .8, .90)
+    leg.SetBorderSize(0)
+    leg.SetFillStyle(0)
+    leg.SetTextSize(0.035)
+    leg.SetHeader(met)
+    leg.AddEntry(h_resp, "Response corrected", "L")
+    leg.AddEntry(h_no_resp, "Nominal", "L")
+
+    plotter.cfg = cfg
+    canvas = plotter.canvas()
+    dummy = plotter.dummy()   
+    canvas.cd()
+    dummy.Draw("HIST")
+    h_resp.Draw("HIST SAME")
+    h_no_resp.Draw("HIST SAME")
+    plotter.aux()
+
+    leg.Draw("SAME")
+
+    canvas.SetGrid()
+    canvas.SetTickx()
+    canvas.SetTicky()
+    canvas.Modify()
+    canvas.Update()
+    canvas.Draw()
+    canvas.SaveAs(f"{outDir}/response_comparison.png")
+    canvas.SaveAs(f"{outDir}/response_comparison.pdf")
+    canvas.Delete()
+
+
+if __name__ == "__main__":
+
+    met = "DeepMETReso" # PFMET, RawPFMET DeepMETReso
+    flavor = "mumu" # mu, e, mumu, ee
+    lowPU = False
+
+    ####################################################################
+    if lowPU:
+        npv_max, npv_fit_min, npv_fit_max = 10, 0, 10
+        lumi_header = "199 pb^{#minus1} (13 TeV)"
+        
+        groups = datagroupsLowPU("lowPU_%s_%s.pkl.lz4" % (flavor, met), flavor=flavor)
+        procs = ['EWK', 'Top', 'Zmumu'] 
+        data = "SingleMuon" if "mu" in flavor else "SingleElectron"
+
+        outDir = "/eos/user/j/jaeyserm/www/wmass/lowPU/METxy_correction/METxy_%s_%s/" % (flavor, met)
+        fOut = "wremnants/data/recoil/lowPU/%s_%s/met_xy_correction.json" % (flavor, met)
+        functions.prepareDir(outDir, True)
+        
+        dictout = {}
+        dictX = METxyCorrection(direction="x", corrType="corr_lep", polyOrderData=1, polyOrderMC=1, procs=procs, data=data)
+        dictY = METxyCorrection(direction="y", corrType="corr_lep", polyOrderData=1, polyOrderMC=1, procs=procs, data=data)
+        
+        
+        dictout['x'] = dictX
+        dictout['y'] = dictY
+        jsOut = json.dumps(dictout, indent = 4)
+        with open(fOut, "w") as outfile: outfile.write(jsOut)
+        os.system("cp %s %s" % (fOut, outDir)) # make copy to web dir
+
+        
+        METxyCorrection(direction="x", corrType="corr_xy", polyOrderData=1, polyOrderMC=1, procs=procs, data=data)
+        METxyCorrection(direction="y", corrType="corr_xy", polyOrderData=1, polyOrderMC=1, procs=procs, data=data)
+    
+    else:
+        lumi_header = "16.8 fb^{#minus1} (13 TeV)"
+
+        if flavor == "mumu":
+            groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+            proc = "Zmumu"
+        else:
+            npv_max, npv_fit_min, npv_fit_max = 60, 0, 55
+            polyOrderDataX, polyOrderMCX = 3, 3
+            polyOrderDataY, polyOrderMCY = 6, 3
+            datagroups = datagroups2016(f"mw_with_mu_eta_pt_{met}.hdf5")
+            procs = ["Zmumu", "Ztautau", "Wtaunu", "Wmunu", "Top", "Diboson"]
+            data = "Data"
+
+            for g in datagroups.groups:
+                datagroups.groups[g]['selectOp'] = None
+
+
+        #outDir = "/eos/user/j/jaeyserm/www/wmass/highPU/METxy_correction/METxy_%s_%s/" % (flavor, met)
+        outDir = f"/home/submit/jaeyserm/public_html/wmass/highPU/Z{flavor}_{met}/plots/"
+        makePlot(xMin=0, xMax=200, yMin=1, yMax=250000)
+

--- a/scripts/recoil/exportHists.py
+++ b/scripts/recoil/exportHists.py
@@ -1,0 +1,44 @@
+
+import sys,array,math,os
+import numpy as np
+import pickle
+import wremnants.datasets.datagroups as datagroups
+
+
+def readProc(groups, hName, procs):
+    groups.setNominalName(hName)
+    groups.loadHistsForDatagroups(hName, syst="")
+    return sum([groups.groups[p].hists[hName] for p in procs])
+    #return groups.groups[procs[0]].hists[hName]
+
+
+if __name__ == "__main__":
+
+    met = "DeepMETReso"
+    flavor = "mumu"
+
+    #groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_{met}.hdf5")
+    groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_DeepMETReso_nnpdf31_noPTcut.hdf5")
+    groups = datagroups.Datagroups(f"mz_wlike_with_mu_eta_pt_DeepMETReso_nnpdf31.hdf5")
+    
+    
+
+    zmumu_para = readProc(groups, "recoil_corr_xy_para_qTbinned", ["Zmumu"])
+    zmumu_perp = readProc(groups, "recoil_corr_xy_perp_qTbinned", ["Zmumu"])
+
+    bkg_para = readProc(groups, "recoil_corr_xy_para_qTbinned", ["Ztautau", "Other"])
+    bkg_perp = readProc(groups, "recoil_corr_xy_perp_qTbinned", ["Ztautau", "Other"])
+
+    singlemuon_para = readProc(groups, "recoil_corr_xy_para_qTbinned", ["Data"])
+    singlemuon_perp = readProc(groups, "recoil_corr_xy_perp_qTbinned", ["Data"])
+
+    savedict = {}
+    savedict['zmumu_para'] = zmumu_para
+    savedict['zmumu_perp'] = zmumu_perp
+    savedict['bkg_para'] = bkg_para
+    savedict['bkg_perp'] = bkg_perp
+    savedict['singlemuon_para'] = singlemuon_para
+    savedict['singlemuon_perp'] = singlemuon_perp
+
+    with open(f"recoil_mz_wlike_with_mu_eta_pt_{met}.pkl", "wb") as f:
+        pickle.dump(savedict, f)

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -147,7 +147,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--theoryCorr", nargs="*", default=["scetlib_dyturbo"], choices=theory_corrections.valid_theory_corrections(),
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
-    parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")   
+    parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--eta", nargs=3, type=float, help="Eta binning as 'nbins min max' (only uniform for now)", default=[48,-2.4,2.4])
     parser.add_argument("--pt", nargs=3, type=float, help="Pt binning as 'nbins,min,max' (only uniform for now)", default=[30,26.,56.])
@@ -159,7 +159,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--noVertexWeight", action='store_true', help="Do not apply reweighting of vertex z distribution in MC to match data")
     parser.add_argument("--validationHists", action='store_true', help="make histograms used only for validations")
     parser.add_argument("--onlyMainHistograms", action='store_true', help="Only produce some histograms, skipping (most) systematics to run faster when those are not needed")
-    parser.add_argument("--met", type=str, choices=["DeepMETReso", "RawPFMET"], help="MET (DeepMETReso or RawPFMET)", default="RawPFMET")                    
+    parser.add_argument("--met", type=str, choices=["DeepMETReso", "RawPFMET"], help="MET (DeepMETReso or RawPFMET)", default="DeepMETReso")
     parser.add_argument("-o", "--outfolder", type=str, default="", help="Output folder")
     parser.add_argument("-e", "--era", type=str, choices=["2016PreVFP","2016PostVFP"], help="Data set to process", default="2016PostVFP")
     parser.add_argument("--nonClosureScheme", type=str, default = "A-M-separated", choices=["none", "A-M-separated", "A-M-combined", "binned", "binned-plus-M"], help = "source of the Z non-closure nuisances")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -153,6 +153,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--pt", nargs=3, type=float, help="Pt binning as 'nbins,min,max' (only uniform for now)", default=[30,26.,56.])
     parser.add_argument("--noRecoil", action='store_true', help="Don't apply recoild correction")
     parser.add_argument("--recoilHists", action='store_true', help="Save all recoil related histograms for calibration and validation")
+    parser.add_argument("--recoilUnc", action='store_true', help="Run the recoil calibration with uncertainties (slower)")
     parser.add_argument("--highptscales", action='store_true', help="Apply highptscales option in MiNNLO for better description of data at high pT")
     parser.add_argument("--dataPath", type=str, default=None, help="Access samples from eos")
     parser.add_argument("--noVertexWeight", action='store_true', help="Do not apply reweighting of vertex z distribution in MC to match data")

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -30,15 +30,16 @@ def add_recoil_uncertainty(card_tool, samples, passSystToFakes=False, pu_type="h
                 passToFakes=passSystToFakes,
             )
     if met == "DeepMETReso":
-        tags = ["para", "perp"]
-        for i, tag in enumerate(tags):
-            card_tool.addSystematic("recoilUnc_%s" % tag,
-                processes=samples,
-                mirror = True,
-                group = "recoil",
-                systAxes = ["recoilVar"],
-                passToFakes=passSystToFakes,
-            )
+        if input_tools.args_from_metadata(card_tool, "recoilUnc"):
+            tags = ["para", "perp"]
+            for i, tag in enumerate(tags):
+                card_tool.addSystematic("recoilUnc_%s" % tag,
+                    processes=samples,
+                    mirror = True,
+                    group = "recoil",
+                    systAxes = ["recoilVar"],
+                    passToFakes=passSystToFakes,
+                )
 
 def setSimultaneousABCD(cardTool, variation_fakerate=0.5, variation_normalization_fake=0.1):
     # Having 1 process for fakes, for each bin 3 free floating parameters, 2 normalization for lowMT and highMT and one fakerate between iso and anti iso

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -29,7 +29,7 @@ def add_recoil_uncertainty(card_tool, samples, passSystToFakes=False, pu_type="h
                 systAxes = ["recoilVar"],
                 passToFakes=passSystToFakes,
             )
-    if met == "DeepMETReso":
+    elif met == "DeepMETReso":
         if input_tools.args_from_metadata(card_tool, "recoilUnc"):
             tags = ["para", "perp"]
             for i, tag in enumerate(tags):

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -11,24 +11,34 @@ def add_recoil_uncertainty(card_tool, samples, passSystToFakes=False, pu_type="h
     met = input_tools.args_from_metadata(card_tool, "met")
     if flavor == "":
         flavor = input_tools.args_from_metadata(card_tool, "flavor")
-    rtag = f"{pu_type}_{flavor}_{met}"
-    if not rtag in recoil_tools.recoil_cfg:
-        logger.warning(f"Recoil corrections for {pu_type}, {flavor}, {met} not available.")
-        return
-    recoil_cfg = recoil_tools.recoil_cfg[rtag]
-    recoil_vars = list(recoil_cfg['corr_z'].keys()) + list(recoil_cfg['unc_z'].keys())
-    recoil_grps = recoil_vars
-    if group_compact:
-        recoil_grps = ["CMS_recoil"]*len(recoil_cfg)
-    for i, tag in enumerate(recoil_vars):
-        card_tool.addSystematic("recoilUnc_%s" % tag,
-            processes=samples,
-            mirror = False,
-            group = recoil_grps[i],
-            systAxes = ["recoilVar"],
-            passToFakes=passSystToFakes,
-        )
-
+    if met == "RawPFMET":
+        rtag = f"{pu_type}_{flavor}_{met}"
+        if not rtag in recoil_tools.recoil_cfg:
+            logger.warning(f"Recoil corrections for {pu_type}, {flavor}, {met} not available.")
+            return
+        recoil_cfg = recoil_tools.recoil_cfg[rtag]
+        recoil_vars = list(recoil_cfg['corr_z'].keys()) + list(recoil_cfg['unc_z'].keys())
+        recoil_grps = recoil_vars
+        if group_compact:
+            recoil_grps = ["CMS_recoil"]*len(recoil_cfg)
+        for i, tag in enumerate(recoil_vars):
+            card_tool.addSystematic("recoilUnc_%s" % tag,
+                processes=samples,
+                mirror = False,
+                group = recoil_grps[i],
+                systAxes = ["recoilVar"],
+                passToFakes=passSystToFakes,
+            )
+    if met == "DeepMETReso":
+        tags = ["para", "perp"]
+        for i, tag in enumerate(tags):
+            card_tool.addSystematic("recoilUnc_%s" % tag,
+                processes=samples,
+                mirror = True,
+                group = "recoil",
+                systAxes = ["recoilVar"],
+                passToFakes=passSystToFakes,
+            )
 
 def setSimultaneousABCD(cardTool, variation_fakerate=0.5, variation_normalization_fake=0.1):
     # Having 1 process for fakes, for each bin 3 free floating parameters, 2 normalization for lowMT and highMT and one fakerate between iso and anti iso

--- a/wremnants/include/lowpu_recoil.h
+++ b/wremnants/include/lowpu_recoil.h
@@ -132,7 +132,7 @@ double qTweight(float qT) {
 
 
 
-Vec_f METLeptonCorrection(double MET_pt, double MET_phi, Vec_f lep_pt_uncorr, Vec_f lep_pt, Vec_f lep_phi) {
+Vec_d METLeptonCorrection(double MET_pt, double MET_phi, Vec_d lep_pt_uncorr, Vec_d lep_pt, Vec_d lep_phi) {
 
 	// correct MET for muon scale corrections (in lab frame pT-phi)
 	TVector2 lep1_raw(lep_pt_uncorr[0]*cos(lep_phi[0]), lep_pt_uncorr[0]*sin(lep_phi[0]));
@@ -145,7 +145,7 @@ Vec_f METLeptonCorrection(double MET_pt, double MET_phi, Vec_f lep_pt_uncorr, Ve
 	double MET_pt_corr = MET_corr.Mod();
     double MET_phi_corr = MET_corr.Phi_mpi_pi(MET_corr.Phi());
 	
-    Vec_f res(2, 0);
+    Vec_d res(2, 0);
     res[0] = MET_pt_corr;
     res[1] = MET_phi_corr;
     
@@ -158,15 +158,15 @@ Vec_f METLeptonCorrection(double MET_pt, double MET_phi, Vec_f lep_pt_uncorr, Ve
 }
 
 
-Vec_f METLeptonCorrection(double MET_pt, double MET_phi, double lep_pt_uncorr, double lep_pt, double lep_phi) {
+Vec_d METLeptonCorrection(double MET_pt, double MET_phi, double lep_pt_uncorr, double lep_pt, double lep_phi) {
 
-    Vec_f lep_pt_uncorr_(1, lep_pt_uncorr);
-    Vec_f lep_pt_(1, lep_pt);
-    Vec_f lep_phi_(1, lep_phi);
+    Vec_d lep_pt_uncorr_(1, lep_pt_uncorr);
+    Vec_d lep_pt_(1, lep_pt);
+    Vec_d lep_phi_(1, lep_phi);
 	return METLeptonCorrection(MET_pt, MET_phi, lep_pt_uncorr_, lep_pt_, lep_phi_);
 }
 
-Vec_f recoilComponents(double MET_pt, double MET_phi, double lep_pt, double lep_phi) {
+Vec_d recoilComponents(double MET_pt, double MET_phi, double lep_pt, double lep_phi) {
     
     // computes the hadronic recoil, defined as -(MET + V), V being the vector sum of the reco (di)lepton system in the lab frame
     double pUx  = MET_pt*cos(MET_phi) + lep_pt*cos(lep_phi); // recoil x in lab frame
@@ -175,7 +175,7 @@ Vec_f recoilComponents(double MET_pt, double MET_phi, double lep_pt, double lep_
 	double Ux	= - (pUx*cos(lep_phi) + pUy*sin(lep_phi));
 	double Uy	= - (- pUx*sin(lep_phi) + pUy*cos(lep_phi));    
 
-    Vec_f res(3, 0);
+    Vec_d res(3, 0);
     res[0] = pU;
     res[1] = Ux;
     res[2] = Uy;
@@ -186,7 +186,7 @@ Vec_f recoilComponents(double MET_pt, double MET_phi, double lep_pt, double lep_
 }
 
 
-Vec_f recoilComponentsGen(double MET_pt, double MET_phi, double lep_pt, double lep_phi, double gen_lep_phi) {
+Vec_d recoilComponentsGen(double MET_pt, double MET_phi, double lep_pt, double lep_phi, double gen_lep_phi) {
     
     // computes the hadronic recoil, defined as -(MET + V), V being the vector sum of the reco (di)lepton system in the lab frame
     // compute recoil as projection on the gen boson phi
@@ -196,7 +196,7 @@ Vec_f recoilComponentsGen(double MET_pt, double MET_phi, double lep_pt, double l
 	double Ux	= - (pUx*cos(gen_lep_phi) + pUy*sin(gen_lep_phi));
 	double Uy	= - (- pUx*sin(gen_lep_phi) + pUy*cos(gen_lep_phi));
 
-    Vec_f res(3, 0);
+    Vec_d res(3, 0);
     res[0] = pU;
     res[1] = Ux;
     res[2] = Uy;
@@ -204,7 +204,7 @@ Vec_f recoilComponentsGen(double MET_pt, double MET_phi, double lep_pt, double l
 	return res;
 }
 
-Vec_f METXYCorrection(double MET_pt, double MET_phi, int npv, int isData) {
+Vec_d METXYCorrection(double MET_pt, double MET_phi, int npv, int isData) {
     
     // preserve the MET magnitude??
 
@@ -213,7 +213,7 @@ Vec_f METXYCorrection(double MET_pt, double MET_phi, int npv, int isData) {
     double pUx = MET_pt*cos(MET_phi);
     double pUy = MET_pt*sin(MET_phi);
     
-    Vec_f res(2, 0);
+    Vec_d res(2, 0);
     res[0] = hypot(pUx, pUy);
     res[1] = atan2(pUy, pUx);
     
@@ -466,9 +466,9 @@ class GaussianSum {
 
 
 // recoil correction
-Vec_f recoilCorrectionBinned(double pU1, double pU2, double qTbinIdx, double qT, int corrType=0, int corrParam=1) {
+Vec_d recoilCorrectionBinned(double pU1, double pU2, double qTbinIdx, double qT, int corrType=0, int corrParam=1) {
     
-    Vec_f res(3, 0);
+    Vec_d res(3, 0);
     //cout << pU1 << " " << pU2 << " " << qTbinIdx << endl; 
     
     res[1] = pU1;
@@ -648,9 +648,9 @@ Vec_f recoilCorrectionBinned(double pU1, double pU2, double qTbinIdx, double qT,
 }
 
 
-Vec_f recoilCorrectionBinnedWtoZ(int q, double pU1, double pU2, double qTbinIdx, double qT, int corrType=0, int corrParam=1) {
+Vec_d recoilCorrectionBinnedWtoZ(int q, double pU1, double pU2, double qTbinIdx, double qT, int corrType=0, int corrParam=1) {
     
-    Vec_f res(3, 0);
+    Vec_d res(3, 0);
     //cout << pU1 << " " << pU2 << " " << qTbinIdx << endl; 
     
     res[1] = pU1;
@@ -807,9 +807,9 @@ GaussianSum constructParametricGauss(string tag, double qT, int syst=-1) {
 
 
 // recoil correction for Z (MC to DATA)
-Vec_f recoilCorrectionParametric(double para, double perp, double qT, string systTag="", int systIdx=-1) {
+Vec_d recoilCorrectionParametric(double para, double perp, double qT, string systTag="", int systIdx=-1) {
     
-    Vec_f res(3, 0);
+    Vec_d res(3, 0);
     //cout << pU1 << " " << pU2 << " " << qTbinIdx << endl; 
     
     res[1] = para;
@@ -875,9 +875,9 @@ Vec_recoil recoilCorrectionParametricUnc(double para, double perp, double qT, st
     /*
     if(tag == "target_para_bkg") {
         
-        Vec_f ret_up = recoilCorrectionParametric(para, perp, qT, "target_para_bkg", 0);
-        Vec_f ret_dw = recoilCorrectionParametric(para, perp, qT, "target_para_bkg", 1);
-        Vec_f ret_nom = recoilCorrectionParametric(para, perp, qT, "target_para");
+        Vec_d ret_up = recoilCorrectionParametric(para, perp, qT, "target_para_bkg", 0);
+        Vec_d ret_dw = recoilCorrectionParametric(para, perp, qT, "target_para_bkg", 1);
+        Vec_d ret_nom = recoilCorrectionParametric(para, perp, qT, "target_para");
         
         if(ret_nom[1] > 60) cout << "qT=" << qT << " para=" << para << " para_nom=" << ret_nom[1] << " para_up=" << ret_up[1] <<  "para_dw=" << ret_dw[1] << endl;
     }
@@ -887,7 +887,7 @@ Vec_recoil recoilCorrectionParametricUnc(double para, double perp, double qT, st
     int nSysts = recoil_unc_no[tag];
     Vec_recoil res(nSysts);
     for(int iSyst = 0; iSyst<nSysts; iSyst++) {
-        Vec_f ret = recoilCorrectionParametric(para, perp, qT, tag, iSyst);
+        Vec_d ret = recoilCorrectionParametric(para, perp, qT, tag, iSyst);
         res[iSyst].para = ret[1];
         res[iSyst].perp = ret[2];
     }
@@ -895,7 +895,7 @@ Vec_recoil recoilCorrectionParametricUnc(double para, double perp, double qT, st
 }
 
 
-Vec_f recoilCorrectionParametricUncWeights(double eval, double qT, string tag_nom, string tag_pert) {
+Vec_d recoilCorrectionParametricUncWeights(double eval, double qT, string tag_nom, string tag_pert) {
     
     GaussianSum nom;
     GaussianSum pert;
@@ -903,7 +903,7 @@ Vec_f recoilCorrectionParametricUncWeights(double eval, double qT, string tag_no
     if(qT > recoil_correction_qTmax) qT = recoil_correction_qTmax; // protection for high qT
     
     int nSysts = recoil_unc_no[tag_pert];
-    Vec_f res(nSysts);
+    Vec_d res(nSysts);
     nom = constructParametricGauss(tag_nom, qT);
     double nom_eval = nom.eval(eval);
     double w;
@@ -926,9 +926,9 @@ Vec_f recoilCorrectionParametricUncWeights(double eval, double qT, string tag_no
 
 
 
-Vec_f METCorrection(double MET_pt, double MET_phi, double rec_para, double rec_perp, double V_pt, double V_phi) {
+Vec_d METCorrection(double MET_pt, double MET_phi, double rec_para, double rec_perp, double V_pt, double V_phi) {
 
-    Vec_f res(2, 0);
+    Vec_d res(2, 0);
 
         
     double lMX = -V_pt*cos(V_phi) - rec_para*cos(V_phi) + rec_perp*sin(V_phi);
@@ -944,9 +944,9 @@ Vec_f METCorrection(double MET_pt, double MET_phi, double rec_para, double rec_p
 	return res;
 }
 
-Vec_f METCorrectionGen(double rec_para, double rec_perp, double lep_pt, double lep_phi, double V_phi) {
+Vec_d METCorrectionGen(double rec_para, double rec_perp, double lep_pt, double lep_phi, double V_phi) {
 
-    Vec_f res(2, 0);
+    Vec_d res(2, 0);
 
         
     double lMX = -lep_pt*cos(lep_phi) - rec_para*cos(V_phi) + rec_perp*sin(V_phi);
@@ -963,9 +963,9 @@ Vec_f METCorrectionGen(double rec_para, double rec_perp, double lep_pt, double l
 }
 
 /*
-Vec_f METCorrection_StatUnc(double MET_pt, double MET_phi, double rec_para, double rec_perp, double V_pt, double V_phi) {
+Vec_d METCorrection_StatUnc(double MET_pt, double MET_phi, double rec_para, double rec_perp, double V_pt, double V_phi) {
 
-    Vec_f res(2, 0);
+    Vec_d res(2, 0);
 
         
     double lMX = -V_pt*cos(V_phi) - rec_para*cos(V_phi) + rec_perp*sin(V_phi);
@@ -982,10 +982,10 @@ Vec_f METCorrection_StatUnc(double MET_pt, double MET_phi, double rec_para, doub
 
 
 
-Vec_f recoilCorrectionParametric_MET_pt_unc(Vec_recoil recoil, double V_pt, double V_phi) {
+Vec_d recoilCorrectionParametric_MET_pt_unc(Vec_recoil recoil, double V_pt, double V_phi) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) {
        
         double lMX = -V_pt*cos(V_phi) - recoil[iSyst].para*cos(V_phi) + recoil[iSyst].perp*sin(V_phi);
@@ -995,10 +995,10 @@ Vec_f recoilCorrectionParametric_MET_pt_unc(Vec_recoil recoil, double V_pt, doub
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_MET_phi_unc(Vec_recoil recoil, double V_pt, double V_phi) {
+Vec_d recoilCorrectionParametric_MET_phi_unc(Vec_recoil recoil, double V_pt, double V_phi) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) {
        
         double lMX = -V_pt*cos(V_phi) - recoil[iSyst].para*cos(V_phi) + recoil[iSyst].perp*sin(V_phi);
@@ -1008,42 +1008,42 @@ Vec_f recoilCorrectionParametric_MET_phi_unc(Vec_recoil recoil, double V_pt, dou
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_para_qT_unc(Vec_recoil recoil, double qT) {
+Vec_d recoilCorrectionParametric_para_qT_unc(Vec_recoil recoil, double qT) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) res[iSyst] = recoil[iSyst].para - qT;
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_para_unc(Vec_recoil recoil, double qT) {
+Vec_d recoilCorrectionParametric_para_unc(Vec_recoil recoil, double qT) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) res[iSyst] = recoil[iSyst].para;
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_perp_unc(Vec_recoil recoil, double qT) {
+Vec_d recoilCorrectionParametric_perp_unc(Vec_recoil recoil, double qT) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) res[iSyst] = recoil[iSyst].perp;
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_magn_unc(Vec_recoil recoil, double qT) {
+Vec_d recoilCorrectionParametric_magn_unc(Vec_recoil recoil, double qT) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) res[iSyst] = sqrt((recoil[iSyst].para-qT)*(recoil[iSyst].para-qT) + recoil[iSyst].perp*recoil[iSyst].perp);
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_mT_unc(Vec_f met_pt, Vec_f met_phi, float pt, float phi, float ptOther, float phiOther) {
+Vec_d recoilCorrectionParametric_mT_unc(Vec_d met_pt, Vec_d met_phi, float pt, float phi, float ptOther, float phiOther) {
     
     int nBins = met_pt.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) {
         
         TVector2 pl = TVector2();
@@ -1058,10 +1058,10 @@ Vec_f recoilCorrectionParametric_mT_unc(Vec_f met_pt, Vec_f met_phi, float pt, f
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_MET_pt_gen_unc(Vec_recoil recoil, double lep_pt, double lep_phi, double V_phi) {
+Vec_d recoilCorrectionParametric_MET_pt_gen_unc(Vec_recoil recoil, double lep_pt, double lep_phi, double V_phi) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) {
        
         double lMX = -lep_pt*cos(lep_phi) - recoil[iSyst].para*cos(V_phi) + recoil[iSyst].perp*sin(V_phi);
@@ -1071,10 +1071,10 @@ Vec_f recoilCorrectionParametric_MET_pt_gen_unc(Vec_recoil recoil, double lep_pt
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_MET_phi_gen_unc(Vec_recoil recoil, double lep_pt, double lep_phi, double V_phi) {
+Vec_d recoilCorrectionParametric_MET_phi_gen_unc(Vec_recoil recoil, double lep_pt, double lep_phi, double V_phi) {
     
     int nBins = recoil.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) {
        
         double lMX = -lep_pt*cos(lep_phi) - recoil[iSyst].para*cos(V_phi) + recoil[iSyst].perp*sin(V_phi);
@@ -1084,10 +1084,10 @@ Vec_f recoilCorrectionParametric_MET_phi_gen_unc(Vec_recoil recoil, double lep_p
 	return res;
 }
 
-Vec_f recoilCorrectionParametric_mT_2_unc(Vec_f met_pt, Vec_f met_phi, float pt, float phi) {
+Vec_d recoilCorrectionParametric_mT_2_unc(Vec_d met_pt, Vec_d met_phi, float pt, float phi) {
     
     int nBins = met_pt.size();
-    Vec_f res(nBins, -1e5);
+    Vec_d res(nBins, -1e5);
     for(int iSyst=0; iSyst<nBins; iSyst++) res[iSyst] = std::sqrt(2*pt*met_pt[iSyst]*(1-std::cos(phi-met_phi[iSyst])));
 	return res;
 }
@@ -1096,43 +1096,43 @@ Vec_f recoilCorrectionParametric_mT_2_unc(Vec_f met_pt, Vec_f met_phi, float pt,
 /*
 Binned recoil correction functions
 */
-Vec_f recoilCorrectionBinned_magn_StatUnc(Vec_f pU, int qTbinIdx) {
+Vec_d recoilCorrectionBinned_magn_StatUnc(Vec_d pU, int qTbinIdx) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     res[qTbinIdx] = pU[0];
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_para_StatUnc(Vec_f pU, int qTbinIdx) {
+Vec_d recoilCorrectionBinned_para_StatUnc(Vec_d pU, int qTbinIdx) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     res[qTbinIdx] = pU[1];
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_para_qT_StatUnc(Vec_f pU, int qTbinIdx, double qT) {
+Vec_d recoilCorrectionBinned_para_qT_StatUnc(Vec_d pU, int qTbinIdx, double qT) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5); // BE CAREFUL, SHOULD BE UNDERFOW
+    Vec_d res(nqTbins, -1e5); // BE CAREFUL, SHOULD BE UNDERFOW
     res[qTbinIdx] = pU[1] + qT;
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_perp_StatUnc(Vec_f pU, int qTbinIdx) {
+Vec_d recoilCorrectionBinned_perp_StatUnc(Vec_d pU, int qTbinIdx) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5); // // BE CAREFUL, SHOULD BE UNDERFOW
+    Vec_d res(nqTbins, -1e5); // // BE CAREFUL, SHOULD BE UNDERFOW
     res[qTbinIdx] = pU[2];
 	return res;
 }
 
 
-Vec_f recoilCorrectionBinned_MET_pt_StatUnc(Vec_f pU, int qTbinIdx, double MET_pt, double MET_phi, double V_pt, double V_phi) {
+Vec_d recoilCorrectionBinned_MET_pt_StatUnc(Vec_d pU, int qTbinIdx, double MET_pt, double MET_phi, double V_pt, double V_phi) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     
             
     double lMX = -V_pt*cos(V_phi) - pU[1]*cos(V_phi) + pU[2]*sin(V_phi);
@@ -1142,10 +1142,10 @@ Vec_f recoilCorrectionBinned_MET_pt_StatUnc(Vec_f pU, int qTbinIdx, double MET_p
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_MET_phi_StatUnc(Vec_f pU, int qTbinIdx, double MET_pt, double MET_phi, double V_pt, double V_phi) {
+Vec_d recoilCorrectionBinned_MET_phi_StatUnc(Vec_d pU, int qTbinIdx, double MET_pt, double MET_phi, double V_pt, double V_phi) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     
             
     double lMX = -V_pt*cos(V_phi) - pU[1]*cos(V_phi) + pU[2]*sin(V_phi);
@@ -1160,10 +1160,10 @@ Vec_f recoilCorrectionBinned_MET_phi_StatUnc(Vec_f pU, int qTbinIdx, double MET_
 
 
 
-Vec_f recoilCorrectionBinned_MET_pt_gen_StatUnc(Vec_f pU, int qTbinIdx, double lep_pt, double lep_phi, double V_phi) {
+Vec_d recoilCorrectionBinned_MET_pt_gen_StatUnc(Vec_d pU, int qTbinIdx, double lep_pt, double lep_phi, double V_phi) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     
             
     double lMX = -lep_pt*cos(lep_phi) - pU[1]*cos(V_phi) + pU[2]*sin(V_phi);
@@ -1173,10 +1173,10 @@ Vec_f recoilCorrectionBinned_MET_pt_gen_StatUnc(Vec_f pU, int qTbinIdx, double l
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_MET_phi_gen_StatUnc(Vec_f pU, int qTbinIdx, double lep_pt, double lep_phi, double V_phi) {
+Vec_d recoilCorrectionBinned_MET_phi_gen_StatUnc(Vec_d pU, int qTbinIdx, double lep_pt, double lep_phi, double V_phi) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     
             
     double lMX = -lep_pt*cos(lep_phi) - pU[1]*cos(V_phi) + pU[2]*sin(V_phi);
@@ -1189,10 +1189,10 @@ Vec_f recoilCorrectionBinned_MET_phi_gen_StatUnc(Vec_f pU, int qTbinIdx, double 
 
 
 
-Vec_f recoilCorrectionBinned_mt_StatUnc(Vec_f met_pt, Vec_f met_phi, int qTbinIdx, float pt, float phi, float ptOther, float phiOther) {
+Vec_d recoilCorrectionBinned_mt_StatUnc(Vec_d met_pt, Vec_d met_phi, int qTbinIdx, float pt, float phi, float ptOther, float phiOther) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
     
     TVector2 pl = TVector2();
     pl.SetMagPhi(ptOther,phiOther);
@@ -1206,10 +1206,10 @@ Vec_f recoilCorrectionBinned_mt_StatUnc(Vec_f met_pt, Vec_f met_phi, int qTbinId
 }
 
 
-Vec_f recoilCorrectionBinned_mt_2_StatUnc(Vec_f met_pt, Vec_f met_phi, int qTbinIdx, float pt, float phi) {
+Vec_d recoilCorrectionBinned_mt_2_StatUnc(Vec_d met_pt, Vec_d met_phi, int qTbinIdx, float pt, float phi) {
     
     int nqTbins = qTbins.size();
-    Vec_f res(nqTbins, -1e5);
+    Vec_d res(nqTbins, -1e5);
   
     res[qTbinIdx] = std::sqrt(2*pt*met_pt[qTbinIdx]*(1-std::cos(phi-met_phi[qTbinIdx])));;
 	return res;
@@ -1222,12 +1222,12 @@ Vec_f recoilCorrectionBinned_mt_2_StatUnc(Vec_f met_pt, Vec_f met_phi, int qTbin
 
 // recoil correction
 /*
-Vec_f recoilCorrectionBinned_StatUnc(double pU1, double pU2, double qTbinIdx, int corrType, int corrIdx) {
+Vec_d recoilCorrectionBinned_StatUnc(double pU1, double pU2, double qTbinIdx, int corrType, int corrIdx) {
     
     int nqTbins = qTbins.size();
 
-    Vec_f t(3, -1);
-    Vec_f res(nqTbins, -1); // per qT bin
+    Vec_d t(3, -1);
+    Vec_d res(nqTbins, -1); // per qT bin
     
     t = recoilCorrectionBinned(pU1, pU2, qTbinIdx, corrType, corrIdx);
     res[qTbinIdx] = t[0];
@@ -1240,7 +1240,7 @@ Vec_recoilType recoilCorrectionBinned_StatUnc(double pU1, double pU2, double qTb
     
     int nqTbins = qTbins.size();
 
-    Vec_f t(3, -1);
+    Vec_d t(3, -1);
     
     RecoilType tmp;
     tmp.pu1 = 0;
@@ -1255,10 +1255,10 @@ Vec_recoilType recoilCorrectionBinned_StatUnc(double pU1, double pU2, double qTb
 	return res;
 }
 
-Vec_f recoilCorrectionBinned_magn_StatUnc(Vec_recoilType pU) {
+Vec_d recoilCorrectionBinned_magn_StatUnc(Vec_recoilType pU) {
     
     unsigned size = pU.size();
-    Vec_f res(size, -1);
+    Vec_d res(size, -1);
     
     for(unsigned int i=0; i < size; i++) {
         res[i] = sqrt(pU[i].pu1*pU[i].pu1 + pU[i].pu2*pU[i].pu2);
@@ -1268,9 +1268,9 @@ Vec_f recoilCorrectionBinned_magn_StatUnc(Vec_recoilType pU) {
 }
 
 */
-Vec_f recoilCorrectionBinned_StatUnc(double pU1, double pU2, int qTbinIdx, int corrType, int corrIdx) {
+Vec_d recoilCorrectionBinned_StatUnc(double pU1, double pU2, int qTbinIdx, int corrType, int corrIdx) {
     
-    Vec_f res = recoilCorrectionBinned(pU1, pU2, qTbinIdx, corrType, corrIdx);
+    Vec_d res = recoilCorrectionBinned(pU1, pU2, qTbinIdx, corrType, corrIdx);
 	return res;
 }
 

--- a/wremnants/include/recoil_helper.h
+++ b/wremnants/include/recoil_helper.h
@@ -1,0 +1,225 @@
+#include <ROOT/RVec.hxx>
+#include <iostream>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <cmath>
+#include "defines.h"
+#include "tfliteutils.h"
+
+
+namespace wrem {
+
+using ROOT::VecOps::RVec;
+
+
+double print_val(double in, double out) {
+
+    cout << in << " " << out << endl;
+        return 0;
+}
+
+
+auto testFunc() {
+    Eigen::TensorFixedSize<double, Eigen::Sizes<500>> tmp;
+    tmp.setConstant(100.);
+
+    auto ret = std::tuple(20, tmp);
+    return ret;
+}
+
+
+class TestHelper {
+public:
+    using out_t = std::tuple<Eigen::TensorFixedSize<double, Eigen::Sizes<500>>, double>;
+    TestHelper() {}
+
+    out_t operator() () {
+
+        out_t ret;
+        std::get<1>(ret) = 20;
+        std::get<0>(ret).setConstant(100.);
+        return ret;
+    }
+};
+
+
+class RecoilCalibrationHelperOld {
+
+public:
+
+    RecoilCalibrationHelperOld(const std::string &filename, const std::string &func_name, double ut_min_, double ut_max_) :
+        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
+            ut_max = ut_max_;
+            ut_min = ut_min_;
+    }
+
+    double operator() (const double &pt, const double &ut) {
+
+        if(ut < ut_max and ut > ut_min) {
+            Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
+            Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_tensor;
+            Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_corr_tensor;
+            pt_tensor(0) = pt;
+            ut_tensor(0) = ut;
+
+            auto const inputs = std::tie(pt_tensor, ut_tensor);
+            auto outputs = std::tie(ut_corr_tensor);
+            (*helper_)(inputs, outputs);
+            return ut_corr_tensor(0);
+        }
+        else {
+            return ut;
+        }
+    }
+
+
+private:
+    std::shared_ptr<narf::tflite_helper> helper_;
+    double ut_max;
+    double ut_min;
+};
+
+
+
+
+
+class ResponseCorrector {
+
+public:
+
+    ResponseCorrector(const std::string &filename, const std::string &func_name) :
+        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {}
+
+    double operator() (const double &pt) {
+
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_corr_tensor;
+        pt_tensor(0) = pt;
+
+        auto const inputs = std::tie(pt_tensor);
+        auto outputs = std::tie(pt_corr_tensor);
+        (*helper_)(inputs, outputs);
+        return pt_corr_tensor(0);
+    }
+
+
+private:
+    std::shared_ptr<narf::tflite_helper> helper_;
+    double ut_max;
+    double ut_min;
+};
+
+
+
+
+
+
+
+
+
+
+
+
+template <size_t N_UNC>
+class RecoilCalibrationHelper {
+
+public:
+
+    struct scalar_tensor {
+        using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<N_UNC>>;
+        using out_scalar_t = Eigen::TensorFixedSize<double, Eigen::Sizes<>>;
+
+        out_scalar_t ut_corr;
+        out_tensor_t unc_weights;
+    };
+
+    using out_t = scalar_tensor;
+
+    RecoilCalibrationHelper(const std::string &filename, const std::string &func_name, const double ut_min_, const double ut_max_) :
+        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
+            ut_max = ut_max_;
+            ut_min = ut_min_;
+    }
+
+    out_t operator() (const double &pt, const double &ut) {
+
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_tensor;
+        pt_tensor(0) = pt;
+        ut_tensor(0) = ut;
+
+        out_t ret;
+        if(ut < ut_max and ut > ut_min) {
+            auto const inputs = std::tie(pt_tensor, ut_tensor);
+            auto outputs = std::tie(ret.ut_corr, ret.unc_weights);
+            (*helper_)(inputs, outputs);
+        }
+        else {
+            ret.ut_corr = ut_tensor;
+            ret.unc_weights.setConstant(1.);
+        }
+        return ret;
+    }
+
+
+private:
+    std::shared_ptr<narf::tflite_helper> helper_;
+    double ut_max;
+    double ut_min;
+};
+
+
+
+template <size_t N_UNC>
+class RecoilCalibrationHelperNoUnc {
+
+public:
+
+    struct scalar_tensor {
+        using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<N_UNC>>;
+        using out_scalar_t = Eigen::TensorFixedSize<double, Eigen::Sizes<>>;
+
+        out_scalar_t ut_corr;
+        out_tensor_t unc_weights;
+    };
+
+    using out_t = scalar_tensor;
+
+    RecoilCalibrationHelperNoUnc(const std::string &filename, const std::string &func_name, const double ut_min_, const double ut_max_) :
+        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
+            ut_max = ut_max_;
+            ut_min = ut_min_;
+    }
+
+    out_t operator() (const double &pt, const double &ut) {
+
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
+        Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_tensor;
+        pt_tensor(0) = pt;
+        ut_tensor(0) = ut;
+
+        out_t ret;
+        ret.unc_weights.setConstant(1.);
+        if(ut < ut_max and ut > ut_min) {
+            auto const inputs = std::tie(pt_tensor, ut_tensor);
+            auto outputs = std::tie(ret.ut_corr);
+            (*helper_)(inputs, outputs);
+        }
+        else {
+            ret.ut_corr = ut_tensor;
+        }
+        return ret;
+    }
+
+
+private:
+    std::shared_ptr<narf::tflite_helper> helper_;
+    double ut_max;
+    double ut_min;
+};
+
+
+}
+
+

--- a/wremnants/include/recoil_helper.h
+++ b/wremnants/include/recoil_helper.h
@@ -12,78 +12,6 @@ namespace wrem {
 
 using ROOT::VecOps::RVec;
 
-
-double print_val(double in, double out) {
-
-    cout << in << " " << out << endl;
-        return 0;
-}
-
-
-auto testFunc() {
-    Eigen::TensorFixedSize<double, Eigen::Sizes<500>> tmp;
-    tmp.setConstant(100.);
-
-    auto ret = std::tuple(20, tmp);
-    return ret;
-}
-
-
-class TestHelper {
-public:
-    using out_t = std::tuple<Eigen::TensorFixedSize<double, Eigen::Sizes<500>>, double>;
-    TestHelper() {}
-
-    out_t operator() () {
-
-        out_t ret;
-        std::get<1>(ret) = 20;
-        std::get<0>(ret).setConstant(100.);
-        return ret;
-    }
-};
-
-
-class RecoilCalibrationHelperOld {
-
-public:
-
-    RecoilCalibrationHelperOld(const std::string &filename, const std::string &func_name, double ut_min_, double ut_max_) :
-        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
-            ut_max = ut_max_;
-            ut_min = ut_min_;
-    }
-
-    double operator() (const double &pt, const double &ut) {
-
-        if(ut < ut_max and ut > ut_min) {
-            Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
-            Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_tensor;
-            Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_corr_tensor;
-            pt_tensor(0) = pt;
-            ut_tensor(0) = ut;
-
-            auto const inputs = std::tie(pt_tensor, ut_tensor);
-            auto outputs = std::tie(ut_corr_tensor);
-            (*helper_)(inputs, outputs);
-            return ut_corr_tensor(0);
-        }
-        else {
-            return ut;
-        }
-    }
-
-
-private:
-    std::shared_ptr<narf::tflite_helper> helper_;
-    double ut_max;
-    double ut_min;
-};
-
-
-
-
-
 class ResponseCorrector {
 
 public:
@@ -112,15 +40,6 @@ private:
 
 
 
-
-
-
-
-
-
-
-
-
 template <size_t N_UNC>
 class RecoilCalibrationHelper {
 
@@ -136,8 +55,10 @@ public:
 
     using out_t = scalar_tensor;
 
-    RecoilCalibrationHelper(const std::string &filename, const std::string &func_name, const double ut_min_, const double ut_max_) :
-        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
+    RecoilCalibrationHelper(const std::string &filename, const std::string &func_name, const double ut_min_, const double ut_max_, bool do_unc_) :
+        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())), 
+        helper_no_unc_(std::make_shared<narf::tflite_helper>(filename, func_name + "_no_unc", ROOT::GetThreadPoolSize())) {
+            do_unc = do_unc_;
             ut_max = ut_max_;
             ut_min = ut_min_;
     }
@@ -152,8 +73,15 @@ public:
         out_t ret;
         if(ut < ut_max and ut > ut_min) {
             auto const inputs = std::tie(pt_tensor, ut_tensor);
-            auto outputs = std::tie(ret.ut_corr, ret.unc_weights);
-            (*helper_)(inputs, outputs);
+            if(do_unc) {
+                auto outputs = std::tie(ret.ut_corr, ret.unc_weights);
+                (*helper_)(inputs, outputs);
+            }
+            else {
+                auto outputs = std::tie(ret.ut_corr);
+                (*helper_no_unc_)(inputs, outputs);
+                ret.unc_weights.setConstant(1.);
+            }
         }
         else {
             ret.ut_corr = ut_tensor;
@@ -165,56 +93,8 @@ public:
 
 private:
     std::shared_ptr<narf::tflite_helper> helper_;
-    double ut_max;
-    double ut_min;
-};
-
-
-
-template <size_t N_UNC>
-class RecoilCalibrationHelperNoUnc {
-
-public:
-
-    struct scalar_tensor {
-        using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<N_UNC>>;
-        using out_scalar_t = Eigen::TensorFixedSize<double, Eigen::Sizes<>>;
-
-        out_scalar_t ut_corr;
-        out_tensor_t unc_weights;
-    };
-
-    using out_t = scalar_tensor;
-
-    RecoilCalibrationHelperNoUnc(const std::string &filename, const std::string &func_name, const double ut_min_, const double ut_max_) :
-        helper_(std::make_shared<narf::tflite_helper>(filename, func_name, ROOT::GetThreadPoolSize())) {
-            ut_max = ut_max_;
-            ut_min = ut_min_;
-    }
-
-    out_t operator() (const double &pt, const double &ut) {
-
-        Eigen::TensorFixedSize<double, Eigen::Sizes<>> pt_tensor;
-        Eigen::TensorFixedSize<double, Eigen::Sizes<>> ut_tensor;
-        pt_tensor(0) = pt;
-        ut_tensor(0) = ut;
-
-        out_t ret;
-        ret.unc_weights.setConstant(1.);
-        if(ut < ut_max and ut > ut_min) {
-            auto const inputs = std::tie(pt_tensor, ut_tensor);
-            auto outputs = std::tie(ret.ut_corr);
-            (*helper_)(inputs, outputs);
-        }
-        else {
-            ret.ut_corr = ut_tensor;
-        }
-        return ret;
-    }
-
-
-private:
-    std::shared_ptr<narf::tflite_helper> helper_;
+    std::shared_ptr<narf::tflite_helper> helper_no_unc_;
+    bool do_unc;
     double ut_max;
     double ut_min;
 };

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -81,11 +81,9 @@ def define_muon_uT_variable(df, isWorZ, smooth3dsf=False, colNamePrefix="goodMuo
         
     return df
 
-def select_z_candidate(df, ptLow, ptHigh, mass_min=60, mass_max=120):
+def select_z_candidate(df, mass_min=60, mass_max=120):
 
     df = df.Filter("Sum(trigMuons) == 1 && Sum(nonTrigMuons) == 1")
-    df = df.Filter(f"trigMuons_pt0 > {ptLow} && trigMuons_pt0 < {ptHigh}")
-    df = df.Filter(f"nonTrigMuons_pt0 > {ptLow} && nonTrigMuons_pt0 < {ptHigh}")
 
     df = df.Define("trigMuons_mom4", "ROOT::Math::PtEtaPhiMVector(trigMuons_pt0, trigMuons_eta0, trigMuons_phi0, wrem::muon_mass)")
     df = df.Define("nonTrigMuons_mom4", "ROOT::Math::PtEtaPhiMVector(nonTrigMuons_pt0, nonTrigMuons_eta0, nonTrigMuons_phi0, wrem::muon_mass)")

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -18,7 +18,7 @@ def select_veto_muons(df, nMuons=1):
 
     return df
 
-def select_good_muons(df, nMuons=1, use_trackerMuons=False, use_isolation=False):
+def select_good_muons(df, ptLow, ptHigh, nMuons=1, use_trackerMuons=False, use_isolation=False):
 
     if use_trackerMuons:
         if dataset.group in bkgMCprocs:
@@ -28,7 +28,7 @@ def select_good_muons(df, nMuons=1, use_trackerMuons=False, use_isolation=False)
     else:
         df = df.Define("Muon_category", "Muon_isGlobal && Muon_highPurity")
 
-    goodMuonsSelection = "vetoMuons && Muon_mediumId && Muon_category"
+    goodMuonsSelection = f"Muon_correctedPt > {ptLow} && Muon_correctedPt < {ptHigh} && vetoMuons && Muon_mediumId && Muon_category"
     if use_isolation:
         # for w like we directly require isolated muons, for w we need non-isolated for qcd estimation
         goodMuonsSelection += " && Muon_pfRelIso04_all < 0.15"

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -11,6 +11,9 @@ import array
 from utilities import common as common
 from utilities import input_tools
 
+
+
+ROOT.gInterpreter.Declare('#include "recoil_helper.h"')
 ROOT.gInterpreter.Declare('#include "lowpu_recoil.h"')
 logger = logging.getLogger("wremnants").getChild(__name__.split(".")[-1])
 
@@ -65,7 +68,7 @@ recoil_cfg['highPU_mumu_DeepMETReso'] = {
     'met_xy'    : f"{common.data_dir}/recoil/highPU/mumu_DeepMETReso/met_xy_correction.json",
     'qt_rw'     : f"{common.data_dir}/recoil/highPU/mumu_DeepMETReso/qT_reweighting.json",
     'qTbins'    : list(np.arange(0, 200, 0.5)) + [200],
-    'qTmax'     : 100.,
+    'qTmax'     : 200.,
     'corr_z'    : { maps_corr_z[i] : f"{common.data_dir}/recoil/highPU/mumu_DeepMETReso/recoil_{tag}.json" for i,tag in enumerate(tags_corr_z) },
     'unc_z'     : {},
     'statUnc'   : False,
@@ -102,15 +105,35 @@ class Recoil:
         self.met = args.met
         self.flavor = flavor 
         self.parametric = True ## remove
+        self.method_cdf = False
         self.args = args
         self.smearWeights = True
         self.storeHists = args.recoilHists
+        self.doResponseCorr = False
+        self.isW = False
         setattr(ROOT.wrem, "recoil_verbose", True if args.verbose > 3 else False)
         
         rtag = f"{pu_type}_{flavor}_{self.met}"
         if not rtag in recoil_cfg:
             logger.warning(f"Recoil corrections for {pu_type}, {flavor}, {self.met} not available. Please run with the --no-recoil option.")
             quit()
+            
+        if self.met == "DeepMETReso" and pu_type == "highPU":
+
+            self.doResponseCorr = True
+            self.parametric = False
+            self.method_cdf = True
+            self.nvars_para = 400
+            self.nvars_perp = 440
+
+            f_tflite = f"{common.data_dir}/recoil/highPU/mumu_DeepMETReso/recoil_DeepMETReso.tflite"
+            if args.recoilUnc:
+                self.recoilHelper_para = ROOT.wrem.RecoilCalibrationHelper[self.nvars_para](f_tflite, "transform_para", -100, 100)
+                self.recoilHelper_perp = ROOT.wrem.RecoilCalibrationHelper[self.nvars_perp](f_tflite, "transform_perp", -100, 100)
+            else:
+                self.recoilHelper_para = ROOT.wrem.RecoilCalibrationHelperNoUnc[self.nvars_para](f_tflite, "transform_para_no_unc", -100, 100)
+                self.recoilHelper_perp = ROOT.wrem.RecoilCalibrationHelperNoUnc[self.nvars_perp](f_tflite, "transform_perp_no_unc", -100, 100)
+            self.responseCorrector = ROOT.wrem.ResponseCorrector(f_tflite, "response_corr")
 
             
         logger.info(f"Apply recoil corrections for {pu_type}, {flavor}, {self.met}")
@@ -129,7 +152,7 @@ class Recoil:
             logger.warning("qT reweighting not enabled.")
 
         # recoil Z calibration
-        for tag in recoil_cfg[rtag]['corr_z']:        
+        for tag in recoil_cfg[rtag]['corr_z']:
             self.addParametric(tag, recoil_cfg[rtag]['corr_z'][tag], doUnc=recoil_cfg[rtag]['statUnc'])
 
         # recoil Z uncertainties
@@ -339,12 +362,10 @@ class Recoil:
                 vec_gauss.push_back(vec_comp)
             vec_qt.push_back(vec_gauss)
         recoil_binned_components.insert((tag, vec_qt))
-        
-        
 
 
     def met_xycorr_setup(self, fIn):
-    
+
         def loadCoeff(d, out):
             npol = d['polyOrder']
             coeff = ROOT.std.vector["float"]()
@@ -364,23 +385,31 @@ class Recoil:
         loadCoeff(jsdata['y']['mc']['nominal'], 'met_xy_corr_y_mc_nom')
         setattr(ROOT.wrem, "applyMETxyCorrection", True)
 
+    def add_histo(self, name, cols, axes, nominal_weight="nominal_weight", with_fakes=False, col_mt="mT_corr_rec"):
+        if self.isW and with_fakes:
+            cols_fakerate = [col_mt if x=="passMT" else x for x in self.cols_fakerate] # get correct mT definition
+            self.results.append(self.df.HistoBoost(name, axes+self.axes_fakerate, cols+cols_fakerate+[nominal_weight]))
+        else:
+            self.results.append(self.df.HistoBoost(name, axes, cols+[nominal_weight]))
+
 
     def recoil_Z(self, df, results, dataset, datasets_to_apply, lep_cols, trg_cols):
-    
+
+        self.isW = False
         self.df = df
         self.results = results
         self.dataset = dataset
         self.datasets_to_apply = datasets_to_apply
-        
+
         self.leptons_pt = lep_cols[0]
         self.leptons_phi = lep_cols[1]
         self.leptons_uncorr_pt = lep_cols[2]
-        
+
         self.trgLep_pt = trg_cols[0]
         self.trgLep_phi = trg_cols[1]
         self.nonTrgLep_pt = trg_cols[2]
         self.nonTrgLep_phi = trg_cols[3]
-        
+
         self.setup_MET()
         self.setup_recoil_Z()
         self.setup_recoil_gen()
@@ -388,44 +417,46 @@ class Recoil:
         self.setup_recoil_Z_unc()
         if self.storeHists:
             self.auxHists()
-        
-        
-        
+
         return self.df
-   
-    def recoil_W(self, df, results, dataset, datasets_to_apply, lep_cols):
-    
+
+    def recoil_W(self, df, results, dataset, datasets_to_apply, lep_cols, cols_fakerate=[], axes_fakerate=[], mtw_min=40):
+
+        self.isW = True
         self.df = df
         self.results = results
         self.dataset = dataset
         self.datasets_to_apply = datasets_to_apply
-        
+        self.mtw_min = mtw_min
+
         self.leptons_pt = lep_cols[0]
         self.leptons_phi = lep_cols[1]
         self.leptons_charge = lep_cols[2]
         self.leptons_uncorr_pt = lep_cols[3]
+
+        self.cols_fakerate = cols_fakerate
+        self.axes_fakerate = axes_fakerate
 
         self.setup_MET()
         self.setup_recoil_gen()
         self.apply_recoil_W()
         self.setup_recoil_W_unc()
         return self.df
-   
-        
+
+
     def setup_MET(self):
         '''
         Define MET variables, apply lepton and XY corrections
         '''
-        
+
         # for the Z, leptons_pt, leptons_phi, leptons_uncorr_pt should be Vec_f with size 2
         # for the W, it should contain only a float/double
 
-    
         if self.met == "PFMET": met_pt, met_phi = "MET_pt", "MET_phi"
         elif self.met == "RawPFMET": met_pt, met_phi = "RawMET_pt", "RawMET_phi"
         elif self.met == "DeepMETReso": met_pt, met_phi = "DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi"
         else: sys.exit("MET type %s not supported" % self.met)
-     
+
         # uncorrected MET
         self.df = self.df.Alias("MET_uncorr_pt", met_pt)
         self.df = self.df.Alias("MET_uncorr_phi", met_phi)
@@ -446,235 +477,226 @@ class Recoil:
         self.df = self.df.Define("METx_corr_xy", "MET_corr_xy_pt*cos(MET_corr_xy_phi)")
         self.df = self.df.Define("METy_corr_xy", "MET_corr_xy_pt*sin(MET_corr_xy_phi)")
 
+        if self.isW:
+            self.df = self.df.Define("mT_corr_lep", f"wrem::mt_2({self.leptons_pt}, {self.leptons_phi}, MET_corr_lep_pt, MET_corr_lep_phi)")
+            self.df = self.df.Define("mT_corr_xy", f"wrem::mt_2({self.leptons_pt}, {self.leptons_phi}, MET_corr_xy_pt, MET_corr_xy_phi)")
+            self.df = self.df.Define("passMT_lep", f"mT_corr_lep > {self.mtw_min}")
+            self.df = self.df.Define("passMT_xy", f"mT_corr_xy > {self.mtw_min}")
+
         if not self.storeHists: 
             return
-            
-        self.results.append(self.df.HistoBoost("MET_uncorr_pt", [self.axis_MET_pt], ["MET_uncorr_pt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_uncorr_phi", [self.axis_MET_phi], ["MET_uncorr_phi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METx_uncorr", [self.axis_MET_xy], ["METx_uncorr", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_uncorr", [self.axis_MET_xy], ["METy_uncorr", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("MET_corr_lep_pt", [self.axis_MET_pt], ["MET_corr_lep_pt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_lep_phi", [self.axis_MET_phi], ["MET_corr_lep_phi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METx_corr_lep", [self.axis_MET_xy], ["METx_corr_lep", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_corr_lep", [self.axis_MET_xy], ["METy_corr_lep", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("MET_corr_xy_pt", [self.axis_MET_pt], ["MET_corr_xy_pt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_xy_phi", [self.axis_MET_phi], ["MET_corr_xy_phi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METx_corr_xy", [self.axis_MET_xy], ["METx_corr_xy", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_corr_xy", [self.axis_MET_xy], ["METy_corr_xy", "nominal_weight"], storage=hist.storage.Double()))
-        
+
+        self.add_histo("MET_uncorr_pt", ["MET_uncorr_pt"], [self.axis_MET_pt])
+        self.add_histo("MET_uncorr_phi", ["MET_uncorr_phi"], [self.axis_MET_phi])
+        self.add_histo("METx_uncorr", ["METx_uncorr"], [self.axis_MET_xy])
+        self.add_histo("METy_uncorr", ["METy_uncorr"], [self.axis_MET_xy])
+
+        self.add_histo("MET_corr_lep_pt", ["MET_corr_lep_pt"], [self.axis_MET_pt])
+        self.add_histo("MET_corr_lep_phi", ["MET_corr_lep_phi"], [self.axis_MET_phi])
+        self.add_histo("METx_corr_lep", ["METx_corr_lep"], [self.axis_MET_xy])
+        self.add_histo("METy_corr_lep", ["METy_corr_lep"], [self.axis_MET_xy])
+
+        self.add_histo("MET_corr_xy_pt", ["MET_corr_xy_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_xy")
+        self.add_histo("MET_corr_xy_phi", ["MET_corr_xy_phi"], [self.axis_MET_phi])
+        self.add_histo("METx_corr_xy", ["METx_corr_xy"], [self.axis_MET_xy])
+        self.add_histo("METy_corr_xy", ["METy_corr_xy"], [self.axis_MET_xy])
 
         # histograms as function of npv, to derive/closure test the XY correction
-        self.results.append(self.df.HistoBoost("METx_corr_lep_npv", [self.axis_npv, self.axis_MET_xy], ["PV_npvs", "METx_corr_lep", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_corr_lep_npv", [self.axis_npv, self.axis_MET_xy], ["PV_npvs", "METy_corr_lep", "nominal_weight"], storage=hist.storage.Double()))
-            
-        self.results.append(self.df.HistoBoost("METx_corr_xy_npv", [self.axis_npv, self.axis_MET_xy], ["PV_npvs", "METx_corr_xy", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_corr_xy_npv", [self.axis_npv, self.axis_MET_xy], ["PV_npvs", "METy_corr_xy", "nominal_weight"], storage=hist.storage.Double()))
-       
-        if self.dataset.is_data:
-            self.results.append(self.df.HistoBoost("METx_corr_lep_runNo", [self.axis_MET_xy, self.axis_run_no], ["METx_corr_lep", "run", "nominal_weight"]))
-            self.results.append(self.df.HistoBoost("METy_corr_lep_runNo", [self.axis_MET_xy, self.axis_run_no], ["METy_corr_lep", "run", "nominal_weight"]))
-            self.results.append(self.df.HistoBoost("npv_runNo", [self.axis_npv, self.axis_run_no], ["PV_npvs", "run", "nominal_weight"]))
-   
+        self.add_histo("METx_corr_lep_npv", ["PV_npvs", "METx_corr_lep"], [self.axis_npv, self.axis_MET_xy])
+        self.add_histo("METy_corr_lep_npv", ["PV_npvs", "METy_corr_lep"], [self.axis_npv, self.axis_MET_xy])
+
+        self.add_histo("METx_corr_xy_npv", ["PV_npvs", "METx_corr_xy"], [self.axis_npv, self.axis_MET_xy])
+        self.add_histo("METy_corr_xy_npv", ["PV_npvs", "METy_corr_xy"], [self.axis_npv, self.axis_MET_xy])
 
     def setup_recoil_Z(self):
         '''
         Setup the uncorrected recoil components
         '''
-        
+
         # construct the 2D vector sum of the two leptons
         self.df = self.df.Define("Lep1_mom2", "ROOT::Math::Polar2DVectorD(%s[0], %s[0])" % (self.leptons_pt, self.leptons_phi))
         self.df = self.df.Define("Lep2_mom2", "ROOT::Math::Polar2DVectorD(%s[1], %s[1])" % (self.leptons_pt, self.leptons_phi))
         self.df = self.df.Define("Z_mom2", "Lep1_mom2 + Lep2_mom2")
         self.df = self.df.Define("qT", "Z_mom2.R()")
         self.df = self.df.Define("qTbin", "wrem::getqTbin(qT)")
-              
+
         if self.dataset.name in self.datasets_to_apply:
             self.df = self.df.Define("qTweight_", "wrem::qTweight(qT)")
             if not self.args.theoryCorrAltOnly and self.args.theoryCorr:
+                # check this
                 self.df = self.df.Define("nominal_weight_qTrw", "nominal_weight_uncorr*qTweight_")
             else:
                 self.df = self.df.Define("nominal_weight_qTrw", "nominal_weight*qTweight_")
-
         else:
             self.df = self.df.Alias("nominal_weight_qTrw", "nominal_weight")
-        
+
         # uncorrected recoil
         self.df = self.df.Define("recoil_uncorr", "wrem::recoilComponents(MET_uncorr_pt, MET_uncorr_phi, qT, Z_mom2.Phi())")
         self.df = self.df.Define("recoil_uncorr_magn", "recoil_uncorr[0]")
         self.df = self.df.Define("recoil_uncorr_para_qT", "recoil_uncorr[1]")
         self.df = self.df.Define("recoil_uncorr_para", "recoil_uncorr[1] + qT")
         self.df = self.df.Define("recoil_uncorr_perp", "recoil_uncorr[2]")
-        
+
         # lep corrected recoil
         self.df = self.df.Define("recoil_corr_lep", "wrem::recoilComponents(MET_corr_lep_pt, MET_corr_lep_phi, qT, Z_mom2.Phi())")
         self.df = self.df.Define("recoil_corr_lep_magn", "recoil_corr_lep[0]")
         self.df = self.df.Define("recoil_corr_lep_para_qT", "recoil_corr_lep[1]")
         self.df = self.df.Define("recoil_corr_lep_para", "recoil_corr_lep[1] + qT")
         self.df = self.df.Define("recoil_corr_lep_perp", "recoil_corr_lep[2]")
-        
+
         # MET XY corrected recoil
         self.df = self.df.Define("recoil_corr_xy", "wrem::recoilComponents(MET_corr_xy_pt, MET_corr_xy_phi, qT, Z_mom2.Phi())")
         self.df = self.df.Define("recoil_corr_xy_magn", "recoil_corr_xy[0]")
         self.df = self.df.Define("recoil_corr_xy_para_qT", "recoil_corr_xy[1]")
         self.df = self.df.Define("recoil_corr_xy_para", "recoil_corr_xy[1] + qT")
         self.df = self.df.Define("recoil_corr_xy_perp", "recoil_corr_xy[2]")
-        
+
         # transverse mass
         self.df = self.df.Define("mT_uncorr", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_uncorr_pt, MET_uncorr_phi)")
         self.df = self.df.Define("mT_corr_lep", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_lep_pt, MET_corr_lep_phi)")
         self.df = self.df.Define("mT_corr_xy", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_xy_pt, MET_corr_xy_phi)")
-        
+
         self.df = self.df.Define("RawMET_sumEt_sqrt", "sqrt(RawMET_sumEt)")
-   
+
         if not self.storeHists: 
             return
-            
-        self.results.append(self.df.HistoBoost("recoil_uncorr_magn", [self.axis_recoil_magn], ["recoil_uncorr_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_uncorr_para_qT", [self.axis_recoil_para_qT], ["recoil_uncorr_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_uncorr_para", [self.axis_recoil_para], ["recoil_uncorr_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_uncorr_perp", [self.axis_recoil_perp], ["recoil_uncorr_perp", "nominal_weight"], storage=hist.storage.Double()))
-          
-        self.results.append(self.df.HistoBoost("recoil_corr_lep_magn", [self.axis_recoil_magn], ["recoil_corr_lep_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_lep_para_qT", [self.axis_recoil_para_qT], ["recoil_corr_lep_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_lep_para", [self.axis_recoil_para], ["recoil_corr_lep_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_lep_perp", [self.axis_recoil_perp], ["recoil_corr_lep_perp", "nominal_weight"], storage=hist.storage.Double()))
-            
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn", [self.axis_recoil_magn], ["recoil_corr_xy_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT", [self.axis_recoil_para_qT], ["recoil_corr_xy_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para", [self.axis_recoil_para], ["recoil_corr_xy_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp", [self.axis_recoil_perp], ["recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_qTrw", [self.axis_recoil_magn], ["recoil_corr_xy_magn", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_qTrw", [self.axis_recoil_para_qT], ["recoil_corr_xy_para_qT", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qTrw", [self.axis_recoil_para], ["recoil_corr_xy_para", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_qTrw", [self.axis_recoil_perp], ["recoil_corr_xy_perp", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("MET_corr_xy_pt_qTrw", [self.axis_MET_pt], ["MET_corr_xy_pt", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        
-        self.results.append(self.df.HistoBoost("mT_uncorr", [self.axis_mt], ["mT_uncorr", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_lep", [self.axis_mt], ["mT_corr_lep", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_xy", [self.axis_mt], ["mT_corr_xy", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_xy_qTrw", [self.axis_mt], ["mT_corr_xy", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("trg_lep_pt", [self.axis_lep_pt], [self.trgLep_pt, "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("trg_lep_pt_qTrw", [self.axis_lep_pt], [self.trgLep_pt, "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        
+
+
+        self.add_histo("recoil_uncorr_magn", ["recoil_uncorr_magn"], [self.axis_recoil_magn])
+        self.add_histo("recoil_uncorr_para_qT", ["recoil_uncorr_para_qT"], [self.axis_recoil_para_qT])
+        self.add_histo("recoil_uncorr_para", ["recoil_uncorr_para"], [self.axis_recoil_para])
+        self.add_histo("recoil_uncorr_perp", ["recoil_uncorr_perp"], [self.axis_recoil_perp])
+
+        self.add_histo("recoil_corr_lep_magn", ["recoil_corr_lep_magn"], [self.axis_recoil_magn])
+        self.add_histo("recoil_corr_lep_para_qT", ["recoil_corr_lep_para_qT"], [self.axis_recoil_para_qT])
+        self.add_histo("recoil_corr_lep_para", ["recoil_corr_lep_para"], [self.axis_recoil_para])
+        self.add_histo("recoil_corr_lep_perp", ["recoil_corr_lep_perp"], [self.axis_recoil_perp])
+
+        self.add_histo("recoil_corr_xy_magn", ["recoil_corr_xy_magn"], [self.axis_recoil_magn])
+        self.add_histo("recoil_corr_xy_para_qT", ["recoil_corr_xy_para_qT"], [self.axis_recoil_para_qT])
+        self.add_histo("recoil_corr_xy_para", ["recoil_corr_xy_para"], [self.axis_recoil_para])
+        self.add_histo("recoil_corr_xy_perp", ["recoil_corr_xy_perp"], [self.axis_recoil_perp])
+
+        self.add_histo("recoil_corr_xy_magn_qTrw", ["recoil_corr_xy_magn"], [self.axis_recoil_magn], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_xy_para_qT_qTrw", ["recoil_corr_xy_para_qT"], [self.axis_recoil_para_qT], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_xy_para_qTrw", ["recoil_corr_xy_para"], [self.axis_recoil_para], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_xy_perp_qTrw", ["recoil_corr_xy_perp"], [self.axis_recoil_perp], nominal_weight="nominal_weight_qTrw")
+
+        self.add_histo("mT_uncorr", ["mT_uncorr"], [self.axis_mt])
+        self.add_histo("mT_corr_lep", ["mT_corr_lep"], [self.axis_mt])
+        self.add_histo("mT_corr_xy", ["mT_corr_xy"], [self.axis_mt])
+        self.add_histo("mT_corr_xy_qTrw", ["mT_corr_xy"], [self.axis_mt], nominal_weight="nominal_weight_qTrw")
+
+        self.add_histo("MET_corr_xy_pt_qTrw", ["MET_corr_xy_pt"], [self.axis_MET_pt], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("trg_lep_pt", [self.trgLep_pt], [self.axis_lep_pt])
+        self.add_histo("trg_lep_pt_qTrw", [self.trgLep_pt], [self.axis_lep_pt], nominal_weight="nominal_weight_qTrw")
 
         # for the correction, binned in qT
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_qTbinned", [self.axis_qT, self.axis_recoil_magn_fine], ["qT", "recoil_corr_xy_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qTbinned", [self.axis_qT, self.axis_recoil_para_fine], ["qT", "recoil_corr_xy_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_qTbinned", [self.axis_qT, self.axis_recoil_para_fine], ["qT", "recoil_corr_xy_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_qTbinned", [self.axis_qT, self.axis_recoil_perp_fine], ["qT", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_qTbinned_qTrw", [self.axis_qT, self.axis_recoil_magn_fine], ["qT", "recoil_corr_xy_magn", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qTbinned_qTrw", [self.axis_qT, self.axis_recoil_para_fine], ["qT", "recoil_corr_xy_para", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_qTbinned_qTrw", [self.axis_qT, self.axis_recoil_para_fine], ["qT", "recoil_corr_xy_para_qT", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_qTbinned_qTrw", [self.axis_qT, self.axis_recoil_perp_fine], ["qT", "recoil_corr_xy_perp", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_npv", [self.axis_npv, self.axis_recoil_para_fine], ["PV_npvs", "recoil_corr_xy_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_npv", [self.axis_npv, self.axis_recoil_perp_fine], ["PV_npvs", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_y", [self.axis_rapidity, self.axis_recoil_para_fine], ["yZ", "recoil_corr_xy_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_y", [self.axis_rapidity, self.axis_recoil_perp_fine], ["yZ", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_sumEt", [self.axis_sumEt, self.axis_recoil_para_fine], ["RawMET_sumEt", "recoil_corr_xy_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_sumEt", [self.axis_sumEt, self.axis_recoil_perp_fine], ["RawMET_sumEt", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("RawMET_sumEt_qTbinned", [self.axis_qT, self.axis_sumEt], ["qT", "RawMET_sumEt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("RawMET_sumEt_sqrt_qTbinned", [self.axis_qT, self.axis_sumEt_sqrt], ["qT", "RawMET_sumEt_sqrt", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_perp", [self.axis_recoil_para, self.axis_recoil_perp], ["recoil_corr_xy_para", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("qT", [self.axis_qT], ["qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("qT_qTrw", [self.axis_qT], ["qT", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        if self.dataset.is_data:
-            self.results.append(self.df.HistoBoost("recoil_uncorr_para_runNo", [self.axis_recoil_para, self.axis_run_no], ["recoil_uncorr_para", "run", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_uncorr_perp_runNo", [self.axis_recoil_perp, self.axis_run_no], ["recoil_uncorr_perp", "run", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_lep_para_runNo", [self.axis_recoil_para, self.axis_run_no], ["recoil_corr_lep_para", "run", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_lep_perp_runNo", [self.axis_recoil_perp, self.axis_run_no], ["recoil_corr_lep_perp", "run", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_xy_para_runNo", [self.axis_recoil_para, self.axis_run_no], ["recoil_corr_xy_para", "run", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_runNo", [self.axis_recoil_perp, self.axis_run_no], ["recoil_corr_xy_perp", "run", "nominal_weight"], storage=hist.storage.Double()))
-           
-            
+        self.add_histo("recoil_corr_xy_magn_qTbinned", ["qT", "recoil_corr_xy_magn"], [self.axis_qT, self.axis_recoil_magn_fine])
+        self.add_histo("recoil_corr_xy_para_qTbinned", ["qT", "recoil_corr_xy_para"], [self.axis_qT, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_para_qT_qTbinned", ["qT", "recoil_corr_xy_para_qT"], [self.axis_qT, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_qTbinned", ["qT", "recoil_corr_xy_perp"], [self.axis_qT, self.axis_recoil_perp_fine])
+
+        self.add_histo("recoil_corr_xy_para_npv", ["PV_npvs", "recoil_corr_xy_para"], [self.axis_npv, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_npv", ["recoil_corr_xy_perp"], [self.axis_npv, self.axis_recoil_perp_fine])
+
+        self.add_histo("recoil_corr_xy_para_y", ["yZ", "recoil_corr_xy_para"], [self.axis_rapidity, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_y", ["yZ", "recoil_corr_xy_perp"], [self.axis_rapidity, self.axis_recoil_perp_fine])
+
+        self.add_histo("recoil_corr_xy_para_sumEt", ["RawMET_sumEt", "recoil_corr_xy_para"], [self.axis_sumEt, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_sumEt", ["RawMET_sumEt", "recoil_corr_xy_perp"], [self.axis_sumEt, self.axis_recoil_perp_fine])
+
+        self.add_histo("RawMET_sumEt_qTbinned", ["qT", "RawMET_sumEt"], [self.axis_qT, self.axis_sumEt])
+        self.add_histo("RawMET_sumEt_sqrt_qTbinned", ["qT", "RawMET_sumEt_sqrt"], [self.axis_qT, self.axis_sumEt_sqrt])
+
+        self.add_histo("recoil_corr_xy_para_perp", ["recoil_corr_xy_para", "recoil_corr_xy_perp"], [self.axis_recoil_para, self.axis_recoil_perp])
+        self.add_histo("qT", ["qT"], [self.axis_qT])
+        self.add_histo("qT_qTrw", ["qT"], [self.axis_qT], nominal_weight="nominal_weight_qTrw")
+
 
 
     def auxHists(self):
-        
-        self.df = self.df.Define("njets", "Jet_pt.size()")
-        self.results.append(self.df.HistoBoost("njets", [self.axis_njets], ["njets", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("npv", [self.axis_npv], ["PV_npvs", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("RawMET_sumEt", [self.axis_npv, self.axis_sumEt], ["PV_npvs", "RawMET_sumEt", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("npv_RawMET_sumEt", [self.axis_sumEt], ["RawMET_sumEt", "nominal_weight"], storage=hist.storage.Double()))
-        
-        # recoil resolutions vs any
-        if self.dataset.is_data:
-            self.results.append(self.df.HistoBoost("njets_runNo", [self.axis_njets, self.axis_run_no], ["njets", "run", "nominal_weight"]))
-            self.results.append(self.df.HistoBoost("RawMET_sumEt_runNo", [self.axis_sumEt, self.axis_run_no], ["RawMET_sumEt", "run", "nominal_weight"]))
 
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_njets", [self.axis_njets, self.axis_recoil_para_fine], ["njets", "recoil_corr_xy_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_njets", [self.axis_njets, self.axis_recoil_perp_fine], ["njets", "recoil_corr_xy_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        # correlation sumET vs qT
-        self.results.append(self.df.HistoBoost("qT_sumEt", [self.axis_qT, self.axis_sumEt], ["qT", "RawMET_sumEt", "nominal_weight"], storage=hist.storage.Double()))
- 
+        self.df = self.df.Define("njets", "Jet_pt.size()")
+        self.add_histo("njets", ["njets"], [self.axis_njets])
+        self.add_histo("RawMET_sumEt", ["RawMET_sumEt"], [self.axis_sumEt])
+
+        self.add_histo("npv", ["PV_npvs"], [self.axis_npv])
+        self.add_histo("npv_RawMET_sumEt", ["PV_npvs", "RawMET_sumEt"], [self.axis_npv, self.axis_sumEt])
+        self.add_histo("qT_sumEt", ["qT", "RawMET_sumEt"], [self.axis_qT, self.axis_sumEt])
+
+        self.add_histo("recoil_corr_xy_para_qT_njets", ["njets", "recoil_corr_xy_para_qT"], [self.axis_njets, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_njets", ["njets", "recoil_corr_xy_perp"], [self.axis_njets, self.axis_recoil_perp_fine])
+
+        # run-dependent stuff for data
+        if self.dataset.is_data and False:
+            self.add_histo("njets_runNo", ["njets", "run"], [self.axis_njets, self.axis_run_no])
+            self.add_histo("RawMET_sumEt_runNo", ["RawMET_sumEt", "run"], [self.axis_sumEt, self.axis_run_no])
+
+            self.add_histo("recoil_uncorr_para_runNo", ["recoil_uncorr_para", "run"], [self.axis_recoil_para, self.axis_run_no])
+            self.add_histo("recoil_uncorr_perp_runNo", ["recoil_uncorr_perp", "run"], [self.axis_recoil_perp, self.axis_run_no])
+            self.add_histo("recoil_corr_lep_para_runNo", ["recoil_corr_lep_para", "run"], [self.axis_recoil_para, self.axis_run_no])
+            self.add_histo("recoil_corr_lep_perp_runNo", ["recoil_corr_lep_perp", "run"], [self.axis_recoil_perp, self.axis_run_no])
+            self.add_histo("recoil_corr_xy_para_runNo", ["recoil_corr_xy_para", "run"], [self.axis_recoil_para, self.axis_run_no])
+            self.add_histo("recoil_corr_xy_perp_runNo", ["recoil_corr_xy_perp", "run"], [self.axis_recoil_perp, self.axis_run_no])
+
+            self.add_histo("METx_corr_lep_runNo", ["METx_corr_lep", "run"], [self.axis_MET_xy, self.axis_run_no])
+            self.add_histo("METy_corr_lep_runNo", ["METy_corr_lep", "run"], [self.axis_MET_xy, self.axis_run_no])
+            self.add_histo("npv_runNo", ["PV_npvs", "run"], [self.axis_npv, self.axis_run_no])
 
     def setup_recoil_gen(self):
-        
-        if not self.dataset.name in self.datasets_to_apply: 
+
+        if not self.dataset.name in self.datasets_to_apply:
             return 
-        
+
         # decompose MET and dilepton (for Z) or lepton (for W) along the generator boson direction
         if self.flavor == "mumu" or self.flavor == "ee": # dilepton
             self.df = self.df.Define("recoil_corr_xy_gen", "wrem::recoilComponentsGen(MET_corr_xy_pt, MET_corr_xy_phi, qT, Z_mom2.Phi(), phiVgen)")
         else: # single lepton
             self.df = self.df.Define("recoil_corr_xy_gen", f"wrem::recoilComponentsGen(MET_corr_xy_pt, MET_corr_xy_phi, {self.leptons_pt}, {self.leptons_phi}, phiVgen)")
 
-
         self.df = self.df.Define("qT_gen", "ptVgen") # pre-fsr defines should be loaded
-        
         self.df = self.df.Define("recoil_corr_xy_magn_gen", "recoil_corr_xy_gen[0]")
         self.df = self.df.Define("recoil_corr_xy_para_gen", "recoil_corr_xy_gen[1] + qT_gen")
         self.df = self.df.Define("recoil_corr_xy_para_qT_gen", "recoil_corr_xy_gen[1]")
         self.df = self.df.Define("recoil_corr_xy_perp_gen", "recoil_corr_xy_gen[2]")
-        
+
         if not self.storeHists: 
             return
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_gen", [self.axis_recoil_magn], ["recoil_corr_xy_magn_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_gen", [self.axis_recoil_para], ["recoil_corr_xy_para_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_gen", [self.axis_recoil_para_qT], ["recoil_corr_xy_para_qT_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_gen", [self.axis_recoil_perp], ["recoil_corr_xy_perp_gen", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_gen_qTbinned", [self.axis_qT, self.axis_recoil_magn_fine], ["qT_gen", "recoil_corr_xy_magn_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_gen_qTbinned", [self.axis_qT, self.axis_recoil_para_fine], ["qT_gen", "recoil_corr_xy_para_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_gen_qTbinned", [self.axis_qT, self.axis_recoil_para_fine], ["qT_gen", "recoil_corr_xy_para_qT_gen", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_gen_qTbinned", [self.axis_qT, self.axis_recoil_perp_fine], ["qT_gen", "recoil_corr_xy_perp_gen", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("qT_gen", [self.axis_qT], ["qT_gen", "nominal_weight"], storage=hist.storage.Double()))
-        
-     
 
-    def apply_recoil_Z(self): 
+        self.add_histo("recoil_corr_xy_magn_gen", ["recoil_corr_xy_magn_gen"], [self.axis_recoil_magn])
+        self.add_histo("recoil_corr_xy_para_gen", ["recoil_corr_xy_para_gen"], [self.axis_recoil_para])
+        self.add_histo("recoil_corr_xy_para_qT_gen", ["recoil_corr_xy_para_qT_gen"], [self.axis_recoil_para_qT])
+        self.add_histo("recoil_corr_xy_perp_gen", ["recoil_corr_xy_perp_gen"], [self.axis_recoil_perp])
+
+        self.add_histo("recoil_corr_xy_magn_gen_qTbinned", ["qT_gen", "recoil_corr_xy_magn_gen"], [self.axis_qT, self.axis_recoil_magn_fine])
+        self.add_histo("recoil_corr_xy_para_gen_qTbinned", ["qT_gen", "recoil_corr_xy_para_gen"], [self.axis_qT, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_para_qT_gen_qTbinned", ["qT_gen", "recoil_corr_xy_para_qT_gen"], [self.axis_qT, self.axis_recoil_para_fine])
+        self.add_histo("recoil_corr_xy_perp_gen_qTbinned", ["qT_gen", "recoil_corr_xy_perp_gen"], [self.axis_qT, self.axis_recoil_perp_fine])
+
+        self.add_histo("qT_gen", ["qT_gen"], [self.axis_qT])
+
+    def apply_recoil_Z(self):
 
         if self.dataset.name in self.datasets_to_apply:
-            
-            if self.parametric: self.df = self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionParametric(recoil_corr_xy_para, recoil_corr_xy_perp, qT)")
-            else: self.df = self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionBinned(recoil_corr_xy_para_qT, recoil_corr_xy_perp, qTbin, qT)") # 
-            self.df = self.df.Define("recoil_corr_rec_magn", "recoil_corr_rec[0]")
-            self.df = self.df.Define("recoil_corr_rec_para_qT", "recoil_corr_rec[1] - qT")
-            self.df = self.df.Define("recoil_corr_rec_para", "recoil_corr_rec[1]")
-            self.df = self.df.Define("recoil_corr_rec_perp", "recoil_corr_rec[2]")
-            
-            self.df = self.df.Define("MET_corr_rec", "wrem::METCorrection(MET_corr_xy_pt, MET_corr_xy_phi, recoil_corr_rec_para_qT, recoil_corr_rec_perp, qT, Z_mom2.Phi()) ")
+
+            if self.parametric:
+                self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionParametric(recoil_corr_xy_para, recoil_corr_xy_perp, qT)")
+                self.df = self.df.Define("recoil_corr_rec_magn", "recoil_corr_rec[0]")
+                self.df = self.df.Define("recoil_corr_rec_para_qT", "recoil_corr_rec[1] - qT")
+                self.df = self.df.Define("recoil_corr_rec_para", "recoil_corr_rec[1]")
+                self.df = self.df.Define("recoil_corr_rec_perp", "recoil_corr_rec[2]")
+            elif self.method_cdf:
+                self.df = self.df.Define("corr_para", self.recoilHelper_para, ["qT", "recoil_corr_xy_para"])
+                self.df = self.df.Define("corr_perp", self.recoilHelper_perp, ["qT", "recoil_corr_xy_perp"])
+                self.df = self.df.Define("recoil_corr_rec_para", "corr_para.ut_corr(0)")
+                self.df = self.df.Define("recoil_corr_rec_perp", "corr_perp.ut_corr(0)")
+                self.df = self.df.Define("recoil_corr_rec_para_qT", "recoil_corr_rec_para - qT")
+                self.df = self.df.Define("recoil_corr_rec_magn", "std::hypot(recoil_corr_rec_para_qT, recoil_corr_rec_perp)")
+
+            self.df = self.df.Define("MET_corr_rec", "wrem::METCorrection(MET_corr_xy_pt, MET_corr_xy_phi, recoil_corr_rec_para_qT, recoil_corr_rec_perp, qT, Z_mom2.Phi())")
             self.df = self.df.Define("MET_corr_rec_pt", "MET_corr_rec[0]")
             self.df = self.df.Define("MET_corr_rec_phi", "MET_corr_rec[1]")
-            
         else:
             self.df = self.df.Alias("recoil_corr_rec_magn", "recoil_corr_xy_magn")
             self.df = self.df.Alias("recoil_corr_rec_para_qT", "recoil_corr_xy_para_qT")
@@ -683,174 +705,142 @@ class Recoil:
             self.df = self.df.Alias("MET_corr_rec_pt", "MET_corr_xy_pt")
             self.df = self.df.Alias("MET_corr_rec_phi", "MET_corr_xy_phi")
 
-       
+        # response correction
+        if self.doResponseCorr:
+            self.df = self.df.Define("response_corr", self.responseCorrector, ["qT"])
+        else:
+            self.df = self.df.Define("response_corr", "0.")
+        self.df = self.df.Define("recoil_corr_rec_resp_para", "recoil_corr_rec_para - response_corr")
+        self.df = self.df.Define("recoil_corr_rec_resp_para_qT", "recoil_corr_rec_resp_para - qT")
+        self.df = self.df.Define("recoil_corr_rec_resp_magn", "std::hypot(recoil_corr_rec_resp_para_qT, recoil_corr_rec_perp)")
+        self.df = self.df.Define("MET_corr_rec_resp", "wrem::METCorrection(MET_corr_xy_pt, MET_corr_xy_phi, recoil_corr_rec_resp_para_qT, recoil_corr_rec_perp, qT, Z_mom2.Phi())")
+        self.df = self.df.Define("MET_corr_rec_resp_pt", "MET_corr_rec_resp[0]")
+        self.df = self.df.Define("MET_corr_rec_resp_phi", "MET_corr_rec_resp[1]")
+        self.df = self.df.Define("mT_corr_rec_resp", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_rec_resp_pt, MET_corr_rec_resp_phi)")
+
         self.df = self.df.Define("MET_corr_rec_xy_dPhi", "wrem::deltaPhi(MET_corr_rec_phi, MET_corr_xy_phi)")
         self.df = self.df.Define("METx_corr_rec", "MET_corr_rec_pt*cos(MET_corr_rec_phi)")
         self.df = self.df.Define("METy_corr_rec", "MET_corr_rec_pt*sin(MET_corr_rec_phi)")
         self.df = self.df.Define("mT_corr_rec", f"wrem::get_mt_wlike({self.trgLep_pt}, {self.trgLep_phi}, {self.nonTrgLep_pt}, {self.nonTrgLep_phi}, MET_corr_rec_pt, MET_corr_rec_phi)")
-        
-        if not self.storeHists: 
-            return
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_magn", [self.axis_recoil_magn], ["recoil_corr_rec_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_qT", [self.axis_recoil_para_qT], ["recoil_corr_rec_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para", [self.axis_recoil_para], ["recoil_corr_rec_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_perp", [self.axis_recoil_perp], ["recoil_corr_rec_perp", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_rec", [self.axis_mt], ["mT_corr_rec", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_pt", [self.axis_MET_pt], ["MET_corr_rec_pt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_phi", [self.axis_MET_phi], ["MET_corr_rec_phi", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_magn_qTbinned", [self.axis_qT, self.axis_recoil_magn], ["qT", "recoil_corr_rec_magn", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_qT_qTbinned", [self.axis_qT, self.axis_recoil_para_qT], ["qT", "recoil_corr_rec_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_qTbinned", [self.axis_qT, self.axis_recoil_para], ["qT", "recoil_corr_rec_para", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_perp_qTbinned", [self.axis_qT, self.axis_recoil_perp], ["qT", "recoil_corr_rec_perp", "nominal_weight"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("MET_corr_rec_pt_qT", [self.axis_qT, self.axis_MET_pt], ["qT", "MET_corr_rec_pt", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_perp_2d", [self.axis_recoil_2d_para, self.axis_recoil_2d_perp], ["recoil_corr_rec_para", "recoil_corr_rec_perp", "nominal_weight"], storage=hist.storage.Double()))
-
-        self.results.append(self.df.HistoBoost("METx_corr_rec", [self.axis_MET_xy], ["METx_corr_rec", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("METy_corr_rec", [self.axis_MET_xy], ["METy_corr_rec", "nominal_weight"], storage=hist.storage.Double()))
-        
 
         self.df = self.df.Define("MET_corr_lep_ll_dPhi", "wrem::deltaPhi(MET_corr_lep_phi, Z_mom2.Phi())")
         self.df = self.df.Define("MET_corr_xy_ll_dPhi", "wrem::deltaPhi(MET_corr_xy_phi, Z_mom2.Phi())")
         self.df = self.df.Define("MET_corr_rec_ll_dPhi", "wrem::deltaPhi(MET_corr_rec_phi, Z_mom2.Phi())")
         self.df = self.df.Define("ll_phi", "Z_mom2.Phi()")
-        self.results.append(self.df.HistoBoost("MET_corr_lep_ll_dPhi", [self.axis_MET_phi], ["MET_corr_lep_ll_dPhi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_xy_ll_dPhi", [self.axis_MET_phi], ["MET_corr_xy_ll_dPhi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_ll_dPhi", [self.axis_MET_phi], ["MET_corr_rec_ll_dPhi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_xy_dPhi", [self.axis_MET_dphi], ["MET_corr_rec_xy_dPhi", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("ll_phi", [self.axis_MET_phi], ["ll_phi", "nominal_weight"], storage=hist.storage.Double()))
-        
+
+        if not self.storeHists: 
+            return
+
+        self.add_histo("recoil_corr_rec_magn", ["recoil_corr_rec_magn"], [self.axis_recoil_magn])
+        self.add_histo("recoil_corr_rec_para_qT", ["recoil_corr_rec_para_qT"], [self.axis_recoil_para_qT])
+        self.add_histo("recoil_corr_rec_para", ["recoil_corr_rec_para"], [self.axis_recoil_para])
+        self.add_histo("recoil_corr_rec_perp", ["recoil_corr_rec_perp"], [self.axis_recoil_perp])
+
+        self.add_histo("mT_corr_rec", ["mT_corr_rec"], [self.axis_mt])
+        self.add_histo("MET_corr_rec_pt", ["MET_corr_rec_pt"], [self.axis_MET_pt])
+        self.add_histo("MET_corr_rec_phi", ["MET_corr_rec_phi"], [self.axis_MET_phi])
+
+        self.add_histo("recoil_corr_rec_magn_qTbinned", ["qT", "recoil_corr_rec_magn"], [self.axis_qT, self.axis_recoil_magn])
+        self.add_histo("recoil_corr_rec_para_qT_qTbinned", ["qT", "recoil_corr_rec_para_qT"], [self.axis_qT, self.axis_recoil_para_qT])
+        self.add_histo("recoil_corr_rec_para_qTbinned", ["qT", "recoil_corr_rec_para"], [self.axis_qT, self.axis_recoil_para])
+        self.add_histo("recoil_corr_rec_perp_qTbinned", ["qT", "recoil_corr_rec_perp"], [self.axis_qT, self.axis_recoil_perp])
+
+        self.add_histo("MET_corr_rec_pt_qT", ["qT", "MET_corr_rec_pt"], [self.axis_qT, self.axis_MET_pt])
+        self.add_histo("recoil_corr_rec_para_perp_2d", ["recoil_corr_rec_para", "recoil_corr_rec_perp"], [self.axis_recoil_2d_para, self.axis_recoil_2d_perp])
+
+        self.add_histo("METx_corr_rec", ["METx_corr_rec"], [self.axis_MET_xy])
+        self.add_histo("METy_corr_rec", ["METy_corr_rec"], [self.axis_MET_xy])
+
+        self.add_histo("MET_corr_lep_ll_dPhi", ["MET_corr_lep_ll_dPhi"], [self.axis_MET_phi])
+        self.add_histo("MET_corr_xy_ll_dPhi", ["MET_corr_xy_ll_dPhi"], [self.axis_MET_phi])
+        self.add_histo("MET_corr_rec_ll_dPhi", ["MET_corr_rec_ll_dPhi"], [self.axis_MET_phi])
+        self.add_histo("MET_corr_rec_xy_dPhi", ["MET_corr_rec_xy_dPhi"], [self.axis_MET_dphi])
+        self.add_histo("ll_phi", ["ll_phi"], [self.axis_MET_phi])
 
         # for validation, reoil plots with weighted qT spectrum
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_magn_qTrw", [self.axis_recoil_magn], ["recoil_corr_rec_magn", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_qT_qTrw", [self.axis_recoil_para_qT], ["recoil_corr_rec_para_qT", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_para_qTrw", [self.axis_recoil_para], ["recoil_corr_rec_para", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_perp_qTrw", [self.axis_recoil_perp], ["recoil_corr_rec_perp", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_pt_qTrw", [self.axis_MET_pt], ["MET_corr_rec_pt", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_rec_qTrw", [self.axis_mt], ["mT_corr_rec", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-    
-     
+        self.add_histo("recoil_corr_rec_magn_qTrw", ["recoil_corr_rec_magn"], [self.axis_recoil_magn], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_rec_para_qT_qTrw", ["recoil_corr_rec_para_qT"], [self.axis_recoil_para_qT], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_rec_para_qTrw", ["recoil_corr_rec_para"], [self.axis_recoil_para], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_rec_perp_qTrw", ["recoil_corr_rec_perp"], [self.axis_recoil_perp], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("MET_corr_rec_pt_qTrw", ["MET_corr_rec_pt"], [self.axis_MET_pt], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("mT_corr_rec_qTrw", ["mT_corr_rec"], [self.axis_mt], nominal_weight="nominal_weight_qTrw")
+
+        # response corr
+        self.add_histo("MET_corr_rec_resp_pt", ["MET_corr_rec_resp_pt"], [self.axis_MET_pt])
+        self.add_histo("mT_corr_rec_resp", ["mT_corr_rec_resp"], [self.axis_mt])
+        self.add_histo("recoil_corr_rec_resp_para", ["recoil_corr_rec_resp_para"], [self.axis_recoil_para])
+
+        self.add_histo("MET_corr_rec_resp_pt_qTrw", ["MET_corr_rec_resp_pt"], [self.axis_MET_pt], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("mT_corr_rec_resp_qTrw", ["mT_corr_rec_resp"], [self.axis_mt], nominal_weight="nominal_weight_qTrw")
+        self.add_histo("recoil_corr_rec_resp_para_qTrw", ["recoil_corr_rec_resp_para"], [self.axis_recoil_para], nominal_weight="nominal_weight_qTrw")
+
     def apply_recoil_W(self): 
-    
 
         if self.dataset.name in self.datasets_to_apply:
-        
             self.df = self.df.Define("qTweight_", "wrem::qTweight(qT_gen)")
             if not self.args.theoryCorrAltOnly and self.args.theoryCorr:
                 self.df = self.df.Define("nominal_weight_qTrw", "nominal_weight_uncorr*qTweight_")
             else:
                 self.df = self.df.Define("nominal_weight_qTrw", "nominal_weight*qTweight_")
-            
-            ''' 
-            self.df = self.df.Define("recoil_corr_wz", "wrem::recoilCorrectionBinnedWtoZ(Lep_charge, recoil_corr_xy_para_gen, recoil_corr_xy_perp_gen, qTbin_gen, qT_gen)")
-            self.df = self.df.Define("recoil_corr_wz_magn", "recoil_corr_wz[0]")
-            self.df = self.df.Define("recoil_corr_wz_para", "recoil_corr_wz[1]")
-            self.df = self.df.Define("recoil_corr_wz_para_qT", "recoil_corr_wz[1] + qT_gen")
-            self.df = self.df.Define("recoil_corr_wz_perp", "recoil_corr_wz[2]")
-            self.df = self.df.Define("recoil_corr_wz_para_qT_perp", "recoil_corr_wz[1] + qT_gen + recoil_corr_wz[2]")
 
-            self.df = self.df.Define("MET_corr_wz", "wrem::METCorrectionGen(recoil_corr_wz_para, recoil_corr_wz_perp, Lep_pt, Lep_phi, phiVgen) ") # was qTgen
-            self.df = self.df.Define("MET_corr_wz_pt", "MET_corr_wz[0]")
-            self.df = self.df.Define("MET_corr_wz_phi", "MET_corr_wz[1]")
-            
-            self.results.append(self.df.HistoBoost("recoil_corr_wz_magn", [self.axis_recoil_magn], ["recoil_corr_wz_magn", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_wz_para", [self.axis_recoil_para], ["recoil_corr_wz_para", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_wz_para_qT", [self.axis_recoil_perp], ["recoil_corr_wz_para_qT", "nominal_weight"], storage=hist.storage.Double()))
-            self.results.append(self.df.HistoBoost("recoil_corr_wz_perp", [self.axis_recoil_perp], ["recoil_corr_wz_perp", "nominal_weight"], storage=hist.storage.Double()))
-            '''     
+            if self.parametric:
+                self.df = self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionParametric(recoil_corr_xy_para_gen, recoil_corr_xy_perp_gen, qT_gen)")
+                self.df = self.df.Define("recoil_corr_rec_para_qT_gen", "recoil_corr_rec[1] - qT_gen")
+                self.df = self.df.Define("recoil_corr_rec_para_gen", "recoil_corr_rec[1]")
+                self.df = self.df.Define("recoil_corr_rec_perp_gen", "recoil_corr_rec[2]")
+            elif self.method_cdf:
+                self.df = self.df.Define("corr_para", self.recoilHelper_para, ["qT_gen", "recoil_corr_xy_para_gen"])
+                self.df = self.df.Define("corr_perp", self.recoilHelper_perp, ["qT_gen", "recoil_corr_xy_perp_gen"])
+                self.df = self.df.Define("recoil_corr_rec_para_gen", "corr_para.ut_corr(0)")
+                self.df = self.df.Define("recoil_corr_rec_perp_gen", "corr_perp.ut_corr(0)")
+                self.df = self.df.Define("recoil_corr_rec_para_qT_gen", "recoil_corr_rec_para_gen - qT_gen")
 
-            
-            if self.parametric: self.df = self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionParametric(recoil_corr_xy_para_gen, recoil_corr_xy_perp_gen, qT_gen)")
-            else: self.df = self.df.Define("recoil_corr_rec", "wrem::recoilCorrectionBinned(recoil_corr_xy_para_gen, recoil_corr_xy_perp_gen, qTbin_gen, qT_gen)")
-            self.df = self.df.Define("recoil_corr_rec_magn_gen", "recoil_corr_rec[0]")
-            self.df = self.df.Define("recoil_corr_rec_para_gen", "recoil_corr_rec[1]")
-            self.df = self.df.Define("recoil_corr_rec_para_qT_gen", "recoil_corr_rec[1] - qT_gen")
-            self.df = self.df.Define("recoil_corr_rec_perp_gen", "recoil_corr_rec[2]")
-            
             self.df = self.df.Define("MET_corr_rec", f"wrem::METCorrectionGen(recoil_corr_rec_para_qT_gen, recoil_corr_rec_perp_gen, {self.leptons_pt}, {self.leptons_phi}, phiVgen) ") 
             self.df = self.df.Define("MET_corr_rec_pt", "MET_corr_rec[0]")
             self.df = self.df.Define("MET_corr_rec_phi", "MET_corr_rec[1]")
-            
-            # compute recoil
-            self.df = self.df.Define("recoil_corr_rec_magn", f"wrem::recoilComponents(MET_corr_rec_pt, MET_corr_rec_phi, {self.leptons_pt}, {self.leptons_phi})")
-            
+
             if self.storeHists: 
-                self.results.append(self.df.HistoBoost("qT_gen_qTrw", [self.axis_qT], ["qT_gen", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(self.df.HistoBoost("recoil_corr_xy_magn_gen_qTrw", [self.axis_recoil_magn], ["recoil_corr_xy_magn_gen", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(self.df.HistoBoost("recoil_corr_xy_para_gen_qTrw", [self.axis_recoil_para], ["recoil_corr_xy_para_gen", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(self.df.HistoBoost("recoil_corr_xy_para_qT_gen_qTrw", [self.axis_recoil_para_qT], ["recoil_corr_xy_para_qT_gen", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(self.df.HistoBoost("recoil_corr_xy_perp_gen_qTrw", [self.axis_recoil_perp], ["recoil_corr_xy_perp_gen", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-            
+                self.add_histo("qT_gen_qTrw", ["qT_gen"], [self.axis_qT], nominal_weight="nominal_weight_qTrw")
+                self.add_histo("recoil_corr_xy_magn_gen_qTrw", ["recoil_corr_xy_magn_gen"], [self.axis_recoil_magn])
+                self.add_histo("recoil_corr_xy_para_gen_qTrw", ["recoil_corr_xy_para_gen"], [self.axis_recoil_para])
+                self.add_histo("recoil_corr_xy_para_qT_gen_qTrw", ["recoil_corr_xy_para_qT_gen"], [self.axis_recoil_para_qT])
+                self.add_histo("recoil_corr_xy_perp_gen_qTrw", ["recoil_corr_xy_perp_gen"], [self.axis_recoil_perp])
+
         else:
-        
             self.df = self.df.Alias("nominal_weight_qTrw", "nominal_weight")
-            # recoil not defined for backgrounds, only MET
-            #self.df = self.df.Alias("recoil_corr_wz_magn", "recoil_corr_xy_magn")
-            #self.df = self.df.Alias("recoil_corr_wz_para", "recoil_corr_xy_para")
-            #self.df = self.df.Define("recoil_corr_wz_para_qT", "recoil_corr_xy_para + qT")
-            #self.df = self.df.Alias("recoil_corr_wz_perp", "recoil_corr_xy_perp")
-            #self.df = self.df.Alias("recoil_corr_wz_para_qT_perp", "recoil_corr_xy_para_qT_perp")
-            
             self.df = self.df.Alias("MET_corr_wz_pt", "MET_corr_xy_pt")
             self.df = self.df.Alias("MET_corr_wz_phi", "MET_corr_xy_phi")
-            
             self.df = self.df.Define("MET_corr_rec_pt", "MET_corr_xy_pt")
             self.df = self.df.Define("MET_corr_rec_phi", "MET_corr_xy_phi")
-            
-            self.df = self.df.Define("recoil_corr_rec_magn", f"wrem::recoilComponents(MET_corr_xy_pt, MET_corr_xy_phi, {self.leptons_pt}, {self.leptons_phi})")
+
+        self.df = self.df.Define("recoil_corr_rec_magn", f"wrem::recoilComponents(MET_corr_xy_pt, MET_corr_xy_phi, {self.leptons_pt}, {self.leptons_phi})")
         
-        self.df = self.df.Define("mT_corr_lep", f"wrem::mt_2({self.leptons_pt}, {self.leptons_phi}, MET_corr_lep_pt, MET_corr_lep_phi)")
-        self.df = self.df.Define("mT_corr_xy", f"wrem::mt_2({self.leptons_pt}, {self.leptons_phi}, MET_corr_xy_pt, MET_corr_xy_phi)")
         self.df = self.df.Define("mT_corr_rec", f"wrem::mt_2({self.leptons_pt}, {self.leptons_phi}, MET_corr_rec_pt, MET_corr_rec_phi)")
-        self.df = self.df.Define("passMT_lep", "mT_corr_lep > 40")
-        self.df = self.df.Define("passMT_xy", "mT_corr_xy > 40")
         self.df = self.df.Define("passMT_rec", "mT_corr_rec > 40")
-        
-        
+
         if not self.storeHists: 
             return
-        
 
-        cols_mT = ["mT_corr_rec", self.leptons_charge, "passMT_rec", "passIso"]
-        cols_MET_pt = ["MET_corr_rec_pt", self.leptons_charge, "passMT_rec", "passIso"]
-        cols_MET_phi = ["MET_corr_rec_phi", self.leptons_charge, "passMT_rec", "passIso"]
-        
-        cols_mT_xy = ["mT_corr_xy", self.leptons_charge, "passMT_xy", "passIso"]
-        cols_MET_pt_xy = ["MET_corr_xy_pt", self.leptons_charge, "passMT_xy", "passIso"]
-        cols_MET_phi_xy = ["MET_corr_xy_phi", self.leptons_charge, "passMT_xy", "passIso"]
-        
-        cols_mT_lep = ["mT_corr_lep", self.leptons_charge, "passMT_lep", "passIso"]
-        cols_MET_pt_lep = ["MET_corr_lep_pt", self.leptons_charge, "passMT_lep", "passIso"]
-        cols_MET_phi_lep = ["MET_corr_lep_phi", self.leptons_charge, "passMT_lep", "passIso"]
-        
-        axes_mT = [self.axis_mt, self.axis_charge, self.axis_passMT, self.axis_passIso]
-        axes_MET_pt = [self.axis_MET_pt, self.axis_charge, self.axis_passMT, self.axis_passIso]
-        axes_MET_phi = [self.axis_MET_phi, self.axis_charge, self.axis_passMT, self.axis_passIso]
-        
-        self.results.append(self.df.HistoBoost("mT_corr_lep", axes_mT, cols_mT_lep + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_xy", axes_mT, cols_mT_xy + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_xy_qTrw", axes_mT, cols_mT_xy + ["nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_rec", axes_mT, cols_mT + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("mT_corr_rec_qTrw", axes_mT, cols_mT + ["nominal_weight_qTrw"], storage=hist.storage.Double()))
+        self.add_histo("mT_corr_lep", ["mT_corr_lep"], [self.axis_mt], with_fakes=True, col_mt="passMT_lep")
+        self.add_histo("mT_corr_xy", ["mT_corr_xy"], [self.axis_mt], with_fakes=True, col_mt="passMT_xy")
+        self.add_histo("mT_corr_xy_qTrw", ["mT_corr_xy"], [self.axis_mt], with_fakes=True, col_mt="passMT_xy", nominal_weight="nominal_weight_qTrw")
+        self.add_histo("mT_corr_rec", ["mT_corr_rec"], [self.axis_mt], with_fakes=True, col_mt="passMT_rec")
+        self.add_histo("mT_corr_rec_qTrw", ["mT_corr_rec"], [self.axis_mt], with_fakes=True, col_mt="passMT_rec", nominal_weight="nominal_weight_qTrw")
 
-        self.results.append(self.df.HistoBoost("MET_corr_lep_pt", axes_MET_pt, cols_MET_pt_lep + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_xy_pt", axes_MET_pt, cols_MET_pt_xy + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_xy_pt_qTrw", axes_MET_pt, cols_MET_pt_xy + ["nominal_weight_qTrw"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_pt", axes_MET_pt, cols_MET_pt + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_pt_qTrw", axes_MET_pt, cols_MET_pt + ["nominal_weight_qTrw"], storage=hist.storage.Double()))
-            
-        self.results.append(self.df.HistoBoost("MET_corr_lep_phi", axes_MET_phi, cols_MET_phi_lep + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_xy_phi", axes_MET_phi, cols_MET_phi_xy + ["nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("MET_corr_rec_phi", axes_MET_phi, cols_MET_phi + ["nominal_weight"], storage=hist.storage.Double()))
-            
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_magn", [self.axis_recoil_magn, self.axis_charge, self.axis_passMT, self.axis_passIso], ["recoil_corr_rec_magn", self.leptons_charge, "passMT_rec", "passIso", "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("recoil_corr_rec_magn_qTrw", [self.axis_recoil_magn, self.axis_charge, self.axis_passMT, self.axis_passIso], ["recoil_corr_rec_magn", self.leptons_charge, "passMT_rec", "passIso", "nominal_weight_qTrw"], storage=hist.storage.Double()))
-        
-        self.results.append(self.df.HistoBoost("trg_lep_pt", [self.axis_lep_pt], [self.leptons_pt, "nominal_weight"], storage=hist.storage.Double()))
-        self.results.append(self.df.HistoBoost("trg_lep_pt_qTrw", [self.axis_lep_pt], [self.leptons_pt, "nominal_weight_qTrw"], storage=hist.storage.Double()))
-    
+        self.add_histo("MET_corr_lep_pt", ["MET_corr_lep_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_lep")
+        self.add_histo("MET_corr_xy_pt", ["MET_corr_xy_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_xy")
+        self.add_histo("MET_corr_xy_pt_qTrw", ["MET_corr_xy_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_xy", nominal_weight="nominal_weight_qTrw")
+        self.add_histo("MET_corr_rec_pt", ["MET_corr_rec_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_rec")
+        self.add_histo("MET_corr_rec_pt_qTrw", ["MET_corr_rec_pt"], [self.axis_MET_pt], with_fakes=True, col_mt="passMT_rec", nominal_weight="nominal_weight_qTrw")
+
+        self.add_histo("MET_corr_lep_phi", ["MET_corr_lep_phi"], [self.axis_MET_phi], with_fakes=True, col_mt="passMT_lep")
+        self.add_histo("MET_corr_xy_phi", ["MET_corr_xy_phi"], [self.axis_MET_phi], with_fakes=True, col_mt="passMT_xy")
+        self.add_histo("MET_corr_rec_phi", ["MET_corr_rec_phi"], [self.axis_MET_phi], with_fakes=True, col_mt="passMT_rec")
+
+        self.add_histo("recoil_corr_rec_magn", ["recoil_corr_rec_magn"], [self.axis_recoil_magn], with_fakes=True, col_mt="passMT_rec")
+        self.add_histo("recoil_corr_rec_magn_qTrw", ["recoil_corr_rec_magn"], [self.axis_recoil_magn], with_fakes=True, col_mt="passMT_rec", nominal_weight="nominal_weight_qTrw")
+
+
 
     def recoil_Z_statUnc_lowPU(self, df, results, axis_recoil_gen, axis_recoil_reco, axis_mt, axis_mll):
         
@@ -886,30 +876,30 @@ class Recoil:
             self.df = self.df.Define("recoil_corr_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned(recoil_corr_xy_para, recoil_corr_xy_perp, qTbin, qT, %d, %d)" % (k[0], k[1]))
            
             self.df = self.df.Define("recoil_corr_magn_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_magn_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin)" % (k[0], k[1]))
-            self.results.append(self.df.HistoBoost("gen_reco_magn_mll_recoilStatUnc_%d_%d" % (k[0], k[1]), [axis_recoil_gen, axis_recoil_reco, axis_recoil_reco_pert, axis_mll, axis_recoil_stat_unc], ["ptVgen", "recoil_corr_rec_magn", "recoil_corr_magn_stat_unc_%d_%d" % (k[0], k[1]), "massZ", "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("gen_reco_magn_mll_recoilStatUnc_%d_%d" % (k[0], k[1]), [axis_recoil_gen, axis_recoil_reco, axis_recoil_reco_pert, axis_mll, axis_recoil_stat_unc], ["ptVgen", "recoil_corr_rec_magn", "recoil_corr_magn_stat_unc_%d_%d" % (k[0], k[1]), "massZ", "recoil_corr_stat_idx", "nominal_weight"]))
             
             
             #self.df = self.df.Define("recoil_corr_para_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_para_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin)" % (k[0], k[1]))
-            #self.results.append(self.df.HistoBoost("gen_reco_para_qT_mll_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_para, axis_recoil_para_pert, axis_recoil_stat_unc], ["recoil_corr_para", "recoil_corr_para_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            #self.results.append(self.df.HistoBoost("gen_reco_para_qT_mll_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_para, axis_recoil_para_pert, axis_recoil_stat_unc], ["recoil_corr_para", "recoil_corr_para_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
             
-            self.results.append(self.df.HistoBoost("recoil_magn_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_magn, axis_recoil_magn_pert, axis_recoil_stat_unc], ["recoil_corr_rec_magn", "recoil_corr_magn_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("recoil_magn_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_magn, axis_recoil_magn_pert, axis_recoil_stat_unc], ["recoil_corr_rec_magn", "recoil_corr_magn_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
             
             
             self.df = self.df.Define("recoil_corr_para_qT_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_para_qT_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin, qT)" % (k[0], k[1]))
-            self.results.append(self.df.HistoBoost("recoil_para_qT_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_para_qT, axis_recoil_para_qT_pert, axis_recoil_stat_unc], ["recoil_corr_rec_para_qT", "recoil_corr_para_qT_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("recoil_para_qT_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_para_qT, axis_recoil_para_qT_pert, axis_recoil_stat_unc], ["recoil_corr_rec_para_qT", "recoil_corr_para_qT_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
             
             self.df = self.df.Define("recoil_corr_perp_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_perp_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin)" % (k[0], k[1]))
-            self.results.append(self.df.HistoBoost("recoil_perp_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_perp, axis_recoil_perp_pert, axis_recoil_stat_unc], ["recoil_corr_rec_perp", "recoil_corr_perp_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("recoil_perp_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_recoil_perp, axis_recoil_perp_pert, axis_recoil_stat_unc], ["recoil_corr_rec_perp", "recoil_corr_perp_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
             
             
             self.df = self.df.Define("recoil_corr_MET_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_MET_pt_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin, MET_corr_xy_pt, MET_corr_xy_phi, qT, Z_mom2.Phi())" % (k[0], k[1]))
-            self.results.append(self.df.HistoBoost("MET_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_MET_pt, axis_MET_pert, axis_recoil_stat_unc], ["MET_corr_rec_pt", "recoil_corr_MET_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("MET_recoilStatUnc_%d_%d" % (k[0], k[1]), [self.axis_MET_pt, axis_MET_pert, axis_recoil_stat_unc], ["MET_corr_rec_pt", "recoil_corr_MET_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
             
             self.df = self.df.Define("recoil_corr_MET_phi_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_MET_phi_StatUnc(recoil_corr_stat_unc_%d_%d, qTbin, MET_corr_lep_pt, MET_corr_lep_phi, qT, Z_mom2.Phi())" % (k[0], k[1]))
             
             
             self.df = self.df.Define("recoil_corr_mt_stat_unc_%d_%d" % (k[0], k[1]), "wrem::recoilCorrectionBinned_mt_StatUnc(recoil_corr_MET_stat_unc_%d_%d, recoil_corr_MET_phi_stat_unc_%d_%d, qTbin, TrigMuon_pt, TrigMuon_phi, NonTrigMuon_pt, NonTrigMuon_phi)" % (k[0], k[1], k[0], k[1]))
-            self.results.append(self.df.HistoBoost("mT_corr_rec_recoilStatUnc_%d_%d" % (k[0], k[1]), [axis_mt, axis_mt_pert, axis_recoil_stat_unc], ["mT_corr_rec", "recoil_corr_mt_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"], storage=hist.storage.Double()))
+            self.results.append(self.df.HistoBoost("mT_corr_rec_recoilStatUnc_%d_%d" % (k[0], k[1]), [axis_mt, axis_mt_pert, axis_recoil_stat_unc], ["mT_corr_rec", "recoil_corr_mt_stat_unc_%d_%d" % (k[0], k[1]), "recoil_corr_stat_idx", "nominal_weight"]))
         
         return df
         
@@ -925,7 +915,18 @@ class Recoil:
                 recoilTensorWeights = f"recoilTensorWeights_{tag}"
                 names = [f"recoil_{tag}{int((j+2)/2)}{'Up' if j % 2 else 'Down'}" for j in range(nVars)]
                 recoil_var_ax = hist.axis.StrCategory(names, name="recoilVar")
-                results.append(df.HistoBoost(f"{hName}_recoilUnc_{tag}", axes if isinstance(axes, list) else [axes], (cols if isinstance(cols, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax], storage=hist.storage.Double()))
+                results.append(df.HistoBoost(f"{hName}_recoilUnc_{tag}", axes if isinstance(axes, list) else [axes], (cols if isinstance(cols, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+        elif self.method_cdf:
+            recoilTensorWeights = "recoilTensorWeights_para"
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_para, name="recoilVar")
+            results.append(df.HistoBoost(f"{hName}_recoilUnc_para", axes if isinstance(axes, list) else [axes], (cols if isinstance(cols, list) else [cols]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+
+            recoilTensorWeights = "recoilTensorWeights_perp"
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_perp, name="recoilVar")
+            results.append(df.HistoBoost(f"{hName}_recoilUnc_perp", axes if isinstance(axes, list) else [axes], (cols if isinstance(cols, list) else [cols]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+
+
+
         else:
             logger.warning("Only smearing weight uncertainties are supported.")
             
@@ -938,19 +939,19 @@ class Recoil:
     def setup_recoil_Z_unc(self):
         if not self.dataset.name in self.datasets_to_apply:
             return
-        
+
         hNames, cols, axes = [], [], [] 
         if self.storeHists:
             hNames = ["recoil_corr_rec_para_qT", "recoil_corr_rec_para", "recoil_corr_rec_perp", "recoil_corr_rec_magn", "MET_corr_rec_pt", "mT_corr_rec"]
             cols = hNames
             axes = [self.axis_recoil_para_qT, self.axis_recoil_para, self.axis_recoil_perp, self.axis_recoil_magn, self.axis_MET_pt, self.axis_mt]
-        
+
         if self.parametric and self.smearWeights:
             recoil_unc_no = getattr(ROOT.wrem, "recoil_unc_no")
             for item in recoil_unc_no:
                 tag = item.first
                 nVars = recoil_unc_no[tag]
-              
+
                 val = "recoil_corr_xy_para" if "para" in tag else "recoil_corr_xy_perp"
                 tag_nom = "%s_%s" % ("target" if "target" in tag else "source", "para" if "para" in tag else "perp") ## revise
                 recoilWeights = f"recoilWeights_{tag}"
@@ -961,23 +962,43 @@ class Recoil:
                 recoil_var_ax = hist.axis.StrCategory(names, name="recoilVar")
 
                 for hName, col, ax in zip(hNames, cols, axes):
-                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax], storage=hist.storage.Double()))
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
 
                 # qT reweighted uncertainties, only for base_cols
                 recoilTensorWeights_qTrw = f"recoilTensorWeights_qTrw_{tag}"
                 self.df = self.df.Define(recoilTensorWeights_qTrw, "Eigen::TensorFixedSize<double, Eigen::Sizes<%d>> res; auto w = nominal_weight_qTrw*%s; std::copy(std::begin(w), std::end(w), res.data()); return res;" % (nVars, recoilWeights))
                 for hName, col, ax in zip(hNames, cols, axes):
-                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax], storage=hist.storage.Double()))
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
+        elif self.method_cdf:
+            recoilTensorWeights = "recoilTensorWeights_para"
+            self.df = self.df.Define(recoilTensorWeights, "auto res = corr_para.unc_weights; res = nominal_weight*res; return res;")
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_para, name="recoilVar")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_para", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
 
-               
+            recoilTensorWeights_qTrw = "recoilTensorWeights_para_qTrw"
+            self.df = self.df.Define(recoilTensorWeights_qTrw, f"auto res = corr_para.unc_weights; res = nominal_weight_qTrw*res; return res;")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_para", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
+
+
+            recoilTensorWeights = "recoilTensorWeights_perp"
+            self.df = self.df.Define(recoilTensorWeights, f"auto res = corr_perp.unc_weights; res = nominal_weight*res; return res;")
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_perp, name="recoilVar")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_perp", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+
+            recoilTensorWeights_qTrw = "recoilTensorWeights_perp_qTrw"
+            self.df = self.df.Define(recoilTensorWeights_qTrw, f"auto res = corr_perp.unc_weights; res = nominal_weight_qTrw*res; return res;")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_perp", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
+
         elif self.parametric and not self.smearWeights:
-        
+
             recoil_unc_no = getattr(ROOT.wrem, "recoil_unc_no")
             for item in recoil_unc_no:
                 tag = item.first
                 nVars = recoil_unc_no[tag]
-                
-
 
                 axis_recoil_unc = hist.axis.Regular(nVars, 0, nVars, underflow=False, overflow=False, name = "axis_recoil_unc_%s" % tag)
                 self.df = self.df.Define("recoil_corr_rec_syst_%s" % tag, "wrem::recoilCorrectionParametricUnc(recoil_corr_xy_para, recoil_corr_xy_perp, qT, \"%s\")" % tag)
@@ -986,7 +1007,7 @@ class Recoil:
                 # MET
                 #df = df.Define("recoil_corr_MET_pt_syst_%s" % tag, "wrem::recoilCorrectionParametric_MET_pt_unc(recoil_corr_rec_syst_%s, qT, Z_mom2.Phi())" % tag)
                 #df = df.Define("recoil_corr_MET_phi_syst_%s" % tag, "wrem::recoilCorrectionParametric_MET_phi_unc(recoil_corr_rec_syst_%s, qT, Z_mom2.Phi())" % tag)
-                #self.results.append(df.HistoBoost("MET_recoilSyst_%s" % tag, [axis_MET_pt, axis_recoil_unc], ["recoil_corr_MET_pt_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"], storage=hist.storage.Double()))
+                #self.results.append(df.HistoBoost("MET_recoilSyst_%s" % tag, [axis_MET_pt, axis_recoil_unc], ["recoil_corr_MET_pt_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"]))
                 
                 
                 # recoil
@@ -994,18 +1015,16 @@ class Recoil:
                 self.df = self.df.Define("recoil_corr_para_syst_%s" % tag, "wrem::recoilCorrectionParametric_para_unc(recoil_corr_rec_syst_%s, qT)"% tag)
                 self.df = self.df.Define("recoil_corr_perp_syst_%s" % tag, "wrem::recoilCorrectionParametric_perp_unc(recoil_corr_rec_syst_%s, qT)"% tag)
                 self.df = self.df.Define("recoil_corr_magn_syst_%s" % tag, "wrem::recoilCorrectionParametric_magn_unc(recoil_corr_rec_syst_%s, qT)"% tag)
-                self.results.append(df.HistoBoost("recoil_corr_rec_para_qT_recoilSyst_%s" % tag, [self.axis_recoil_para_qT, axis_recoil_unc], ["recoil_corr_para_qT_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(df.HistoBoost("recoil_corr_rec_para_recoilSyst_%s" % tag, [self.axis_recoil_para, axis_recoil_unc], ["recoil_corr_para_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(df.HistoBoost("recoil_corr_rec_perp_recoilSyst_%s" % tag, [self.axis_recoil_perp, axis_recoil_unc], ["recoil_corr_perp_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"], storage=hist.storage.Double()))
-                self.results.append(df.HistoBoost("recoil_corr_rec_magn_recoilSyst_%s" % tag, [self.axis_recoil_magn, axis_recoil_unc], ["recoil_corr_magn_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"], storage=hist.storage.Double()))
+                self.results.append(df.HistoBoost("recoil_corr_rec_para_qT_recoilSyst_%s" % tag, [self.axis_recoil_para_qT, axis_recoil_unc], ["recoil_corr_para_qT_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"]))
+                self.results.append(df.HistoBoost("recoil_corr_rec_para_recoilSyst_%s" % tag, [self.axis_recoil_para, axis_recoil_unc], ["recoil_corr_para_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"]))
+                self.results.append(df.HistoBoost("recoil_corr_rec_perp_recoilSyst_%s" % tag, [self.axis_recoil_perp, axis_recoil_unc], ["recoil_corr_perp_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"]))
+                self.results.append(df.HistoBoost("recoil_corr_rec_magn_recoilSyst_%s" % tag, [self.axis_recoil_magn, axis_recoil_unc], ["recoil_corr_magn_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight_qTrw"]))
                 
                 # mT
                 #df = df.Define("recoil_corr_mT_recoilSyst_%s" % tag, "wrem::recoilCorrectionParametric_mT_unc(recoil_corr_MET_pt_syst_%s, recoil_corr_MET_phi_syst_%s, TrigMuon_pt, TrigMuon_phi, NonTrigMuon_pt, NonTrigMuon_phi)" % (tag, tag))
-                #results.append(df.HistoBoost("mT_corr_rec_recoilSyst_%s" % tag, [axis_mt, axis_recoil_unc], ["recoil_corr_mT_recoilSyst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"], storage=hist.storage.Double()))
-           
-              
-        
-        
+                #results.append(df.HistoBoost("mT_corr_rec_recoilSyst_%s" % tag, [axis_mt, axis_recoil_unc], ["recoil_corr_mT_recoilSyst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"]))
+
+
     def setup_recoil_W_unc(self):
         if not self.dataset.name in self.datasets_to_apply:
             return
@@ -1032,14 +1051,39 @@ class Recoil:
                 recoil_var_ax = hist.axis.StrCategory(names, name="recoilVar")
 
                 for hName, col, ax in zip(hNames, cols, axes):
-                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax], storage=hist.storage.Double()))
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
                      
                 # qT reweighted uncertainties
                 recoilTensorWeights_qTrw = f"recoilTensorWeights_qTrw_{tag}"
                 self.df = self.df.Define(recoilTensorWeights_qTrw, "Eigen::TensorFixedSize<double, Eigen::Sizes<%d>> res; auto w = nominal_weight_qTrw*%s; std::copy(std::begin(w), std::end(w), res.data()); return res;" % (nVars, recoilWeights))
                 for hName, col, ax in zip(hNames, cols, axes):
-                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax], storage=hist.storage.Double()))
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_{tag}", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
 
+        elif self.method_cdf:
+            recoilTensorWeights = "recoilTensorWeights_para"
+            self.df = self.df.Define(recoilTensorWeights, "auto res = corr_para.unc_weights; res = nominal_weight*res; return res;")
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_para, name="recoilVar")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_para", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+
+            recoilTensorWeights_qTrw = "recoilTensorWeights_para_qTrw"
+            self.df = self.df.Define(recoilTensorWeights_qTrw, f"auto res = corr_para.unc_weights; res = nominal_weight_qTrw*res; return res;")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_para", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
+
+
+            recoilTensorWeights = "recoilTensorWeights_perp"
+            self.df = self.df.Define(recoilTensorWeights, f"auto res = corr_perp.unc_weights; res = nominal_weight*res; return res;")
+            recoil_var_ax = hist.axis.Integer(0, self.nvars_perp, name="recoilVar")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_recoilUnc_perp", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights], tensor_axes=[recoil_var_ax]))
+
+            recoilTensorWeights_qTrw = "recoilTensorWeights_perp_qTrw"
+            self.df = self.df.Define(recoilTensorWeights_qTrw, f"auto res = corr_perp.unc_weights; res = nominal_weight_qTrw*res; return res;")
+            for hName, col, ax in zip(hNames, cols, axes):
+                    self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_perp", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
+
+               
         
         elif self.parametric and not self.smearWeights:
         
@@ -1055,11 +1099,11 @@ class Recoil:
                 # MET 
                 df = df.Define("recoil_corr_MET_pt_syst_%s" % tag, "wrem::recoilCorrectionParametric_MET_pt_gen_unc(recoil_corr_rec_syst_%s, Lep_pt, Lep_phi, phiVgen)" % tag)
                 df = df.Define("recoil_corr_MET_phi_syst_%s" % tag, "wrem::recoilCorrectionParametric_MET_phi_gen_unc(recoil_corr_rec_syst_%s, Lep_pt, Lep_phi, phiVgen)" % tag)
-                results.append(df.HistoBoost("MET_recoilSyst_%s" % tag, [axis_MET_pt, axis_recoil_unc, axis_charge, axis_passIso], ["recoil_corr_MET_pt_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "Lep_charge", "passIso", "nominal_weight"], storage=hist.storage.Double()))
+                results.append(df.HistoBoost("MET_recoilSyst_%s" % tag, [axis_MET_pt, axis_recoil_unc, axis_charge, axis_passIso], ["recoil_corr_MET_pt_syst_%s" % tag, "recoil_corr_rec_systIdx_%s" % tag, "Lep_charge", "passIso", "nominal_weight"]))
                 
                 # mT
                 df = df.Define("recoil_corr_mT_recoilSyst_%s" % tag, "wrem::recoilCorrectionParametric_mT_2_unc(recoil_corr_MET_pt_syst_%s, recoil_corr_MET_phi_syst_%s, Lep_pt, Lep_phi)" % (tag, tag))
-                results.append(df.HistoBoost("mT_corr_rec_recoilSyst_%s" % tag, [axis_mt, axis_charge, axis_passIso, axis_recoil_unc], ["recoil_corr_mT_recoilSyst_%s" % tag, "Lep_charge", "passIso", "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"], storage=hist.storage.Double()))
+                results.append(df.HistoBoost("mT_corr_rec_recoilSyst_%s" % tag, [axis_mt, axis_charge, axis_passIso, axis_recoil_unc], ["recoil_corr_mT_recoilSyst_%s" % tag, "Lep_charge", "passIso", "recoil_corr_rec_systIdx_%s" % tag, "nominal_weight"]))
            
            
                 val = "recoil_corr_xy_para_qT_gen" if "para" in tag else "recoil_corr_xy_perp_gen"
@@ -1068,8 +1112,8 @@ class Recoil:
                 df = df.Define(tmp, "wrem::recoilCorrectionParametricUncWeights(%s, qT_gen,  \"%s\", \"%s\")" % (val, tag_nom, tag))
                 df = df.Define(tmp+"_tensor", "Eigen::TensorFixedSize<double, Eigen::Sizes<%d>> res; auto w = nominal_weight*%s; std::copy(std::begin(w), std::end(w), res.data()); return res;" % (nVars, tmp))
 
-                results.append(df.HistoBoost("mT_corr_rec_recoilSystWeight_%s" % tag, [axis_mt, axis_charge, axis_passMT, axis_passIso], ["mT_corr_rec", "Lep_charge", "passMT", "passIso", tmp+"_tensor"], storage=hist.storage.Double()))
-                ###results.append(df.HistoBoost("mT_corr_rec_recoilSyst_weight_%s" % tag, [axis_mt, axis_charge, axis_passIso], ["mT_corr_rec", "Lep_charge", "passIso", tmp+"_tensor"], storage=hist.storage.Double()))
-                results.append(df.HistoBoost("recoil_magn_recoilSystWeight_%s" % tag, [axis_recoil_magn, axis_charge, axis_passMT, axis_passIso], ["recoil_corr_rec_magn", "Lep_charge", "passMT", "passIso", tmp+"_tensor"], storage=hist.storage.Double()))
-                results.append(df.HistoBoost("MET_recoilSystWeight_%s" % tag, [axis_MET_pt, axis_charge, axis_passMT, axis_passIso], ["MET_corr_rec_pt", "Lep_charge", "passMT", "passIso", tmp+"_tensor"], storage=hist.storage.Double()))
+                results.append(df.HistoBoost("mT_corr_rec_recoilSystWeight_%s" % tag, [axis_mt, axis_charge, axis_passMT, axis_passIso], ["mT_corr_rec", "Lep_charge", "passMT", "passIso", tmp+"_tensor"]))
+                ###results.append(df.HistoBoost("mT_corr_rec_recoilSyst_weight_%s" % tag, [axis_mt, axis_charge, axis_passIso], ["mT_corr_rec", "Lep_charge", "passIso", tmp+"_tensor"]))
+                results.append(df.HistoBoost("recoil_magn_recoilSystWeight_%s" % tag, [axis_recoil_magn, axis_charge, axis_passMT, axis_passIso], ["recoil_corr_rec_magn", "Lep_charge", "passMT", "passIso", tmp+"_tensor"]))
+                results.append(df.HistoBoost("MET_recoilSystWeight_%s" % tag, [axis_MET_pt, axis_charge, axis_passMT, axis_passIso], ["MET_corr_rec_pt", "Lep_charge", "passMT", "passIso", tmp+"_tensor"]))
 

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -723,7 +723,7 @@ class Recoil:
         self.df = self.df.Define("MET_corr_rec_ll_dPhi", "wrem::deltaPhi(MET_corr_rec_phi, Z_mom2.Phi())")
         self.df = self.df.Define("ll_phi", "Z_mom2.Phi()")
 
-        if not self.storeHists: 
+        if not self.storeHists:
             return
 
         self.add_histo("recoil_corr_rec_magn", ["recoil_corr_rec_magn"], [self.axis_recoil_magn])
@@ -932,7 +932,7 @@ class Recoil:
         return self.add_recoil_unc_Z(df, results, dataset, cols, axes, hName) # currently use the Z implementation
 
     def setup_recoil_Z_unc(self):
-        if not self.dataset.name in self.datasets_to_apply:
+        if not self.dataset.name in self.datasets_to_apply or not self.storeHists:
             return
 
         hNames, cols, axes = [], [], [] 
@@ -1021,9 +1021,9 @@ class Recoil:
 
 
     def setup_recoil_W_unc(self):
-        if not self.dataset.name in self.datasets_to_apply:
+        if not self.dataset.name in self.datasets_to_apply or not self.storeHists:
             return
-    
+
         hNames, cols, axes = [], [], [] 
         if self.storeHists:
             hNames = ["MET_corr_rec_pt", "mT_corr_rec"]
@@ -1035,7 +1035,7 @@ class Recoil:
             for item in recoil_unc_no:
                 tag = item.first
                 nVars = recoil_unc_no[tag]
-              
+
                 val = "recoil_corr_xy_para_gen" if "para" in tag else "recoil_corr_xy_perp_gen"
                 tag_nom = "%s_%s" % ("target" if "target" in tag else "source", "para" if "para" in tag else "perp")
                 recoilWeights = f"recoilWeights_{tag}"
@@ -1078,8 +1078,7 @@ class Recoil:
             for hName, col, ax in zip(hNames, cols, axes):
                     self.results.append(self.df.HistoBoost(f"{hName}_qTrw_recoilUnc_perp", ax if isinstance(col, list) else [ax], (col if isinstance(col, list) else [col]) + [recoilTensorWeights_qTrw], tensor_axes=[recoil_var_ax]))
 
-               
-        
+
         elif self.parametric and not self.smearWeights:
         
             recoil_unc_no = getattr(ROOT.wrem, "recoil_unc_no")

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -17,10 +17,12 @@ logger = logging.child_logger(__name__)
 def valid_theory_corrections():
     corr_files = glob.glob(common.data_dir+"TheoryCorrections/*Corr*.pkl.lz4")
     matches = [re.match("(^.*)Corr[W|Z]\.pkl\.lz4", os.path.basename(c)) for c in corr_files]
-    return [m[1] for m in matches if m]
+    return [m[1] for m in matches if m] + ['none']
 
 def load_corr_helpers(procs, generators):
     corr_helpers = {}
+    if 'none' in generators:
+        return corr_helpers
     for proc in procs:
         corr_helpers[proc] = {}
         for generator in generators:

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -17,12 +17,10 @@ logger = logging.child_logger(__name__)
 def valid_theory_corrections():
     corr_files = glob.glob(common.data_dir+"TheoryCorrections/*Corr*.pkl.lz4")
     matches = [re.match("(^.*)Corr[W|Z]\.pkl\.lz4", os.path.basename(c)) for c in corr_files]
-    return [m[1] for m in matches if m] + ['none']
+    return [m[1] for m in matches if m]
 
 def load_corr_helpers(procs, generators):
     corr_helpers = {}
-    if 'none' in generators:
-        return corr_helpers
     for proc in procs:
         corr_helpers[proc] = {}
         for generator in generators:


### PR DESCRIPTION
Implemented the DeepMET recoil calibration with uncertainties using the TFLite model. Currently, by default, the recoil uncertainties are switched OFF, as they take a lot of time to run. In a next PR, we'll address the performance issue. The central correction is applied regardless. So run with recoil uncertainties, use the option --recoilUnc

Added option to run the analysis without theory corrections: --theoryCorr none