### PR TITLE
Rework MiNNLO scale variations and Refine NP Uncertainties

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -67,7 +67,7 @@ axis_lin = hist.axis.Regular(5, 0, 5, name = "lin")
 
 
 
-qcdScaleByHelicity_helper = wremnants.makeQCDScaleByHelicityHelper()
+qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 axis_ptVgen = qcdScaleByHelicity_helper.hist.axes["ptVgen"]
 axis_chargeVgen = qcdScaleByHelicity_helper.hist.axes["chargeVgen"]
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -139,7 +139,7 @@ axis_recoWpt = hist.axis.Regular(40, 0., 80., name = "recoWpt", underflow=False,
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.makeQCDScaleByHelicityHelper()
+qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 
 if args.noScaleFactors:
     logger.info("Running with no scale factors")

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -98,7 +98,7 @@ if args.unfolding:
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.makeQCDScaleByHelicityHelper(is_w_like = True)
+qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -66,7 +66,7 @@ bins_mll = [60, 65, 70, 72, 74, 76, 78] + list(range(80, 100, 1)) + [100, 102, 1
 axis_mll = hist.axis.Variable(bins_mll, name = "mll") 
 axis_lin = hist.axis.Regular(5, 0, 5, name = "lin")
 
-qcdScaleByHelicity_helper = wremnants.makeQCDScaleByHelicityHelper(is_w_like = True)
+qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
 axis_ptVgen = qcdScaleByHelicity_helper.hist.axes["ptVgen"]
 axis_chargeVgen = qcdScaleByHelicity_helper.hist.axes["chargeVgen"]
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -82,7 +82,7 @@ axis_eta_mT = hist.axis.Variable([-2.4, 2.4], name = "eta")
 # define helpers
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.makeQCDScaleByHelicityHelper(is_w_like = True)
+qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -256,22 +256,22 @@ if not args.skipAngularCoeffs:
                 new_moments = moments
                 w_moments = hh.addHists(w_moments, new_moments, createNew=False)
 
-    coeffs={}
+    moments_out={}
     # Common.ptV_binning is the approximate 5% quantiles, rounded to integers. Rebin for approx 10% quantiles
     if z_moments:
         if not args.useTheoryAgnosticBinning:
             z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
             z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
-        coeffs["Z"] = wremnants.moments_to_angular_coeffs(z_moments) 
+        moments_out["Z"] = z_moments
     if w_moments:
         if not args.useTheoryAgnosticBinning:
             w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
-        coeffs["W"] = wremnants.moments_to_angular_coeffs(w_moments)
-    if coeffs:
-        outfname = "w_z_coeffs"
+        moments_out["W"] = w_moments
+    if moments_out:
+        outfname = "w_z_moments"
         if args.signedY:
             outfname += "_signedY"
         if args.useTheoryAgnosticBinning:
             outfname += "_theoryAgnosticBinning"
         outfname += ".hdf5"
-        output_tools.write_analysis_output(coeffs, outfname, args, update_name=not args.forceDefaultName)
+        output_tools.write_analysis_output(moments_out, outfname, args, update_name=not args.forceDefaultName)

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -388,15 +388,19 @@ class CardTool(object):
             return axLabel.format(i=entry)
         if formatWithValue:
             if formatWithValue == "center":
-                edges = axis.centers
+                entry = axis.centers[entry]
             elif formatWithValue == "low":
-                edges = axis.edges[:-1]
+                entry = axis.edges[:-1][entry]
             elif formatWithValue == "high":
-                edges = axis.edges[1:]
+                entry = axis.edges[1:][entry]
+            elif formatWithValue == "edges":
+                low = axis.edges[entry]
+                high = axis.edges[entry+1]
+                lowstr = f"{low:0.1f}".replace(".", "p") if not low.is_integer() else str(int(low))
+                highstr = f"{high:0.1f}".replace(".", "p") if not high.is_integer() else str(int(high))
+                entry = f"{lowstr}_{highstr}"
             else:
                 raise ValueError(f"Invalid formatWithValue choice {formatWithValue}.")
-
-            entry = edges[entry]
 
         if type(entry) in [float, np.float64]:
             entry = f"{entry:0.1f}".replace(".", "p") if not entry.is_integer() else str(int(entry))

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -168,10 +168,11 @@ class TheoryHelper(object):
                     # Drop the uncertainties for low pt since this is covered by the resummation uncertainties
                     skip_entries.extend([{pt_ax : complex(0, x)} for x in binning[:pt_idx]])
 
-            func = hh.rebinHist
+            func = syst_tools.hist_to_variations
             action_map = {proc : func for proc in expanded_samples}
-            action_args["axis_name"] = pt_ax
-            action_args["edges"] = binning
+            action_args["gen_axes"] = [pt_ax]
+            action_args["rebin_axes"] = [pt_ax]
+            action_args["rebin_edges"] = [binning]
 
         # Skip MiNNLO unc. 
         if self.resumUnc and not (pt_binned or helicity):

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -28,11 +28,13 @@ axis_helicity_multidim = hist.axis.Integer(-1, 8, name="helicitySig", overflow=F
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):
     if filename is None:
-        filename = f"{common.data_dir}/angularCoefficients/w_z_coeffs_theoryAgnosticBinning.hdf5"
+        filename = f"{common.data_dir}/angularCoefficients/w_z_moments_theoryAgnosticBinning.hdf5"
     with h5py.File(filename, "r") as ff:
         out = narf.ioutils.pickle_load_h5py(ff["results"])
 
-    corrh = out["Z"] if is_w_like else out["W"]
+    moments = out["Z"] if is_w_like else out["W"]
+
+    corrh = moments_to_angular_coeffs(moments)
 
     if 'muRfact' in corrh.axes.name:
         corrh = corrh[{'muRfact' : 1.j,}]

--- a/wremnants/include/theoryTools.h
+++ b/wremnants/include/theoryTools.h
@@ -110,7 +110,7 @@ Eigen::TensorFixedSize<int, Eigen::Sizes<2>> prefsrLeptons(const ROOT::VecOps::R
   helicity_tensor csAngularMoments(const CSVars &csvars) {
     const helicity_tensor &angular = csAngularFactors(csvars);
 
-    // using definition from arxiv:1606.00689 to align with ATLAS
+    // using definition from arxiv:1606.00689 Eq. 1 and 5 to align with ATLAS
     helicity_tensor scales;
     scales.setValues({ 0., 20./3., 5., 20., 4., 4., 5., 5., 4. });
 

--- a/wremnants/include/theory_corrections.h
+++ b/wremnants/include/theory_corrections.h
@@ -152,13 +152,14 @@ public:
         const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
 
         constexpr std::array<Eigen::Index, 3> reshapedims = {nhelicity, 1, 1};
+        constexpr std::array<Eigen::Index, 3> broadcastdims = {1, ncorrs, nvars};
         constexpr std::array<Eigen::Index, 1> reduceddims = {0};
 
-        const auto coeffs_with_angular = coeffs*angular.reshape(reshapedims).broadcast(sizes);
-        auto uncorr_hel = coeffs_with_angular.chip(0, 1);
-        auto corr_hel = coeffs_with_angular.chip(1, 1);
+        const auto coeffs_with_angular = coeffs*angular.reshape(reshapedims).broadcast(broadcastdims);
+        const auto uncorr_hel = coeffs_with_angular.chip(0, 1);
+        const auto corr_hel = coeffs_with_angular.chip(1, 1);
 
-        var_tensor_t corr_weight_vars = corr_hel.sum(reduceddims)/uncorr_hel.sum(reduceddims)*nominal_weight;
+        const var_tensor_t corr_weight_vars = corr_hel.sum(reduceddims)/uncorr_hel.sum(reduceddims)*nominal_weight;
 
         return corr_weight_vars;
     }

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -223,10 +223,7 @@ def expand_hist_by_duplicate_axis(href, ref_ax_name, new_ax_name, swap_axes=Fals
     hnew = hist.Hist(*new_axes, data=np.moveaxis(exp_data, 1, ref_ax_idx+1))
     return hnew
 
-def hist_to_variations(hist_in, gen_axes = [], sum_axes = []):
-    print("hist_to_variations")
-    print("gen_axes", gen_axes)
-    print("sum_axes", sum_axes)
+def hist_to_variations(hist_in, gen_axes = [], sum_axes = [], rebin_axes=[], rebin_edges=[]):
 
     if hist_in.name is None:
         out_name = "hist_variations"
@@ -235,24 +232,22 @@ def hist_to_variations(hist_in, gen_axes = [], sum_axes = []):
 
     s = hist.tag.Slicer()
 
+    #do rebinning
+    for rebin_axis, edges in zip(rebin_axes, rebin_edges):
+        hist_in = hh.rebinHist(hist_in, rebin_axis, edges)
+
     axisNames = hist_in.axes.name
     sum_expr = {axis : s[::hist.sum] for axis in sum_axes if axis in axisNames}
-    print("sum_expr first", sum_expr)
     hist_in = hist_in[sum_expr]
     axisNames = hist_in.axes.name
 
     gen_sum_expr = {genAxis : s[::hist.sum] for genAxis in gen_axes if genAxis in axisNames}
-    print("sum_expr second", sum_expr)
     if len(gen_sum_expr) == 0:
         # all the axes have already been projected out, nothing else to do
         return hist_in
 
     nom_hist = hist_in[{"vars" : 0}]
     nom_hist_sum = nom_hist[gen_sum_expr]
-
-    print("hist_in", hist_in.values(flow=True).shape)
-    print("nom_hist", nom_hist.values(flow=True).shape)
-    print("nom_hist_sum", nom_hist_sum.values(flow=True).shape)
 
     variation_data = hist_in.view(flow=True) - nom_hist.view(flow=True)[..., None] + nom_hist_sum.view(flow=True)[..., *len(gen_sum_expr)*[None], None]
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -388,7 +388,7 @@ def add_qcdScale_hist(results, df, axes, cols, base_name="nominal", addhelicity=
 def add_qcdScaleByHelicityUnc_hist(results, df, helper, axes, cols, base_name="nominal", addhelicity=False):
     name = Datagroups.histName(base_name, syst="qcdScaleByHelicity")
     if "helicityWeight_tensor" not in df.GetColumnNames():
-        df = df.Define("helicityWeight_tensor", helper, ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "scaleWeights_tensor", "nominal_weight"])
+        df = df.Define("helicityWeight_tensor", helper, ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhi", "nominal_weight"])
     if addhelicity:
         qcdbyHelicity, qcdbyHelicity_axes = make_qcdscale_helper_helicity(helper.tensor_axes)
         df = df.Define('scaleWeights_tensor_wnom_helicity', qcdbyHelicity, ['helicityWeight_tensor', 'helWeight_tensor'])
@@ -575,8 +575,8 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
     ## here should probably not force using the same ptVgen axis when addhelicity=True
     #scale_axes = [*axes, axis_chargeVgen] if addhelicity else [*axes, axis_ptVgen, axis_chargeVgen]
     #scale_cols = [*cols, "chargeVgen"] if addhelicity else [*cols, "ptVgen", "chargeVgen"]
-    scale_axes = [*axes, axis_ptVgen, axis_chargeVgen]
-    scale_cols = [*cols, "ptVgen", "chargeVgen"]
+    scale_axes = [*axes, axis_ptVgen]
+    scale_cols = [*cols, "ptVgen"]
 
     df = theory_tools.define_scale_tensor(df)
     df = define_mass_weights(df, dataset_name)

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -8,6 +8,7 @@ import lz4.frame
 import pickle
 import re
 import glob
+import h5py
 from .correctionsTensor_helper import makeCorrectionsTensor
 from utilities import boostHistHelpers as hh, common, logging
 from utilities.io_tools import input_tools
@@ -170,6 +171,102 @@ def make_corr_by_helicity(ref_helicity_hist, target_sigmaul, target_sigma4, coef
 
     corr_coeffs = set_corr_ratio_flow(corr_coeffs)
     return corr_coeffs
+
+def make_qcd_uncertainty_helper_by_helicity(is_w_like = False, filename=None):
+    if filename is None:
+        filename = f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
+
+    # load moments from file
+    with h5py.File(filename, "r") as h5file:
+        results = narf.ioutils.pickle_load_h5py(h5file["results"])
+        moments = results["Z"] if is_w_like else results["W"]
+
+    moments_nom = moments[{"muRfact" : 1.j, "muFfact" : 1.j}].values()
+
+    # set disallowed combinations of mur/muf equal to nominal
+    moments.values()[..., 0, 2] = moments_nom
+    moments.values()[..., 2, 0] = moments_nom
+
+    # flatten scale variations and compute envelope
+    moments_flat = np.reshape(moments.values(), (*moments.values().shape[:-2], -1))
+    moments_min = np.min(moments_flat, axis=-1)
+    moments_max = np.max(moments_flat, axis=-1)
+
+    # build variation histogram in the format expected by the corrector
+    corr_ax = hist.axis.Boolean(name="corr")
+
+    def get_names(ihel):
+        base_name = f"helicity_{ihel}"
+        return f"{base_name}_Down", f"{base_name}_Up"
+
+    var_names = []
+    for ihel in range(-1, 8):
+        var_names.extend(get_names(ihel))
+
+    vars_ax = hist.axis.StrCategory(var_names, name="vars")
+
+    axes_no_scale = moments.axes[:-2]
+    corr_coeffs = hist.Hist(*axes_no_scale, corr_ax, vars_ax)
+
+    # set all moments equal to nominal
+    corr_coeffs.values()[...] = moments_nom[..., None, None]
+
+    # set envelope variations
+    for ihel in range(-1, 8):
+        downvar, upvar = get_names(ihel)
+
+        corr_coeffs.values()[..., ihel+1, 1, var_names.index(downvar)] = moments_min[..., ihel+1]
+        corr_coeffs.values()[..., ihel+1, 1, var_names.index(upvar)] = moments_max[..., ihel+1]
+
+    helper = makeCorrectionsTensor(corr_coeffs, ROOT.wrem.CentralCorrByHelicityHelper, tensor_rank=3)
+
+    # override tensor_axes since the output is different here
+    helper.tensor_axes = [vars_ax]
+
+    return helper
+
+def make_helicity_test_corrector(is_w_like = False, filename = None):
+
+    # load moments from file
+    with h5py.File(filename, "r") as h5file:
+        results = narf.ioutils.pickle_load_h5py(h5file["results"])
+        moments = results["Z"] if is_w_like else results["W"]
+
+    coeffs = theory_tools.moments_to_angular_coeffs(moments)
+
+    coeffs_nom = coeffs[{"muRfact" : 1.j, "muFfact" : 1.j}].values()
+
+    corr_ax = hist.axis.Boolean(name="corr")
+    vars_ax = hist.axis.StrCategory(["test_ai", "test_sigmaUL","test_all"], name="vars")
+
+    axes_no_scale = coeffs.axes[:-2]
+    corr_coeffs = hist.Hist(*axes_no_scale, corr_ax, vars_ax)
+
+    corr_coeffs.values()[...] = coeffs_nom[..., None, None]
+
+    # set synthetic test variation
+    corr_coeffs.values()[..., 1, 1, 0] *= 1.1
+
+    corr_coeffs.values()[..., :, 1, 1] *= 1.1
+
+    corr_coeffs.values()[..., :, 1, 2] *= 1.1
+    corr_coeffs.values()[..., 1, 1, 2] *= 1.2
+    corr_coeffs.values()[..., 2, 1, 2] *= 1.3
+    corr_coeffs.values()[..., 3, 1, 2] *= 1.4
+    corr_coeffs.values()[..., 4, 1, 2] *= 1.5
+    corr_coeffs.values()[..., 5, 1, 2] *= 1.6
+    corr_coeffs.values()[..., 6, 1, 2] *= 1.7
+    corr_coeffs.values()[..., 7, 1, 2] *= 1.8
+    corr_coeffs.values()[..., 8, 1, 2] *= 1.9
+
+    print("corr_coeffs", corr_coeffs)
+
+    helper = makeCorrectionsTensor(corr_coeffs, ROOT.wrem.CentralCorrByHelicityHelper, tensor_rank=3)
+
+    # override tensor_axes since the output is different here
+    helper.tensor_axes = [vars_ax]
+
+    return helper
 
 def make_angular_coeff(sigmai_hist, ul_hist):
     return hh.divideHists(sigmai_hist, ul_hist, cutoff=0.0001)

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -379,8 +379,6 @@ def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_cen
 
         var_axis = helpers[generator].tensor_axes[-1]
 
-        print("var_axis", var_axis)
-
         def is_flavor_dependent_np(var_label):
             return var_label.startswith("Omega") \
                     or var_label.startswith("Delta_Omega") \

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -379,15 +379,23 @@ def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_cen
 
         var_axis = helpers[generator].tensor_axes[-1]
 
-        # special treatment for Omega since it needs to be decorrelated in charge and rapidity
-        if isinstance(var_axis, hist.axis.StrCategory) and any(var_label.startswith("Omega") for var_label in var_axis):
-            omegaidxs = [var_axis.index(var_label) for var_label in var_axis if var_label.startswith("Omega")]
+        print("var_axis", var_axis)
+
+        def is_flavor_dependent_np(var_label):
+            return var_label.startswith("Omega") \
+                    or var_label.startswith("Delta_Omega") \
+                    or var_label.startswith("Lambda2") \
+                    or var_label.startswith("Delta_Lambda2")
+
+        # special treatment for Lambda2/Omega since they need to be decorrelated in charge and possibly rapidity
+        if isinstance(var_axis, hist.axis.StrCategory) and any(is_flavor_dependent_np(var_label) for var_label in var_axis):
+            omegaidxs = [var_axis.index(var_label) for var_label in var_axis if is_flavor_dependent_np(var_label)]
 
             # include nominal as well
             omegaidxs = [0] + omegaidxs
 
             if f"{generator}Omega" not in df.GetColumnNames():
-                df = df.Define(f"{generator}Omega",
+                df = df.Define(f"{generator}FlavDepNP",
                                 f"""
                                 constexpr std::array<std::ptrdiff_t, {len(omegaidxs)}> idxs = {{{",".join([str(idx) for idx in omegaidxs])}}};
                                 Eigen::TensorFixedSize<double, Eigen::Sizes<{len(omegaidxs)}>> res;
@@ -397,14 +405,14 @@ def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_cen
                                 return res;
                                 """)
 
-            axis_Omega = hist.axis.StrCategory([var_axis[idx] for idx in omegaidxs], name = var_axis.name)
+            axis_FlavDepNP = hist.axis.StrCategory([var_axis[idx] for idx in omegaidxs], name = var_axis.name)
 
-            hist_name_Omega = f"{name}_{generator}Omega"
+            hist_name_FlavDepNP = f"{name}_{generator}FlavDepNP"
             axis_chargegen = axis_chargeWgen if isW else axis_chargeZgen
-            axes_Omega = axes + [axis_absYVgen, axis_chargegen]
-            cols_Omega = cols + ["absYVgen", "chargeVgen", f"{generator}Omega"]
-            unc_Omega = df.HistoBoost(hist_name_Omega, axes_Omega, cols_Omega, tensor_axes = [axis_Omega])
-            res.append(unc_Omega)
+            axes_FlavDepNP = axes + [axis_absYVgen, axis_chargegen]
+            cols_FlavDepNP = cols + ["absYVgen", "chargeVgen", f"{generator}FlavDepNP"]
+            unc_FlavDepNP = df.HistoBoost(hist_name_FlavDepNP, axes_FlavDepNP, cols_FlavDepNP, tensor_axes = [axis_FlavDepNP])
+            res.append(unc_FlavDepNP)
 
     return res
 


### PR DESCRIPTION
MiNNLO scale variations are reworked to be based on envelopes of helicity cross sections rather than per-event weights, since these are subject to large statistical fluctuations due to the large variance in the weight distributions.

In addition, inclusive variations for each helicity cross section (except for sigma_-1) are added on top of the pt-binned variations in order to protect against underestimating the correlated part of the uncertainty.

There are also several fixes/improvements to the NP uncertainties:
-Delta_Lambda2 was missing (trivial bug)
-Lambda2/Delta_Lambda2 parameters (and Omega) are now decorrelated in gen charge, even for the non-binned case
-Lambda4 is now treated as a fully correlated parameter since we assume that any x and flavour dependence in this model is contained in Lambda2 and/or Delta_Lambda2