### PR TITLE
Attempt to fix mt  plot in CI for Wmass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,11 +193,8 @@ jobs:
       - name: wmass plotting
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $HIST_FILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
-      - name: wmass plot mt_plus
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416 -c plus
-
-      - name: wmass plot mt_minus
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416 -c minus
+      - name: wmass plot mt
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName transverseMass --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot MET
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -p $WEB_DIR -f $PLOT_DIR $HIST_FILE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $HIST_FILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: wmass plot mt
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName transverseMass --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416
 
       - name: wmass plot MET
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -p $WEB_DIR -f $PLOT_DIR $HIST_FILE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,8 +193,11 @@ jobs:
       - name: wmass plotting
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -p $WEB_DIR -f $PLOT_DIR -a W $HIST_FILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
-      - name: wmass plot mt
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416
+      - name: wmass plot mt_plus
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416 -c plus
+
+      - name: wmass plot mt_minus
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName mTStudyForFakes --hists mt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE --presel hasJets DphiMuonMet=0.7854,3.1416 -c minus
 
       - name: wmass plot MET
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -p $WEB_DIR -f $PLOT_DIR $HIST_FILE

--- a/scripts/analysisTools/tests/testFakesVsMt.py
+++ b/scripts/analysisTools/tests/testFakesVsMt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ## example
-# python tests/testFakesVsMt.py /scratch/mciprian/CombineStudies/12July2023/mw_with_mu_eta_pt_scetlib_dyturboCorr_testFakes_deepMet.hdf5 plots/fromMyWremnants/fitResults/12July2023/testFakes_3DSF/deepMET/noDphiCut/testFakesVsMt/ --palette 87 --rebinx 4 --rebiny 2 --mtBinEdges "0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75" --mtNominalRange "0,40" --mtFitRange "0,40" --fitPolDegree 1 --integralMtMethod sideband -v 4 --maxPt 50  --met deepMET [--dphiStudy] [--jetCut] [--dphiMuonMetCut 0.25]
+# python tests/testFakesVsMt.py /scratch/mciprian/CombineStudies/12July2023/mw_with_mu_eta_pt_scetlib_dyturboCorr_testFakes_deepMet.hdf5 plots/fromMyWremnants/fitResults/12July2023/testFakes_3DSF/deepMET/noDphiCut/testFakesVsMt/ --palette 87 --rebinx 4 --rebiny 2 --mtBinEdges "0,5,10,15,20,25,30,35,40,45,50,55,60,65" --mtNominalRange "0,40" --mtFitRange "0,40" --fitPolDegree 1 --integralMtMethod sideband -v 4 --maxPt 50  --met deepMET [--dphiStudy] [--jetCut] [--dphiMuonMetCut 0.25]
 #
 # Note: --jet-cut is used to enforce the jet requirement to derive the FRF,
 #       however the validation is made using the nominal histogram, which may or may not have had that cut included
@@ -17,7 +17,7 @@ import narf.fitutils
 import wremnants
 import hist
 import lz4.frame, pickle
-from wremnants.datasets.datagroups2016 import make_datagroups_2016
+from wremnants.datasets.datagroups import Datagroups
 from wremnants import histselections as sel
 
 import numpy as np
@@ -516,7 +516,7 @@ def runStudy(charge, outfolder, rootfilename, args):
     canvas_unroll.cd()
     canvas_unroll.SetBottomMargin(bottomMargin)
 
-    groups = make_datagroups_2016(args.inputfile[0], applySelection=False)
+    groups = Datagroups(args.inputfile[0])
     datasets = groups.getNames() # this has all the original defined groups
     datasetsNoQCD = list(filter(lambda x: x != "QCD", datasets)) # exclude QCD MC if present
     datasetsNoFakes = list(filter(lambda x: x != "Fake", datasets)) 
@@ -623,11 +623,13 @@ def runStudy(charge, outfolder, rootfilename, args):
         if d == "Fake":
             # do ABCD method for Fakes, using binned mT axis
             hnarf_asNominal = sel.fakeHistABCD(hnarf_asNominal,
-                                               boolMT=False, thresholdMT=mtThreshold,
-                                               axisNameMT="mt", integrateMT=True)
+                                               thresholdMT=mtThreshold,
+                                               axis_name_mt="mt",
+                                               integrateMT=True)
             hnarf_forMtWithDataDrivenFakes = sel.fakeHistABCD(hnarf_forMtWithDataDrivenFakes,
-                                                              boolMT=False, thresholdMT=mtThreshold,
-                                                              axisNameMT="mt", integrateMT=False)
+                                                              thresholdMT=mtThreshold,
+                                                              axis_name_mt="mt",
+                                                              integrateMT=False)
         else:
             nMtBins = hnarf_asNominal.axes["mt"].size
             # just select signal region: pass isolation and mT > mtThreshold with overflow included

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -202,8 +202,7 @@ if __name__ == "__main__":
         label = getBetterLabel(k, args.isWlike)
         if compare:
             #print(k)
-            #bincontentAlt = nuisGroup_nameVal_alt[k.replace("QCDscaleWPtHelicityMiNNLO","QCDscalePtHelicityMiNNLO")]
-            bincontentAlt = nuisGroup_nameVal_alt[k]
+            bincontentAlt = nuisGroup_nameVal_alt[k] if k in nuisGroup_nameVal_alt.keys() else 0.0
             if args.scaleToMeV: bincontentAlt *= args.prefitUncertainty
             logger.info("%s: %2.3f / %2.3f" % (label, bincontent, bincontentAlt))
         else:
@@ -211,9 +210,6 @@ if __name__ == "__main__":
         h1.GetXaxis().SetBinLabel(ik+1, label)
         h1.SetBinContent(ik+1,bincontent)
         if compare:
-            #bincontentAlt = nuisGroup_nameVal_alt[k.replace("QCDscaleWPtHelicityMiNNLO","QCDscalePtHelicityMiNNLO")]
-            bincontentAlt = nuisGroup_nameVal_alt[k]
-            if args.scaleToMeV: bincontentAlt *= args.prefitUncertainty
             h2.SetBinContent(ik+1,bincontentAlt)
 
     if args.justPrint:

--- a/scripts/analysisTools/w_mass_13TeV/smoothLeptonScaleFactors.py
+++ b/scripts/analysisTools/w_mass_13TeV/smoothLeptonScaleFactors.py
@@ -665,7 +665,8 @@ def fitTurnOnTF(hist, key, outname, mc, channel="el", hist_chosenFunc=0, drawFit
             hAcceptBand.SetBinContent(i, yMaxBand)
             hAcceptBand.SetBinError(i, 0.0)
     hAcceptBand.SetFillColorAlpha(ROOT.kYellow+1, 0.5)
-    hAcceptBand.Draw("HIST SAME")
+    if step != "tracking":
+        hAcceptBand.Draw("HIST SAME")
     ########################################
     
     # Now the bottom panel
@@ -734,17 +735,17 @@ def fitTurnOnTF(hist, key, outname, mc, channel="el", hist_chosenFunc=0, drawFit
         dataRatio.SetBinContent(ib, dataRatio.GetBinContent(ib) / denVal)
         dataRatio.SetBinError(  ib, dataRatio.GetBinError(ib)   / denVal)
         
-    miny, maxy = getMinMaxMultiHisto(ratios+[den, dataRatio], excludeEmpty=True, sumError=True,
-                                     excludeUnderflow=True, excludeOverflow=True)
+    rminy, rmaxy = getMinMaxMultiHisto(ratios+[den, dataRatio], excludeEmpty=True, sumError=True,
+                                       excludeUnderflow=True, excludeOverflow=True)
     # append here so that the min max doesn't include it, sometimes the last points skyrocket
     if addCurve:
         ratios.append(ratioCurve)
 
-    diffy = maxy - miny
+    diffy = rmaxy - rminy
     offset = 0.1
-    miny -= offset * diffy
-    maxy += offset * diffy
-    frame.GetYaxis().SetRangeUser(miny, maxy)
+    rminy -= offset * diffy
+    rmaxy += offset * diffy
+    frame.GetYaxis().SetRangeUser(rminy, rmaxy)
     frame.Draw()
     den.Draw("E4SAME")
     denOnlyLine = copy.deepcopy(den.Clone("denOnlyLine"))
@@ -772,6 +773,7 @@ def fitTurnOnTF(hist, key, outname, mc, channel="el", hist_chosenFunc=0, drawFit
 
     ### Draw band to highlight acceptance
     hAcceptBandRatio = copy.deepcopy(hist.Clone("hAcceptBandRatio"))
+    hAcceptBandRatio.Reset("ICESM")
     yMaxBand = maxy
     for i in range(1, 1 + hAcceptBandRatio.GetNbinsX()):
         if hAcceptBandRatio.GetBinCenter(i) > 26.0 and hAcceptBandRatio.GetBinCenter(i) < 55.0:
@@ -781,7 +783,8 @@ def fitTurnOnTF(hist, key, outname, mc, channel="el", hist_chosenFunc=0, drawFit
             hAcceptBandRatio.SetBinContent(i, yMaxBand)
             hAcceptBandRatio.SetBinError(i, 0.0)
     hAcceptBandRatio.SetFillColorAlpha(ROOT.kYellow+1, 0.5)
-    hAcceptBandRatio.Draw("HIST SAME")
+    if step != "tracking":
+        hAcceptBandRatio.Draw("HIST SAME")
     ########################################
     
     pad2.RedrawAxis("sameaxis")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -98,10 +98,14 @@ elif args.theoryAgnostic:
 
 # axes for study of fakes
 axis_mt_fakes = hist.axis.Regular(120, 0., 120., name = "mt", underflow=False, overflow=True)
-axis_iso_fakes = hist.axis.Regular(60, 0., 0.6, name = "PFrelIso04", underflow=False, overflow=True)
 axis_dphi_fakes = hist.axis.Regular(8, 0., np.pi, name = "DphiMuonMet", underflow=False, overflow=False)
 axis_hasjet_fakes = hist.axis.Boolean(name = "hasJets") # only need case with 0 jets or > 0 for now
 mTStudyForFakes_axes = [axis_eta, axis_pt, axis_charge, axis_mt_fakes, axis_passIso, axis_hasjet_fakes, axis_dphi_fakes]
+
+# for mt, met, ptW plots, to compute the fakes properly (but FR pretty stable vs pt and also vs eta)
+# may not exactly reproduce the same pt range as analysis, though
+axis_eta_utilityHist = hist.axis.Regular(24, -2.4, 2.4, name = "eta", overflow=False, underflow=False)
+axis_pt_utilityHist = hist.axis.Regular(6, 26, 56, name = "pt", overflow=False, underflow=False)
 
 axis_met = hist.axis.Regular(200, 0., 200., name = "met", underflow=False, overflow=True)
 
@@ -360,16 +364,12 @@ def build_graph(df, dataset):
         dphiMuonMetCut = args.dphiMuonMetCut * np.pi
         df = df.Filter(f"deltaPhiMuonMet > {dphiMuonMetCut}") # pi/4 was found to be a good threshold for signal with mT > 40 GeV
 
-    if auxiliary_histograms:
-        mtIsoJetCharge = df.HistoBoost("mtIsoJetCharge", [axis_mt_fakes, axis_iso_fakes, axis_hasjet_fakes, axis_charge], ["transverseMass", "goodMuons_pfRelIso04_all0", "hasCleanJet", "goodMuons_charge0", "nominal_weight"])
-        results.append(mtIsoJetCharge)
-        
     df = df.Define("passMT", f"transverseMass >= {mtw_min}")
 
     if auxiliary_histograms:
         # utility plot, mt and met, to plot them later
-        results.append(df.HistoBoost("MET", [axis_met, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
-        results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_charge, axis_passIso, axis_passMT], ["transverseMass", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
+        results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
+        results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
 
     ## TODO: next part should be improved, there is quite a lot of duplication of what could happen later in the loop
     ## FIXME: should be isW, to include Wtaunu

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -11,6 +11,7 @@ from wremnants import logging
 import pathlib
 import hist
 import re
+import numpy as np
 
 xlabels = {
     "pt" : r"p$_{T}^{\ell}$ (GeV)",
@@ -73,6 +74,7 @@ parser.add_argument("--fitresult", type=str, help="Specify a fitresult root file
 parser.add_argument("--prefit", action='store_true', help="Use the prefit uncertainty from the fitresult root file, instead of the postfit. (--fitresult has to be given)")
 parser.add_argument("--eoscp", action='store_true', help="Use of xrdcp for eos output rather than the mount")
 parser.add_argument("--selection", type=str, help="Specify custom selections as comma seperated list (e.g. '--selection passIso=0,passMT=1' )")
+parser.add_argument("--presel", type=str, nargs="*", help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 
 subparsers = parser.add_subparsers(dest="variation")
 variation = subparsers.add_parser("variation", help="Arguments for adding variation hists")
@@ -119,6 +121,22 @@ datasets = groups.getNames()
 logger.info(f"Will plot datasets {datasets}")
 
 select = {} if args.channel == "all" else {"charge" : -1.j if args.channel == "minus" else 1.j}
+
+if len(args.presel):
+    s = hist.tag.Slicer()
+    presel = {}
+    logger.debug(args.presel)
+    logger.debug(f"Will apply the global preselection")
+    for ps in args.presel:
+        if "=" in ps:
+            axName,axRange = ps.split("=")
+            axMin,axMax = map(float, axRange.split(","))
+            logger.info(f"{axName} in [{axMin},{axMax}]")
+            presel[axName] = s[complex(0, axMin):complex(0, axMax):hist.sum]
+        else:
+            logger.info(f"Integrating boolean {ps} axis")
+            presel[ps] = s[::hist.sum]
+    groups.setGlobalAction(lambda h: h[presel])
 
 if args.selection:
     for selection in args.selection.split(","):

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -74,7 +74,7 @@ parser.add_argument("--fitresult", type=str, help="Specify a fitresult root file
 parser.add_argument("--prefit", action='store_true', help="Use the prefit uncertainty from the fitresult root file, instead of the postfit. (--fitresult has to be given)")
 parser.add_argument("--eoscp", action='store_true', help="Use of xrdcp for eos output rather than the mount")
 parser.add_argument("--selection", type=str, help="Specify custom selections as comma seperated list (e.g. '--selection passIso=0,passMT=1' )")
-parser.add_argument("--presel", type=str, nargs="*", help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
+parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 
 subparsers = parser.add_subparsers(dest="variation")
 variation = subparsers.add_parser("variation", help="Arguments for adding variation hists")

--- a/wremnants/datasets/datagroups2016.py
+++ b/wremnants/datasets/datagroups2016.py
@@ -54,7 +54,7 @@ def make_datagroups_2016(dg, combine=False, pseudodata_pdfset = None, applySelec
         )
         dg.addGroup("DYlowMass",
             members = list(filter(lambda y: y.group == "DYlowMass", dg.datasets.values())),
-            label = r"Z$\to\mu\mu$ $10<m<50$\,GeV",
+            label = r"Z$\to\mu\mu$, $10<m<50$ GeV",
             color = "deepskyblue",
             selectOp = sigOp,
         )


### PR DESCRIPTION
The histogram used to plot mT was not appropriate for the computation of the fakes, because it didn't have eta-pt axes.

Instead of adding those axes to the current transverseMass histogram, making it quite bigger, I would propose reusing the histogram mTStudyForFakes which has all axes and is already available.
However, it has additional axes which must be integrated out for the plot, so this PR add a new option to **scripts/plotting/makeDataMCStackPlot.py** to achieve that (it reuses existing features of datagroups to manipulate histograms through some sort of selection).

From a local test I got these histograms [0], identical to those I make with independent scripts.
I would also suggest making the plots splitting by charge since they are not necessarily identical, which requires using the already existing option -c <plus|minus>.

Locally I tested the code with this command (for charge plus):
```
python scripts/plotting/makeDataMCStackPlot.py mw.hdf5  -p /eos/user/m/mciprian/www/WMassAnalysis/fromMyWremnants/testPlot/ --baseName mTStudyForFakes --hists mt -c plus -f testOpt --presel hasJets DphiMuonMet=0.7854,3.1416
```

Final remark: implementing the met plot (possibly also ptW) requires in any case to define new histograms, so at that point one may also use a new one for mt with all the necessary axes, but the new feature added to the plotting script might still be useful. To avoid having too large histograms, I would use alternate versions of the eta-pt axes with less bins, since the fake rate is pretty stable versus pt and eta (except around the transition region between barrel and endcap)

[0] https://mciprian.web.cern.ch/mciprian/WMassAnalysis/fromMyWremnants/testPlot/testOpt/