### PR TITLE
fixing bug in propagateToHelicityOption

### DIFF
--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -94,6 +94,7 @@ def build_graph(df, dataset):
 
     weight_expr = "std::copysign(1.0, genWeight)"
     df = df.Define("weight", weight_expr)
+    df = df.DefinePerSample("unity","1.")
     # This sum should happen before any change of the weight
     weightsum = df.SumAndCount("weight")
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -375,13 +375,14 @@ def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal", a
             alphaSHist = df.HistoBoost(alphaSHistName, axes, [*cols, tensorASName], tensor_axes=[as_ax], storage=hist.storage.Double())
 
             if propagateToHelicity:
-                df=df.Define("unity","1.")
+
                 pdfhelper = ROOT.wrem.makeHelicityMomentPdfTensor[npdf]()
                 df = df.Define(f"helicity_moments_{tensorName}_tensor", pdfhelper, ["csSineCosThetaPhi", f"{tensorName}", "unity"])
-                alphahelper = ROOT.wrem.makeHelicityMomentPdfTensor[2]()
+                alphahelper = ROOT.wrem.makeHelicityMomentPdfTensor[3]()
                 df = df.Define(f"helicity_moments_{tensorASName}_tensor", alphahelper, ["csSineCosThetaPhi", f"{tensorASName}", "unity"])
-                pdfHist_hel = df.HistoBoost(f"helicity_{pdfHistName}", axes, [*cols, f"helicity_moments_{tensorName}_tensor"], tensor_axes=[wremnants.axis_helicity,pdf_ax], storage=hist.storage.Double())
-                alphaSHist_hel = df.HistoBoost(f"helicity_{alphaSHistName}", axes, [*cols, f"helicity_moments_{tensorASName}_tensor"], tensor_axes=[wremnants.axis_helicity,as_ax], storage=hist.storage.Double())
+                pdfHist_hel = df.HistoBoost(f"helicity_{pdfHistName}", axes, [*cols, f"helicity_moments_{tensorName}_tensor"], tensor_axes=[axis_helicity,pdf_ax], storage=hist.storage.Double())
+                print(df.GetColumnType(f"helicity_moments_{tensorASName}_tensor"))
+                alphaSHist_hel = df.HistoBoost(f"helicity_{alphaSHistName}", axes, [*cols, f"helicity_moments_{tensorASName}_tensor"], tensor_axes=[axis_helicity,as_ax], storage=hist.storage.Double())
                 results.extend([pdfHist_hel, alphaSHist_hel])
 
         results.extend([pdfHist, alphaSHist])


### PR DESCRIPTION
This PR restores the possibility to run the gen distributions with the propagateToHelicityOption.
It should by construction pass the CI because it doesn't affect any code which isn't under that option. After we verify that I can merge it