### PR TITLE
Add qt/Q Variable in Gen Histmaker, will not change anything else

### DIFF
--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -251,10 +251,7 @@ def build_graph(df, dataset):
     return results, weightsum
 
 resultdict = narf.build_and_run(datasets, build_graph)
-if(args.ptqVgen):
-    output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('.py', f'_pdf_{args.pdfs[0]}_vars_qtbyQ.hdf5')}", args, update_name=not args.forceDefaultName)
-else:
-    output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args, update_name=not args.forceDefaultName)
+output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args, update_name=not args.forceDefaultName)
 
 logger.info("computing angular coefficients")
 z_moments = None

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -10,6 +10,7 @@ from wremnants.datasets.dataset_tools import getDatasets
 import hist
 import math
 import os
+import numpy as np
 from utilities.differential import get_theoryAgnostic_axes
 
 
@@ -22,6 +23,7 @@ parser.add_argument("--skipEWHists", action='store_true', help="Also store histo
 parser.add_argument("--signedY", action='store_true', help="use signed Y")
 parser.add_argument("--applySelection", action='store_true', help="Apply selection on leptons")
 parser.add_argument("--auxiliaryHistograms", action="store_true", help="Safe auxiliary histograms (mainly for ew analysis)")
+parser.add_argument("--ptqVgen", action='store_true', help="To store qt by Q variable instead of ptVgen")
 
 parser = common.set_parser_default(parser, "filterProcs", common.vprocs)
 parser = common.set_parser_default(parser, "theoryCorr", [])
@@ -74,6 +76,10 @@ else:
     name = "ptVgen", underflow=False,
 )
 
+axis_ptqVgen = hist.axis.Variable(
+    [round(x, 4) for x in list(np.arange(0, 0.1 + 0.0125, 0.0125))]+[round(x, 4) for x in list(np.arange(0.1+0.025, 0.5 + 0.025, 0.025))], name = "ptqVgen", underflow=False
+)
+
 axis_chargeWgen = hist.axis.Regular(
     2, -2, 2, name="chargeVgen", underflow=False, overflow=False
 )
@@ -119,13 +125,21 @@ def build_graph(df, dataset):
     df = theory_tools.define_theory_weights_and_corrs(df, dataset.name, corr_helpers, args)
 
     if isZ:
-        nominal_axes = [axis_massZgen, axis_rapidity, axis_ptVgen, axis_chargeZgen]
+        if(args.ptqVgen):
+            nominal_axes = [axis_massZgen, axis_rapidity, axis_ptqVgen, axis_chargeZgen]
+        else:
+            nominal_axes = [axis_massZgen, axis_rapidity, axis_ptVgen, axis_chargeZgen]
         lep_axes = [axis_l_eta_gen, axis_l_pt_gen, axis_chargeZgen]
     else:
-        nominal_axes = [axis_massWgen, axis_rapidity, axis_ptVgen, axis_chargeWgen]
+        if(args.ptqVgen):
+            nominal_axes = [axis_massWgen, axis_rapidity, axis_ptqVgen, axis_chargeWgen]
+        else:
+            nominal_axes = [axis_massWgen, axis_rapidity, axis_ptVgen, axis_chargeWgen]
         lep_axes = [axis_l_eta_gen, axis_l_pt_gen, axis_chargeWgen]
-
-    nominal_cols = ["massVgen", col_rapidity, "ptVgen", "chargeVgen"]
+    if(args.ptqVgen):
+        nominal_cols = ["massVgen", col_rapidity, "ptqVgen", "chargeVgen"]
+    else:
+        nominal_cols = ["massVgen", col_rapidity, "ptVgen", "chargeVgen"]
     lep_cols = ["etaPrefsrLep", "ptPrefsrLep", "chargeVgen"]
 
     if args.singleLeptonHists and (isW or isZ):
@@ -237,7 +251,10 @@ def build_graph(df, dataset):
     return results, weightsum
 
 resultdict = narf.build_and_run(datasets, build_graph)
-output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args, update_name=not args.forceDefaultName)
+if(args.ptqVgen):
+    output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('.py', f'_pdf_{args.pdfs[0]}_vars_qtbyQ.hdf5')}", args, update_name=not args.forceDefaultName)
+else:
+    output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args, update_name=not args.forceDefaultName)
 
 logger.info("computing angular coefficients")
 z_moments = None

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -23,7 +23,6 @@ parser.add_argument("--skipEWHists", action='store_true', help="Also store histo
 parser.add_argument("--signedY", action='store_true', help="use signed Y")
 parser.add_argument("--applySelection", action='store_true', help="Apply selection on leptons")
 parser.add_argument("--auxiliaryHistograms", action="store_true", help="Safe auxiliary histograms (mainly for ew analysis)")
-parser.add_argument("--ptqVgen", action='store_true', help="To store qt by Q variable instead of ptVgen")
 
 parser = common.set_parser_default(parser, "filterProcs", common.vprocs)
 parser = common.set_parser_default(parser, "theoryCorr", [])

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -23,6 +23,7 @@ parser.add_argument("--skipEWHists", action='store_true', help="Also store histo
 parser.add_argument("--signedY", action='store_true', help="use signed Y")
 parser.add_argument("--applySelection", action='store_true', help="Apply selection on leptons")
 parser.add_argument("--auxiliaryHistograms", action="store_true", help="Safe auxiliary histograms (mainly for ew analysis)")
+parser.add_argument("--ptqVgen", action='store_true', help="To store qt by Q variable instead of ptVgen, GEN only ", default=None)
 
 parser = common.set_parser_default(parser, "filterProcs", common.vprocs)
 parser = common.set_parser_default(parser, "theoryCorr", [])

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -125,21 +125,12 @@ def build_graph(df, dataset):
     df = theory_tools.define_theory_weights_and_corrs(df, dataset.name, corr_helpers, args)
 
     if isZ:
-        if(args.ptqVgen):
-            nominal_axes = [axis_massZgen, axis_rapidity, axis_ptqVgen, axis_chargeZgen]
-        else:
-            nominal_axes = [axis_massZgen, axis_rapidity, axis_ptVgen, axis_chargeZgen]
+        nominal_axes = [axis_massZgen, axis_rapidity, axis_ptqVgen if args.ptqVgen else axis_ptVgen, axis_chargeZgen]
         lep_axes = [axis_l_eta_gen, axis_l_pt_gen, axis_chargeZgen]
     else:
-        if(args.ptqVgen):
-            nominal_axes = [axis_massWgen, axis_rapidity, axis_ptqVgen, axis_chargeWgen]
-        else:
-            nominal_axes = [axis_massWgen, axis_rapidity, axis_ptVgen, axis_chargeWgen]
+        nominal_axes = [axis_massWgen, axis_rapidity, axis_ptqVgen if args.ptqVgen else axis_ptVgen, axis_chargeWgen]
         lep_axes = [axis_l_eta_gen, axis_l_pt_gen, axis_chargeWgen]
-    if(args.ptqVgen):
-        nominal_cols = ["massVgen", col_rapidity, "ptqVgen", "chargeVgen"]
-    else:
-        nominal_cols = ["massVgen", col_rapidity, "ptVgen", "chargeVgen"]
+    nominal_cols = ["massVgen", col_rapidity, "ptqVgen" if args.ptqVgen else "ptVgen", "chargeVgen"]
     lep_cols = ["etaPrefsrLep", "ptPrefsrLep", "chargeVgen"]
 
     if args.singleLeptonHists and (isW or isZ):

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -204,7 +204,6 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--genVars", type=str, nargs="+", default=["ptGen", "absEtaGen"], choices=["qGen", "ptGen", "absEtaGen", "ptVGen", "absYVGen"], help="Generator level variable")
     parser.add_argument("--genBins", type=int, nargs="+", default=[16, 0], help="Number of generator level bins")
     parser.add_argument("--poiAsNoi", action='store_true', help="Experimental option only with --theoryAgnostic or --unfolding, it will make the histogram to do the POIs as NOIs trick (some postprocessing will happen later in CardTool.py)")
-    parser.add_argument("--ptqVgen", action='store_true', help="To store qt by Q variable instead of ptVgen, GEN only ", default=None)
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -204,6 +204,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--genVars", type=str, nargs="+", default=["ptGen", "absEtaGen"], choices=["qGen", "ptGen", "absEtaGen", "ptVGen", "absYVGen"], help="Generator level variable")
     parser.add_argument("--genBins", type=int, nargs="+", default=[16, 0], help="Number of generator level bins")
     parser.add_argument("--poiAsNoi", action='store_true', help="Experimental option only with --theoryAgnostic or --unfolding, it will make the histogram to do the POIs as NOIs trick (some postprocessing will happen later in CardTool.py)")
+    parser.add_argument("--ptqVgen", action='store_true', help="To store qt by Q variable instead of ptVgen, GEN only ", default=None)
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -58,9 +58,9 @@ def write_analysis_output(results, outfile, args, update_name=True):
         to_append.append(args.theoryCorr[0]+"Corr")
     if args.maxFiles is not None:
         to_append.append(f"maxFiles_{args.maxFiles}".replace("-","m"))
-    if args.pdfs and args.pdfs != ["msht20"]:
+    if args.pdfs[0] != "msht20": 
         to_append.append(args.pdfs[0])
-    if args.ptqVgen:
+    if hasattr(args, "ptqVgen") and args.ptqVgen:
         to_append.append("vars_qtbyQ")
 
     if to_append and update_name:

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -58,6 +58,10 @@ def write_analysis_output(results, outfile, args, update_name=True):
         to_append.append(args.theoryCorr[0]+"Corr")
     if args.maxFiles is not None:
         to_append.append(f"maxFiles_{args.maxFiles}".replace("-","m"))
+    if args.pdfs and args.pdfs != ["msht20"]:
+        to_append.append(args.pdfs[0])
+    if args.ptqVgen:
+        to_append.append("vars_qtbyQ")
 
     if to_append and update_name:
         outfile = outfile.replace(".hdf5", f"_{'_'.join(to_append)}.hdf5")

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -62,7 +62,7 @@ pdfMap = {
     },
     "nnpdf30" : {
         "name" : "pdfNNPDF30",
-        "branch" : "LHEPdfWeightAltSet13",
+        "branch" : "LHEPdfWeightAltSet7",
         "combine" : "symHessian",
         "entries" : 101,
         "alphas" : ["LHEPdfWeightAltSet13[0]", "LHEPdfWeightAltSet15[0]", "LHEPdfWeightAltSet16[0]"],
@@ -167,6 +167,7 @@ def define_prefsr_vars(df):
     df = df.Define("genV", "ROOT::Math::PxPyPzEVector(genl)+ROOT::Math::PxPyPzEVector(genlanti)")
     df = df.Define("ptVgen", "genV.pt()")
     df = df.Define("massVgen", "genV.mass()")
+    df = df.Define("ptqVgen", "genV.pt()/genV.mass()")
     df = df.Define("yVgen", "genV.Rapidity()")
     df = df.Define("phiVgen", "genV.Phi()")
     df = df.Define("absYVgen", "std::fabs(yVgen)")


### PR DESCRIPTION
This PR primarily adds the boson qt bY Q variable. An option is included to select the axis ptqVgen. Subsequently, if-else conditions are implemented to store kinematics and calculate Ai with respect to this variable. Otherwise, it will proceed with ptVgen as is. Additionally, the NNPDF30 branch name has been fixed. I trust this modification will not impact or interfere with any other aspects of the code. 