### PR TITLE
Threads and progress

### DIFF
--- a/scripts/ci/run_with_singularity.sh
+++ b/scripts/ci/run_with_singularity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export APPTAINER_BIND="/scratch,/eos,/cvmfs" 
-CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v23
+CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v25
 
 # Ensure kerberos permissions for eos access (requires systemd kerberos setup)
 if [ -d $XDG_RUNTIME_DIR/krb5cc ]; then

--- a/scripts/ci/run_with_singularity.sh
+++ b/scripts/ci/run_with_singularity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export APPTAINER_BIND="/scratch,/eos,/cvmfs" 
-CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v25
+CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v26
 
 # Ensure kerberos permissions for eos access (requires systemd kerberos setup)
 if [ -d $XDG_RUNTIME_DIR/krb5cc ]; then


### PR DESCRIPTION
Updated singularity image eliminates most spurious threads from Tensorflow Lite by adding a dedicated patch (previously one spurious thread per RDF-thread per tflite helper, now reduced to one thread in total for tflite)

Updated env variables in narf eliminate an addition ncores threads from Eigen.

Updated singularity image contains a general update of package versions, but also ROOT 6.30.02 (plus our patches for improved PyROOT debugging which aren't upstream yet)

narf has been adapted to implement a variation on the Progress Bar feature (but in a way which is compatible with RunGraphs)

Zero physics changes expected (but maybe some numerical differences/reshuffling depending)