### PR TITLE
Developments for theory agnostic and few other things

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -390,7 +390,7 @@ jobs:
           lfs: 'true'
 
       - name: lowpu z mumu combine unfolding setup
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE_MU $HIST_FILE_E $HIST_FILE_MUMU $HIST_FILE_EE --fitvar ptll-charge ptll-charge ptll ptll -o $COMBINED_DIR --unfolding --hdf5 --sparse --ewUnc 
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE_MU $HIST_FILE_E $HIST_FILE_MUMU $HIST_FILE_EE --fitvar ptW-charge ptW-charge ptll ptll -o $COMBINED_DIR --unfolding --hdf5 --sparse --ewUnc 
 
       - name: lowpu combine unfolding fit 
         run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ unfolding $COMBINED_DIR card_sparse.hdf5 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,6 +218,9 @@ jobs:
       - name: wmass plot MET
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
+      - name: wmass plot Wpt
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 1 --yscale 1.5 --baseName WbosonRecoPt --hists recoWpt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
+
       - name: wmass plot massShift
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -a massVariation --yscale 1.4 --hist pt --baseName nominal -r 0.98 1.02 -p $WEB_DIR -f $PLOT_DIR $HIST_FILE variation --varName massWeightW --selectEntries massShiftW100MeVUp massShiftW100MeVDown --varLabel massShift100MeVUp massShift100MeVDown --selectAxis massShift --color grey grey
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,7 +219,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot Wpt
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 1 --yscale 1.5 --baseName WbosonRecoPt --hists recoWpt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 1 --yscale 1.5 --baseName ptW --hists recoWpt -p $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot massShift
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -a massVariation --yscale 1.4 --hist pt --baseName nominal -r 0.98 1.02 -p $WEB_DIR -f $PLOT_DIR $HIST_FILE variation --varName massWeightW --selectEntries massShiftW100MeVUp massShiftW100MeVDown --varLabel massShift100MeVUp massShift100MeVDown --selectAxis massShift --color grey grey
@@ -253,8 +253,8 @@ jobs:
       - name: lowpu w mu analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_lowPU.py -o $WREMNANTS_OUTDIR -j $NTHREADS --forceDefaultName --noRecoil --unfolding
 
-      - name: lowpu w mu plot ptll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --hists ptll -p $WEB_DIR -f $PLOT_DIR/lowPU -a mu $HIST_FILE_MU variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+      - name: lowpu w mu plot ptW
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --hists ptW -p $WEB_DIR -f $PLOT_DIR/lowPU -a mu $HIST_FILE_MU variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: lowpu w mu plot pt
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --baseName lep_pt --hists pt -a mu -p $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
@@ -269,13 +269,13 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE_MU --baseName transverseMass --fitvar mt -o $WREMNANTS_OUTDIR
 
       - name: lowpu w mu plot response matrix
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/response_matrix.py --axes ptll-ptVGen --procFilters Wmunu -p mu -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/response_matrix.py --axes ptW-ptVGen --procFilters Wmunu -p mu -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
 
       - name: lowpu w e analysis
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_lowPU.py -o $WREMNANTS_OUTDIR -j $NTHREADS --forceDefaultName --unfolding --noRecoil --flavor e
 
-      - name: lowpu w e plot ptll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --hists ptll -p $WEB_DIR -f $PLOT_DIR/lowPU -a e $HIST_FILE_E variation --varName nominal_uncorr --varLabel MiNNLO --colors red
+      - name: lowpu w e plot ptW
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --hists ptW -p $WEB_DIR -f $PLOT_DIR/lowPU -a e $HIST_FILE_E variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: lowpu w e plot pt
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --baseName lep_pt --hists pt -a e -p $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
@@ -290,7 +290,7 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE_E --baseName transverseMass --fitvar mt -o $WREMNANTS_OUTDIR
 
       - name: lowpu w e plot response matrix
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/response_matrix.py --axes ptll-ptVGen --procFilters Wenu -p e -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/response_matrix.py --axes ptW-ptVGen --procFilters Wenu -p e -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
 
       - name: aggregate combine inputs
         run: |
@@ -305,10 +305,10 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh $COMBINED_DIR/fitresults_123456789.root $WEB_DIR/$PLOT_DIR/lowPU impactsW.html
 
       # - name: lowpu w e combine unfolding fit 
-      #   run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ unfolding $WREMNANTS_OUTDIR/WMass_lowPU_ptll/ WMass_lowPU_plus.txt WMass_lowPU_minus.txt xnorm=WMass_lowPU_inclusive_xnorm.txt
+      #   run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ unfolding $WREMNANTS_OUTDIR/WMass_lowPU_ptW/ WMass_lowPU_plus.txt WMass_lowPU_minus.txt xnorm=WMass_lowPU_inclusive_xnorm.txt
 
       # - name: lowpu w combine unfolding plot xsec 
-      #   run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/unfolding_xsec.py $HIST_FILE_E --fitresult $WREMNANTS_OUTDIR/WMass_lowPU_ptll/fitresults_123456789.root -o $WEB_DIR -f $PLOT_DIR/lowPU --debug --rrange 0.0 2.0 --lumi=0.200181002
+      #   run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/unfolding_xsec.py $HIST_FILE_E --fitresult $WREMNANTS_OUTDIR/WMass_lowPU_ptW/fitresults_123456789.root -o $WEB_DIR -f $PLOT_DIR/lowPU --debug --rrange 0.0 2.0 --lumi=0.200181002
 
   lowpu-z:
     # The type of runner that the job will run on

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -93,6 +93,7 @@ def readNuisances(args, infile=None, logger=None):
             nuisGroup_nameVal[label] = impMat.GetBinContent(1,iy)
         elif args.excludeNuisgroups and matchExclude.match(label):
             continue
+        nuisGroup_nameVal[label] = impMat.GetBinContent(1,iy)
     return totalUncertainty,nuisGroup_nameVal
 
 

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -259,7 +259,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
             cardTool.setPseudodataDatagroups(make_datagroup(args.pseudoDataFile,
                                                                   excludeGroups=excludeGroup,
                                                                   filterGroups=filterGroup,
-                                                                  applySelection= not xnorm)
+                                                                  applySelection= not xnorm and not args.ABCD) # ensure consistency with the main datagroups
             )
     cardTool.setLumiScale(args.lumiScale)
 
@@ -683,7 +683,7 @@ if __name__ == "__main__":
         logger.warning("For now setting --theoryAgnostic activates --unfolding, they should do the same things")
         if args.genAxes is None:
             args.genAxes = ["ptVgenSig", "absYVgenSig", "helicitySig"]
-            logger.warning("Automatically setting '--genAxes ptVgenSig absYVgenSig helicitySig' for theory agnostic analysis")
+            logger.warning(f"Automatically setting '--genAxes {' '.join(args.genAxes)}' for theory agnostic analysis")
             if args.poiAsNoi:
                 logger.warning("This is only needed to properly get the systematic axes")
                 

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -268,18 +268,25 @@ def setup(args, inputFile, fitvar, xnorm=False):
         
     passSystToFakes = wmass and not args.skipSignalSystOnFakes and args.qcdProcessName not in excludeGroup and (filterGroup == None or args.qcdProcessName in filterGroup) and not xnorm
 
-    # FIXME: try to reuse some lambda functions to avoid mistakes, or maybe define some general functions?
-    cardTool.addProcessGroup("single_v_samples", lambda x: any(x.startswith(init) for init in ["W", "Z", "BkgW", "BkgZ"]) and x[1] not in ["W","Z"])
-    if wmass:
-        cardTool.addProcessGroup("w_samples", lambda x: any(x.startswith(init) for init in ["W", "BkgW"]) and x[1] not in ["W","Z"])
-        if not xnorm:
-            cardTool.addProcessGroup("single_v_nonsig_samples", lambda x: x[0] == "Z" and x[1] not in ["W","Z"])
+    # TODO: move to a common place if it is  useful, also use regular expressions for better flexibility? In that case "name".startswith("n") is simply re.match("^n", "name")
+    def assertSample(name, startsWith=["W", "Z"], excludeMatch=[]):
+        return any(name.startswith(init) for init in startsWith) and all(excl not in name for excl in excludeMatch)
 
-    cardTool.addProcessGroup("single_vmu_samples", lambda x: any(x.startswith(init) for init in ["W", "Z", "BkgW", "BkgZ"]) and x[1] not in ["W","Z"] and "tau" not in x)
-    cardTool.addProcessGroup("signal_samples", lambda x: ((wmass and any(x.startswith(init) for init in ["W", "BkgW"])) or (any(x.startswith(init) for init in ["Z", "BkgZ"]) and not wmass)) and x[1] not in ["W","Z"] and "tau" not in x)
-    cardTool.addProcessGroup("signal_samples_inctau", lambda x: ((wmass and any(x.startswith(init) for init in ["W", "BkgW"])) or (any(x.startswith(init) for init in ["Z", "BkgZ"]) and not wmass)) and x[1] not in ["W","Z"])
-    cardTool.addProcessGroup("signal_samples_noOutAcc", lambda x: ((x[0] == "W" and wmass) or (x[0] == "Z" and not wmass)) and x[1] not in ["W","Z"] and "tau" not in x)
-    cardTool.addProcessGroup("signal_samples_inctau_noOutAcc", lambda x: ((x[0] == "W" and wmass) or (x[0] == "Z" and not wmass)) and x[1] not in ["W","Z"])
+    dibosonMatch = ["WW", "WZ", "ZZ"] # CHECK: is ZW needed?
+    WMatch = ["W", "BkgW"] # TODO: the name of out-of-acceptance might be changed at some point, maybe to WmunuOutAcc, so W will match it as well (and can exclude it using "OutAcc" if needed)
+    ZMatch = ["Z", "BkgZ"]
+    signalMatch = WMatch if wmass else ZMatch
+
+    cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
+    if wmass:
+        cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
+        if not xnorm:
+            cardTool.addProcessGroup("single_v_nonsig_samples", lambda x: assertSample(x, startsWith=ZMatch, excludeMatch=dibosonMatch))
+    cardTool.addProcessGroup("single_vmu_samples",    lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=[*dibosonMatch, "tau"]))
+    cardTool.addProcessGroup("signal_samples",        lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch, "tau"]))
+    cardTool.addProcessGroup("signal_samples_inctau", lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch]))
+    cardTool.addProcessGroup("signal_samples_noOutAcc",        assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch, "tau"]))
+    cardTool.addProcessGroup("signal_samples_inctau_noOutAcc", assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch]))
     cardTool.addProcessGroup("MCnoQCD", lambda x: x not in ["QCD", "Data"])
 
     if not (args.theoryAgnostic or args.unfolding) :

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -285,8 +285,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
     cardTool.addProcessGroup("single_vmu_samples",    lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples",        lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples_inctau", lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch]))
-    cardTool.addProcessGroup("signal_samples_noOutAcc",        assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch, "tau"]))
-    cardTool.addProcessGroup("signal_samples_inctau_noOutAcc", assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch]))
+    cardTool.addProcessGroup("signal_samples_noOutAcc",        lambda x: assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch, "tau"]))
+    cardTool.addProcessGroup("signal_samples_inctau_noOutAcc", lambda x: assertSample(x, startsWith=["W" if wmass else "Z"], excludeMatch=[*dibosonMatch]))
     cardTool.addProcessGroup("MCnoQCD", lambda x: x not in ["QCD", "Data"])
 
     if not (args.theoryAgnostic or args.unfolding) :

--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -85,11 +85,11 @@ if args.unfolding:
 # axes for final cards/fitting
 nominal_axes = [
     axis_fakerate_pt, axis_fakerate_eta, axis_charge, 
-    hist.axis.Variable([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 75, 90, 150], name = "ptll", underflow=False, overflow=True),    
+    hist.axis.Variable([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60, 75, 90, 150], name = "ptW", underflow=False, overflow=True),    
     axis_passIso, axis_passMT]
 
 # corresponding columns
-nominal_cols = ["lep_pt", "lep_eta", "lep_charge", "ptll", "passIso",  "passMT"]
+nominal_cols = ["lep_pt", "lep_eta", "lep_charge", "ptW", "passIso",  "passMT"]
 
 # mt final cards/fitting
 axis_mT = hist.axis.Variable([0] + list(range(40, 100, 1)) + [100, 102, 104, 106, 108, 112, 116, 120, 130, 150, 200], name = "mt",underflow=False, overflow=True)
@@ -275,9 +275,7 @@ def build_graph(df, dataset):
    
     # results.append(df.HistoBoost("qcd_space", [axis_pt, axis_eta, axis_iso, axis_charge, axis_mT], ["lep_pt", "lep_eta", "lep_iso", "lep_charge", "transverseMass", "nominal_weight"]))  
 
-    df = df.Define("pxll", "lep_pt * std::cos(lep_phi) + MET_corr_rec_pt * std::cos(MET_corr_rec_phi)")
-    df = df.Define("pyll", "lep_pt * std::sin(lep_phi) + MET_corr_rec_pt * std::sin(MET_corr_rec_phi)")
-    df = df.Define("ptll", "std::sqrt(pxll*pxll + pyll*pyll)")
+    df = df.Define("ptW", "wrem::pt_2(lep_pt, lep_phi, MET_corr_rec_pt, MET_corr_rec_phi)")
 
     results.append(df.HistoBoost("nominal", axes, [*cols, "nominal_weight"]))
     results.append(df.HistoBoost("transverseMass", axes_mT, [*cols_mT, "nominal_weight"]))

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -388,7 +388,7 @@ def build_graph(df, dataset):
         # utility plot, mt and met, to plot them later (need eta-pt to make fakes)
         results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
         results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
-        results.append(df.HistoBoost("WbosonRecoPt", [axis_recoWpt, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["WbosonRecoPt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
+        results.append(df.HistoBoost("WbosonRecoPt", [axis_recoWpt, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["WbosonRecoPt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
 
     ## FIXME: should be isW, to include Wtaunu, but for now we only split Wmunu
     if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance"):

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -366,7 +366,7 @@ def build_graph(df, dataset):
         df = df.Alias("MET_corr_rec_pt", "MET_pt")
         df = df.Alias("MET_corr_rec_phi", "MET_phi")
 
-    df = df.Define("WbosonRecoPt", "wrem::pt_2(goodMuons_pt0, goodMuons_phi0, MET_corr_rec_pt, MET_corr_rec_phi)")
+    df = df.Define("ptW", "wrem::pt_2(goodMuons_pt0, goodMuons_phi0, MET_corr_rec_pt, MET_corr_rec_phi)")
     df = df.Define("transverseMass", "wrem::mt_2(goodMuons_pt0, goodMuons_phi0, MET_corr_rec_pt, MET_corr_rec_phi)")
     df = df.Define("hasCleanJet", "Sum(goodCleanJetsNoPt && Jet_pt > 30) >= 1")
 
@@ -388,7 +388,7 @@ def build_graph(df, dataset):
         # utility plot, mt and met, to plot them later (need eta-pt to make fakes)
         results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
         results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
-        results.append(df.HistoBoost("WbosonRecoPt", [axis_recoWpt, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["WbosonRecoPt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
+        results.append(df.HistoBoost("ptW", [axis_recoWpt, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["ptW", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
 
     ## FIXME: should be isW, to include Wtaunu, but for now we only split Wmunu
     if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance"):

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -121,6 +121,7 @@ axis_eta_utilityHist = hist.axis.Regular(24, -2.4, 2.4, name = "eta", overflow=F
 axis_pt_utilityHist = hist.axis.Regular(6, 26, 56, name = "pt", overflow=False, underflow=False)
 
 axis_met = hist.axis.Regular(100, 0., 200., name = "met", underflow=False, overflow=True)
+axis_recoWpt = hist.axis.Regular(40, 0., 80., name = "recoWpt", underflow=False, overflow=True)
 
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
@@ -365,6 +366,7 @@ def build_graph(df, dataset):
         df = df.Alias("MET_corr_rec_pt", "MET_pt")
         df = df.Alias("MET_corr_rec_phi", "MET_phi")
 
+    df = df.Define("WbosonRecoPt", "wrem::pt_2(goodMuons_pt0, goodMuons_phi0, MET_corr_rec_pt, MET_corr_rec_phi)")
     df = df.Define("transverseMass", "wrem::mt_2(goodMuons_pt0, goodMuons_phi0, MET_corr_rec_pt, MET_corr_rec_phi)")
     df = df.Define("hasCleanJet", "Sum(goodCleanJetsNoPt && Jet_pt > 30) >= 1")
 
@@ -386,6 +388,7 @@ def build_graph(df, dataset):
         # utility plot, mt and met, to plot them later (need eta-pt to make fakes)
         results.append(df.HistoBoost("MET", [axis_met, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso, axis_passMT], ["MET_corr_rec_pt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "passMT", "nominal_weight"]))
         results.append(df.HistoBoost("transverseMass", [axis_mt_fakes, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["transverseMass", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
+        results.append(df.HistoBoost("WbosonRecoPt", [axis_recoWpt, axis_eta_utilityHist, axis_pt_utilityHist, axis_charge, axis_passIso], ["WbosonRecoPt", "goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "passIso", "nominal_weight"]))
 
     ## FIXME: should be isW, to include Wtaunu, but for now we only split Wmunu
     if isWmunu and args.theoryAgnostic and not hasattr(dataset, "out_of_acceptance"):

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -12,6 +12,7 @@ import os
 
 
 parser.add_argument("--skipAngularCoeffs", action='store_true', help="Skip the conversion of helicity moments to angular coeff fractions")
+parser.add_argument("--addHelicityToPDFs", action='store_true', help="Add helicity tensor for PDFs")
 parser.add_argument("--singleLeptonHists", action='store_true', help="Also store single lepton kinematics")
 parser.add_argument("--photonHists", action='store_true', help="Also store photon kinematics")
 parser.add_argument("--skipEWHists", action='store_true', help="Also store histograms for EW reweighting. Use with --filter horace")
@@ -113,7 +114,7 @@ def build_graph(df, dataset):
         else:
             df = df.Define('ptPrefsrLep', 'genlanti.pt()')
             df = df.Define('etaPrefsrLep', 'genlanti.eta()')
-        results.append(df.HistoBoost("nominal_genlep", lep_axes, [*lep_cols, "nominal_weight"], storage=hist.storage.Double()))
+        results.append(df.HistoBoost("nominal_genlep", lep_axes, [*lep_cols, "nominal_weight"], storage=hist.storage.Weight()))
 
     if not args.skipEWHists and (isW or isZ):
         if isZ:
@@ -185,7 +186,7 @@ def build_graph(df, dataset):
                 results.append(df.HistoBoost("nominal_sublPhoton", [axis_photonPt, axis_photonEta], ["sublPhotonPt", "sublPhotonEta", "nominal_weight"], storage=hist.storage.Weight()))
                 results.append(df.HistoBoost("nominal_trailPhoton", [axis_photonPt, axis_photonEta], ["trailPhotonPt", "trailPhotonEta", "nominal_weight"], storage=hist.storage.Weight()))
 
-    nominal_gen = df.HistoBoost("nominal_gen", nominal_axes, [*nominal_cols, "nominal_weight"], storage=hist.storage.Double())
+    nominal_gen = df.HistoBoost("nominal_gen", nominal_axes, [*nominal_cols, "nominal_weight"], storage=hist.storage.Weight())
 
     results.append(nominal_gen)
     if not 'horace' in dataset.name and not 'winhac' in dataset.name:
@@ -193,11 +194,14 @@ def build_graph(df, dataset):
             df = theory_tools.define_scale_tensor(df)
             syst_tools.add_qcdScale_hist(results, df, nominal_axes, nominal_cols, "nominal_gen")
             df = df.Define("helicity_moments_scale_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhi, scaleWeights_tensor, nominal_weight)")
-            helicity_moments_scale = df.HistoBoost("helicity_moments_scale", nominal_axes, [*nominal_cols, "helicity_moments_scale_tensor"], tensor_axes = [wremnants.axis_helicity, *wremnants.scale_tensor_axes], storage=hist.storage.Double())
+            helicity_moments_scale = df.HistoBoost("helicity_moments_scale", nominal_axes, [*nominal_cols, "helicity_moments_scale_tensor"], tensor_axes = [wremnants.axis_helicity, *wremnants.scale_tensor_axes], storage=hist.storage.Weight())
             results.append(helicity_moments_scale)
 
         if "LHEPdfWeight" in df.GetColumnNames():
-            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen")
+            if args.addHelicityToPDFs:
+                weightsByHelicity_helper = wremnants.makehelicityWeightHelper()
+                df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "yVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
+            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen", addhelicity=args.addHelicityToPDFs)
 
     if args.theoryCorr and dataset.name in corr_helpers:
         results.extend(theory_tools.make_theory_corr_hists(df, "nominal_gen", nominal_axes, nominal_cols,
@@ -246,10 +250,10 @@ if not args.skipAngularCoeffs:
     if z_moments:
         z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning)
         z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
-        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments)
+        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments, sumW2=True) # sumW2=True depends on how histograms are defined before, must be consistent
     if w_moments:
         w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning)
-        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
+        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments, sumW2=True) # sumW2=True depends on how histograms are defined before, must be consistent
     if coeffs:
         outfname = "w_z_coeffs_absY.hdf5" if args.absY else "w_z_coeffs.hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -250,10 +250,10 @@ if not args.skipAngularCoeffs:
     if z_moments:
         z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning)
         z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
-        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments, sumW2=True) # sumW2=True depends on how histograms are defined before, must be consistent
+        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments, sumW2=False) # sumW2 is not set to True internally when the input histogram has weights, in fact it could be removed
     if w_moments:
         w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning)
-        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments, sumW2=True) # sumW2=True depends on how histograms are defined before, must be consistent
+        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments, sumW2=False) # ditto
     if coeffs:
         outfname = "w_z_coeffs_absY.hdf5" if args.absY else "w_z_coeffs.hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/plotting/response_matrix.py
+++ b/scripts/plotting/response_matrix.py
@@ -56,6 +56,7 @@ translate_label = {
     "abs(eta)" : "$\mathrm{Reco}\ |\eta|$",
     "absEtaGen" : "$\mathrm{Gen}\ |\eta|$",
     "ptll" : "$\mathrm{Reco}\ p_\mathrm{T}(V)\ [\mathrm{GeV}]$",
+    "ptW" :  "$\mathrm{Reco}\ p_\mathrm{T}(W)\ [\mathrm{GeV}]$",
     "ptVGen" : "$\mathrm{Gen}\ p_\mathrm{T}(V)\ [\mathrm{GeV}]$",
     "abs(yll)" : "$\mathrm{Reco}\ |Y(\mathrm{V})|$",
     "absYVGen" : "$\mathrm{Gen}\ |Y(\mathrm{V})|$",

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -657,7 +657,8 @@ class CardTool(object):
                 hdata = hdata[{systAxName : self.pseudoDataIdx }] 
 
         self.writeHist(hdata, self.getDataName(), self.pseudoData+"_sum")
-        self.writeHist(procDict[self.getFakeName()].hists[self.pseudoData], self.getFakeName(), self.pseudoData+"_sum")
+        if self.getFakeName() in procDict:
+            self.writeHist(procDict[self.getFakeName()].hists[self.pseudoData], self.getFakeName(), self.pseudoData+"_sum")
 
     def writeForProcesses(self, syst, processes, label, check_systs=True):
         logger.info("-"*50)

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -643,7 +643,7 @@ class CardTool(object):
             logger.warning(f"These processes are taken from nominal datagroups: {processesFromNomi}")
             datagroupsFromNomi = self.datagroups
             datagroupsFromNomi.loadHistsForDatagroups(
-                baseName=self.pseudoData, syst=self.nominalName, label=self.pseudoData,
+                baseName=self.pseudoData, syst=self.nominalName, label=self.pseudoData, # CHECK: shouldn't it be syst=self.pseudoData?
                 procsToRead=processesFromNomi,
                 scaleToNewLumi=self.lumiScale,
                 fakerateIntegrationAxes=self.getFakerateIntegrationAxes())
@@ -657,6 +657,7 @@ class CardTool(object):
                 hdata = hdata[{systAxName : self.pseudoDataIdx }] 
 
         self.writeHist(hdata, self.getDataName(), self.pseudoData+"_sum")
+        self.writeHist(procDict[self.getFakeName()].hists[self.pseudoData], self.getFakeName(), self.pseudoData+"_sum")
 
     def writeForProcesses(self, syst, processes, label, check_systs=True):
         logger.info("-"*50)

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -834,10 +834,11 @@ class CardTool(object):
             group = info["group"]
             groupFilter = info["groupFilter"]
             for chan in self.channels:
+                nameChan = name.replace("CHANNEL",chan)
                 include = [(str(info["size"]) if x in info["processes"] else "-").ljust(self.procColumnsSpacing) for x in nondata_chan[chan]]
-                self.cardContent[chan] += f'{name.ljust(self.spacing)} lnN{" "*(self.systTypeSpacing-2)} {"".join(include)}\n'
-                if group and len(list(filter(groupFilter, [name]))):
-                    self.addSystToGroup(group, chan, name)
+                self.cardContent[chan] += f'{nameChan.ljust(self.spacing)} lnN{" "*(self.systTypeSpacing-2)} {"".join(include)}\n'
+                if group and len(list(filter(groupFilter, [nameChan]))):
+                    self.addSystToGroup(group, chan, nameChan)
 
     def fillCardWithSyst(self, syst):
         # note: this function doesn't act on all systematics all at once

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -35,7 +35,7 @@ class CardTool(object):
         self.nominalTemplate = f"{pathlib.Path(__file__).parent}/../scripts/combine/Templates/datacard.txt"
         self.spacing = 28
         self.systTypeSpacing = 16
-        self.procColumnsSpacing = 30
+        self.procColumnsSpacing = 20
         self.nominalName = "nominal"
         self.datagroups = None
         self.pseudodata_datagroups = None
@@ -862,6 +862,8 @@ class CardTool(object):
         include_chan = {}
         for chan in nondata_chan.keys():
             include_chan[chan] = [(str(scale) if x in procs else "-").ljust(self.procColumnsSpacing) for x in nondata_chan[chan]]
+            # remove unnecessary trailing spaces after the last element
+            include_chan[chan][-1] = include_chan[chan][-1].rstrip()
                 
         shape = "shapeNoConstraint" if systInfo["noConstraint"] else "shape"
             
@@ -888,6 +890,7 @@ class CardTool(object):
                             keys = list(systInfo["customizeNuisanceAttributes"][regexpCustom].keys())
                             if "scale" in keys:
                                 include_line = [(str(systInfo["customizeNuisanceAttributes"][regexpCustom]["scale"]) if x in procs else "-").ljust(self.procColumnsSpacing) for x in nondata_chan[chan]]
+                                include_line[-1] = include_line[-1].rstrip()
                             if "shapeType" in keys:
                                 systShape = systInfo["customizeNuisanceAttributes"][regexpCustom]["shapeType"]
                 self.cardContent[chan] += f"{systname.ljust(self.spacing)} {systShape.ljust(self.systTypeSpacing)} {''.join(include_line)}\n"

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -551,16 +551,16 @@ class Datagroups(object):
 
         logger.debug(f"Gen axes are now {self.gen_axes}")
 
-    def getGenBinIndices(self, h):
+    def getGenBinIndices(self, h, axesToRead=[]):
         gen_bins = []
-        for gen_axis in self.gen_axes:
+        for gen_axis in (axesToRead if len(axesToRead) else self.gen_axes):
             if gen_axis not in h.axes.name:
                 raise RuntimeError(f"Gen axis '{gen_axis}' not found in histogram axes '{h.axes.name}'!")
 
             gen_bins.append(range(h.axes[gen_axis].size))
         return gen_bins
 
-    def defineSignalBinsUnfolding(self, group_name, new_name=None, member_filter=None):
+    def defineSignalBinsUnfolding(self, group_name, new_name=None, member_filter=None, histToReadAxes="xnorm", axesToRead=[]):
         if group_name not in self.groups.keys():
             raise RuntimeError(f"Base group {group_name} not found in groups {self.groups.keys()}!")
 
@@ -568,9 +568,9 @@ class Datagroups(object):
         if member_filter is not None:
             base_members = [m for m in filter(lambda x, f=member_filter: f(x), base_members)]            
 
-        nominal_hist = self.results[base_members[0].name]["output"]["xnorm"].get()
+        nominal_hist = self.results[base_members[0].name]["output"][histToReadAxes].get()
 
-        gen_bin_indices = self.getGenBinIndices(nominal_hist)
+        gen_bin_indices = self.getGenBinIndices(nominal_hist, axesToRead=axesToRead)
 
         for indices in itertools.product(*gen_bin_indices):
 

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -32,6 +32,18 @@ constexpr double muon_mass = 0.1056583745;
     //     std::cout << var << std::endl;
     //     return 1;
     // }
+
+float pt_2(float pt1, float phi1, float pt2, float phi2) {
+
+    TVector2 p1 = TVector2();
+    p1.SetMagPhi(pt1, phi1);
+
+    TVector2 sum = TVector2();
+    sum.SetMagPhi(pt2, phi2);
+    sum = p1 + sum;
+
+    return sum.Mod();
+}
     
 float mt_2(float pt1, float phi1, float pt2, float phi2) {
     return std::sqrt(2*pt1*pt2*(1-std::cos(phi1-phi2)));


### PR DESCRIPTION
This PR updates the theory agnostic setup with POI as NOI, by adding the possibility to split signal into in-acceptance (IA) and out-of-acceptance (OOA). This is the only way to allow some systematics to be propagated only to one part (e.g. theory ones). 
Consequently, the naming of the OOA template in the card is modified (using current features of datagroups to define a new group BkgWmunu including only the OOA).

To work, one has to use --separateOOAfromSignal when running the W histmaker. 
This PR also includes a fix to a bug, which was filtering away OOA events from the previous implementation (thus signal was only the IA when running with --theoryAgnostic --poiAsNoi)

One thing that is still missing is the possibility to assign a norm uncertainty on the OOA (either when split from IA or when the signal is inclusive). In the former case, a nor uncertainty would be essentially equivalent to a lnN, which is easy to add, while in the latter case it requires a change in the histmaker to store the OOA variation.

**Additional (could go in a separate PR):**
- This PR also updates the gen histmaker scripts/histmakers/w_z_gen_dists.py setting the storage of all histograms to Weight (was needed to correctly plot the Ai). Also added an option to apply helicity weights to PDF (to get the proper fractions for each PDF hessian).
- Fix bug in scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py introduced in a recent PR, which was removing all groups from the plot unless option -k was explicitly used
- add reco Wpt histogram to W histmaker and CI

**Brief list of main changes.**
- option --separateOOAfromSignal in W histmaker, to be used with --theoryAgnostic --poiAsNoi (might add subparsers to tidy up)
- update setupCombine.py to automatically deal with the case when OOA and IA are split (could be extended to the unfolding, after agreeing on a naming conventions for the OOA template)
- adding reco Wpt plot to W histmaker, to check the goodness of fake estimate with CI
- small update CardTool.py to reduce amount of white space written in datacard between process columns to improve readability
- augmenting some functions to define signal bins in wremnants/datasets/datagroups.py (but currently the customisation that was introduced is not yet used anywhere, it might be in the near future)
- slight modifications in scripts/histmakers/w_z_gen_dists.py
- bug fix for scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py 