### PR TITLE
Updates to Ai definitions, plotting and uncertainties on Ai's/helicity cross sections

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/bendavid/narf.git
 [submodule "wremnants-data"]
 	path = wremnants-data
-	url = https://gitlab.cern.ch/cms-wmass/wremnants-data.git
+	url = https://gitlab.cern.ch/emanca/wremnants-data

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/bendavid/narf.git
 [submodule "wremnants-data"]
 	path = wremnants-data
-	url = https://gitlab.cern.ch/emanca/wremnants-data
+	url = https://gitlab.cern.ch/cms-wmass/wremnants-data.git

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -416,7 +416,6 @@ def build_graph(df, dataset):
             results.append(df.HistoBoost(theoryAgnosticHistName, nominal_axes_theoryAgnostic, [*nominal_cols_theoryAgnostic, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
         else:
             results.append(df.HistoBoost("nominal", axes, [*cols, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
-            results.append(df.HistoBoost("nominal_int", nominal_axes, [*nominal_cols, "nominal_weight"]))
             setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, axes, cols, args)
             # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
             return results, weightsum

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -416,6 +416,7 @@ def build_graph(df, dataset):
             results.append(df.HistoBoost(theoryAgnosticHistName, nominal_axes_theoryAgnostic, [*nominal_cols_theoryAgnostic, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
         else:
             results.append(df.HistoBoost("nominal", axes, [*cols, "nominal_weight_helicity"], tensor_axes=[axis_helicity]))
+            results.append(df.HistoBoost("nominal_int", nominal_axes, [*nominal_cols, "nominal_weight"]))
             setTheoryAgnosticGraph(df, results, dataset, reco_sel_GF, era, axes, cols, args)
             # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
             return results, weightsum

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -40,11 +40,16 @@ axis_massWgen = hist.axis.Variable([5., 13000.], name="massVgen", underflow=True
 
 axis_massZgen = hist.axis.Regular(12, 60., 120., name="massVgen")
 
-axis_absYVgen = hist.axis.Variable(
-    # [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
-    [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 10.], #same axis as theory agnostic norms
-    name = "absYVgen", underflow=False
-)
+if not args.useTheoryAgnosticBinning:
+    axis_absYVgen = hist.axis.Variable(
+        [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
+        name = "absYVgen", underflow=False
+    )
+else:
+    axis_absYVgen = hist.axis.Variable(
+        [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 10.], #same axis as theory agnostic norms
+        name = "absYVgen", underflow=False
+    )
 
 axis_ygen = hist.axis.Regular(10, -5., 5., name="y")
 axis_rapidity = axis_absYVgen if args.absY else axis_ygen

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -18,7 +18,7 @@ parser.add_argument("--useTheoryAgnosticBinning", action='store_true', help="Use
 parser.add_argument("--singleLeptonHists", action='store_true', help="Also store single lepton kinematics")
 parser.add_argument("--photonHists", action='store_true', help="Also store photon kinematics")
 parser.add_argument("--skipEWHists", action='store_true', help="Also store histograms for EW reweighting. Use with --filter horace")
-parser.add_argument("--absY", action='store_true', help="use absolute |Y|")
+parser.add_argument("--signedY", action='store_true', help="use signed Y")
 parser.add_argument("--applySelection", action='store_true', help="Apply selection on leptons")
 parser.add_argument("--auxiliaryHistograms", action="store_true", help="Safe auxiliary histograms (mainly for ew analysis)")
 
@@ -52,8 +52,8 @@ else:
     )
 
 axis_ygen = hist.axis.Regular(10, -5., 5., name="y")
-axis_rapidity = axis_absYVgen if args.absY else axis_ygen
-col_rapidity =  "absYVgen" if args.absY else "yVgen"
+axis_rapidity = axis_ygen if args.signedY else axis_absYVgen
+col_rapidity =  "yVgen" if args.signedY else "absYVgen"
 
 if not args.useTheoryAgnosticBinning:
     axis_ptVgen = hist.axis.Variable(
@@ -268,5 +268,5 @@ if not args.skipAngularCoeffs:
             w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
         coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
     if coeffs:
-        outfname = "w_z_coeffs_absY.hdf5" if args.absY else "w_z_coeffs.hdf5"
+        outfname = "w_z_coeffs_signedY.hdf5" if args.signedY else "w_z_coeffs.hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -268,5 +268,10 @@ if not args.skipAngularCoeffs:
             w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
         coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
     if coeffs:
-        outfname = "w_z_coeffs_signedY.hdf5" if args.signedY else "w_z_coeffs.hdf5"
+        outfname = "w_z_coeffs"
+        if args.signedY:
+            outfname += "_signedY"
+        if args.useTheoryAgnosticBinning:
+            outfname += "_theoryAgnosticBinning"
+        outfname += ".hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -41,18 +41,25 @@ axis_massWgen = hist.axis.Variable([5., 13000.], name="massVgen", underflow=True
 axis_massZgen = hist.axis.Regular(12, 60., 120., name="massVgen")
 
 axis_absYVgen = hist.axis.Variable(
-    [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
+    # [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
+    [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4], #same axis as theory agnostic norms
     name = "absYVgen", underflow=False
 )
 
-axis_ygen = hist.axis.Regular(200, -5., 5., name="y")
+axis_ygen = hist.axis.Regular(10, -5., 5., name="y")
 axis_rapidity = axis_absYVgen if args.absY else axis_ygen
 col_rapidity =  "absYVgen" if args.absY else "yVgen"
 
 axis_ptVgen = hist.axis.Variable(
+<<<<<<< HEAD
      list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0], 
     #list(range(0,101)), # this is the same binning as hists from theory corrections
     #common.ptV_binning,
+=======
+    # list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 1500.0], 
+    # list(range(0,101)), # this is the same binning as hists from theory corrections
+    [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.], #same axis as theory agnostic norms
+>>>>>>> 72120d85 (using theory agnostic binning for w gen analysis)
     name = "ptVgen", underflow=False,
 )
 

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -13,8 +13,8 @@ import os
 
 
 parser.add_argument("--skipAngularCoeffs", action='store_true', help="Skip the conversion of helicity moments to angular coeff fractions")
-parser.add_argument("--addHelicityToPDFs", action='store_true', help="Add helicity tensor for PDFs")
 parser.add_argument("--propagatePDFstoHelicity", action='store_true', help="Propagate PDF uncertainties to helicity moments")
+parser.add_argument("--useTheoryAgnosticBinning", action='store_true', help="Use theory agnostic binning (coarser) to produce the gen results")
 parser.add_argument("--singleLeptonHists", action='store_true', help="Also store single lepton kinematics")
 parser.add_argument("--photonHists", action='store_true', help="Also store photon kinematics")
 parser.add_argument("--skipEWHists", action='store_true', help="Also store histograms for EW reweighting. Use with --filter horace")
@@ -50,9 +50,16 @@ axis_ygen = hist.axis.Regular(10, -5., 5., name="y")
 axis_rapidity = axis_absYVgen if args.absY else axis_ygen
 col_rapidity =  "absYVgen" if args.absY else "yVgen"
 
-axis_ptVgen = hist.axis.Variable(
-    # list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0],
-    [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.,100.], #same axis as theory agnostic norms
+if not args.useTheoryAgnosticBinning:
+    axis_ptVgen = hist.axis.Variable(
+     list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0], 
+    #common.ptV_binning,
+    name = "ptVgen", underflow=False,
+)
+else:
+    axis_ptVgen = hist.axis.Variable(
+     [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.,100.], #same axis as theory agnostic norms, 
+    #common.ptV_binning,
     name = "ptVgen", underflow=False,
 )
 
@@ -203,7 +210,7 @@ def build_graph(df, dataset):
             if args.addHelicityToPDFs:
                 weightsByHelicity_helper = wremnants.makehelicityWeightHelper()
                 df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "yVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
-            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen",addhelicity=args.addHelicityToPDFs, propagateToHelicity=args.propagatePDFstoHelicity)
+            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen", propagateToHelicity=args.propagatePDFstoHelicity)
 
     if args.theoryCorr and dataset.name in corr_helpers:
         results.extend(theory_tools.make_theory_corr_hists(df, "nominal_gen", nominal_axes, nominal_cols,
@@ -250,12 +257,14 @@ if not args.skipAngularCoeffs:
     coeffs={}
     # Common.ptV_binning is the approximate 5% quantiles, rounded to integers. Rebin for approx 10% quantiles
     if z_moments:
-        # z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
-        # z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
-        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments, sumW2=False) # sumW2 is not set to True internally when the input histogram has weights, in fact it could be removed
+        if not args.useTheoryAgnosticBinning:
+            z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
+            z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
+        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments) 
     if w_moments:
-        w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
-        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments, sumW2=False) # ditto
+        if not args.useTheoryAgnosticBinning:
+            w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
+        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
     if coeffs:
         outfname = "w_z_coeffs_absY.hdf5" if args.absY else "w_z_coeffs.hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -207,9 +207,6 @@ def build_graph(df, dataset):
             results.append(helicity_moments_scale)
 
         if "LHEPdfWeight" in df.GetColumnNames():
-            if args.addHelicityToPDFs:
-                weightsByHelicity_helper = wremnants.makehelicityWeightHelper()
-                df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "yVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
             syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen", propagateToHelicity=args.propagatePDFstoHelicity)
 
     if args.theoryCorr and dataset.name in corr_helpers:

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -41,8 +41,8 @@ axis_massWgen = hist.axis.Variable([5., 13000.], name="massVgen", underflow=True
 axis_massZgen = hist.axis.Regular(12, 60., 120., name="massVgen")
 
 axis_absYVgen = hist.axis.Variable(
-    # [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
-    [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4], #same axis as theory agnostic norms
+    [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
+    # [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4], #same axis as theory agnostic norms
     name = "absYVgen", underflow=False
 )
 
@@ -51,15 +51,8 @@ axis_rapidity = axis_absYVgen if args.absY else axis_ygen
 col_rapidity =  "absYVgen" if args.absY else "yVgen"
 
 axis_ptVgen = hist.axis.Variable(
-<<<<<<< HEAD
      list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0], 
-    #list(range(0,101)), # this is the same binning as hists from theory corrections
-    #common.ptV_binning,
-=======
-    # list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 1500.0], 
-    # list(range(0,101)), # this is the same binning as hists from theory corrections
-    [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.], #same axis as theory agnostic norms
->>>>>>> 72120d85 (using theory agnostic binning for w gen analysis)
+    # [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.], #same axis as theory agnostic norms
     name = "ptVgen", underflow=False,
 )
 

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -14,6 +14,7 @@ import os
 
 parser.add_argument("--skipAngularCoeffs", action='store_true', help="Skip the conversion of helicity moments to angular coeff fractions")
 parser.add_argument("--addHelicityToPDFs", action='store_true', help="Add helicity tensor for PDFs")
+parser.add_argument("--propagatePDFstoHelicity", action='store_true', help="Propagate PDF uncertainties to helicity moments")
 parser.add_argument("--singleLeptonHists", action='store_true', help="Also store single lepton kinematics")
 parser.add_argument("--photonHists", action='store_true', help="Also store photon kinematics")
 parser.add_argument("--skipEWHists", action='store_true', help="Also store histograms for EW reweighting. Use with --filter horace")
@@ -202,7 +203,7 @@ def build_graph(df, dataset):
             if args.addHelicityToPDFs:
                 weightsByHelicity_helper = wremnants.makehelicityWeightHelper()
                 df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "yVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
-            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen", addhelicity=args.addHelicityToPDFs)
+            syst_tools.add_pdf_hists(results, df, dataset.name, nominal_axes, nominal_cols, args.pdfs, "nominal_gen",addhelicity=args.addHelicityToPDFs, propagateToHelicity=args.propagatePDFstoHelicity)
 
     if args.theoryCorr and dataset.name in corr_helpers:
         results.extend(theory_tools.make_theory_corr_hists(df, "nominal_gen", nominal_axes, nominal_cols,

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -41,8 +41,8 @@ axis_massWgen = hist.axis.Variable([5., 13000.], name="massVgen", underflow=True
 axis_massZgen = hist.axis.Regular(12, 60., 120., name="massVgen")
 
 axis_absYVgen = hist.axis.Variable(
-    [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
-    # [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4], #same axis as theory agnostic norms
+    # [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
+    [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 10.], #same axis as theory agnostic norms
     name = "absYVgen", underflow=False
 )
 
@@ -51,8 +51,8 @@ axis_rapidity = axis_absYVgen if args.absY else axis_ygen
 col_rapidity =  "absYVgen" if args.absY else "yVgen"
 
 axis_ptVgen = hist.axis.Variable(
-     list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0], 
-    # [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.], #same axis as theory agnostic norms
+    # list(range(0,151))+[160., 190.0, 220.0, 250.0, 300.0, 400.0, 500.0, 800.0, 13000.0],
+    [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.,100.], #same axis as theory agnostic norms
     name = "ptVgen", underflow=False,
 )
 
@@ -250,12 +250,12 @@ if not args.skipAngularCoeffs:
     coeffs={}
     # Common.ptV_binning is the approximate 5% quantiles, rounded to integers. Rebin for approx 10% quantiles
     if z_moments:
-        z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
-        z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
-        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments) 
+        # z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
+        # z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
+        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments, sumW2=False) # sumW2 is not set to True internally when the input histogram has weights, in fact it could be removed
     if w_moments:
         w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
-        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
+        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments, sumW2=False) # ditto
     if coeffs:
         outfname = "w_z_coeffs_absY.hdf5" if args.absY else "w_z_coeffs.hdf5"
         output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -1,4 +1,3 @@
-import wremnants
 from wremnants import plot_tools,theory_tools,histselections as sel
 from utilities import boostHistHelpers as hh
 from utilities.io_tools import input_tools, output_tools

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -1,7 +1,11 @@
+import wremnants
 from wremnants import plot_tools,theory_tools,histselections as sel
-from utilities.io_tools import input_tools
+from utilities import boostHistHelpers as hh
+from utilities.io_tools import input_tools, output_tools
 import matplotlib.pyplot as plt
 from matplotlib import cm
+import numpy as np
+import boost_histogram as bh
 import argparse
 import pathlib
 import os
@@ -14,6 +18,8 @@ xlabels = {
     "pt" : r"p$_{T}^{\ell}$ (GeV)",
     "eta" : r"$\eta^{\ell}$",
     "unrolled" : r"(p$_{T}^{\ell}$, $\eta^{\ell}$) bin",
+    "unrolled_gen" : r"($|\mathrm{y}^{Z}|$,p$_{T}^{Z}$) bin",
+    "unrolled_gen_hel" : r"($|\mathrm{y}^{Z}|$,p$_{T}^{Z}$) bin",
     "ptVgen" : r"p$_{T}^{Z}$ (GeV)",
     "absYVgen" : r"$|\mathrm{y}^{Z}|$",
     "ptll" : r"p$_{\mathrm{T}}^{\ell\ell}$ (GeV)",
@@ -39,42 +45,100 @@ for pdf in args.pdfs:
     if pdf not in theory_tools.pdfMap:
         raise ValueError(f"pdf {pdf} is not a valid hist (not defined in theory_tools.pdfMap)")
 
-if "Z" in args.datasets[0][0]:
+print(args.datasets[0][0])
+if "W" in args.datasets[0][0]:
     xlabels["ptVgen"] = xlabels["ptVgen"].replace("Z", "W")
     xlabels["absYVgen"] = xlabels["absYVgen"].replace("Z", "W")
+    xlabels["unrolled_gen"] = xlabels["unrolled_gen"].replace("Z", "W")
+    xlabels["unrolled_gen_hel"] = xlabels["unrolled_gen_hel"].replace("Z", "W")
 
 pdfInfo = theory_tools.pdfMap 
 pdfNames = [pdfInfo[pdf]["name"] for pdf in args.pdfs]
-histNames = pdfNames if not args.baseName or "nominal" in args.baseName else [f"{args.baseName}_{pdfName}" for pdfName in pdfNames]
+histNames = pdfNames if not args.baseName else [f"{args.baseName}_{pdfName}" for pdfName in pdfNames]
+
 pdfHists = input_tools.read_all_and_scale(args.infile, args.datasets, histNames)
-axis_label = "tensor_axis_0"
+axis_label = "pdfVar"
 
 uncType = [pdfInfo[pdf]["combine"] for pdf in args.pdfs]
 uncScale = [pdfInfo[pdf]["scale"] if "scale" in pdfInfo[pdf] else 1. for pdf in args.pdfs]
-uncHists = [(h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)) for h,unc in zip(pdfHists, uncType, uncScale)]
-names = [(pdfName+" $\pm1\sigma$", "", "") for pdfName in pdfNames]
+uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(pdfHists, uncType, uncScale)]
+names = [[pdfName+" $\pm1\sigma$", "", ""] for pdfName in pdfNames]
 cmap = cm.get_cmap("tab10")
 colors = [[cmap(i)]*3 for i in range(len(args.pdfs))]
+
+
+if "unrolled_gen_hel" in args.obs:
+    moments = input_tools.read_all_and_scale(args.infile, args.datasets, ["helicity_moments_scale"])
+    coeffs =  theory_tools.scale_angular_moments(moments[0].project('helicity','absYVgen','ptVgen','muRfact','muFfact'))
+    moments_pdf = input_tools.read_all_and_scale(args.infile, args.datasets, [f"helicity_{args.baseName}_{pdfName}" for pdfName in pdfNames])
+    coeffs_pdf = []
+    for moments in moments_pdf:
+        coeffs_pdf.append(theory_tools.scale_angular_moments(moments.project('helicity','absYVgen','ptVgen',axis_label)))
+    uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(coeffs_pdf, uncType, uncScale)]
+
+    # add alphaS
+    alphaNames = []
+    axis_label = "alphasVar"
+    for ipdf,pdf in enumerate(args.pdfs):
+        if pdfInfo[pdf]["alphasRange"] == "001":
+            alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS001")
+        else:
+            alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS002")
+        alphaHists = input_tools.read_all_and_scale(args.infile, args.datasets, alphaNames)
+        alphaHists_hel = []
+        for alphaHist in alphaHists:
+            alphaHists_hel.append(theory_tools.scale_angular_moments(alphaHist.project('helicity','absYVgen','ptVgen',axis_label)))
+        uncHists[ipdf].extend([alphaHists_hel[ipdf][...,0],alphaHists_hel[ipdf][...,1]])
+        names[ipdf].extend([pdfNames[ipdf]+"alpha $\pm1\sigma$",""])
+        colors[ipdf].extend([[cmap(i)]*2 for i in range(len(args.pdfs),2*len(args.pdfs))][0])
+    
+    # add QCD scales
+    uncHists.append([coeffs[{"muRfact" : 2.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 0.5j, "muFfact" : 0.5j}],coeffs[{"muRfact" : 2.j, "muFfact" : 1.j}], coeffs[{"muRfact" : 0.5j, "muFfact" : 1.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 0.5j}]])
+    names.append(["QCDscale_muRmuFUp","QCDscale_muRmuFDown","QCDscale_muRUp","QCDscale_muRDown","QCDscale_muFUp","QCDscale_muFDown"])
+    colors.append([[cmap(i)]*6 for i in range(1)][0])
+    # uncHists.append([coeffs[{"muRfact" : 1.j, "muFfact" : 1.j}]])
+    # names.append(["QCDscale_central"])
+    # colors.append([[cmap(i)]*1 for i in range(2*len(args.pdfs),2*len(args.pdfs)+1)][0])
 
 # TODO
 #if args.together:
 
-outdir = plot_tools.make_plot_dir(args.outpath, args.outfolder)
+outdir = output_tools.make_plot_dir(args.outpath, args.outfolder)
+plot_names = args.pdfs
+plot_names.append("QCD_scales")
 
 for obs in args.obs:
-    for name,color,labels,hists in zip(args.pdfs,colors, names, uncHists):
+    all_hists = []
+    all_colors = []
+    all_names = []
+    for name,color,labels,hists in zip(plot_names,colors, names, uncHists):
         # This is the reference
-        action = sel.unrolledHist if obs == "unrolled" else lambda x: x.project(obs) 
-        hists1D = [action(x) for x in hists]
-        plot_cols = color
-        plot_labels = labels
-        # Add the nominal for reference
-        if len(uncHists) > 1:
-            hists1D = [uncHists[0], *hists1D]
-            plot_cols = [*colors[0], *color]
-            plot_labels = [*names[0], *labels]
+        if not "unrolled" in obs:
+            action = lambda x: x.project(obs)
+            hists1D = [action(x) for x in hists]
+        else:
+            obs2unroll = ["absYVgen","ptVgen"] if "unrolled_gen" in obs else ["pt","eta"]
+            action = sel.unrolledHist
+            if not "hel" in obs:
+                hists1D = [action(x,obs2unroll,binwnorm=True) for x in hists]
+            else:
+                hists1D = [action(x[{'helicity': 3.j}],obs2unroll,binwnorm=True) for x in hists]
+
+        all_hists.extend(hists1D)
+        all_colors.extend(color)
+        all_names.extend(labels)
+    
+    # Add the nominal for reference
+    if len(uncHists) > 1:
+        hists1D = [all_hists[0], *all_hists]
+        plot_cols = [colors[0][0], *all_colors]
+        plot_labels = ["", *all_names]
+        print(all_names)
         fig = plot_tools.makePlotWithRatioToRef(hists1D, colors=plot_cols, labels=plot_labels, alpha=0.7,
-                rrange=args.rrange, ylabel="$\sigma$/bin", xlabel=xlabels[obs], rlabel=f"x/{args.pdfs[0].upper()}", binwnorm=1.0, nlegcols=1)
-        outfile = f"{name}Hist_{obs}_{args.channel}"
+            rrange=args.rrange, ylabel="$\sigma$/bin", xlabel=xlabels[obs], rlabel=f"x/{args.pdfs[0].upper()}", binwnorm=None, nlegcols=1)
+        outfile = f"{name}Hist_{obs}_{args.channel}_sigma3"
+        ax1, ax2 = fig.axes
+        ax1.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D]),np.maximum.reduce([h.values() for h in hists1D]),color="grey",alpha=0.5, label="theory agnostic variation")
+        ax2.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D])/hists1D[0].values(),np.maximum.reduce([h.values() for h in hists1D])/hists1D[0].values(),color="grey",alpha=0.5, label="theory agnostic variation")
         plot_tools.save_pdf_and_png(outdir, outfile)
         plot_tools.write_index_and_log(outdir, outfile)

--- a/utilities/differential.py
+++ b/utilities/differential.py
@@ -59,13 +59,15 @@ def get_theoryAgnostic_axes():
 
     # Note that the helicity axis is defined elsewhere, and must not be added to the list of axes returned here
     axis_ptVgen = hist.axis.Variable(
-        [0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
+        #[0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
+        [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.],
         #[0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
         #[0., 1000.],
         name = "ptVgenSig", underflow=False, overflow=False
     )
     axis_absYVgen = hist.axis.Variable(
-        [0, 0.5, 1., 1.5, 2.0, 2.5],
+        #[0, 0.5, 1., 1.5, 2.0, 2.5],
+        [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4],
         #[0.25*i for i in range(11)],
         #[0, 5.0],
         name = "absYVgenSig", underflow=False, overflow=False

--- a/utilities/differential.py
+++ b/utilities/differential.py
@@ -60,7 +60,7 @@ def get_theoryAgnostic_axes():
     # Note that the helicity axis is defined elsewhere, and must not be added to the list of axes returned here
     axis_ptVgen = hist.axis.Variable(
         #[0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50.],
-        [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.],
+        [0., 3., 6., 9.7,12.4,16.,21.4,29.5,60.],
         #[0., 2.5, 5., 7.5, 10., 12.5, 15., 17.5, 20., 25., 30., 35., 40., 45., 50.],
         #[0., 1000.],
         name = "ptVgenSig", underflow=False, overflow=False

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -85,8 +85,6 @@ def write_analysis_output(results, outfile, args, update_name=True):
     to_append = []
     if args.theoryCorr and not args.theoryCorrAltOnly:
         to_append.append(args.theoryCorr[0]+"Corr")
-    if args.maxFiles is not None:
-        to_append.append(f"maxFiles{args.maxFiles}")
 
     if to_append and update_name:
         outfile = outfile.replace(".hdf5", f"_{'_'.join(to_append)}.hdf5")

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -85,6 +85,8 @@ def write_analysis_output(results, outfile, args, update_name=True):
     to_append = []
     if args.theoryCorr and not args.theoryCorrAltOnly:
         to_append.append(args.theoryCorr[0]+"Corr")
+    if args.maxFiles is not None:
+        to_append.append(f"maxFiles_{args.maxFiles}".replace("-","m"))
 
     if to_append and update_name:
         outfile = outfile.replace(".hdf5", f"_{'_'.join(to_append)}.hdf5")

--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -10,6 +10,7 @@ narf.clingutils.Declare('#include "histHelpers.h"')
 narf.clingutils.Declare('#include "utils.h"')
 narf.clingutils.Declare('#include "csVariables.h"')
 narf.clingutils.Declare('#include "EtaPtCorrelatedEfficiency.h"')
+narf.clingutils.Declare('#include "theoryTools.h"')
 
 from .muon_prefiring import make_muon_prefiring_helpers
 from .muon_efficiencies_smooth import make_muon_efficiency_helpers_smooth

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -28,7 +28,8 @@ axis_helicity_multidim = hist.axis.Integer(-1, 8, name="helicitySig", overflow=F
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):
     if filename is None:
-        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_absY_scetlib_dyturboCorr.hdf5" 
+        # filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_absY_scetlib_dyturboCorr.hdf5"
+        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_minnlo_agnosticbinning.hdf5"
     with h5py.File(filename, "r") as ff:
         out = narf.ioutils.pickle_load_h5py(ff["results"])
 

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -28,8 +28,7 @@ axis_helicity_multidim = hist.axis.Integer(-1, 8, name="helicitySig", overflow=F
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):
     if filename is None:
-        # filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_absY_scetlib_dyturboCorr.hdf5"
-        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_minnlo_agnosticbinning.hdf5"
+        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_theoryAgnosticBinning.hdf5"
     with h5py.File(filename, "r") as ff:
         out = narf.ioutils.pickle_load_h5py(ff["results"])
 

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -38,12 +38,11 @@ def makehelicityWeightHelper(is_w_like = False, filename=None):
         corrh = corrh[{'muRfact' : 1.j,}]
     if 'muFfact' in corrh.axes.name:
         corrh = corrh[{'muFfact' : 1.j,}]
-    missing = set(["absYVgen", "ptVgen", "chargeVgen", "helicity", "massVgen"]).difference(set(corrh.axes.name))
-    if missing != set():
-        raise ValueError (f"Axes {missing} are not present in the coeff histogram")
     
-    corrh = corrh.project('massVgen','absYVgen','ptVgen','chargeVgen', 'helicity')
-
+    axes_names = ['massVgen','absYVgen','ptVgen','chargeVgen', 'helicity']
+    if not list(corrh.axes.name) == axes_names:
+        raise ValueError (f"Axes [{corrh.axes.name}] are not the ones this functions expects ({axes_names})")
+    
     if np.count_nonzero(corrh[{"helicity" : -1.j}] == 0):
         logger.warning("Zeros in sigma UL for the angular coefficients will give undefined behaviour!")
     # histogram has to be without errors to load the tensor directly

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -23,25 +23,27 @@ narf.clingutils.Declare('#include "syst_helicity_utils.h"')
 data_dir = f"{pathlib.Path(__file__).parent}/data/"
 
 #UL, A0...A4
-axis_helicity_multidim = hist.axis.Integer(-1, 5, name="helicitySig", overflow=False, underflow=False)
+axis_helicity_multidim = hist.axis.Integer(-1, 8, name="helicitySig", overflow=False, underflow=False)
 
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):
     if filename is None:
-        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_scetlib_dyturboCorr.hdf5" 
+        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_absY_scetlib_dyturboCorr.hdf5" 
     with h5py.File(filename, "r") as ff:
         out = narf.ioutils.pickle_load_h5py(ff["results"])
 
     corrh = out["Z"] if is_w_like else out["W"]
+
     if 'muRfact' in corrh.axes.name:
         corrh = corrh[{'muRfact' : 1.j,}]
     if 'muFfact' in corrh.axes.name:
         corrh = corrh[{'muFfact' : 1.j,}]
-    missing = set(["y", "ptVgen", "chargeVgen", "helicity", "massVgen"]).difference(set(corrh.axes.name))
+    missing = set(["absYVgen", "ptVgen", "chargeVgen", "helicity", "massVgen"]).difference(set(corrh.axes.name))
     if missing != set():
         raise ValueError (f"Axes {missing} are not present in the coeff histogram")
     
-    corrh = corrh.project('massVgen','y','ptVgen','chargeVgen', 'helicity')
+    corrh = corrh.project('massVgen','absYVgen','ptVgen','chargeVgen', 'helicity')
+
     if np.count_nonzero(corrh[{"helicity" : -1.j}] == 0):
         logger.warning("Zeros in sigma UL for the angular coefficients will give undefined behaviour!")
     # histogram has to be without errors to load the tensor directly
@@ -71,7 +73,7 @@ def make_muon_eff_syst_helper_helicity(helper_syst, nhelicity=6):
     return helper_syst_helicity, tensor_axes
 
 #mass weights
-def make_massweight_helper_helicity(mass_axis, nhelicity=6):
+def make_massweight_helper_helicity(mass_axis, nhelicity=9):
     tensor_axes=[axis_helicity_multidim, mass_axis]
     helper = ROOT.wrem.tensor1D_helper_helicity[mass_axis.size, nhelicity]()
     return helper, tensor_axes

--- a/wremnants/include/csVariables.h
+++ b/wremnants/include/csVariables.h
@@ -42,35 +42,35 @@ struct CSVars {
 
 };
 
-CSVars csSineCosThetaPhi(const PtEtaPhiMVector& antilepton, const PtEtaPhiMVector& lepton) {
-    PxPyPzEVector antilepton_v(antilepton);
-    PxPyPzEVector dilepton = antilepton_v + PxPyPzEVector(lepton);
+CSVars csSineCosThetaPhi(const PtEtaPhiMVector &antilepton, const PtEtaPhiMVector &lepton)
+{
+    PxPyPzEVector lepton_v(lepton);
+    PxPyPzEVector dilepton = lepton_v + PxPyPzEVector(antilepton);
     const int zsign = std::copysign(1.0, dilepton.z());
     const double energy = 6500.;
-    PxPyPzEVector proton1(0., 0., zsign*energy, energy);
-    PxPyPzEVector proton2(0., 0., -1.*zsign*energy, energy);
+    PxPyPzEVector proton1(0., 0., zsign * energy, energy);
+    PxPyPzEVector proton2(0., 0., -1. * zsign * energy, energy);
 
     auto dilepCM = dilepton.BoostToCM();
     ROOT::Math::Boost dilepCMBoost(dilepCM);
 
     auto pro1boost = unitBoostedVector(dilepCMBoost, proton1);
     auto pro2boost = unitBoostedVector(dilepCMBoost, proton2);
-    auto antilepton_boost = unitBoostedVector(dilepCMBoost, antilepton_v);
-    auto csFrame = (pro1boost-pro2boost).Unit();
-    auto csYaxis = cross(pro1boost, pro2boost).Unit();
+    auto lepton_boost = unitBoostedVector(dilepCMBoost, lepton_v);
+    auto csFrame = (pro1boost - pro2boost).Unit();
+    auto csYaxis = cross(pro1boost, -pro2boost).Unit();
     auto csXaxis = cross(csYaxis, csFrame).Unit();
 
-    double costheta = dot(csFrame, antilepton_boost);
-    auto csCross = cross(csFrame, antilepton_boost);
-    double sintheta = csCross.R()/(csFrame.R()*antilepton_boost.R());
+    double costheta = dot(csFrame, lepton_boost);
+    auto csCross = cross(csFrame, lepton_boost);
+    double sintheta = csCross.R() / (csFrame.R() * lepton_boost.R());
 
-    double sinphi = dot(csYaxis, antilepton_boost)/sintheta;
-    double cosphi = dot(csXaxis, antilepton_boost)/sintheta;
+    double sinphi = dot(csYaxis, lepton_boost) / sintheta;
+    double cosphi = dot(csXaxis, lepton_boost) / sintheta;
 
     CSVars angles = {sintheta, costheta, sinphi, cosphi};
     return angles;
 }
 
 }
-
 #endif

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -103,7 +103,7 @@ class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
      const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
      helweight_tensor_t helWeights;
      double sum = coeffs(0) * moments(9); // 1.*cos^2(theta)
-     helWeights(0) = coeffs(0) * moments(9)
+     helWeights(0) = coeffs(0) * moments(9);
      for(unsigned int i = 1; i < NHELICITY;i++) {
        if(i<6) helWeights(i) = coeffs(i) * moments(i);//save only upto 6 for further use
        sum += coeffs(i) * moments(i);//full sum of all components

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -80,35 +80,32 @@ class tensorRank2_helper_helicity {
   }
 }; 
 
-
-Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY -1>> scalarmultiplyHelWeightTensor(double wt, Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY -1>>& helTensor) {
+Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>> scalarmultiplyHelWeightTensor(double wt, Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>>& helTensor) {
   return wt*helTensor;
 }
 
- template <typename T>
+template <typename T>
 class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
    using base_t = TensorCorrectionsHelper<T>;
    using tensor_t = typename T::storage_type::value_type::tensor_t;
    static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
-   //static constexpr auto nhelicity = NHELICITY;
-   static constexpr auto NHELICITY_WEIGHTS = NHELICITY -1;
+   static constexpr auto NHELICITY_WEIGHTS = NHELICITY;
    // TODO: Can presumably get the double type from the template param
-   typedef Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY_WEIGHTS>> helweight_tensor_t;
-   
+   using helweight_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY_WEIGHTS>>;
+
  public:
    using base_t::base_t;
-   
+
    helweight_tensor_t operator() (double mV, double yV, double ptV, int qV, const CSVars &csvars, double nominal_weight) {
      //static_assert(nhelicity == NHELICITY);
-     const auto &moments = csAngularFactors(csvars);
-     const auto &coeffs = base_t::get_tensor(mV, yV, ptV, qV);
+     const auto moments = csAngularFactors(csvars);
+     const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
      helweight_tensor_t helWeights;
-     double sum = coeffs(0) * moments(9); // 1.*cos^2(theta)
-     helWeights(0) = coeffs(0) * moments(9);
-     for(unsigned int i = 1; i < NHELICITY-1;i++) {
-       helWeights(i) = coeffs(i) * moments(i);
+     double sum = 0.;
+     for(unsigned int i = 0; i < NHELICITY; i++) {
+       if (i<NHELICITY_WEIGHTS) helWeights(i) = coeffs(i) * moments(i);
        sum += coeffs(i) * moments(i);//full sum of all components
-     }       
+     }
      double factor = 1./sum;
      helweight_tensor_t helWeights_tensor = factor*helWeights;
      return helWeights_tensor;

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -6,6 +6,7 @@
 #include "theory_corrections.h"
 
 namespace wrem {
+
   //class to expand the muon eff stat var tensor with helcitity weights
 template <std::size_t nEta, std::size_t nPt, std::size_t ch, std::size_t nhelicity>
 class muon_eff_helper_stat_helicity {  
@@ -80,7 +81,7 @@ class tensorRank2_helper_helicity {
 }; 
 
 
-Eigen::TensorFixedSize<double, Eigen::Sizes<6>> scalarmultiplyHelWeightTensor(double wt, Eigen::TensorFixedSize<double, Eigen::Sizes<6>>& helTensor) {
+Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY -1>> scalarmultiplyHelWeightTensor(double wt, Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY -1>>& helTensor) {
   return wt*helTensor;
 }
 
@@ -90,7 +91,7 @@ class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
    using tensor_t = typename T::storage_type::value_type::tensor_t;
    static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
    //static constexpr auto nhelicity = NHELICITY;
-   static constexpr auto NHELICITY_WEIGHTS = 6;
+   static constexpr auto NHELICITY_WEIGHTS = NHELICITY -1;
    // TODO: Can presumably get the double type from the template param
    typedef Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY_WEIGHTS>> helweight_tensor_t;
    
@@ -99,13 +100,13 @@ class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
    
    helweight_tensor_t operator() (double mV, double yV, double ptV, int qV, const CSVars &csvars, double nominal_weight) {
      //static_assert(nhelicity == NHELICITY);
-     const auto moments = csAngularFactors(csvars);
-     const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
+     const auto &moments = csAngularFactors(csvars);
+     const auto &coeffs = base_t::get_tensor(mV, yV, ptV, qV);
      helweight_tensor_t helWeights;
      double sum = coeffs(0) * moments(9); // 1.*cos^2(theta)
      helWeights(0) = coeffs(0) * moments(9);
-     for(unsigned int i = 1; i < NHELICITY;i++) {
-       if(i<6) helWeights(i) = coeffs(i) * moments(i);//save only upto 6 for further use
+     for(unsigned int i = 1; i < NHELICITY-1;i++) {
+       helWeights(i) = coeffs(i) * moments(i);
        sum += coeffs(i) * moments(i);//full sum of all components
      }       
      double factor = 1./sum;

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -102,8 +102,9 @@ class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
      const auto moments = csAngularFactors(csvars);
      const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
      helweight_tensor_t helWeights;
-     double sum = 0.;
-     for(unsigned int i = 0; i < NHELICITY;i++) {
+     double sum = coeffs(0) * moments(9); // 1.*cos^2(theta)
+     helWeights(0) = coeffs(0) * moments(9)
+     for(unsigned int i = 1; i < NHELICITY;i++) {
        if(i<6) helWeights(i) = coeffs(i) * moments(i);//save only upto 6 for further use
        sum += coeffs(i) * moments(i);//full sum of all components
      }       

--- a/wremnants/include/theoryTools.h
+++ b/wremnants/include/theoryTools.h
@@ -80,8 +80,8 @@ Eigen::TensorFixedSize<int, Eigen::Sizes<2>> prefsrLeptons(const ROOT::VecOps::R
 
 }
 
-const size_t NHELICITY = 10;
-  typedef Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>> helicity_tensor;
+  constexpr size_t NHELICITY = 9;
+  using helicity_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>> ;
 
   helicity_tensor csAngularFactors(const CSVars &csvars)
   {
@@ -95,7 +95,7 @@ const size_t NHELICITY = 10;
     const double cos2ThetaCS = 1. - 2. * sinThetaCS * sinThetaCS;
     const double cos2PhiCS = 1. - 2. * sinPhiCS * sinPhiCS;
     helicity_tensor angular;
-    angular(0) = 1.;
+    angular(0) = 1. + cosThetaCS * cosThetaCS;
     angular(1) = 0.5 * (1. - 3. * cosThetaCS * cosThetaCS);
     angular(2) = sin2ThetaCS * cosPhiCS;
     angular(3) = 0.5 * sinThetaCS * sinThetaCS * cos2PhiCS;
@@ -104,9 +104,25 @@ const size_t NHELICITY = 10;
     angular(6) = sinThetaCS * sinThetaCS * sin2PhiCS;
     angular(7) = sin2ThetaCS * sinPhiCS;
     angular(8) = sinThetaCS * sinPhiCS;
-    angular(9) = 1. + cosThetaCS * cosThetaCS;
     return angular;
   }
+
+  helicity_tensor csAngularMoments(const CSVars &csvars) {
+    const helicity_tensor &angular = csAngularFactors(csvars);
+
+    // using definition from arxiv:1606.00689 to align with ATLAS
+    helicity_tensor scales;
+    scales.setValues({ 0., 20./3., 5., 20., 4., 4., 5., 5., 4. });
+
+    helicity_tensor offsets;
+    offsets.setValues({ 1., 2./3., 0., 0., 0., 0., 0., 0., 0. });
+
+    const helicity_tensor moments = scales*angular + offsets;
+
+    return moments;
+  }
+
+
 
 
 using scale_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<3, 3>>;
@@ -145,10 +161,9 @@ using helicity_scale_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NHEL
     constexpr std::array<Eigen::Index, 3> broadcasthelicities = {nhelicity, 1, 1};
     constexpr std::array<Eigen::Index, 3> reshapescale = {1, nmur, nmuf};
 
-    Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, 1, 1>> angular = csAngularFactors(csvars).reshape(broadcasthelicities);
+    Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, 1, 1>> moments = csAngularMoments(csvars).reshape(broadcasthelicities);
 
-    return original_weight * scale_tensor.reshape(reshapescale).broadcast(broadcasthelicities) * angular.broadcast(broadcastscales);
-    //return original_weight * angular.broadcast(broadcastscales) * scale_tensor.reshape(broadcastscales).broadcast(broadcasthelicities);
+    return original_weight * scale_tensor.reshape(reshapescale).broadcast(broadcasthelicities) * moments.broadcast(broadcastscales);
   }
 
   template <Eigen::Index Npdfs>
@@ -165,12 +180,13 @@ using helicity_scale_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NHEL
 
       constexpr Eigen::Index nhelicity = NHELICITY;
 
-      constexpr std::array<Eigen::Index, 2> broadcastscales = {1, Npdfs};
+      constexpr std::array<Eigen::Index, 2> broadcastpdf = {1, Npdfs};
       constexpr std::array<Eigen::Index, 2> broadcasthelicities = {nhelicity, 1};
-      const auto angular = csAngularFactors(csvars).reshape(broadcasthelicities);
+      constexpr std::array<Eigen::Index, 2> reshapepdf = {1, Npdfs};
+      const auto moments = csAngularMoments(csvars).reshape(broadcasthelicities);
 
       helicity_pdf_tensor_t helicity_pdf_tensor;
-      helicity_pdf_tensor = original_weight * angular.broadcast(broadcastscales) * pdf_tensor.reshape(broadcastscales).broadcast(broadcasthelicities);
+      helicity_pdf_tensor = original_weight * moments.broadcast(broadcastpdf) * pdf_tensor.reshape(reshapepdf).broadcast(broadcasthelicities);
 
       return helicity_pdf_tensor;
     }

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -88,7 +88,8 @@ using base_t = TensorCorrectionsHelper<T>;
 
 using tensor_t = typename T::storage_type::value_type::tensor_t;
 static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
-static constexpr auto nhelicity = sizes[0];
+// static constexpr auto nhelicity = sizes[0];
+static constexpr auto nhelicity = 10; // Placeholder 
 static constexpr auto nmur = sizes[1];
 static constexpr auto nmuf = sizes[2];
 
@@ -136,6 +137,7 @@ static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
 static constexpr auto nhelicity = sizes[0];
 static constexpr auto ncorrs = sizes[1];
 static constexpr auto nvars = sizes[2];
+const size_t NHELICITY = 10;
 
 // TODO: Can presumably get the double type from the template param
 typedef Eigen::TensorFixedSize<double, Eigen::Sizes<nvars>> var_tensor_t;

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -121,7 +121,7 @@ public:
         Eigen::TensorFixedSize<double, Eigen::Sizes<1, nmur, nmuf>> denominator;
 
         for(unsigned int imur = 0; imur < 3;imur++) {
-            for(unsigned int imuf = 1; imuf < 3;imuf++) {
+            for(unsigned int imuf = 0; imuf < 3;imuf++) {
                 angular_with_coeffs(0,imur,imuf) = coeffs(0,imur,imuf)*angular(9); // 1.0 times 1+cos^2theta for all scales
                 denominator(0,imur,imuf) = coeffs(0,imur,imuf)*angular(9);
                 for(unsigned int ihel = 1; ihel < NHELICITY-1;ihel++) {

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -150,13 +150,19 @@ public:
         static_assert(nhelicity == NHELICITY);
         static_assert(ncorrs == 2);
 
-        const auto angular = csAngularFactors(csvars);
-        const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
+        const auto &angular = csAngularFactors(csvars);
+        const auto &coeffs = base_t::get_tensor(mV, yV, ptV, qV);
 
         constexpr std::array<Eigen::Index, 3> reshapedims = {nhelicity, 1, 1};
         constexpr std::array<Eigen::Index, 1> reduceddims = {0};
 
-        const auto coeffs_with_angular = coeffs*angular.reshape(reshapedims).broadcast(sizes);
+        Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, 1, 1>> coeffs_with_angular = coeffs*angular.reshape(reshapedims).broadcast(sizes);
+
+        coeffs_with_angular(0) = coeffs(0) * angular(9);
+        for(unsigned int i = 1; i < NHELICITY-1;i++) {
+            coeffs_with_angular(i) = coeffs(i) * angular(i);
+        }
+
         auto uncorr_hel = coeffs_with_angular.chip(0, 1);
         auto corr_hel = coeffs_with_angular.chip(1, 1);
 

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -88,8 +88,7 @@ using base_t = TensorCorrectionsHelper<T>;
 
 using tensor_t = typename T::storage_type::value_type::tensor_t;
 static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
-// static constexpr auto nhelicity = sizes[0];
-static constexpr auto nhelicity = 10;
+static constexpr auto nhelicity = sizes[0];
 static constexpr auto nmur = sizes[1];
 static constexpr auto nmuf = sizes[2];
 
@@ -105,31 +104,20 @@ public:
     tensor_t operator() (double mV, double yV, double ptV, int qV, const CSVars &csvars, const scale_tensor_t &scale_tensor, double nominal_weight) {
         // denominator for each scale combination
         constexpr std::array<Eigen::Index, 1> helicitydims = { 0 };
-        constexpr std::array<Eigen::Index, 3> broadcasthelicities = { nhelicity-1, 1, 1 };
+        constexpr std::array<Eigen::Index, 3> broadcasthelicities = { nhelicity, 1, 1 };
         constexpr std::array<Eigen::Index, 3> reshapeden = { 1, nmur, nmuf };
 
         // pure angular terms without angular coeffs multiplied through
-        const auto &angular = csAngularFactors(csvars);
-        const auto &coeffs = base_t::get_tensor(mV, yV, ptV, qV);
+        const auto angular = csAngularFactors(csvars).reshape(broadcasthelicities);
 
         static_assert(sizes.size() == 3);
         static_assert(nhelicity == NHELICITY);
 
         constexpr std::array<Eigen::Index, 3> broadcastscales = { 1, nmur, nmuf };
         // now multiplied through by angular coefficients (1.0 for 1+cos^2theta term)
-        tensor_t angular_with_coeffs;
-        Eigen::TensorFixedSize<double, Eigen::Sizes<1, nmur, nmuf>> denominator;
+        const tensor_t angular_with_coeffs = angular.broadcast(broadcastscales)*base_t::get_tensor(mV, yV, ptV, qV);
 
-        for(unsigned int imur = 0; imur < 3;imur++) {
-            for(unsigned int imuf = 0; imuf < 3;imuf++) {
-                angular_with_coeffs(0,imur,imuf) = coeffs(0,imur,imuf)*angular(9); // 1.0 times 1+cos^2theta for all scales
-                denominator(0,imur,imuf) = coeffs(0,imur,imuf)*angular(9);
-                for(unsigned int ihel = 1; ihel < NHELICITY-1;ihel++) {
-                    angular_with_coeffs(ihel,imur,imuf) = coeffs(ihel,imur,imuf)*angular(ihel);
-                    denominator(0,imur,imuf)+=coeffs(ihel,imur,imuf)*angular(ihel);
-                }
-            }
-        }
+        auto denominator = angular_with_coeffs.sum(helicitydims).reshape(reshapeden).broadcast(broadcasthelicities);
 
         constexpr std::array<Eigen::Index, 3> reshapescale = { 1, nmur, nmuf };
         auto scale = scale_tensor.reshape(reshapescale).broadcast(broadcasthelicities);
@@ -148,7 +136,6 @@ static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
 static constexpr auto nhelicity = sizes[0];
 static constexpr auto ncorrs = sizes[1];
 static constexpr auto nvars = sizes[2];
-const size_t NHELICITY = 10;
 
 // TODO: Can presumably get the double type from the template param
 typedef Eigen::TensorFixedSize<double, Eigen::Sizes<nvars>> var_tensor_t;
@@ -161,21 +148,15 @@ public:
         static_assert(nhelicity == NHELICITY);
         static_assert(ncorrs == 2);
 
-        const auto &angular = csAngularFactors(csvars);
-        const auto &coeffs = base_t::get_tensor(mV, yV, ptV, qV);
+        const auto angular = csAngularFactors(csvars);
+        const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
 
         constexpr std::array<Eigen::Index, 3> reshapedims = {nhelicity, 1, 1};
         constexpr std::array<Eigen::Index, 1> reduceddims = {0};
 
-        Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity-1, 1, 1>> coeffs_with_angular = coeffs*angular;
-
-        coeffs_with_angular(0) = coeffs(0) * angular(9);
-        for(unsigned int i = 1; i < NHELICITY-1;i++) {
-            coeffs_with_angular(i) = coeffs(i) * angular(i);
-        }
-
-        auto uncorr_hel = coeffs_with_angular.chip(0, nhelicity-1).reshape(reshapedims).broadcast(sizes).chip(0, 1);
-        auto corr_hel = coeffs_with_angular.chip(0, nhelicity-1).reshape(reshapedims).broadcast(sizes).chip(1, 1);
+        const auto coeffs_with_angular = coeffs*angular.reshape(reshapedims).broadcast(sizes);
+        auto uncorr_hel = coeffs_with_angular.chip(0, 1);
+        auto corr_hel = coeffs_with_angular.chip(1, 1);
 
         var_tensor_t corr_weight_vars = corr_hel.sum(reduceddims)/uncorr_hel.sum(reduceddims)*nominal_weight;
 

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -10,32 +10,6 @@
 
 namespace wrem {
 
-const size_t NHELICITY = 9;
-typedef Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>> helicity_tensor;
-
-helicity_tensor csAngularFactors(const CSVars& csvars) {
-    const double sinThetaCS = csvars.sintheta;
-    const double cosThetaCS = csvars.costheta;
-    const double sinPhiCS = csvars.sinphi;
-    const double cosPhiCS = csvars.cosphi;
-
-    const double sin2ThetaCS = 2.*sinThetaCS*cosThetaCS;
-    const double sin2PhiCS = 2.*sinPhiCS*cosPhiCS;
-    const double cos2ThetaCS = 1. - 2.*sinThetaCS*sinThetaCS;
-    const double cos2PhiCS= 1. - 2.*sinPhiCS*sinPhiCS;
-    helicity_tensor angular;
-    angular(0) = 1.+cosThetaCS*cosThetaCS;
-    angular(1) = 0.5*(1. - 3.*cosThetaCS*cosThetaCS);
-    angular(2) = sin2ThetaCS*cosPhiCS;
-    angular(3) = 0.5*sinThetaCS*sinThetaCS*cos2PhiCS;
-    angular(4) = sinThetaCS*cosPhiCS;
-    angular(5) = cosThetaCS;
-    angular(6) = sinThetaCS*sinThetaCS*sin2PhiCS;
-    angular(7) = sin2ThetaCS*sinPhiCS;
-    angular(8) = sinThetaCS*sinPhiCS;
-    return angular;
-}
-
 template <typename T>
 class TensorCorrectionsHelper {
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -2,7 +2,6 @@ import ROOT
 import hist
 import numpy as np
 from utilities import boostHistHelpers as hh, common, logging
-import wremnants
 from wremnants import theory_tools
 from wremnants.datasets.datagroups import Datagroups
 from wremnants.helicity_utils import *

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -10,7 +10,6 @@ import collections.abc
 import copy
 
 logger = logging.child_logger(__name__)
-narf.clingutils.Declare('#include "theoryTools.h"')
 
 def syst_transform_map(base_hist, hist_name):
     pdfInfo = theory_tools.pdfMap

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -365,10 +365,11 @@ def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal", a
             alphaSHist = df.HistoBoost(alphaSHistName, axes, [*cols, tensorASName], tensor_axes=[as_ax], storage=hist.storage.Double())
 
             if propagateToHelicity:
+                df=df.Define("unity","1.")
                 pdfhelper = ROOT.wrem.makeHelicityMomentPdfTensor[npdf]()
-                df = df.Define(f"helicity_moments_{tensorName}_tensor", pdfhelper, ["csSineCosThetaPhi", f"{tensorName}", "nominal_weight"])
+                df = df.Define(f"helicity_moments_{tensorName}_tensor", pdfhelper, ["csSineCosThetaPhi", f"{tensorName}", "unity"])
                 alphahelper = ROOT.wrem.makeHelicityMomentPdfTensor[2]()
-                df = df.Define(f"helicity_moments_{tensorASName}_tensor", alphahelper, ["csSineCosThetaPhi", f"{tensorASName}", "nominal_weight"])
+                df = df.Define(f"helicity_moments_{tensorASName}_tensor", alphahelper, ["csSineCosThetaPhi", f"{tensorASName}", "unity"])
                 pdfHist_hel = df.HistoBoost(f"helicity_{pdfHistName}", axes, [*cols, f"helicity_moments_{tensorName}_tensor"], tensor_axes=[wremnants.axis_helicity,pdf_ax], storage=hist.storage.Double())
                 alphaSHist_hel = df.HistoBoost(f"helicity_{alphaSHistName}", axes, [*cols, f"helicity_moments_{tensorASName}_tensor"], tensor_axes=[wremnants.axis_helicity,as_ax], storage=hist.storage.Double())
                 results.extend([pdfHist_hel, alphaSHist_hel])

--- a/wremnants/theoryAgnostic_tools.py
+++ b/wremnants/theoryAgnostic_tools.py
@@ -21,7 +21,7 @@ def select_fiducial_space(df, ptVgenMax, absYVgenMax, accept=True):
 def define_helicity_weights(df):
     # define the helicity tensor, here nominal_weight will only have theory weights, no experimental pieces, it is defined in theory_tools.define_theory_weights_and_corrs
     weightsByHelicity_helper = wremnants.makehelicityWeightHelper()
-    df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "yVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
+    df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
     df = df.Define("nominal_weight_helicity", "wrem::scalarmultiplyHelWeightTensor(nominal_weight,helWeight_tensor)")
     return df
 


### PR DESCRIPTION
This builds on top of (and replaces) https://github.com/WMass/WRemnants/pull/310

The updated definition of the Ai's and helicity cross sections and other additions are maintained, but the angular terms and moments are factorized in such a way that 9 elements can be used everywhere for the corresponding helicity tensors.

The scaling and offsets to convert from moments to angular coefficients have been moved into the C++ code as part of this change, which significantly simplifies the corresponding python function.