### PR TITLE
Implementation of theory-motivated agnostic bands

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -355,41 +355,25 @@ def setup(args, inputFile, fitvar, xnorm=False):
             with h5py.File(f"{common.data_dir}/angularCoefficients/theoryband_variations.hdf5", "r") as ff:
                 scale_hists = narf.ioutils.pickle_load_h5py(ff["theorybands"])
             # First do in acceptance bins, then OOA later (for OOA we need to group bins into macro regions)
-            nuisanceBaseName = f"norm{label}_"
-            cardTool.addSystematic("yieldsTheoryAgnostic",
-                                   rename=f"normWplus",
-                                   **noi_args,
-                                   mirror=False,
-                                   systAxes=poi_axes+["downUpVar"],
-                                   processes=["signal_samples"],
-                                   baseName=f"normWplus_",
-                                   noConstraint=True if args.priorNormXsec < 0 else False,
-                                   scale=1,
-                                   formatWithValue=[None,None,"low",None],
-                                   #customizeNuisanceAttributes={".*AngCoeff4" : {"scale" : 1, "shapeType": "shapeNoConstraint"}},
-                                   labelsByAxis=["PtV", "YVBin", "Helicity","downUpVar"],
-                                   systAxesFlow=[], # only bins in acceptance in this call
-                                   skipEntries=[{"helicitySig" : [6,7,8]}], # removing last three indices out of 9 (0,1,...,7,8) corresponding to A5,6,7
-                                   actionMap={
-                                    m.name: (lambda h, scale_hist=scale_hists[m.name]: hh.addHists(h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}], hh.multiplyHists(hh.addGenericAxis(h,common.down_up_axis), hh.rescaleBandVariation(scale_hist,args.theoryAgnosticBandSize),flow=False), scale2=args.scaleNormXsecHistYields)) if "plus" in m.name else (lambda h: h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}]) for g in cardTool.procGroups["signal_samples"] for m in cardTool.datagroups.groups[g].members},
-                                   )
-            cardTool.addSystematic("yieldsTheoryAgnostic",
-                                   rename=f"normWminus",
-                                   **noi_args,
-                                   mirror=False,
-                                   systAxes=poi_axes+["downUpVar"],
-                                   processes=["signal_samples"],
-                                   baseName=f"normWminus_",
-                                   noConstraint=True if args.priorNormXsec < 0 else False,
-                                   scale=1,
-                                   formatWithValue=[None,None,"low",None],
-                                   #customizeNuisanceAttributes={".*AngCoeff4" : {"scale" : 1, "shapeType": "shapeNoConstraint"}},
-                                   labelsByAxis=["PtVBin", "YVBin", "Helicity", "downUpVar"],
-                                   systAxesFlow=[], # only bins in acceptance in this call
-                                   skipEntries=[{"helicitySig" : [6,7,8]}], # removing last three indices out of 9 (0,1,...,7,8) corresponding to A5,6,7
-                                   actionMap={
-                                    m.name: (lambda h, scale_hist=scale_hists[m.name]: hh.addHists(h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}], hh.multiplyHists(hh.addGenericAxis(h,common.down_up_axis), hh.rescaleBandVariation(scale_hist,args.theoryAgnosticBandSize),flow=False), scale2=args.scaleNormXsecHistYields)) if "minus" in m.name else (lambda h: h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}]) for g in cardTool.procGroups["signal_samples"] for m in cardTool.datagroups.groups[g].members},
-                                   )
+            nuisanceBaseName = f"norm{label}"
+            for sign in ["plus", "minus"]:
+                cardTool.addSystematic("yieldsTheoryAgnostic",
+                                    rename=f"{nuisanceBaseName}{sign}",
+                                    **noi_args,
+                                    mirror=False,
+                                    systAxes=poi_axes+["downUpVar"],
+                                    processes=["signal_samples"],
+                                    baseName=f"{nuisanceBaseName}{sign}_",
+                                    noConstraint=True if args.priorNormXsec < 0 else False,
+                                    scale=1,
+                                    formatWithValue=[None,None,"low",None],
+                                    #customizeNuisanceAttributes={".*AngCoeff4" : {"scale" : 1, "shapeType": "shapeNoConstraint"}},
+                                    labelsByAxis=["PtV", "YVBin", "Helicity","downUpVar"],
+                                    systAxesFlow=[], # only bins in acceptance in this call
+                                    skipEntries=[{"helicitySig" : [6,7,8]}], # removing last three indices out of 9 (0,1,...,7,8) corresponding to A5,6,7
+                                    actionMap={
+                                        m.name: (lambda h, scale_hist=scale_hists[m.name]: hh.addHists(h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}], hh.multiplyHists(hh.addGenericAxis(h,common.down_up_axis), hh.rescaleBandVariation(scale_hist,args.theoryAgnosticBandSize),flow=False))) if sign in m.name else (lambda h: h[{ax: hist.tag.Slicer()[::hist.sum] for ax in poi_axes}]) for g in cardTool.procGroups["signal_samples"] for m in cardTool.datagroups.groups[g].members},
+                                    )
             # now OOA
             nuisanceBaseNameOOA = f"{nuisanceBaseName}OOA_"
             # TODO: implement a loop to generalize it

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -10,6 +10,7 @@ from wremnants.datasets.dataset_tools import getDatasets
 import hist
 import math
 import os
+from utilities.differential import get_theoryAgnostic_axes
 
 
 parser.add_argument("--skipAngularCoeffs", action='store_true', help="Skip the conversion of helicity moments to angular coeff fractions")
@@ -40,6 +41,10 @@ axis_massWgen = hist.axis.Variable([5., 13000.], name="massVgen", underflow=True
 
 axis_massZgen = hist.axis.Regular(12, 60., 120., name="massVgen")
 
+theoryAgnostic_axes, _ = get_theoryAgnostic_axes()
+axis_ptV_thag = theoryAgnostic_axes[0]
+axis_yV_thag = theoryAgnostic_axes[1]
+
 if not args.useTheoryAgnosticBinning:
     axis_absYVgen = hist.axis.Variable(
         [0., 0.25, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 2.75, 3., 3.25, 3.5, 4., 5.], # this is the same binning as hists from theory corrections
@@ -47,7 +52,7 @@ if not args.useTheoryAgnosticBinning:
     )
 else:
     axis_absYVgen = hist.axis.Variable(
-        [0., 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 10.], #same axis as theory agnostic norms
+        axis_yV_thag.edges, #same axis as theory agnostic norms
         name = "absYVgen", underflow=False
     )
 
@@ -63,7 +68,7 @@ if not args.useTheoryAgnosticBinning:
 )
 else:
     axis_ptVgen = hist.axis.Variable(
-     [0., 3., 6., 9.62315204,12.36966732,16.01207711,21.35210602,29.50001253,60.,100.], #same axis as theory agnostic norms, 
+    axis_ptV_thag.edges, #same axis as theory agnostic norms, 
     #common.ptV_binning,
     name = "ptVgen", underflow=False,
 )

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -1,6 +1,8 @@
 from wremnants import plot_tools,theory_tools,histselections as sel
 from utilities import boostHistHelpers as hh
 from utilities.io_tools import input_tools, output_tools
+import hist
+import utilities.common
 import matplotlib.pyplot as plt
 from matplotlib import cm
 import numpy as np
@@ -9,9 +11,12 @@ import argparse
 import pathlib
 import os
 import pickle
-import lz4.frame
+import h5py
+import narf.ioutils
 import logging
 import shutil
+import copy
+from utilities.differential import get_theoryAgnostic_axes
 
 xlabels = {
     "pt" : r"p$_{T}^{\ell}$ (GeV)",
@@ -44,100 +49,120 @@ for pdf in args.pdfs:
     if pdf not in theory_tools.pdfMap:
         raise ValueError(f"pdf {pdf} is not a valid hist (not defined in theory_tools.pdfMap)")
 
-print(args.datasets[0][0])
-if "W" in args.datasets[0][0]:
-    xlabels["ptVgen"] = xlabels["ptVgen"].replace("Z", "W")
-    xlabels["absYVgen"] = xlabels["absYVgen"].replace("Z", "W")
-    xlabels["unrolled_gen"] = xlabels["unrolled_gen"].replace("Z", "W")
-    xlabels["unrolled_gen_hel"] = xlabels["unrolled_gen_hel"].replace("Z", "W")
+band_hists = {}
 
-pdfInfo = theory_tools.pdfMap 
-pdfNames = [pdfInfo[pdf]["name"] for pdf in args.pdfs]
-histNames = pdfNames if not args.baseName else [f"{args.baseName}_{pdfName}" for pdfName in pdfNames]
+for dataset in args.datasets:
+    if "W" in args.datasets[0][0]:
+        xlabels["ptVgen"] = xlabels["ptVgen"].replace("Z", "W")
+        xlabels["absYVgen"] = xlabels["absYVgen"].replace("Z", "W")
+        xlabels["unrolled_gen"] = xlabels["unrolled_gen"].replace("Z", "W")
+        xlabels["unrolled_gen_hel"] = xlabels["unrolled_gen_hel"].replace("Z", "W")
 
-pdfHists = input_tools.read_all_and_scale(args.infile, args.datasets, histNames)
-axis_label = "pdfVar"
+    pdfInfo = theory_tools.pdfMap 
+    pdfNames = [pdfInfo[pdf]["name"] for pdf in args.pdfs]
+    histNames = pdfNames if not args.baseName else [f"{args.baseName}_{pdfName}" for pdfName in pdfNames]
 
-uncType = [pdfInfo[pdf]["combine"] for pdf in args.pdfs]
-uncScale = [pdfInfo[pdf]["scale"] if "scale" in pdfInfo[pdf] else 1. for pdf in args.pdfs]
-uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(pdfHists, uncType, uncScale)]
-names = [[pdfName+" $\pm1\sigma$", "", ""] for pdfName in pdfNames]
-cmap = cm.get_cmap("tab10")
-colors = [[cmap(i)]*3 for i in range(len(args.pdfs))]
+    pdfHists = input_tools.read_all_and_scale(args.infile, args.datasets, histNames)
+    axis_label = "pdfVar"
 
-if "unrolled_gen_hel" in args.obs:
-    moments = input_tools.read_all_and_scale(args.infile, args.datasets, ["helicity_moments_scale"])
-    coeffs =  theory_tools.moments_to_angular_coeffs(moments[0].project('helicity','absYVgen','ptVgen','muRfact','muFfact'))
-    moments_pdf = input_tools.read_all_and_scale(args.infile, args.datasets, [f"helicity_{args.baseName}_{pdfName}" for pdfName in pdfNames])
-    coeffs_pdf = []
-    for moments in moments_pdf:
-        coeffs_pdf.append(theory_tools.moments_to_angular_coeffs(moments.project('helicity','absYVgen','ptVgen',axis_label)))
-    uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(coeffs_pdf, uncType, uncScale)]
+    uncType = [pdfInfo[pdf]["combine"] for pdf in args.pdfs]
+    uncScale = [pdfInfo[pdf]["scale"] if "scale" in pdfInfo[pdf] else 1. for pdf in args.pdfs]
+    uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(pdfHists, uncType, uncScale)]
+    names = [[pdfName+" $\pm1\sigma$", "", ""] for pdfName in pdfNames]
+    cmap = cm.get_cmap("tab10")
+    colors = [[cmap(i)]*3 for i in range(len(args.pdfs))]
 
-    # add alphaS
-    alphaNames = []
-    axis_label = "alphasVar"
-    for ipdf,pdf in enumerate(args.pdfs):
-        if pdfInfo[pdf]["alphasRange"] == "001":
-            alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS001")
-        else:
-            alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS002")
-        alphaHists = input_tools.read_all_and_scale(args.infile, args.datasets, alphaNames)
-        alphaHists_hel = []
-        for alphaHist in alphaHists:
-            alphaHists_hel.append(theory_tools.moments_to_angular_coeffs(alphaHist.project('helicity','absYVgen','ptVgen',axis_label)))
-        uncHists[ipdf].extend([alphaHists_hel[ipdf][...,0],alphaHists_hel[ipdf][...,1]])
-        names[ipdf].extend([pdfNames[ipdf]+"alpha $\pm1\sigma$",""])
-        colors[ipdf].extend([[cmap(i)]*2 for i in range(len(args.pdfs),2*len(args.pdfs))][0])
-    
-    # add QCD scales
-    # uncHists.append([coeffs[{"muRfact" : 2.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 0.5j, "muFfact" : 0.5j}],coeffs[{"muRfact" : 2.j, "muFfact" : 1.j}], coeffs[{"muRfact" : 0.5j, "muFfact" : 1.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 0.5j}]])
-    # names.append(["QCDscale_muRmuFUp","QCDscale_muRmuFDown","QCDscale_muRUp","QCDscale_muRDown","QCDscale_muFUp","QCDscale_muFDown"])
-    # colors.append([[cmap(i)]*6 for i in range(1)][0])
-    uncHists.append([coeffs[{'muRfact':1.j,'muFfact':1.j}]])
-    names.append(["QCDscale_central"])
-    colors.append([[cmap(i)]*1 for i in range(2*len(args.pdfs),2*len(args.pdfs)+1)][0])
+    if "unrolled_gen_hel" in args.obs:
+        moments = input_tools.read_all_and_scale(args.infile, args.datasets, ["nominal_gen_helicity_moments_scale"])
+        coeffs =  theory_tools.moments_to_helicities(moments[0].project('ptVgen','absYVgen','helicity','muRfact','muFfact'))
+        moments_pdf = input_tools.read_all_and_scale(args.infile, args.datasets, [f"helicity_{args.baseName}_{pdfName}" for pdfName in pdfNames])
+        coeffs_pdf = []
+        for moments in moments_pdf:
+            coeffs_pdf.append(theory_tools.moments_to_helicities(moments.project('ptVgen','absYVgen','helicity',axis_label)))
+        uncHists = [[h[{axis_label : 0}], *theory_tools.hessianPdfUnc(h, axis_label, unc, scale)] for h,unc,scale in zip(coeffs_pdf, uncType, uncScale)]
 
-# TODO
-#if args.together:
+        # add alphaS
+        # alphaNames = []
+        # axis_label = "alphasVar"
+        # for ipdf,pdf in enumerate(args.pdfs):
+        #     if pdfInfo[pdf]["alphasRange"] == "001":
+        #         alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS001")
+        #     else:
+        #         alphaNames.append(f"helicity_{args.baseName}_{pdfNames[ipdf]}alphaS002")
+        #     alphaHists = input_tools.read_all_and_scale(args.infile, args.datasets, alphaNames)
+        #     alphaHists_hel = []
+        #     for alphaHist in alphaHists:
+        #         alphaHists_hel.append(theory_tools.moments_to_angular_coeffs(alphaHist.project('helicity','absYVgen','ptVgen',axis_label)))
+        #     uncHists[ipdf].extend([alphaHists_hel[ipdf][...,0],alphaHists_hel[ipdf][...,1]])
+        #     names[ipdf].extend([pdfNames[ipdf]+"alpha $\pm1\sigma$",""])
+        #     colors[ipdf].extend([[cmap(i)]*2 for i in range(len(args.pdfs),2*len(args.pdfs))][0])
+        
+        # add QCD scales
+        uncHists.append([coeffs[{"muRfact" : 2.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 0.5j, "muFfact" : 0.5j}],coeffs[{"muRfact" : 2.j, "muFfact" : 1.j}], coeffs[{"muRfact" : 0.5j, "muFfact" : 1.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 2.j}],coeffs[{"muRfact" : 1.j, "muFfact" : 0.5j}]])
+        names.append(["QCDscale_muRmuFUp","QCDscale_muRmuFDown","QCDscale_muRUp","QCDscale_muRDown","QCDscale_muFUp","QCDscale_muFDown"])
+        colors.append([[cmap(i)]*6 for i in range(1)][0])
+        # uncHists.append([coeffs[{'muRfact':1.j,'muFfact':1.j}]])
+        # names.append(["QCDscale_central"])
+        # colors.append([[cmap(i)]*1 for i in range(2*len(args.pdfs),2*len(args.pdfs)+1)][0])
 
-outdir = output_tools.make_plot_dir(args.outpath, args.outfolder)
-plot_names = args.pdfs
-plot_names.append("QCD_scales")
+    outdir = output_tools.make_plot_dir(args.outpath, args.outfolder)
+    plot_names = copy.copy(args.pdfs)
+    plot_names.append("QCD_scales")
 
-for obs in args.obs:
-    all_hists = []
-    all_colors = []
-    all_names = []
-    for name,color,labels,hists in zip(plot_names,colors, names, uncHists):
-        # This is the reference
-        if not "unrolled" in obs:
-            action = lambda x: x.project(obs)
-            hists1D = [action(x) for x in hists]
-        else:
-            obs2unroll = ["absYVgen","ptVgen"] if "unrolled_gen" in obs else ["pt","eta"]
-            action = sel.unrolledHist
-            if not "hel" in obs:
-                hists1D = [action(x,obs2unroll,binwnorm=True) for x in hists]
+    theoryAgnostic_axes, _ = get_theoryAgnostic_axes(ptV_flow=True, absYV_flow=True)
+    axis_ptV = theoryAgnostic_axes[0]
+    axis_yV = theoryAgnostic_axes[1]
+
+    hvariations = hist.Hist(axis_ptV,axis_yV,uncHists[0][0].axes["helicity"],utilities.common.down_up_axis, name=f"theorybands_{dataset}")
+
+    print(hvariations)
+
+    for ihel in coeffs.axes["helicity"].edges[:-1]:
+        for obs in args.obs:
+            all_hists = []
+            all_colors = []
+            all_names = []
+            for name,color,labels,hists in zip(plot_names,colors, names, uncHists):
+                # This is the reference
+                if not "unrolled" in obs:
+                    action = lambda x: x.project(obs)
+                    hists1D = [action(x) for x in hists]
+                else:
+                    obs2unroll = ["ptVgen","absYVgen"] if "unrolled_gen" in obs else ["pt","eta"]
+                    action = sel.unrolledHist
+                    if not "hel" in obs:
+                        hists1D = [action(x,obs2unroll,binwnorm=True) for x in hists]
+                    else:
+                        hists1D = [action(x[{'helicity': ihel*1.j}],obs2unroll,binwnorm=True) for x in hists]
+
+                all_hists.extend(hists1D)
+                all_colors.extend(color)
+                all_names.extend(labels)
+            
+            # Add the nominal for reference
+            
+            hists1D = [all_hists[0], *all_hists]
+            plot_cols = [colors[0][0], *all_colors]
+            plot_labels = ["", *all_names]
+            # print([h.values() for h in hists1D])
+            fig = plot_tools.makePlotWithRatioToRef(hists1D, colors=plot_cols, labels=plot_labels, alpha=0.7,
+                rrange=args.rrange, ylabel="$\sigma$/bin", xlabel=xlabels[obs], rlabel=f"x/{args.pdfs[0].upper()}", binwnorm=None, nlegcols=1)
+            outfile = f"{name}Hist_{obs}_{args.channel}_sigma{ihel}"
+            ax1, ax2 = fig.axes
+            ax1.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D]),np.maximum.reduce([h.values() for h in hists1D]),color="grey",alpha=0.5, label="theory agnostic variation")
+            ax2.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D])/hists1D[0].values(),np.maximum.reduce([h.values() for h in hists1D])/hists1D[0].values(),color="grey",alpha=0.5, label="theory agnostic variation")
+            plot_tools.save_pdf_and_png(outdir, outfile)
+            plot_tools.write_index_and_log(outdir, outfile)
+
+            if ihel == -1:
+                variations = np.stack([0.5*np.ones_like(np.minimum.reduce([h.values() for h in hists1D])/hists1D[0].values()),0.5*np.ones_like(np.maximum.reduce([h.values() for h in hists1D])/hists1D[0].values())],axis=-1).reshape(len(uncHists[0][0].axes["ptVgen"]),len(uncHists[0][0].axes["absYVgen"]),2)
             else:
-                hists1D = [action(x[{'helicity': 6.j}],obs2unroll) for x in hists]
+                variations = np.stack([np.minimum.reduce([h.values() for h in hists1D])/hists1D[0].values(),np.maximum.reduce([h.values() for h in hists1D])/hists1D[0].values()],axis=-1).reshape(len(uncHists[0][0].axes["ptVgen"]),len(uncHists[0][0].axes["absYVgen"]),2)
 
-        all_hists.extend(hists1D)
-        all_colors.extend(color)
-        all_names.extend(labels)
-    
-    # Add the nominal for reference
-    
-    
-    hists1D = [all_hists[0], *all_hists]
-    plot_cols = [colors[0][0], *all_colors]
-    plot_labels = ["", *all_names]
-    print([h.values() for h in hists1D])
-    fig = plot_tools.makePlotWithRatioToRef(hists1D, colors=plot_cols, labels=plot_labels, alpha=0.7,
-        rrange=args.rrange, ylabel="$\sigma$/bin", xlabel=xlabels[obs], rlabel=f"x/{args.pdfs[0].upper()}", binwnorm=None, nlegcols=1)
-    outfile = f"{name}Hist_{obs}_{args.channel}_sigma6"
-    ax1, ax2 = fig.axes
-    ax1.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D]),np.maximum.reduce([h.values() for h in hists1D]),color="grey",alpha=0.5, label="theory agnostic variation")
-    ax2.fill_between(hists1D[0].axes[0].centers,np.minimum.reduce([h.values() for h in hists1D])/hists1D[0].values(),np.maximum.reduce([h.values() for h in hists1D])/hists1D[0].values(),color="grey",alpha=0.5, label="theory agnostic variation")
-    plot_tools.save_pdf_and_png(outdir, outfile)
-    plot_tools.write_index_and_log(outdir, outfile)
+            hvariations[{'helicity': ihel*1.j}][...] = variations
+
+        
+    band_hists[dataset] = hvariations
+outfile = "theoryband_variations.hdf5"
+with h5py.File(outfile, 'w') as f:
+    narf.ioutils.pickle_dump_h5py("theorybands", band_hists, f)

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -582,3 +582,23 @@ def swap_histogram_bins(histo, axis1, axis1_bin1, axis1_bin2, axis2=None, axis2_
     new_histo.view(flow=flow)[*slices2] = data[*slices1] if axis1_replace is None else data[*slicesR]
     new_histo.view(flow=flow)[*slices1] = data[*slices2] if axis1_replace is None else data[*slicesR]
     return new_histo
+
+def rescaleBandVariation(histo, factor):
+
+    if factor==1.:
+        return histo
+    else:
+        upper_env = histo.values()[...,1]
+        lower_env = histo.values()[...,0]
+
+        var = np.abs(upper_env-lower_env)/2
+        centr = (upper_env+lower_env)/2
+        new_upper = factor*var+centr
+        new_lower = -factor*var+centr
+
+        # leave sigmaUL variation to 50%
+        new_upper[...,0] = 1.5*np.ones((new_upper.shape[0],new_upper.shape[1]))
+        new_lower[...,0] = 0.5*np.ones((new_lower.shape[0],new_lower.shape[1]))
+
+        histo[...]= np.stack([new_lower,new_upper],axis=-1)
+        return histo

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -126,25 +126,25 @@ def multiplyWithVariance(vals1, vals2, vars1=None, vars2=None):
         
     return outvals, outvars
 
-def multiplyHists(h1, h2, allowBroadcast=True, createNew=True):
+def multiplyHists(h1, h2, allowBroadcast=True, createNew=True, flow=True):
     if allowBroadcast:
-        h1 = broadcastSystHist(h1, h2)
-        h2 = broadcastSystHist(h2, h1)
+        h1 = broadcastSystHist(h1, h2, flow=flow)
+        h2 = broadcastSystHist(h2, h1, flow=flow)
 
     if h1.storage_type == hist.storage.Double and h2.storage_type == hist.storage.Double:
         return h1*h2 
 
     with_variance = h1.storage_type == hist.storage.Weight and h2.storage_type == hist.storage.Weight
     outh = h1
-    vals, varis = multiplyWithVariance(h1.values(flow=True), h2.values(flow=True), 
-                        h1.variances(flow=True) if with_variance else None, h2.variances(flow=True) if with_variance else None)
+    vals, varis = multiplyWithVariance(h1.values(flow=flow), h2.values(flow=flow), 
+                        h1.variances(flow=flow) if with_variance else None, h2.variances(flow=flow) if with_variance else None)
 
     if createNew:
         outh = hist.Hist(*outh.axes, storage=outh.storage_type())
 
-    outh.values(flow=True)[...] = vals
+    outh.values(flow=flow)[...] = vals
     if varis is not None:
-        outh.variances(flow=True)[...] = varis
+        outh.variances(flow=flow)[...] = varis
 
     return outh
 

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -141,7 +141,6 @@ def multiplyHists(h1, h2, allowBroadcast=True, createNew=True, flow=True):
 
     if createNew:
         outh = hist.Hist(*outh.axes, storage=outh.storage_type())
-
     outh.values(flow=flow)[...] = vals
     if varis is not None:
         outh.variances(flow=flow)[...] = varis
@@ -216,6 +215,22 @@ def addSystAxis(h, size=1, offset=0):
         hnew[...] = newvals
     else:
         hnew = hist.Hist(*h.axes,hist.axis.Regular(size,offset,size+offset, name="systIdx"), storage=hist.storage.Weight())
+        # Broadcast to new shape
+        newvals = hnew.values()+h.values()[...,np.newaxis]
+        newvars = hnew.variances()+h.variances()[...,np.newaxis]
+        hnew[...] = np.stack((newvals, newvars), axis=-1)
+
+    return hnew
+
+def addGenericAxis(h, axis):
+
+    if h.storage_type == hist.storage.Double:
+        hnew = hist.Hist(*h.axes,axis)
+        # Broadcast to new shape
+        newvals = hnew.values()+h.values()[...,np.newaxis]
+        hnew[...] = newvals
+    else:
+        hnew = hist.Hist(*h.axes,axis, storage=hist.storage.Weight())
         # Broadcast to new shape
         newvals = hnew.values()+h.values()[...,np.newaxis]
         newvars = hnew.variances()+h.variances()[...,np.newaxis]

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -381,7 +381,6 @@ def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal", a
                 alphahelper = ROOT.wrem.makeHelicityMomentPdfTensor[3]()
                 df = df.Define(f"helicity_moments_{tensorASName}_tensor", alphahelper, ["csSineCosThetaPhi", f"{tensorASName}", "unity"])
                 pdfHist_hel = df.HistoBoost(f"helicity_{pdfHistName}", axes, [*cols, f"helicity_moments_{tensorName}_tensor"], tensor_axes=[axis_helicity,pdf_ax], storage=hist.storage.Double())
-                print(df.GetColumnType(f"helicity_moments_{tensorASName}_tensor"))
                 alphaSHist_hel = df.HistoBoost(f"helicity_{alphaSHistName}", axes, [*cols, f"helicity_moments_{tensorASName}_tensor"], tensor_axes=[axis_helicity,as_ax], storage=hist.storage.Double())
                 results.extend([pdfHist_hel, alphaSHist_hel])
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -122,6 +122,14 @@ pdfMap = {
         "alphas" : ["LHEPdfWeight[0]", "LHEPdfWeight[41]", "LHEPdfWeight[42]"],
         "alphasRange" : "002", # TODO: IS that true?
     },
+    "herapdf20" : {
+        "name" : "pdfHERAPDF20",
+        "branch" : "LHEPdfWeightAltSet20",
+        "combine" : "asymHessian",
+        "entries" : 29,
+        "alphas" : ["LHEPdfWeightAltSet20[0]", "LHEPdfWeightAltSet22[0]", "LHEPdfWeightAltSet23[0]"], # alphas 116-120
+        "alphasRange" : "002",
+    },
 }
 
 only_central_pdf_datasets = [

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -7,6 +7,7 @@ from utilities import boostHistHelpers as hh,common,logging
 from wremnants import theory_corrections
 from scipy import ndimage
 import narf.clingutils
+from math import sqrt
 
 logger = logging.child_logger(__name__)
 narf.clingutils.Declare('#include "theoryTools.h"')
@@ -448,6 +449,16 @@ def moments_to_angular_coeffs(hist_moments_scales, cutoff=1e-5):
     )
 
     return hist_coeffs_scales
+
+def moments_to_helicities(hist_moments_scales):
+    factors = np.array([1., 1./2., 1./(2.*sqrt(2.)), 1./4, 1./(4.*sqrt(2.)),1./2.,1./2.,1./(2.*sqrt(2.)),1./(4.*sqrt(2.))])
+    
+    hfactors = hist.Hist(hist_moments_scales.axes["helicity"],
+        data = factors
+            )
+    hist_moments_scales_new = hh.multiplyHists(hfactors,hist_moments_scales)
+
+    return hist_moments_scales_new
 
 def qcdByHelicityLabels():
     coeffs = ["const"]+[f"a{i}" for i in range(8)]


### PR DESCRIPTION
The bands can be produced using the script makePdfUncPlot.py and then are used by default by setupCombine to build the shapes. It's possible to increase the size of the band using the new option theoryAgnosticBandSize which defaults to 1. The size of the OOA is hardcoded to 1 and the variations on sigmaUL are always 50%, even if the band is increased. I also corrected a problem in the implementation that prevented the fit to run correctly when --hdf5 option is used. Everything has been tested locally and it works and the output makes sense. We wish to merge this ASAP (at most tomorrow morning) to run the bias tests with @jeyserma together with the traditional analysis, therefore @cippy and @davidwalter2 please tell me what you think.