### PR TITLE
Add extra herapdf20 uncertainties

### DIFF
--- a/utilities/common.py
+++ b/utilities/common.py
@@ -153,6 +153,8 @@ def common_parser(for_reco_highPU=False):
     class PDFFilterAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
             # Filter unique values, but keep first item in its position
+            if "herapdf20" in values:
+                values.append("herapdf20ext")
             unique_values = [values[0], *set([x for x in values[1:]])]
             setattr(namespace, self.dest, unique_values)
 

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -447,6 +447,18 @@ class TheoryHelper(object):
                 skipEntries=[{pdf_ax : "^pdf0[a-z]*"}],
                 **pdf_args
             )
+            if pdfName == 'pdfHERAPDF20':
+                self.card_tool.addSystematic(pdf_hist+'ext',
+                    skipEntries=[{pdf_ax : "^pdf0[a-z]*"}],
+                    processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+                    mirror=True,
+                    group=pdfName,
+                    splitGroup={f"{pdfName}NoAlphaS": '.*'},
+                    passToFakes=self.propagate_to_fakes,
+                    actionMap=action,
+                    scale=pdfInfo.get("scale", 1)*scale,
+                    systAxes=[pdf_ax],
+                )
 
         asRange = pdfInfo['alphasRange']
         asname = f"{pdfName}alphaS{asRange}" if not from_corr else pdf_hist.replace("Vars", "_pdfas")

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -350,7 +350,7 @@ def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal", a
         tensorASName = f"{pdfName}ASWeights_tensor"
         npdf=pdfInfo["entries"]
         pdfHistName = Datagroups.histName(base_name, syst=pdfName)
-        names = getattr(theory_tools, f"pdfNames{'Sym' if pdfInfo['combine'] == 'symHessian' else 'Asym'}Hessian")(pdfInfo["entries"]+(pdfInfo["entriesExt"] if "entriesExt" in pdfInfo else 0), pdfName)
+        names = getattr(theory_tools, f"pdfNames{'Sym' if pdfInfo['combine'] == 'symHessian' else 'Asym'}Hessian")(pdfInfo["entries"], pdfName)
         pdf_ax = hist.axis.StrCategory(names, name="pdfVar")
         if tensorName not in df.GetColumnNames():
             logger.warning(f"PDF {pdf} was not found for sample {dataset}. Skipping uncertainty hist!")

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -350,7 +350,7 @@ def add_pdf_hists(results, df, dataset, axes, cols, pdfs, base_name="nominal", a
         tensorASName = f"{pdfName}ASWeights_tensor"
         npdf=pdfInfo["entries"]
         pdfHistName = Datagroups.histName(base_name, syst=pdfName)
-        names = getattr(theory_tools, f"pdfNames{'Sym' if pdfInfo['combine'] == 'symHessian' else 'Asym'}Hessian")(pdfInfo["entries"], pdfName)
+        names = getattr(theory_tools, f"pdfNames{'Sym' if pdfInfo['combine'] == 'symHessian' else 'Asym'}Hessian")(pdfInfo["entries"]+(pdfInfo["entriesExt"] if "entriesExt" in pdfInfo else 0), pdfName)
         pdf_ax = hist.axis.StrCategory(names, name="pdfVar")
         if tensorName not in df.GetColumnNames():
             logger.warning(f"PDF {pdf} was not found for sample {dataset}. Skipping uncertainty hist!")

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -127,9 +127,15 @@ pdfMap = {
         "branch" : "LHEPdfWeightAltSet20",
         "combine" : "asymHessian",
         "entries" : 29,
-        "branchExt" : "LHEPdfWeightAltSet21",
-        "entriesExt": 13*2,
         "alphas" : ["LHEPdfWeightAltSet20[0]", "LHEPdfWeightAltSet22[0]", "LHEPdfWeightAltSet23[0]"], # alphas 116-120
+        "alphasRange" : "002",
+    },
+    "herapdf20ext" : {
+        "name" : "pdfHERAPDF20ext",
+        "branch" : "LHEPdfWeightAltSet21",
+        "combine" : "symHessian",
+        "entries" : 14,
+        "alphas" : ["LHEPdfWeightAltSet20[0]", "LHEPdfWeightAltSet22[0]", "LHEPdfWeightAltSet23[0]"], # dummy AS
         "alphasRange" : "002",
     },
 }
@@ -269,9 +275,6 @@ def define_pdf_columns(df, dataset_name, pdfs, noAltUnc):
 
         if pdfName == "pdfMSHT20":
             df = pdfBugfixMSHT20(df, tensorName)
-
-        if pdfName == "pdfHERAPDF20":
-            df = pdfHERAPDF20(df, tensorName, entries, pdfInfo["branchExt"], pdfInfo["entriesExt"])
 
         df = df.Define(tensorASName, f"Eigen::TensorFixedSize<double, Eigen::Sizes<{len(pdfInfo['alphas'])}>> res; " + \
                 " ".join([f"res({i}) = nominal_weight/central_pdf_weight*{p};" for i,p in enumerate(pdfInfo['alphas'])]) + \
@@ -564,24 +567,3 @@ def pdfBugfixMSHT20(df , tensorPDFName):
         f"auto& res = {tensorPDFName};"
         f"res(15) = {tensorPDFName}(0) - ({tensorPDFName}(15) - {tensorPDFName}(0));"
         "return res")
-
-def pdfHERAPDF20(df , tensorPDFName, entriesMain, branchExt, entriesExt):
-    # extend HERA pdfs with extra variations which should be symmetrized
-    # remove the first from the VAR branch, equal to the nominal
-    start = 0
-    entries_branch = 14 # total entries in the nano branch
-    df = df.Define(f"{tensorPDFName}_ext", f"auto res = wrem::clip_tensor(wrem::vec_to_tensor_t<double, {entries_branch}>({branchExt}, {start}), theory_weight_truncate); res = nominal_weight/central_pdf_weight*res; return res;")
-    df = df.Define(
-        f"{tensorPDFName}_ext_sym",
-        (f"Eigen::TensorFixedSize<double, Eigen::Sizes<{entriesMain+entriesExt}>> res;"
-        "for(int i=0; i<res.size(); i++) {"
-        f"   if(i < {entriesMain}) res(i) = {tensorPDFName}(i);"
-        "    else {"
-        f"      int k = i-{entriesMain}; res(i) = (k%2 == 0) ? {tensorPDFName}_ext(k/2+1) : ({tensorPDFName}(0) - ({tensorPDFName}_ext((k-1)/2+1) - {tensorPDFName}(0)));" # +1 to remove the first index
-        "    }"
-        "}"
-        "return res"
-        )
-    )
-    return df.Redefine(tensorPDFName, f"{tensorPDFName}_ext_sym")
-


### PR DESCRIPTION
Added the extra herapdf20 uncertainties: https://lhapdfsets.web.cern.ch/current/HERAPDF20_NLO_VAR/HERAPDF20_NLO_VAR.info

These uncertainties are symmetrized by symmetrizing the weights around the central value and concatenated to the main herapdf20 uncertainty tensor. Symmetrization is cross-checked as well as the propagation to the fit.

This PR doesn't change the main analysis as the herapdf20 is not used.