### PR TITLE
Theory agnostic fit with POI as NOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,36 @@ source WRemnants/setup.sh
 
 Make histograms (only nominal and mass variations for now, systematics are being developed)
 ```
-/usr/bin/time -v python scripts/histmakers/mw_with_mu_eta_pt.py -o outputFolder/ --met DeepMETReso  --theoryAgnostic
+/usr/bin/time -v python scripts/histmakers/mw_with_mu_eta_pt.py -o outputFolder/ --theoryAgnostic --noAuxiliaryHistograms
 ```
 
 Prepare datacards and root files with TH2 (stat-only for now)
 ```
 /usr/bin/time -v python scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/  --absolutePathInCard --theoryAgnostic
 ```
-To remove the backgrounds and run signal only one can add __--excludeProcGroups Top Diboson Fake Zmumu Ztautau Wtaunu BkgWmunu__
+To remove the backgrounds and run signal only one can add __--excludeProcGroups Top Diboson Fake Zmumu DYlowMass Ztautau Wtaunu BkgWmunu__
 
 Run the fit (for charge combination)
 ```
 python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta_statOnly/ --skip-fit-data --theoryAgnostic --comb
 ```
+### Theory agnostic analysis with POIs as NOIs
 
+Make histograms (only nominal and mass variations for now, systematics are being developed)
+```
+/usr/bin/time -v python scripts/histmakers/mw_with_mu_eta_pt.py -o outputFolder/ --theoryAgnostic --poiAsNoi
+```
+
+Prepare datacards and root files with TH2 (stat-only for now)
+```
+/usr/bin/time -v python scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/ --absolutePathInCard --theoryAgnostic --poiAsNoi --priorNormXsec 0.5
+```
+To remove the backgrounds and run signal only one can add __--filterProcGroups Wmunu__
+
+Run the fit (for charge combination). Note that it is the same command as the traditional analysis
+```
+python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta_statOnly/ --skip-fit-data --comb
+```
             
 ### Traditional analysis
     
@@ -107,7 +123,7 @@ Make the datacards for single charges and prepare the TH2 histograms for combine
 python WRemnants/scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5 -o outputFolder/
 ```
 The input file is the output of the previous step.
-The default path specified with __-o__ is the local folder. A subfolder with name identifying the specific analysis (e.g. WMass_pt_eta/) is automatically created inside it. Some options may add tags to the folder name: for example, using --doStatOnly will  call the folder WMass_pt_eta_statOnly/.
+The default path specified with __-o__ is the local folder. A subfolder with name identifying the specific analysis (e.g. WMass_pt_eta/) is automatically created inside it. Some options may add tags to the folder name: for example, using --doStatOnly will  call the folder WMass_pt_eta_statOnly/. Can use --absolutePathInCard to write absolute path for files in the datacard, so to allow one to run the fit from any location.
  
 Combine the datacards for single charges and run the fit (Asimov only)
 ```
@@ -115,7 +131,7 @@ python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta/ --c
 ```
 Run the fits for single charges (Asimov only). These can be produced in the same output folder as the combination, since a postfix is automatically appended to the output card and fit result files.
 ```
-python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta/ --fit-single-charge --skip-fit-data [-c plus|minus|both]
+python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta/ --fit-single-charge --skip-fit-data [-c <plus|minus|both>]
 ```
 
 **NOTE**:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Make histograms (only nominal and mass variations for now, systematics are being
 
 Prepare datacards and root files with TH2 (stat-only for now)
 ```
-/usr/bin/time -v python scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/  --absolutePathInCard --theoryAgnostic
+/usr/bin/time -v python scripts/combine/setupCombine.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/  --absolutePathInCard --theoryAgnostic
 ```
 To remove the backgrounds and run signal only one can add __--excludeProcGroups Top Diboson Fake Zmumu DYlowMass Ztautau Wtaunu BkgWmunu__
 
@@ -101,7 +101,7 @@ Make histograms (this has all systematics too unlike the standard theory agnosti
 
 Prepare datacards and root files with TH2
 ```
-/usr/bin/time -v python scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/ --absolutePathInCard --theoryAgnostic --poiAsNoi --priorNormXsec 0.5
+/usr/bin/time -v python scripts/combine/setupCombine.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/ --absolutePathInCard --theoryAgnostic --poiAsNoi --priorNormXsec 0.5
 ```
 To remove the backgrounds and run signal only one can add __--filterProcGroups Wmunu__
 
@@ -120,7 +120,7 @@ More options are loaded from **WRemnants/utilities/common.py**
 
 Make the datacards for single charges and prepare the TH2 histograms for combinetf.
 ```
-python WRemnants/scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5 -o outputFolder/
+python WRemnants/scripts/combine/setupCombine.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5 -o outputFolder/
 ```
 The input file is the output of the previous step.
 The default path specified with __-o__ is the local folder. A subfolder with name identifying the specific analysis (e.g. WMass_pt_eta/) is automatically created inside it. Some options may add tags to the folder name: for example, using --doStatOnly will  call the folder WMass_pt_eta_statOnly/. Can use --absolutePathInCard to write absolute path for files in the datacard, so to allow one to run the fit from any location.
@@ -147,7 +147,7 @@ Plot Wmass histograms from hdf5 file (from Wmass histmaker) in the 4 iso-MT regi
 python scripts/analysisTools/tests/testShapesIsoMtRegions.py mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5 outputFolder/ [--isoMtRegion 0 1 2 3]
 ```
     
-Plot prefit shapes (requires root file from setupCombineWmass.py as input)
+Plot prefit shapes (requires root file from setupCombine.py as input)
 ```
 python scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py WMassCombineInput.root outputFolder/ [-l 16.8] [--pseudodata <pseudodataHistName>] [--wlike]
 ```

--- a/README.md
+++ b/README.md
@@ -94,20 +94,20 @@ python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta_stat
 ```
 ### Theory agnostic analysis with POIs as NOIs
 
-Make histograms (only nominal and mass variations for now, systematics are being developed)
+Make histograms (this has all systematics too unlike the standard theory agnostic setup)
 ```
 /usr/bin/time -v python scripts/histmakers/mw_with_mu_eta_pt.py -o outputFolder/ --theoryAgnostic --poiAsNoi
 ```
 
-Prepare datacards and root files with TH2 (stat-only for now)
+Prepare datacards and root files with TH2
 ```
 /usr/bin/time -v python scripts/combine/setupCombineWMass.py -i outputFolder/mw_with_mu_eta_pt_scetlib_dyturboCorr.hdf5  -o outputFolder/ --absolutePathInCard --theoryAgnostic --poiAsNoi --priorNormXsec 0.5
 ```
 To remove the backgrounds and run signal only one can add __--filterProcGroups Wmunu__
 
-Run the fit (for charge combination). Note that it is the same command as the traditional analysis
+Run the fit (for charge combination). Note that it is the same command as the traditional analysis, without --theoryAgnostic
 ```
-python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta_statOnly/ --skip-fit-data --comb
+python WRemnants/scripts/combine/fitManager.py -i outputFolder/WMass_pt_eta/ --skip-fit-data --comb
 ```
             
 ### Traditional analysis

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -1649,6 +1649,8 @@ def drawNTH1(hists=[],
                 #h1.SetMarkerSize(2)
         else:
             h.SetLineWidth(lineWidth)
+            h.SetFillStyle(0)
+
     #ymax = max(ymax, max(h1.GetBinContent(i)+h1.GetBinError(i) for i in range(1,h1.GetNbinsX()+1)))
     # if min and max were not set, set them based on histogram content
     if ymin == ymax == 0.0:

--- a/scripts/analysisTools/tests/testShapesIsoMtRegions.py
+++ b/scripts/analysisTools/tests/testShapesIsoMtRegions.py
@@ -54,6 +54,7 @@ if __name__ == "__main__":
                         help='Choose what charge to plot')
     parser.add_argument("--isoMtRegion", type=int, nargs='+', default=[0,1,2,3], choices=[0,1,2,3], help="Integer index for iso-Mt regions to plot (conversion is index = passIso * 1 + passMT * 2 as in common.getIsoMtRegionFromID)");
     parser.add_argument(     '--useQCDMC', action='store_true',   help='Use QCD MC instead of Fakes for MC stack')
+    parser.add_argument(     '--noFake', action='store_true',   help='Do not use Fakes for MC stack')
     args = parser.parse_args()
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
@@ -103,6 +104,8 @@ if __name__ == "__main__":
         groups = Datagroups(fname)
         datasets = groups.getNames()
         logger.warning(datasets)
+        if args.noFake:
+            datasets = list(filter(lambda x: x != "Fake", datasets))
         if args.processes is not None and len(args.processes):
             datasets = list(filter(lambda x: x in args.processes, datasets))
         logger.info(f"Will plot datasets {datasets}")
@@ -167,7 +170,7 @@ if __name__ == "__main__":
     logger.info(f"Writing some shapes in {rootfile.GetName()}")
     rootfile.Close()
 
-    if (args.processes == None or "Fake" in args.processes):
+    if ((args.processes == None or "Fake" in args.processes) and not args.noFake):
         ptBinRanges = []
         XlabelUnroll = ""
         k = list(histForFRF.keys())[0]

--- a/scripts/analysisTools/w_mass_13TeV/makeRatioTH2.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeRatioTH2.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
     parser.add_argument(      '--drawOption',  default='colz0', type=str, help='Draw option for TH2')
     parser.add_argument(      '--set-ratio-unc', dest="setRatioUnc", default="num", choices=["num", "den", "both"], help="Set how to compute uncertainty for the ratio (num or den simply use the one of those component, neglecting the other, both propagates both) ")
     parser.add_argument(      '--integrate1D', action="store_true",  help="In addition to other plots, integrate the shapes in 1D and plot them as TH1 with ratio panel")
+    parser.add_argument(      '--legendEntries1D',  default=("Numerator","Denominator"), type=str, nargs=2, help='Entries for legend when integrating in 1D')
     args = parser.parse_args()
     
     f1 = args.file1[0]
@@ -173,20 +174,20 @@ if __name__ == "__main__":
             print("Error: you need to pass the binning to roll 1D histograms into 2D")
             quit()
 
-    if args.integrate1D:
-        pass
-            
     xMin = args.xRange[0]
     xMax = args.xRange[1]
     yMin = args.yRange[0]
     yMax = args.yRange[1]
 
-    hratio = hinput1.Clone(args.outhistname)
+    h1for1Dproj = copy.deepcopy(hinput1.Clone("h1for1Dproj"))
+    h2for1Dproj = copy.deepcopy(hinput2.Clone("h2for1Dproj"))
+    
+    hratio = copy.deepcopy(hinput1.Clone(args.outhistname))
     hratio.SetTitle(args.histTitle)                
                 
     hsum = None
     if args.makeAsymmetry:
-        hsum = hinput1.Clone("diff")
+        hsum = copy.deepcopy(hinput1.Clone("diff"))
         hsum.Add(hinput2)
         hratio.Add(hinput2, -1.)
         #hratio.Divide(hsum) # do this below
@@ -359,7 +360,27 @@ if __name__ == "__main__":
                      fillStyleSecondHistogram=1001, fillColorSecondHistogram=ROOT.kGray,
                      colorVec=colorUnrollHists)
 
-    
+    if args.integrate1D:
+        canvas1D = ROOT.TCanvas("canvas1D","",800,900)
+        hinput1_projX = h1for1Dproj.ProjectionX(f"{h1for1Dproj.GetName()}_x", 1, h1for1Dproj.GetNbinsY(), "e")
+        hinput1_projY = h1for1Dproj.ProjectionY(f"{h1for1Dproj.GetName()}_y", 1, h1for1Dproj.GetNbinsX(), "e")
+        hinput2_projX = h2for1Dproj.ProjectionX(f"{h2for1Dproj.GetName()}_x", 1, h2for1Dproj.GetNbinsY(), "e")
+        hinput2_projY = h2for1Dproj.ProjectionY(f"{h2for1Dproj.GetName()}_y", 1, h2for1Dproj.GetNbinsX(), "e")
+        hinput1_projX.SetFillStyle(0)
+        hinput1_projY.SetFillStyle(0)
+        hinput2_projX.SetFillStyle(0)
+        hinput2_projY.SetFillStyle(0)
+        drawNTH1([hinput1_projX, hinput2_projX], [args.legendEntries1D[0], args.legendEntries1D[1]], xAxisTitle, "Events", f"{args.outhistname}_projX", outname,
+                 topMargin=0.1, leftMargin=0.16, rightMargin=0.05, labelRatioTmp="Ratio::0.99,1.02",
+                 legendCoords="0.16,0.95,0.8,0.9;1", lowerPanelHeight=0.4, skipLumi=True, passCanvas=canvas1D,
+                 transparentLegend=True, onlyLineColor=True, noErrorRatioDen=False,
+                 useLineFirstHistogram=True, setOnlyLineRatio=False, lineWidth=2)
+        drawNTH1([hinput1_projY, hinput2_projY], [args.legendEntries1D[0], args.legendEntries1D[1]], yAxisTitle, "Events", f"{args.outhistname}_projY", outname,
+                 topMargin=0.1, leftMargin=0.16, rightMargin=0.05, labelRatioTmp="Ratio::0.99,1.02",
+                 legendCoords="0.16,0.95,0.8,0.9;1", lowerPanelHeight=0.4, skipLumi=True, passCanvas=canvas1D,
+                 transparentLegend=True, onlyLineColor=True, noErrorRatioDen=False,
+                 useLineFirstHistogram=True, setOnlyLineRatio=False, lineWidth=2)
+
     # making distribution of pulls
     if args.makePulls:
         hpull = ROOT.TH1D("pulls","Distribution of pulls",100,-5,5)

--- a/scripts/analysisTools/w_mass_13TeV/makeRatioTH2.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeRatioTH2.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
     parser.add_argument(      '--binning-file-to-roll', dest="binFileToRoll", default="", help="File with binning to roll 1D into 2D (the reco binning is used)")
     parser.add_argument(      '--drawOption',  default='colz0', type=str, help='Draw option for TH2')
     parser.add_argument(      '--set-ratio-unc', dest="setRatioUnc", default="num", choices=["num", "den", "both"], help="Set how to compute uncertainty for the ratio (num or den simply use the one of those component, neglecting the other, both propagates both) ")
+    parser.add_argument(      '--integrate1D', action="store_true",  help="In addition to other plots, integrate the shapes in 1D and plot them as TH1 with ratio panel")
     args = parser.parse_args()
     
     f1 = args.file1[0]
@@ -148,10 +149,6 @@ if __name__ == "__main__":
         # this is needed only for muons, for electrons I save directly the smoothed FR (PR)
         neta = hist1.GetNbinsX()
         etabins = [hist1.GetXaxis().GetBinLowEdge(i) for i in range(1,2+neta)]
-        #etamin = hist1.GetXaxis().GetBinLowEdge(1)
-        #etamax = hist1.GetXaxis().GetBinLowEdge(1+neta)
-        #hFR1 = ROOT.TH2D(hist1.GetName()+"_FRorPR","",195,26,65,neta,etamin,etamax)
-        #hFR2 = ROOT.TH2D(hist2.GetName()+"_FRorPR","",195,26,65,neta,etamin,etamax)
         hFR1 = ROOT.TH2D(hist1.GetName()+"_FRorPR","",195,26,65,neta,array('d',etabins))
         hFR2 = ROOT.TH2D(hist2.GetName()+"_FRorPR","",195,26,65,neta,array('d',etabins))
         for ix in range (1,1+hFR1.GetNbinsX()):
@@ -176,6 +173,9 @@ if __name__ == "__main__":
             print("Error: you need to pass the binning to roll 1D histograms into 2D")
             quit()
 
+    if args.integrate1D:
+        pass
+            
     xMin = args.xRange[0]
     xMax = args.xRange[1]
     yMin = args.yRange[0]

--- a/scripts/analysisTools/w_mass_13TeV/makeSystRatios.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeSystRatios.py
@@ -364,8 +364,9 @@ if __name__ == "__main__":
             print("Not running drawNTH1() function to draw curves, there are too many lines ({})".format(len(systList[p])))
         else:
             drawNTH1(systList[p], systLeg[p], "Unrolled eta-p_{T} bin", "Events", f"nominalAndSyst_{p}{systPostfix}", outdir,
-                     leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
-                     legendCoords="0.06,0.99,0.82,0.98;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                     topMargin=0.2, leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
+                     legendCoords="0.06,0.99,0.84,0.99;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                     yAxisExtendConstant=1.4, ytextOffsetFromTop=0.22,
                      drawVertLines="{a},{b}".format(a=nominals[p].GetNbinsY(),b=nominals[p].GetNbinsX()),
                      textForLines=ptBinRanges, transparentLegend=False,
                      onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True, setOnlyLineRatio=True, lineWidth=1)
@@ -385,8 +386,9 @@ if __name__ == "__main__":
                 histFakesOnSignal = [systList[p][0]] + [x for x in systList_FakeOnSignal]
                 drawNTH1(histFakesOnSignal, systLeg[p], "Unrolled eta-p_{T} bin", "Events",
                          f"nominalAndSyst_{p}{systPostfix}_FakeOnSignal", outdir,
-                         leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
-                         legendCoords="0.06,0.99,0.82,0.98;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                         topMargin=0.2, leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
+                         legendCoords="0.06,0.99,0.84,0.99;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                         yAxisExtendConstant=1.4, ytextOffsetFromTop=0.22,
                          drawVertLines="{a},{b}".format(a=nominals[p].GetNbinsY(),b=nominals[p].GetNbinsX()),
                          textForLines=ptBinRanges, transparentLegend=False,
                          onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True,
@@ -434,8 +436,9 @@ if __name__ == "__main__":
             
         drawNTH1(systList_WmunuAndFake, systLeg_WmunuAndFake, "Unrolled eta-p_{T} bin", "Events",
                  f"nominalAndSyst_{systPostfix}_WmunuAndFake", outdir,
-                 leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
-                 legendCoords="0.06,0.99,0.82,0.98;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                 topMargin=0.2, leftMargin=0.06, rightMargin=0.01, labelRatioTmp="syst/nomi",
+                 legendCoords="0.06,0.99,0.84,0.99;4", lowerPanelHeight=0.5, skipLumi=True, passCanvas=canvas_unroll,
+                 yAxisExtendConstant=1.4, ytextOffsetFromTop=0.22,
                  drawVertLines="{a},{b}".format(a=nominals[p].GetNbinsY(),b=nominals[p].GetNbinsX()),
                  textForLines=ptBinRanges, transparentLegend=False,
                  onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True,

--- a/scripts/analysisTools/w_mass_13TeV/plotTemplateWithAi.py
+++ b/scripts/analysisTools/w_mass_13TeV/plotTemplateWithAi.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import re
+import os, os.path
+import argparse
+import shutil
+
+## safe batch mode
+import sys
+args = sys.argv[:]
+sys.argv = ['-b']
+import ROOT
+sys.argv = args
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from copy import *
+import wremnants
+
+from scripts.analysisTools.plotUtils.utility import *
+
+sys.path.append(os.getcwd())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("rootfile", type=str, nargs=1, help="Input file with TH2 histograms")
+    parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
+    parser.add_argument('-c','--charges', dest='charges', choices=['plus', 'minus', 'both'], default='both', type=str, help='Charges to process')
+    args = parser.parse_args()
+
+    fname = args.rootfile[0]
+    outdir = args.outdir[0]
+    createPlotDirAndCopyPhp(outdir)
+    
+    ROOT.TH1.SetDefaultSumw2()
+
+    adjustSettings_CMS_lumi()    
+    canvas1D = ROOT.TCanvas("canvas1D","",800,1000) 
+
+    canvas_unroll = ROOT.TCanvas("canvas_unroll","",3000,800) 
+    leftMargin = 0.06
+    rightMargin = 0.01
+    bottomMargin = 0.12
+    canvas_unroll.SetTickx(1)
+    canvas_unroll.SetTicky(1)
+    canvas_unroll.cd()
+    canvas_unroll.SetLeftMargin(leftMargin)
+    canvas_unroll.SetRightMargin(rightMargin)
+    canvas_unroll.cd()
+    canvas_unroll.SetBottomMargin(bottomMargin)
+
+    setTDRStyle() # this one removes the stat box
+
+    
+    charges = ["plus", "minus"] if args.charges == "both" else [args.charges]
+
+    for charge in charges:
+
+        nomihists = {ai: None for ai in range(6)}
+        # read histograms
+        infile = safeOpenFile(fname)
+        for ai in nomihists.keys():
+            #nomihists[ai] = safeGetObject(infile, f"Wmunu/nominal_Wmunu_PtVBin0YVBin0AnfCoeff{ai}_{charge}", detach=True) # process name as subfolder
+            #
+            # how to read input histograms depends on input file, format has changed a lot
+            # Wmunu_qGen1_absYVgenSig4_ptVgenSig9_helicity5
+            icW = 0 if charge == "minus" else 1
+            print(f"Reading Ai {ai-1}")
+            for iyW in range(5):
+                for iptW in range(10):
+                    folder = f"Wmunu_qGen{icW}_absYVgenSig{iyW}_ptVgenSig{iptW}_helicity{ai}"
+                    hread = f"{folder}/x_{folder}_{charge}"
+                    #print(f"Reading {hread}")
+                    tmp = safeGetObject(infile, hread, detach=True) # process name as subfolder
+                    if nomihists[ai] == None:
+                        nomihists[ai] = copy.deepcopy(tmp)
+                    else:
+                        nomihists[ai].Add(tmp)
+        infile.Close()
+
+        outdir_dataMC = f"{outdir}dataMC_{charge}/"
+        createPlotDirAndCopyPhp(outdir_dataMC)
+
+        nomihists_unroll = {}
+        for k in nomihists.keys():
+            nomihists_unroll[k] = unroll2Dto1D(nomihists[k], newname=f"unrolled_{nomihists[k].GetName()}", cropNegativeBins=False)
+
+        nomihists_projEta = {}
+        nomihists_projPt = {}
+        for k in nomihists.keys():
+            nomihists_projEta[k] = nomihists[k].ProjectionX(f"{nomihists[k].GetName()}_eta", 1, nomihists[k].GetNbinsY(), "e")
+            nomihists_projPt[k] = nomihists[k].ProjectionY(f"{nomihists[k].GetName()}_pt", 1, nomihists[k].GetNbinsX(), "e")
+            
+        legEntry = {0: "Unpolarized term #sigma_{UL}"}
+        for ai in range(1,6):
+            ai_id = ai - 1
+            legEntry[ai] = f"Angular term #propto A{ai_id}"
+
+        ptBinRanges = []
+        for ipt in range(0, nomihists[0].GetNbinsY()):
+            if ipt%4:
+                ptBinRanges.append("")
+            else:
+                ptBinRanges.append("#splitline{{[{ptmin},{ptmax}]}}{{GeV}}".format(ptmin=int(nomihists[0].GetYaxis().GetBinLowEdge(ipt+1)),
+                                                                                   ptmax=int(nomihists[0].GetYaxis().GetBinLowEdge(ipt+2))))
+
+        drawNTH1([nomihists_unroll[ai] for ai in nomihists_unroll.keys()], [legEntry[l] for l in legEntry.keys()], "Unrolled eta-p_{T} bin", "Events::0,110000", f"WmunuCrossSection_byAngoularCoefficients_{charge}", outdir_dataMC,
+                 topMargin=0.2, leftMargin=0.06, rightMargin=0.01, labelRatioTmp="A_{i} / #sigma_{UL}::-0.12,0.12",
+                 yAxisExtendConstant=1.4, ytextOffsetFromTop=0.22,
+                 legendCoords="0.06,0.99,0.87,0.99;4", lowerPanelHeight=0.3, skipLumi=True, passCanvas=canvas_unroll,
+                 drawVertLines="{a},{b}".format(a=nomihists[0].GetNbinsY(),b=nomihists[0].GetNbinsX()),
+                 textForLines=ptBinRanges, transparentLegend=False,
+                 onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True, setOnlyLineRatio=True, lineWidth=1)
+
+        drawNTH1([nomihists_projEta[ai] for ai in nomihists_unroll.keys()], [legEntry[l] for l in legEntry.keys()], "Muon #eta", "Events", f"WmunuCrossSection_byAngoularCoefficients_{charge}_1Deta", outdir_dataMC,
+                 topMargin=0.25, leftMargin=0.16, rightMargin=0.05, labelRatioTmp="A_{i} / #sigma_{UL}::-0.12,0.12",
+                 legendCoords="0.01,0.99,0.81,0.99;2", lowerPanelHeight=0.3, skipLumi=True, passCanvas=canvas1D,
+                 transparentLegend=False,
+                 onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True, setOnlyLineRatio=True, lineWidth=2)
+        
+        drawNTH1([nomihists_projPt[ai] for ai in nomihists_unroll.keys()], [legEntry[l] for l in legEntry.keys()], "Muon p_{T} (GeV)", "Events", f"WmunuCrossSection_byAngoularCoefficients_{charge}_1Dpt", outdir_dataMC,
+                 topMargin=0.25, leftMargin=0.16, rightMargin=0.05, labelRatioTmp="A_{i} / #sigma_{UL}::-0.12,0.12",
+                 legendCoords="0.01,0.99,0.81,0.99;2", lowerPanelHeight=0.3, skipLumi=True, passCanvas=canvas1D,
+                 transparentLegend=False,
+                 onlyLineColor=True, noErrorRatioDen=True, useLineFirstHistogram=True, setOnlyLineRatio=True, lineWidth=2)

--- a/scripts/combine/fitManager.py
+++ b/scripts/combine/fitManager.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     parser.add_argument("-D", "--dataset",  dest="dataname", default="data_obs",  type=str,  help="Name of the observed dataset (pass name without x_ in the beginning). Useful to fit another pseudodata histogram")
     parser.add_argument("--combinetf-option",  dest="combinetfOption", default="",  type=str,  help="Pass other options to combinetf (TODO: some are already activated with other options, might move them here)")
     parser.add_argument("-t",  "--toys", type=int, default=0, help="Run combinetf for N toys if argument N is positive")
-    parser.add_argument(       '--theoryAgnostic', action='store_true', help='Run theory agnostic fit, with masked channels and so on')
+    parser.add_argument(       '--theoryAgnostic', action='store_true', help='Run theory agnostic fit, with masked channels and so on (not needed when using POIs as NOIs)')
     args = parser.parse_args()
 
     if not args.dryRun:

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -24,7 +24,7 @@ def make_parser(parser=None):
     parser.add_argument("--absolutePathInCard", action="store_true", help="In the datacard, set Absolute path for the root file where shapes are stored")
     parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file (e.g., 'nominal')", default="nominal")
     parser.add_argument("--noHist", action='store_true', help="Skip the making of 2D histograms (root file is left untouched if existing)")
-    parser.add_argument("--qcdProcessName" , type=str, default=None, help="Name for QCD process")
+    parser.add_argument("--qcdProcessName" , type=str, default="Fake", help="Name for QCD process (must be consistent with what is used in datagroups2016.py")
     # setting on the fit behaviour
     parser.add_argument("--fitvar", nargs="+", help="Variable to fit", default=["eta-pt-charge"])
     parser.add_argument("--rebin", type=int, nargs='*', default=[], help="Rebin axis by this value (default, 1, does nothing)")
@@ -172,7 +172,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     cardTool.setProjectionAxes(fitvar)
     cardTool.setFakerateAxes(args.fakerateAxes)
     if wmass and args.ABCD:
-        # In case of ABCD we need to have different fake processes fir e and mu to have uncorrelated uncertainties
+        # In case of ABCD we need to have different fake processes for e and mu to have uncorrelated uncertainties
         cardTool.setFakeName(datagroups.fakeName + (datagroups.flavor if datagroups.flavor else "")) 
         cardTool.unroll=True
     if args.sumChannels or xnorm or dilepton or (wmass and args.ABCD):
@@ -313,7 +313,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                # scalePrefitHistYields=2, # multiply yields of input hist by 2, should be equivalent to scaling the prior using "scale=2"
                                noConstraint=True if args.priorNormXsec < 0 else False,
                                #customizeNuisanceAttributes={".*AngCoeff4" : {"scale" : 1, "shapeType": "shapeNoConstraint"}},
-                               systAxes=["ptVgenSig", "absYVgenSig", "helicity"],
+                               systAxes=["ptVgenSig", "absYVgenSig", "helicitySig"],
                                labelsByAxis=["PtVBin", "YVBin", "AngCoeff"],
                                passToFakes=passSystToFakes,
                                )
@@ -651,7 +651,7 @@ if __name__ == "__main__":
         args.unfolding = True
         logger.warning("For now setting --theoryAgnostic activates --unfolding, they should do the same things")
         if args.genAxes is None:
-            args.genAxes = ["ptVgenSig", "absYVgenSig", "helicity"]
+            args.genAxes = ["ptVgenSig", "absYVgenSig", "helicitySig"]
             logger.warning("Automatically setting '--genAxes ptVgenSig absYVgenSig helicity' for theory agnostic analysis")
             if args.poiAsNoi:
                 logger.warning("This is only needed to properly get the systematic axes")

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -277,19 +277,18 @@ def setup(args,xnorm=False):
                            passToFakes=passSystToFakes,
     )
 
-    # TODO: move this after the doStatOnly
+    # this appears within doStatOnly because technically these nuisances should be part of it
     if args.theoryAgnostic and args.poiAsNoi:
         cardTool.addSystematic("yieldsTheoryAgnostic",
                                processes=["signal_samples"],
                                group=f"normXsec{label}",
                                mirror=True,
                                baseName=f"norm{label}CHANNEL_",
-                               #scaleAndSumNominal=args.priorNormXsec, # multiply yields of input hist by 0.5 and then sum the nominal
                                scale=1 if args.priorNormXsec < 0 else args.priorNormXsec, # histogram represents an (args.priorNormXsec*100)% prior
-                               #noiGroup=args.priorNormXsec < 0, # should not be needed
-                               sumNominal=True,
+                               sumNominalToHist=True,
+                               # scalePrefitHistYields=2, # multiply yields of input hist by 2, should be equivalent to scaling the prior using "scale=2"
                                noConstraint=True if args.priorNormXsec < 0 else False,
-                               #customizeNuisance={".*AngCoeff4" : {"scale" : 1, "shape": "shapeNoConstraint"}},
+                               #customizeNuisanceAttributes={".*AngCoeff4" : {"scale" : 1, "shapeType": "shapeNoConstraint"}},
                                systAxes=["ptVgenSig", "absYVgenSig", "helicity"],
                                labelsByAxis=["PtVBin", "YVBin", "AngCoeff"],
                                passToFakes=passSystToFakes,

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -129,20 +129,7 @@ def setup(args,xnorm=False):
         datagroups.unconstrainedProcesses.append(base_group)
     elif args.unfolding:
 
-        if args.theoryAgnostic and args.poiAsNoi:
-            pass
-        
-            ## currently the following doesn't work because datagroups.defineSignalBinsUnfolding require xnorm histograms
-            # if wmass:
-            #     # gen level bins, split only by charge
-            #     if "minus" in args.recoCharge:
-            #         datagroups.defineSignalBinsUnfolding(base_group, f"W_qGen0", member_filter=lambda x: x.name.startswith("Wminus"))
-            #     if "plus" in args.recoCharge:
-            #         datagroups.defineSignalBinsUnfolding(base_group, f"W_qGen1", member_filter=lambda x: x.name.startswith("Wplus"))
-            # else:
-            #     datagroups.defineSignalBinsUnfolding(base_group, "Z", member_filter=lambda x: x.name.startswith(base_group))
-
-        else:
+        if not (args.theoryAgnostic and args.poiAsNoi):
             constrainMass = False if args.theoryAgnostic else True
             datagroups.setGenAxes(args.genAxes)
 

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -301,9 +301,11 @@ def setup(args,xnorm=False):
                                baseName=f"norm{label}CHANNEL_",
                                #scaleAndSumNominal=args.priorNormXsec, # multiply yields of input hist by 0.5 and then sum the nominal
                                scale=1 if args.priorNormXsec < 0 else args.priorNormXsec, # histogram represents an (args.priorNormXsec*100)% prior
+                               #noiGroup=args.priorNormXsec < 0, # should not be needed
                                sumNominal=True,
                                noConstraint=True if args.priorNormXsec < 0 else False,
-                               systAxes=[x for x in args.genAxes],
+                               customizeNuisance={".*AngCoeff4" : {"scale" : 1, "shape": "shapeNoConstraint"}},
+                               systAxes=["ptVgenSig", "absYVgenSig", "helicity"],
                                labelsByAxis=["PtVBin", "YVBin", "AngCoeff"],
                                passToFakes=passSystToFakes,
                                )

--- a/scripts/combine/setupCombineWMass.py
+++ b/scripts/combine/setupCombineWMass.py
@@ -289,7 +289,7 @@ def setup(args,xnorm=False):
                                #noiGroup=args.priorNormXsec < 0, # should not be needed
                                sumNominal=True,
                                noConstraint=True if args.priorNormXsec < 0 else False,
-                               customizeNuisance={".*AngCoeff4" : {"scale" : 1, "shape": "shapeNoConstraint"}},
+                               #customizeNuisance={".*AngCoeff4" : {"scale" : 1, "shape": "shapeNoConstraint"}},
                                systAxes=["ptVgenSig", "absYVgenSig", "helicity"],
                                labelsByAxis=["PtVBin", "YVBin", "AngCoeff"],
                                passToFakes=passSystToFakes,
@@ -626,8 +626,8 @@ if __name__ == "__main__":
         args.unfolding = True
         logger.warning("For now setting --theoryAgnostic activates --unfolding, they should do the same things")
         if args.genAxes is None:
-            args.genAxes = ["absYVgenSig", "ptVgenSig", "helicity"]
-            logger.warning("Automatically setting '--genAxes absYVgenSig ptVgenSig helicity' for theory agnostic analysis")
+            args.genAxes = ["ptVgenSig", "absYVgenSig", "helicity"]
+            logger.warning("Automatically setting '--genAxes ptVgenSig absYVgenSig helicity' for theory agnostic analysis")
             if args.poiAsNoi:
                 logger.warning("This is only needed to properly get the systematic axes")
                 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -116,7 +116,7 @@ mTStudyForFakes_axes = [axis_eta, axis_pt, axis_charge, axis_mt_fakes, axis_pass
 axis_eta_utilityHist = hist.axis.Regular(24, -2.4, 2.4, name = "eta", overflow=False, underflow=False)
 axis_pt_utilityHist = hist.axis.Regular(6, 26, 56, name = "pt", overflow=False, underflow=False)
 
-axis_met = hist.axis.Regular(150, 0., 150., name = "met", underflow=False, overflow=True)
+axis_met = hist.axis.Regular(2, 0., 200., name = "met", underflow=False, overflow=True)
 
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
@@ -381,9 +381,8 @@ def build_graph(df, dataset):
         results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
         results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
 
-    ## TODO: next part should be improved, there is quite a lot of duplication of what could happen later in the loop
-    ## FIXME: should be isW, to include Wtaunu
-    if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance")::
+    ## FIXME: should be isW, to include Wtaunu, but for now we only split Wmunu
+    if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance"):
         df = theoryAgnostic_tools.define_helicity_weights(df)
         if args.poiAsNoi:
             theoryAgnosticHistName = Datagroups.histName("nominal", syst="yieldsTheoryAgnostic")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -43,7 +43,7 @@ if args.poiAsNoi and not args.theoryAgnostic:
 if args.theoryAgnostic or args.unfolding:
     parser = common.set_parser_default(parser, "excludeFlow", True)
     if args.theoryAgnostic:
-        parser = common.set_parser_default(parser, "genVars", ["ptVgenSig", "absYVgenSig", "helicity"]) # TODO check sorting
+        parser = common.set_parser_default(parser, "genVars", ["ptVgenSig", "absYVgenSig", "helicitySig"]) # TODO check sorting
         # temporary, to ensure running with stat only for original theory agnostic until systematics are all implemented
         if not args.poiAsNoi:
             logger.warning("Running theory agnostic with only nominal and mass weight histograms for now.")
@@ -119,7 +119,7 @@ mTStudyForFakes_axes = [axis_eta, axis_pt, axis_charge, axis_mt_fakes, axis_pass
 axis_eta_utilityHist = hist.axis.Regular(24, -2.4, 2.4, name = "eta", overflow=False, underflow=False)
 axis_pt_utilityHist = hist.axis.Regular(6, 26, 56, name = "pt", overflow=False, underflow=False)
 
-axis_met = hist.axis.Regular(2, 0., 200., name = "met", underflow=False, overflow=True)
+axis_met = hist.axis.Regular(100, 0., 200., name = "met", underflow=False, overflow=True)
 
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -23,6 +23,7 @@ parser.add_argument("--noScaleFactors", action="store_true", help="Don't use sca
 parser.add_argument("--lumiUncertainty", type=float, help="Uncertainty for luminosity in excess to 1 (e.g. 1.012 means 1.2\%)", default=1.012)
 parser.add_argument("--noGenMatchMC", action='store_true', help="Don't use gen match filter for prompt muons with MC samples (note: QCD MC never has it anyway)")
 parser.add_argument("--theoryAgnostic", action='store_true', help="Add V qT,Y axes and helicity axes for W samples")
+parser.add_argument("--poiAsNoi", action='store_true', help="Experimental option only with --theoryAgnostic, it will make the histogram to do the POIs and NOIs trick (some postprocessing will happen later in CardTool.py)")
 parser.add_argument("--halfStat", action='store_true', help="Test half data and MC stat, selecting odd events, just for tests")
 parser.add_argument("--makeMCefficiency", action="store_true", help="Save yields vs eta-pt-ut-passMT-passIso-passTrigger to derive 3D efficiencies for MC isolation and trigger (can run also with --onlyMainHistograms)")
 parser.add_argument("--onlyTheorySyst", action="store_true", help="Keep only theory systematic variations, mainly for tests")
@@ -35,8 +36,9 @@ logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
 if args.theoryAgnostic:
     # temporary, to ensure running with stat only until systematics are all implemented
-    logger.warning("Running theory agnostic with only nominal and mass weight histograms for now.")
-    parser = common.set_parser_default(parser, "onlyMainHistograms", True)
+    if not args.poiAsNoi:
+        logger.warning("Running theory agnostic with only nominal and mass weight histograms for now.")
+        parser = common.set_parser_default(parser, "onlyMainHistograms", True)
     parser = common.set_parser_default(parser, "genVars", ["absYVgenSig", "ptVgenSig", "helicity"])
     args = parser.parse_args()
     
@@ -98,12 +100,16 @@ elif args.theoryAgnostic:
 
 # axes for study of fakes
 axis_mt_fakes = hist.axis.Regular(120, 0., 120., name = "mt", underflow=False, overflow=True)
-axis_iso_fakes = hist.axis.Regular(60, 0., 0.6, name = "PFrelIso04", underflow=False, overflow=True)
 axis_dphi_fakes = hist.axis.Regular(8, 0., np.pi, name = "DphiMuonMet", underflow=False, overflow=False)
 axis_hasjet_fakes = hist.axis.Boolean(name = "hasJets") # only need case with 0 jets or > 0 for now
 mTStudyForFakes_axes = [axis_eta, axis_pt, axis_charge, axis_mt_fakes, axis_passIso, axis_hasjet_fakes, axis_dphi_fakes]
 
-axis_met = hist.axis.Regular(200, 0., 200., name = "met", underflow=False, overflow=True)
+# for mt, met, ptW plots, to compute the fakes properly (but FR pretty stable vs pt and also vs eta)
+# may not exactly reproduce the same pt range as analysis, though
+axis_eta_utilityHist = hist.axis.Regular(24, -2.4, 2.4, name = "eta", overflow=False, underflow=False)
+axis_pt_utilityHist = hist.axis.Regular(6, 26, 56, name = "pt", overflow=False, underflow=False)
+
+axis_met = hist.axis.Regular(150, 0., 150., name = "met", underflow=False, overflow=True)
 
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
@@ -162,9 +168,6 @@ if not args.noRecoil:
 # graph building for W sample with helicity weights
 def setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, nominal_axes_thAgn, nominal_cols_thAgn, args):
     logger.info(f"Setting theory agnostic graph for {dataset.name}")
-    df = theoryAgnostic_tools.define_helicity_weights(df)
-    nominalByHelicity = df.HistoBoost("nominal", nominal_axes_thAgn, [*nominal_cols_thAgn, "nominal_weight_helicity"], tensor_axes=[axis_helicity])
-    results.append(nominalByHelicity)
 
     if not args.onlyMainHistograms:
         if not args.onlyTheorySyst:
@@ -193,7 +196,7 @@ def build_graph(df, dataset):
     require_prompt = "tau" not in dataset.name # for muon GEN-matching   
     
     # disable auxiliary histograms when unfolding to reduce memory consumptions
-    auxiliary_histograms = not args.unfolding and not args.theoryAgnostic and not args.noAuxiliaryHistograms
+    auxiliary_histograms = not args.unfolding and not (args.theoryAgnostic and not args.poiAsNoi) and not args.noAuxiliaryHistograms
 
     apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
 
@@ -231,7 +234,8 @@ def build_graph(df, dataset):
         else:
             logger.debug("Select events in fiducial phase space for theory agnostic analysis")
             df = theoryAgnostic_tools.select_fiducial_space(df, theoryAgnostic_axes[0].edges[-1], theoryAgnostic_axes[1].edges[-1], accept=True)
-            theoryAgnostic_tools.add_xnorm_histograms(results, df, args, dataset.name, corr_helpers, qcdScaleByHelicity_helper, theoryAgnostic_axes, theoryAgnostic_cols)
+            if not args.poiAsNoi:
+                theoryAgnostic_tools.add_xnorm_histograms(results, df, args, dataset.name, corr_helpers, qcdScaleByHelicity_helper, theoryAgnostic_axes, theoryAgnostic_cols)
             # helicity axis is special, defined through a tensor later, theoryAgnostic_ only includes W rapidity and pt for now
             axes = [*nominal_axes, *theoryAgnostic_axes]
             cols = [*nominal_cols, *theoryAgnostic_cols]
@@ -359,26 +363,29 @@ def build_graph(df, dataset):
     if not args.makeMCefficiency:
         dphiMuonMetCut = args.dphiMuonMetCut * np.pi
         df = df.Filter(f"deltaPhiMuonMet > {dphiMuonMetCut}") # pi/4 was found to be a good threshold for signal with mT > 40 GeV
-
-    if auxiliary_histograms:
-        mtIsoJetCharge = df.HistoBoost("mtIsoJetCharge", [axis_mt_fakes, axis_iso_fakes, axis_hasjet_fakes, axis_charge], ["transverseMass", "goodMuons_pfRelIso04_all0", "hasCleanJet", "goodMuons_charge0", "nominal_weight"])
-        results.append(mtIsoJetCharge)
         
     df = df.Define("passMT", f"transverseMass >= {mtw_min}")
 
     if auxiliary_histograms:
-        # utility plot, mt and met, to plot them later
-        results.append(df.HistoBoost("MET", [axis_met, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
-        results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_charge, axis_passIso, axis_passMT], ["transverseMass", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
+        # utility plot, mt and met, to plot them later (need eta-pt to make fakes)
+        results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
+        results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
 
     ## TODO: next part should be improved, there is quite a lot of duplication of what could happen later in the loop
     ## FIXME: should be isW, to include Wtaunu
     if isWmunu and args.theoryAgnostic:
-        setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, axes, cols, args)
-        if hasattr(dataset, "out_of_acceptance"):
-            # Rename dataset to not overwrite the original one
-            dataset.name = "Bkg"+dataset.name
-        return results, weightsum
+        df = theoryAgnostic_tools.define_helicity_weights(df)
+        if args.poiAsNoi:
+            logger.debug("Creating special histogram 'yieldsTheoryAgnostic' for theory agnostic to treat POIs as NOIs")
+            results.append(df.HistoBoost("yieldsTheoryAgnostic", axes, [*cols, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
+        else:
+            results.append(df.HistoBoost("nominal", axes, [*cols, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
+            setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, axes, cols, args)
+            if hasattr(dataset, "out_of_acceptance"):
+                # Rename dataset to not overwrite the original one
+                dataset.name = "Bkg"+dataset.name
+            # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
+            return results, weightsum
         
     if not args.onlyMainHistograms:
         syst_tools.add_QCDbkg_jetPt_hist(results, df, axes, cols, jet_pt=30)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -45,7 +45,7 @@ if args.theoryAgnostic:
     if not args.poiAsNoi:
         logger.warning("Running theory agnostic with only nominal and mass weight histograms for now.")
         parser = common.set_parser_default(parser, "onlyMainHistograms", True)
-    parser = common.set_parser_default(parser, "genVars", ["absYVgenSig", "ptVgenSig", "helicity"])
+    parser = common.set_parser_default(parser, "genVars", ["ptVgenSig", "absYVgenSig", "helicity"]) # TODO check sorting
     args = parser.parse_args()
     
 thisAnalysis = ROOT.wrem.AnalysisType.Wmass

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -383,7 +383,7 @@ def build_graph(df, dataset):
 
     ## TODO: next part should be improved, there is quite a lot of duplication of what could happen later in the loop
     ## FIXME: should be isW, to include Wtaunu
-    if isWmunu and args.theoryAgnostic:
+    if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance")::
         df = theoryAgnostic_tools.define_helicity_weights(df)
         if args.poiAsNoi:
             theoryAgnosticHistName = Datagroups.histName("nominal", syst="yieldsTheoryAgnostic")
@@ -392,9 +392,6 @@ def build_graph(df, dataset):
         else:
             results.append(df.HistoBoost("nominal", axes, [*cols, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
             setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, axes, cols, args)
-            if hasattr(dataset, "out_of_acceptance"):
-                # Rename dataset to not overwrite the original one
-                dataset.name = "Bkg"+dataset.name
             # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
             return results, weightsum
         

--- a/utilities/differential.py
+++ b/utilities/differential.py
@@ -56,13 +56,14 @@ def get_theoryAgnostic_axes():
 
     # Note that the helicity axis is defined elsewhere, and must not be added to the list of axes returned here
     axis_ptVgen = hist.axis.Variable(
-        [0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
+        #[0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
         #[0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 22.5, 25., 30., 35., 40., 45., 50.],
+        [0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
         name = "ptVgenSig", underflow=False, overflow=False
     )
     axis_absYVgen = hist.axis.Variable(
-        [0, 0.5, 1., 1.5, 2.0, 2.5],
-        #[0.25*i for i in range(11)],
+        #[0, 0.5, 1., 1.5, 2.0, 2.5],
+        [0.25*i for i in range(11)],
         #[0, 1.25, 2.5],
         name = "absYVgenSig", underflow=False, overflow=False
     )

--- a/utilities/differential.py
+++ b/utilities/differential.py
@@ -57,19 +57,19 @@ def get_theoryAgnostic_axes():
     # Note that the helicity axis is defined elsewhere, and must not be added to the list of axes returned here
     axis_ptVgen = hist.axis.Variable(
         #[0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
-        #[0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 22.5, 25., 30., 35., 40., 45., 50.],
         [0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
+        #[0., 1000.],
         name = "ptVgenSig", underflow=False, overflow=False
     )
     axis_absYVgen = hist.axis.Variable(
         #[0, 0.5, 1., 1.5, 2.0, 2.5],
         [0.25*i for i in range(11)],
-        #[0, 1.25, 2.5],
+        #[0, 5.0],
         name = "absYVgenSig", underflow=False, overflow=False
     )
     
     axes = [axis_ptVgen, axis_absYVgen]
-    cols = ["absYVgen", "ptVgen"] # name of the branch, not of the axis
+    cols = ["ptVgen", "absYVgen"] # name of the branch, not of the axis
     
     return axes, cols
         

--- a/utilities/differential.py
+++ b/utilities/differential.py
@@ -56,14 +56,14 @@ def get_theoryAgnostic_axes():
 
     # Note that the helicity axis is defined elsewhere, and must not be added to the list of axes returned here
     axis_ptVgen = hist.axis.Variable(
-        #[0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
-        [0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
+        [0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
+        #[0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
         #[0., 1000.],
         name = "ptVgenSig", underflow=False, overflow=False
     )
     axis_absYVgen = hist.axis.Variable(
-        #[0, 0.5, 1., 1.5, 2.0, 2.5],
-        [0.25*i for i in range(11)],
+        [0, 0.5, 1., 1.5, 2.0, 2.5],
+        #[0.25*i for i in range(11)],
         #[0, 5.0],
         name = "absYVgenSig", underflow=False, overflow=False
     )

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -243,6 +243,7 @@ class CardTool(object):
                       systNameReplace=[], systNamePrepend=None, groupFilter=None, passToFakes=False,
                       rename=None, splitGroup={}, decorrelateByBin={}, noiGroup=False,
                       sumNominal=False,
+                      scaleHist=None,
                       customizeNuisance={},
                       ):
         # note: setting Up=Down seems to be pathological for the moment, it might be due to the interpolation in the fit
@@ -289,6 +290,7 @@ class CardTool(object):
                 "splitGroup" : splitGroup if len(splitGroup) else {group : ".*"}, # dummy dictionary if splitGroup=None, to allow for uniform treatment
                 "scale" : scale,
                 "sumNominal" : sumNominal,
+                "scaleHist": scaleHist,
                 "customizeNuisance" : customizeNuisance,
                 "mirror" : mirror,
                 "mirrorDownVarEqualToUp" : mirrorDownVarEqualToUp,
@@ -581,6 +583,11 @@ class CardTool(object):
             systInfo = self.systematics[syst]
             procDict = self.datagroups.getDatagroups()
             hnom = procDict[proc].hists[self.nominalName]
+            #logger.debug(f"{proc}: {syst}: {h.axes.name}")
+            if systInfo["scaleHist"] != None:
+                scaleFactor = systInfo["scaleHist"]
+                logger.warning(f"Scaling yields of histogram for syst = {syst} by {scaleFactor}")
+                h = hh.scaleHist(h, scaleFactor, createNew=True)
             if systInfo["sumNominal"]:
                 logger.warning(f"Adding histogram for syst = {syst} to nominal to define actual variation")
                 h = hh.addHists(h, hnom, allowBroadcast=True, createNew=True, scale1=None, scale2=None)

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -536,7 +536,8 @@ class Datagroups(object):
         else:
             # infer gen axes from metadata
             args = self.getMetaInfo()["args"]
-            if args.get("unfolding", False) is False and args.get("addHelicityHistos", False) is False:
+            ## TODO: this should be addHelicityHisto->theoryAgnostic since the option changed name, BUT this breaks the poiAsNoi case
+            if args.get("unfolding", False) is False and (args.get("theoryAgnostic", False) is False or args.get("poiAsNoi", False) is True):
                 self.gen_axes = None
                 return
 

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -257,7 +257,6 @@ class Datagroups(object):
             hasFake = False
             procsToReadSort = [x for x in procsToRead]
         # Note: if 'hasFake' is kept as False (but Fake exists), the original behaviour for which Fake reads everything again is restored
-            
         for procName in procsToReadSort:
             logger.debug(f"Reading group {procName}")
             
@@ -359,7 +358,6 @@ class Datagroups(object):
                         logger.debug(f"Summing {read_syst} to {procName} for {member.name}")
 
                     group.hists[label] = hh.addHists(group.hists[label], h, createNew=False) if group.hists[label] else h
-                    logger.debug("Sum done")
 
             if not nominalIfMissing and group.hists[label] is None:
                 continue
@@ -634,7 +632,6 @@ class Datagroups(object):
 
         h = output[histname]
         if isinstance(h, narf.ioutils.H5PickleProxy):
-            logger.debug(f"Get narf hist")
             h = h.get()
 
         return h

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -536,8 +536,7 @@ class Datagroups(object):
         else:
             # infer gen axes from metadata
             args = self.getMetaInfo()["args"]
-            ## TODO: this should be addHelicityHisto->theoryAgnostic since the option changed name, BUT this breaks the poiAsNoi case
-            if args.get("unfolding", False) is False and (args.get("theoryAgnostic", False) is False or args.get("poiAsNoi", False) is True):
+            if not args.get("unfolding", False) and (not args.get("theoryAgnostic", False) or args.get("poiAsNoi", False)):
                 self.gen_axes = None
                 return
 

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -23,7 +23,7 @@ narf.clingutils.Declare('#include "syst_helicity_utils.h"')
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 
 #UL, A0...A4
-axis_helicity_multidim = hist.axis.Integer(-1, 5, name="helicity", overflow=False, underflow=False)
+axis_helicity_multidim = hist.axis.Integer(-1, 5, name="helicitySig", overflow=False, underflow=False)
 
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):

--- a/wremnants/muon_efficiencies_smooth.py
+++ b/wremnants/muon_efficiencies_smooth.py
@@ -105,11 +105,11 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
             ## temporary patch for missing histograms
             if eff_type == "antitrigger":
                 hist_name = hist_name.replace("antitrigger", "trigger")
-                if templateAnalysisArg != "wrem::AnalysisType::Dilepton":
+                if templateAnalysisArg == "wrem::AnalysisType::Dilepton":
                     logger.warning(f"Substituting temporarily missing 2D histogram for 'antitrigger' with 'trigger'")
             elif eff_type == "isoantitrig":
                 hist_name = hist_name.replace("isoantitrig", "isonotrig")
-                if templateAnalysisArg != "wrem::AnalysisType::Dilepton":
+                if templateAnalysisArg == "wrem::AnalysisType::Dilepton":
                     logger.warning(f"Substituting temporarily missing 2D histogram for 'isoantitrig' with 'isonotrig'")
             hist_root = input_tools.safeGetRootObject(fin, hist_name)
             #logger.debug(f"syst: {eff_type} -> {hist_name}")

--- a/wremnants/muon_efficiencies_smooth.py
+++ b/wremnants/muon_efficiencies_smooth.py
@@ -105,10 +105,12 @@ def make_muon_efficiency_helpers_smooth(filename = data_dir + "/testMuonSF/allSm
             ## temporary patch for missing histograms
             if eff_type == "antitrigger":
                 hist_name = hist_name.replace("antitrigger", "trigger")
-                logger.warning(f"Substituting temporarily missing 2D histogram for 'antitrigger' with 'trigger'")
+                if templateAnalysisArg != "wrem::AnalysisType::Dilepton":
+                    logger.warning(f"Substituting temporarily missing 2D histogram for 'antitrigger' with 'trigger'")
             elif eff_type == "isoantitrig":
                 hist_name = hist_name.replace("isoantitrig", "isonotrig")
-                logger.warning(f"Substituting temporarily missing 2D histogram for 'isoantitrig' with 'isonotrig'")
+                if templateAnalysisArg != "wrem::AnalysisType::Dilepton":
+                    logger.warning(f"Substituting temporarily missing 2D histogram for 'isoantitrig' with 'isonotrig'")
             hist_root = input_tools.safeGetRootObject(fin, hist_name)
             #logger.debug(f"syst: {eff_type} -> {hist_name}")
 


### PR DESCRIPTION
First implementation, which exploits the same code that was previously developed for the original theory agnostic fit. A new option --poiAsNoi is added, to be used in conjunction with previous --theoryAgnostic.
This creates a new systematic histogram with the cross section (event yields) binned in W pt-y-Ai (essentially it is the nominal histogram of the original theory agnostic fit). Other than that, the histmaker works exactly as in the traditional mW analysis, with all the currently implemented systematics.

Then, in setupCombineWmass.py this new histogram is summed to the nominal of the traditional analysis to form a histogram with the actual cross section variation in each bin with respect to the nominal itself. A new option --priorNormXsec is added to set the value of the prior in proportion to the prefit cross section in each gen bin when running the fit.

Also, a new "sumNominal" and "customizeNuisance" arguments are added to CardTool.addSystematics. The former internally sums the nominal histogram to the input systematic histogram, to form the actual systematic variation. The later allows one to define independent scaling factors or shape/shapeNoConstraint keywords for the nuisances within a given histogram (was used to define nuisances as shapeNoConstraint for only some Ai while still constraining others)

The README is update accordingly, adding few fixes for the other parts.