### PR TITLE
Add theory agnostic analysis with POI as NOI to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,8 +150,9 @@ jobs:
           submodules: 'recursive'
           lfs: 'true'
 
+      # run this with --theoryAgnostic --poiAsNoi since it only adds one histogram without changing anything else
       - name: wmass analysis
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_with_mu_eta_pt.py -j $((NTHREADS)) --maxFiles $((MAX_FILES)) --forceDefaultName -o $WREMNANTS_OUTDIR
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mw_with_mu_eta_pt.py -j $((NTHREADS)) --maxFiles $((MAX_FILES)) --forceDefaultName -o $WREMNANTS_OUTDIR --theoryAgnostic --poiAsNoi
 
   w-fit:
     # The type of runner that the job will run on
@@ -191,6 +192,16 @@ jobs:
 
       - name: wmass combine impacts
         run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh $WREMNANTS_OUTDIR/WMass_eta_pt_charge/fitresults_123456789.root $WEB_DIR/$PLOT_DIR impactsW.html
+
+      # theory agnostic with POI as NOI
+      - name: wmass theory agnostic combine setup
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --lumiScale $LUMI_SCALE -o ${WREMNANTS_OUTDIR}/theoryAgnostic_poisAsNoi/ --theoryAgnostic --poiAsNoi
+
+      - name: wmass theory agnostic combine fit
+        run: cmssw-cc7 --command-to-run scripts/ci/run_combine.sh /home/c/cmsmwbot/combinetf/CMSSW_10_6_30/src/ mass ${WREMNANTS_OUTDIR}/theoryAgnostic_poisAsNoi/WMass_eta_pt_charge WMass_plus.txt WMass_minus.txt 
+
+      - name: wmass combine impacts
+        run: scripts/ci/run_with_singularity.sh scripts/ci/show_impacts.sh ${WREMNANTS_OUTDIR}/theoryAgnostic_poisAsNoi/WMass_eta_pt_charge/fitresults_123456789.root $WEB_DIR/$PLOT_DIR impactsW_theoryAgnostic.html
 
   w-plotting:
     # The type of runner that the job will run on

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -75,11 +75,19 @@ def make_parser(parser=None):
     parser.add_argument("--poiAsNoi", action='store_true', help="Experimental option only with --theoryAgnostic or --unfolding, to treat POIs ad NOIs, with a single signal histogram")
     parser.add_argument("--priorNormXsec", type=float, default=1, help="Prior for shape uncertainties on cross sections for theory agnostic or unfolding analysis with POIs as NOIs (1 means 100\%). If negative, it will use shapeNoConstraint in the fit")
     parser.add_argument("--scaleNormXsecHistYields", type=float, default=None, help="Scale yields of histogram with cross sections variations for theory agnostic analysis with POIs as NOIs. Can be used together with --priorNormXsec")
-    parser.add_argument("--noNormNuisanceOOA", action='store_true', help="Remove normalization uncertainty on out-of-acceptance template bins. Currently only with --poiAsNoi")
     parser.add_argument("--addTauToSignal", action='store_true', help="Events from the same process but from tau final states are added to the signal")
     # utility options to deal with charge when relevant, mainly for theory agnostic but also unfolding
     parser.add_argument("--recoCharge", type=str, default=["plus", "minus"], nargs="+", choices=["plus", "minus"], help="Specify reco charge to use, default uses both. This is a workaround for unfolding/theory-agnostic fit when running a single reco charge, as gen bins with opposite gen charge have to be filtered out")
     parser.add_argument("--forceRecoChargeAsGen", action="store_true", help="Force gen charge to match reco charge in CardTool, this only works when the reco charge is used to define the channel")
+    # TODO: some options that should exist only for a specific case, can implement a subparser to substitute --unfolding and --theoryAgnostic
+    # some options are actually in common between them, so an intermediate subparser might be used
+    ##parsers = parser.add_subparsers(dest='analysisFitSetup')
+    ##theoryAgnosticParser = parsers.add_parser("unfolding", help="Activate unfolding analysis")
+    ##theoryAgnosticParser = parsers.add_parser("theoryAgnostic", help="Activate theory agnostic analysis")
+    ##theoryAgnosticParser.add_argument("--noPDFandQCDtheorySystOnSignal", action='store_true', help="Removes PDF and theory uncertainties on signal processes with norm uncertainties when using --poiAsNoi")
+    #
+    # WIP parser.add_argument("--noNormNuisanceOOA", action='store_true', help="Remove normalization uncertainty on out-of-acceptance template bins. Only implemented with --poiAsNoi")
+    parser.add_argument("--noPDFandQCDtheorySystOnSignal", action='store_true', help="Removes PDF and theory uncertainties on signal processes with norm uncertainties when using --poiAsNoi")
 
     return parser
 
@@ -524,7 +532,14 @@ def setup(args, inputFile, fitvar, xnorm=False):
         scale_pdf_unc=args.scalePdf,
         minnlo_unc=args.minnloScaleUnc,
     )
-    theory_helper.add_all_theory_unc(nonsig=not xnorm)
+
+    theorySystSamples = ["signal_samples_inctau", "single_v_nonsig_samples"]
+    if xnorm:
+        theorySystSamples = ["signal_samples"]
+    if args.noPDFandQCDtheorySystOnSignal:
+        theorySystSamples = "single_v_nonsig_samples"
+
+    theory_helper.add_all_theory_unc(theorySystSamples, skipFromSignal=args.noPDFandQCDtheorySystOnSignal)
 
     if xnorm or datagroups.mode == "vgen":
         return cardTool
@@ -549,21 +564,6 @@ def setup(args, inputFile, fitvar, xnorm=False):
     if not args.noEfficiencyUnc:
 
         if not lowPU:
-
-            ## this is only needed when using 2D SF from 3D with ut-integration, let's comment for now
-            # if wmass:
-            #     cardTool.addSystematic("sf2d", 
-            #         processes=['MCnoQCD'],
-            #         outNames=["sf2dDown","sf2dUp"],
-            #         group="SF3Dvs2D",
-            #         scale = 1.0,
-            #         mirror = True,
-            #         mirrorDownVarEqualToNomi=False, # keep False, True is pathological
-            #         noConstraint=False,
-            #         systAxes=[],
-            #         #labelsByAxis=["downUpVar"],
-            #         passToFakes=passSystToFakes,
-            #     )
 
             chargeDependentSteps = common.muonEfficiency_chargeDependentSteps
             effTypesNoIso = ["reco", "tracking", "idip", "trigger"]

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -269,6 +269,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
         cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
         if not xnorm:
             cardTool.addProcessGroup("single_v_nonsig_samples", lambda x: assertSample(x, startsWith=ZMatch, excludeMatch=dibosonMatch))
+            cardTool.addProcessGroup("single_v_nonsig_samples_inctau", lambda x: assertSample(x, startsWith=[*ZMatch, "Wtaunu"], excludeMatch=dibosonMatch))
     cardTool.addProcessGroup("single_vmu_samples",    lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples",        lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples_inctau", lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch]))
@@ -537,7 +538,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
 
     to_fakes = passSystToFakes and not args.noQCDscaleFakes and not xnorm
     
-    theory_helper = combine_theory_helper.TheoryHelper(cardTool)
+    theory_helper = combine_theory_helper.TheoryHelper(cardTool, wmass)
     theory_helper.configure(resumUnc=args.resumUnc, 
         propagate_to_fakes=to_fakes,
         np_model=args.npUnc,
@@ -553,7 +554,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     if xnorm:
         theorySystSamples = ["signal_samples"]
     if args.noPDFandQCDtheorySystOnSignal:
-        theorySystSamples = "single_v_nonsig_samples"
+        theorySystSamples = "single_v_nonsig_samples_inctau"
 
     theory_helper.add_all_theory_unc(theorySystSamples, skipFromSignal=args.noPDFandQCDtheorySystOnSignal)
 

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -538,7 +538,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
 
     to_fakes = passSystToFakes and not args.noQCDscaleFakes and not xnorm
     
-    theory_helper = combine_theory_helper.TheoryHelper(cardTool, wmass)
+    theory_helper = combine_theory_helper.TheoryHelper(cardTool, hasNonsigSamples=(wmass and not xnorm))
     theory_helper.configure(resumUnc=args.resumUnc, 
         propagate_to_fakes=to_fakes,
         np_model=args.npUnc,

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -267,9 +267,9 @@ def setup(args, inputFile, fitvar, xnorm=False):
     cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
     if wmass:
         cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
+        cardTool.addProcessGroup("wtau_samples", lambda x: assertSample(x, startsWith=["Wtaunu"]))
         if not xnorm:
             cardTool.addProcessGroup("single_v_nonsig_samples", lambda x: assertSample(x, startsWith=ZMatch, excludeMatch=dibosonMatch))
-            cardTool.addProcessGroup("single_v_nonsig_samples_inctau", lambda x: assertSample(x, startsWith=[*ZMatch, "Wtaunu"], excludeMatch=dibosonMatch))
     cardTool.addProcessGroup("single_vmu_samples",    lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples",        lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples_inctau", lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch]))
@@ -554,7 +554,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     if xnorm:
         theorySystSamples = ["signal_samples"]
     if args.noPDFandQCDtheorySystOnSignal:
-        theorySystSamples = "single_v_nonsig_samples_inctau"
+        theorySystSamples = ["wtau_samples", "single_v_nonsig_samples"]
 
     theory_helper.add_all_theory_unc(theorySystSamples, skipFromSignal=args.noPDFandQCDtheorySystOnSignal)
 

--- a/utilities/styles/styles.py
+++ b/utilities/styles/styles.py
@@ -82,6 +82,7 @@ common_groups = [
     "CMS_recoil",
     "CMS_background",
     "theory_ew",
+    "normXsecW"
 ]
 nuisance_groupings = {
     "max": common_groups + [

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -11,7 +11,7 @@ class TheoryHelper(object):
     def __init__(self, card_tool, hasNonsigSamples=False):
         toCheck = ['signal_samples', 'signal_samples_inctau', 'single_v_samples']
         if hasNonsigSamples:
-            toCheck.extend(['single_v_nonsig_samples', 'single_v_nonsig_samples_inctau'])
+            toCheck.extend(['single_v_nonsig_samples', 'wtau_samples'])
         for group in toCheck:
             if group not in card_tool.procGroups:
                 raise ValueError(f"Must define '{group}' procGroup in CardTool for theory uncertainties")
@@ -236,7 +236,7 @@ class TheoryHelper(object):
         logger.debug(f"Selected TNP nuisances: {selected_tnp_nuisances}")
 
         self.card_tool.addSystematic(name=self.corr_hist_name,
-            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
             group="resumTNP",
             splitGroup={"resum": ".*"},
             systAxes=["vars"],
@@ -303,7 +303,7 @@ class TheoryHelper(object):
 
 
         self.card_tool.addSystematic(name=self.corr_hist_name,
-            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
             passToFakes=self.propagate_to_fakes,
             systAxes=[self.syst_ax],
             action=lambda h: h[{self.syst_ax : var_vals}],
@@ -421,7 +421,7 @@ class TheoryHelper(object):
         pdf_ax = self.syst_ax if from_corr else "pdfVar"
         symHessian = pdfInfo["combine"] == "symHessian"
         pdf_args = dict(
-            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
             mirror=True if symHessian else False,
             group=pdfName,
             splitGroup={f"{pdfName}NoAlphaS": '.*'},
@@ -444,7 +444,7 @@ class TheoryHelper(object):
         # TODO: For now only MiNNLO alpha_s is supported
         asRange = pdfInfo['alphasRange']
         self.card_tool.addSystematic(f"{pdfName}alphaS{asRange}", 
-            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
             mirror=False,
             group=pdfName,
             splitGroup={f"{pdfName}AlphaS": '.*'},

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -8,8 +8,11 @@ logger = logging.child_logger(__name__)
 
 class TheoryHelper(object):
     valid_np_models = ["Lambda", "Omega", "Delta_Lambda", "Delta_Omega", "binned_Omega", "none"]
-    def __init__(self, card_tool):
-        for group in ['signal_samples', 'signal_samples_inctau', 'single_v_samples', 'single_v_nonsig_samples']:
+    def __init__(self, card_tool, wmass=False):
+        toCheck = ['signal_samples', 'signal_samples_inctau', 'single_v_samples']
+        if wmass:
+            toCheck.extend(['single_v_nonsig_samples', 'single_v_nonsig_samples_inctau'])
+        for group in toCheck:
             if group not in card_tool.procGroups:
                 raise ValueError(f"Must define '{group}' procGroup in CardTool for theory uncertainties")
         
@@ -233,7 +236,7 @@ class TheoryHelper(object):
         logger.debug(f"Selected TNP nuisances: {selected_tnp_nuisances}")
 
         self.card_tool.addSystematic(name=self.corr_hist_name,
-            processes=['single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
             group="resumTNP",
             splitGroup={"resum": ".*"},
             systAxes=["vars"],
@@ -300,7 +303,7 @@ class TheoryHelper(object):
 
 
         self.card_tool.addSystematic(name=self.corr_hist_name,
-            processes=['single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
             passToFakes=self.propagate_to_fakes,
             systAxes=[self.syst_ax],
             action=lambda h: h[{self.syst_ax : var_vals}],
@@ -418,7 +421,7 @@ class TheoryHelper(object):
         pdf_ax = self.syst_ax if from_corr else "pdfVar"
         symHessian = pdfInfo["combine"] == "symHessian"
         pdf_args = dict(
-            processes=['single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
             mirror=True if symHessian else False,
             group=pdfName,
             splitGroup={f"{pdfName}NoAlphaS": '.*'},
@@ -441,7 +444,7 @@ class TheoryHelper(object):
         # TODO: For now only MiNNLO alpha_s is supported
         asRange = pdfInfo['alphasRange']
         self.card_tool.addSystematic(f"{pdfName}alphaS{asRange}", 
-            processes=['single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+            processes=['single_v_nonsig_samples_inctau'] if self.skipFromSignal else ['single_v_samples'],
             mirror=False,
             group=pdfName,
             splitGroup={f"{pdfName}AlphaS": '.*'},

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -8,9 +8,9 @@ logger = logging.child_logger(__name__)
 
 class TheoryHelper(object):
     valid_np_models = ["Lambda", "Omega", "Delta_Lambda", "Delta_Omega", "binned_Omega", "none"]
-    def __init__(self, card_tool, wmass=False):
+    def __init__(self, card_tool, hasNonsigSamples=False):
         toCheck = ['signal_samples', 'signal_samples_inctau', 'single_v_samples']
-        if wmass:
+        if hasNonsigSamples:
             toCheck.extend(['single_v_nonsig_samples', 'single_v_nonsig_samples_inctau'])
         for group in toCheck:
             if group not in card_tool.procGroups:


### PR DESCRIPTION
Testing if it works. For the histogram it reuses the same file as for the traditional analysis, which is augmented with the yieldsTheoryAgnostic histogram. Then the setupCombine and fit parts are simply duplicated from the standard wmass workflow.

No change should be expected for the traditional analysis in the impacts and other plots. A new plot is added for the impact from the theory agnostic fit (but it is possible the fit doesn't even converge when using a small fraction of the MC stat, to be seen).