### PR TITLE
Minor fixes about histmaker output file name and dilepton validation histograms

### DIFF
--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -269,7 +269,7 @@ def build_graph(df, dataset):
             df = syst_tools.add_theory_hists(results, df, args, dataset.name, corr_helpers, qcdScaleByHelicity_helper, [all_axes[obs]], [obs], base_name=f"nominal_{obs}", for_wmass=False)
 
     # test plots
-    if args.validationHists:
+    if args.validationHists and args.useDileptonTriggerSelection:
         df_plusTrig = df.Filter("trigMuons_passTrigger0")
         df_minusTrig = df.Filter("nonTrigMuons_passTrigger0")
         df_bothTrig = df.Filter("trigMuons_passTrigger0 && nonTrigMuons_passTrigger0")

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -85,7 +85,7 @@ def write_analysis_output(results, outfile, args, update_name=True):
     to_append = []
     if args.theoryCorr and not args.theoryCorrAltOnly:
         to_append.append(args.theoryCorr[0]+"Corr")
-    if args.maxFiles is not None and args.maxFiles >= 0:
+    if args.maxFiles is not None:
         to_append.append(f"maxFiles{args.maxFiles}")
 
     if to_append and update_name:

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -85,7 +85,7 @@ def write_analysis_output(results, outfile, args, update_name=True):
     to_append = []
     if args.theoryCorr and not args.theoryCorrAltOnly:
         to_append.append(args.theoryCorr[0]+"Corr")
-    if args.maxFiles is not None:
+    if args.maxFiles is not None and args.maxFiles >= 0:
         to_append.append(f"maxFiles{args.maxFiles}")
 
     if to_append and update_name:


### PR DESCRIPTION
The current validation histograms in the dilepton histmaker are supposed to be used when running the actual dilepton trigger selection (which is not the default in any case). 

Also, when running with --maxFiles != None the number is appended to the output file name for convenience (typical use case was when running with few files for tests while avoiding overriding other possible existing files). However this is annoying when the argument to --maxFiles is negative, also because with the full stat one doesn't want any additional tag on the name, so now this is appended only when positive.
If requested, I could implement the appending of "fullStat" when "--maxFiles -1"

This PR doesn't change anything to the physics, and was tested locally.