### PR TITLE
Fix MiNNLO scale variations

### DIFF
--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -142,6 +142,9 @@ class TheoryHelper(object):
         skip_entries = []
         action_map = {}
 
+        # skip nominal
+        skip_entries.append({"vars" : "nominal"})
+
         # NOTE: The map needs to be keyed on the base procs not the group names, which is
         # admittedly a bit nasty
         expanded_samples = self.card_tool.getProcNames([sample_group])

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -202,6 +202,9 @@ def make_qcd_uncertainty_helper_by_helicity(is_w_like = False, filename=None):
     axes_no_scale = moments.axes[:-2]
     corr_coeffs = hist.Hist(*axes_no_scale, corr_ax, vars_ax)
 
+    # set all moments, including overflow/underflow to default safe value (leads to weight of 1.0 by construction)
+    corr_coeffs.values(flow=True)[...] = 1.
+
     # set all moments equal to nominal
     corr_coeffs.values()[...] = moments_nom[..., None, None]
 

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -194,6 +194,7 @@ def make_qcd_uncertainty_helper_by_helicity(is_w_like = False, filename=None):
         return f"{base_name}_Down", f"{base_name}_Up"
 
     var_names = []
+    var_names.append("nominal")
     for ihel in range(-1, 8):
         var_names.extend(get_names(ihel))
 


### PR DESCRIPTION
Fixes two critical issues with the MiNNLO QCD scale variations

1) Events in gen overflow bins were receiving NaN weights.  These events now receive no QCD scale variation. 
This was especially a problem for the Z where the gen mass range is 60-120GeV (and this is already flagged as something we need to improve by adding more gen bins on the left and right so that the number of events in gen underflow/overflow surviving the reco selection becomes smaller)
In the W case this was still leading to NaN in one or a few bins (probably from events where the W is in the gen rapidity overflow)

2) The nominal was not being included in the QCD scale variation histogram, breaking the logic of the hist_to_variations function (effectively adding a spurious term proportional to the sigmaUL down variation/nominal, explaining this infamous 0.97 factor)