### PR TITLE
Add new datasets using symlinks

### DIFF
--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -37,27 +37,35 @@ dataDictV9 = {
 
     'WplusmunuPostVFP' : { 
                       'filepaths' : 
-                      ["{BASE_PATH}/WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root"],
+                      ["{BASE_PATH}/WplusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                       "{BASE_PATH}/WplusJetsToMuNu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root"
+                      ],
                       'xsec' : xsec_WpmunuPostVFP,
                       'group': "Wmunu",
     },
     'WminusmunuPostVFP' : { 
                       'filepaths' : 
-                      ["{BASE_PATH}/WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root"],
+                      ["{BASE_PATH}/WminusJetsToMuNu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                       "{BASE_PATH}/WminusJetsToMuNu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                      ],
                       'xsec' : xsec_WmmunuPostVFP,
                       'group': "Wmunu",
     },
 
     'WplustaunuPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/WplusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root"],
+                         ["{BASE_PATH}/WplusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                          "{BASE_PATH}/WplusJetsToTauNu_TauToMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                         ],
                          'xsec' : BR_TAUToMU*xsec_WpmunuPostVFP,
                          'group': "Wtaunu",
     },
     
     'WminustaunuPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root"],
+                         ["{BASE_PATH}/WminusJetsToTauNu_TauToMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                          "{BASE_PATH}/WminusJetsToTauNu_TauToMu_H2ErratumFix_PDFExt_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}/*/*/*.root",
+                         ],
                          'xsec' : BR_TAUToMU*xsec_WmmunuPostVFP,
                          'group': "Wtaunu",
     },

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -31,7 +31,10 @@ def makeFilelist(paths, maxFiles=-1, format_args={}, is_data=False, oneMCfileEve
         if format_args:
             path = path.format(**format_args)
             logger.debug(f"Reading files from path {path}")
-        filelist.extend(glob.glob(path) if path[:4] != "/eos" else buildXrdFileList(path, "eoscms.cern.ch"))
+        files = glob.glob(path) if path[:4] != "/eos" else buildXrdFileList(path, "eoscms.cern.ch")
+        if len(files) == 0:
+            logger.warning(f"Did not find any files matching path {path}!")
+        filelist.extend(files)
 
     if oneMCfileEveryN != None and not is_data:
         tmplist = []


### PR DESCRIPTION
After creating symlinks so the new samples have the expected format with the TrackFit and NanoProd tags, they can simply be added. With the current setup they will be skipped, with a warning message, when running from /scratch at lxplus8s10, and will be included when using --dataPath /eos/cms/store/cmst3...

A warning message is printed in the case where they aren't found (e.g., running from scratch). At MIT/Pisa this technically should work but reading from eos will be way slower.

TODO: We should implement a mode to load all the samples but only process up to a max number of events. We could probably also just set the default maxfiles to large number in the meantime