### PR TITLE
new script to browse content of hdf5 files

### DIFF
--- a/scripts/utilities/browse_hdf5.py
+++ b/scripts/utilities/browse_hdf5.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+import lz4.frame
+import pickle
+import hist
+from utilities import boostHistHelpers as hh, logging
+#import wremnants
+import hdf5plugin
+import h5py
+import narf
+from narf import ioutils
+import ROOT
+
+logger = logging.child_logger(__name__)
+
+if __name__ == "__main__":    
+
+     parser = argparse.ArgumentParser()
+     parser.add_argument("inputfile", type=str, nargs=1, help="Input file")
+     parsers = parser.add_subparsers(dest='printMode')
+     printAll = parsers.add_parser("all", help="Print everything in the input file")
+     printProcs = parsers.add_parser("proc", help="Print only names of processes")
+     printHist = parsers.add_parser("hist", help="Print more information about histograms")
+     # printHist.add_argument("-w", "--what", type=str, default="all",
+     #                       choices=["all", "procs", "hists", "axes"],
+     #                       help="What to print")
+     printHist.add_argument("-p", "--process", type=str, default=None,
+                           help="Select this process to print")
+     printHist.add_argument("-n", "--histo", type=str, default=None,
+                           help="Select single histogram to print with this name, and printout will have more information")
+     printHist.add_argument("-a", "--axis", type=str, default=None,
+                           help="Select single axis to print with this name")
+     printHist.add_argument("--noAxes", "--noAxes", action='store_true',
+                           help="Don't print axes")
+     args = parser.parse_args()
+
+     h5file = h5py.File(args.inputfile[0], "r")
+     results = narf.ioutils.pickle_load_h5py(h5file["results"])
+
+     if args.printMode == "all":
+          print(results)
+     elif args.printMode == "proc":
+          procs = list(filter(lambda x: x != "meta_info", results.keys() ))
+          print("\nList of processes:\n")
+          for ip,p in enumerate(procs):
+               print(f"{ip+1}: {p}")
+          print()
+     elif args.printMode == "hist":
+           print("="*30)
+           print("GOING TO PRINT HISTOGRAMS")
+           print("="*30)
+           #print(results.keys())
+           for p in results.keys():
+                if p == "meta_info":
+                     continue
+                if args.process and p != args.process:
+                     continue
+                print("-"*30)
+                print(f"Process {p}")
+                space = " "*5
+                for k in results[p]["output"].keys():
+                     if args.histo and k != args.histo:
+                          continue
+                     print(f"{space}{k}")                         
+                     if not args.noAxes:
+                          histObj = results[p]['output'][k]
+                          if isinstance(histObj, ioutils.H5PickleProxy):
+                               histObj = histObj.get()
+                          print(f"{space}  Axes = {histObj.axes.name}")
+                          for n in histObj.axes:
+                               if args.axis and n.name != args.axis:
+                                    continue
+                               print(f"{space}{space} {n}")


### PR DESCRIPTION
Some people including myself expressed the interest in having a simple interface to browse an hdf5 file to explore its content, given that it's not as trivial as opening a root file and doing ".ls".
I hope it helps.

This PR overrides PR#272, which I've already closed.

It also implements the comments received in the previous PR, about using sub_parsers to  avoid inconsistent options that are only valid when other are called.

Examples:
### only print process names 
- python scripts/utilities/browse_hdf5.py input.hdf5 proc
### print histograms for process Diboson and details of axis named eta
- python scripts/utilities/browse_hdf5.py input.hdf5 hist -p Diboson -a eta
### print histograms for process Top and all histogram names without details on axes
- python scripts/utilities/browse_hdf5.py input.hdf5 hist -p Top --noAxes
### print histograms for process Top and details of histogram named nominal_effSystTnP
- python scripts/utilities/browse_hdf5.py input.hdf5 hist -p Top -n nominal_effSystTnP