### PR TITLE
Custom nano also for backgrounds

### DIFF
--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -40,8 +40,7 @@ datasets = getDatasets(maxFiles=args.maxFiles,
                        nanoVersion="v9",
                        base_path=args.dataPath,
                        extended = "msht20an3lo" not in args.pdfs,
-                       era = era,
-                       bkgPathTag="BKGV9" if args.noCustomBkgNano else "")
+                       era = era)
 
 # dilepton invariant mass cuts
 mass_min = 60
@@ -193,20 +192,20 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition, noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition)
 
     # for dilepton analysis we will call trigMuons (nonTrigMuons) those with charge plus (minus). In fact both might be triggering, naming scheme might be improved
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons", noCustomBkgNano=args.noCustomBkgNano)
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons", noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
 
     if args.useDileptonTriggerSelection:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0")
     else:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
 
     df = df.Define("ptll", "ll_mom4.pt()")
     df = df.Define("yll", "ll_mom4.Rapidity()")

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -35,12 +35,13 @@ thisAnalysis = ROOT.wrem.AnalysisType.Dilepton if args.useDileptonTriggerSelecti
 era = args.era
 
 datasets = getDatasets(maxFiles=args.maxFiles,
-                        filt=args.filterProcs,
-                        excl=args.excludeProcs, 
-                        nanoVersion="v9",
-                        base_path=args.dataPath,
-                        extended = "msht20an3lo" not in args.pdfs,
-                        era = era)
+                       filt=args.filterProcs,
+                       excl=args.excludeProcs, 
+                       nanoVersion="v9",
+                       base_path=args.dataPath,
+                       extended = "msht20an3lo" not in args.pdfs,
+                       era = era,
+                       bkgPathTag="BKGV9" if args.noCustomBkgNano else "")
 
 # dilepton invariant mass cuts
 mass_min = 60
@@ -192,20 +193,20 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition)
+    df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition, noCustomBkgNano=args.noCustomBkgNano)
 
     # for dilepton analysis we will call trigMuons (nonTrigMuons) those with charge plus (minus). In fact both might be triggering, naming scheme might be improved
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons", noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons", noCustomBkgNano=args.noCustomBkgNano)
 
     if args.useDileptonTriggerSelection:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0")
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", "nonTrigMuons_eta0", "nonTrigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
     else:
-        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
+        df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
 
     df = df.Define("ptll", "ll_mom4.pt()")
     df = df.Define("yll", "ll_mom4.Rapidity()")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -39,8 +39,7 @@ datasets = getDatasets(maxFiles=args.maxFiles,
                        excl=args.excludeProcs, 
                        nanoVersion="v9", base_path=args.dataPath,
                        extended = "msht20an3lo" not in args.pdfs,
-                       era=era,
-                       bkgPathTag="BKGV9" if args.noCustomBkgNano else "")
+                       era=era)
 
 # dilepton invariant mass cuts
 mass_min = 60
@@ -167,16 +166,16 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition, noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition)
 
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons", noCustomBkgNano=args.noCustomBkgNano)
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons", noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
 
-    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
 
     if dataset.is_data:
         df = df.DefinePerSample("nominal_weight", "1.0")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -35,11 +35,12 @@ thisAnalysis = ROOT.wrem.AnalysisType.Wlike
 era = args.era
 
 datasets = getDatasets(maxFiles=args.maxFiles,
-                        filt=args.filterProcs,
-                        excl=args.excludeProcs, 
-                        nanoVersion="v9", base_path=args.dataPath,
-                        extended = "msht20an3lo" not in args.pdfs,
-                        era=era)
+                       filt=args.filterProcs,
+                       excl=args.excludeProcs, 
+                       nanoVersion="v9", base_path=args.dataPath,
+                       extended = "msht20an3lo" not in args.pdfs,
+                       era=era,
+                       bkgPathTag="BKGV9" if args.noCustomBkgNano else "")
 
 # dilepton invariant mass cuts
 mass_min = 60
@@ -166,16 +167,16 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition)
+    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=True, isoDefinition=args.isolationDefinition, noCustomBkgNano=args.noCustomBkgNano)
 
     df = muon_selections.define_trigger_muons(df, what_analysis=thisAnalysis)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons")
-    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons")
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "trigMuons", noCustomBkgNano=args.noCustomBkgNano)
+    df = muon_selections.select_standalone_muons(df, dataset, args.trackerMuons, "nonTrigMuons", noCustomBkgNano=args.noCustomBkgNano)
 
-    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0")
+    df = muon_selections.apply_triggermatching_muon(df, dataset, "trigMuons_eta0", "trigMuons_phi0", noCustomBkgNano=args.noCustomBkgNano)
 
     if dataset.is_data:
         df = df.DefinePerSample("nominal_weight", "1.0")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -186,6 +186,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--recoilUnc", action='store_true', help="Run the recoil calibration with uncertainties (slower)")
     parser.add_argument("--highptscales", action='store_true', help="Apply highptscales option in MiNNLO for better description of data at high pT")
     parser.add_argument("--dataPath", type=str, default=None, help="Access samples from this path (default reads from local machine), for eos use 'root://eoscms.cern.ch//store/cmst3/group/wmass/w-mass-13TeV/NanoAOD/'")
+    parser.add_argument("--noCustomBkgNano", action='store_true', help="Don't use the custom NanoAOD for backgrounds (older central ones will be used)")
     parser.add_argument("--noVertexWeight", action='store_true', help="Do not apply reweighting of vertex z distribution in MC to match data")
     parser.add_argument("--validationHists", action='store_true', help="make histograms used only for validations")
     parser.add_argument("--onlyMainHistograms", action='store_true', help="Only produce some histograms, skipping (most) systematics to run faster when those are not needed")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -186,7 +186,6 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--recoilUnc", action='store_true', help="Run the recoil calibration with uncertainties (slower)")
     parser.add_argument("--highptscales", action='store_true', help="Apply highptscales option in MiNNLO for better description of data at high pT")
     parser.add_argument("--dataPath", type=str, default=None, help="Access samples from this path (default reads from local machine), for eos use 'root://eoscms.cern.ch//store/cmst3/group/wmass/w-mass-13TeV/NanoAOD/'")
-    parser.add_argument("--noCustomBkgNano", action='store_true', help="Don't use the custom NanoAOD for backgrounds (older central ones will be used)")
     parser.add_argument("--noVertexWeight", action='store_true', help="Do not apply reweighting of vertex z distribution in MC to match data")
     parser.add_argument("--validationHists", action='store_true', help="make histograms used only for validations")
     parser.add_argument("--onlyMainHistograms", action='store_true', help="Only produce some histograms, skipping (most) systematics to run faster when those are not needed")

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -24,8 +24,8 @@ dataDictV9 = {
     },
     'DYJetsToMuMuMass10to50PostVFP' : {
                    'filepaths' :
-                    ["{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
-                     "{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
+                    ["{BASE_PATH}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}",
+                     "{BASE_PATH}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                    'xsec' : common.xsec_ZmmMass10to50PostVFP,
                    'group': "DYlowMass",
     },
@@ -70,106 +70,106 @@ dataDictV9 = {
     },
     'TTLeptonicPostVFP' : { 
                           'filepaths' : 
-                          ["{BASE_PATH}/{BKG_PATH_TAG}/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+                          ["{BASE_PATH}/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                           'xsec' : 88.29,
                           'group' : "Top",
     },
 
     'TTSemileptonicPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/{BKG_PATH_TAG}/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"],
+                         ["{BASE_PATH}/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                          'xsec' : 366.34,
                          'group' : "Top",
     },
     'SingleTschanLepDecaysPostVFP' : { 
                                           'filepaths' : 
-                                          ["{BASE_PATH}/{BKG_PATH_TAG}/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"],
+                                          ["{BASE_PATH}/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                                           'xsec' : 3.609,
                                           'group' : "Top",
     },
     'SingleTtWAntitopPostVFP' : { 
                                      'filepaths' : 
-                                     ["{BASE_PATH}/{BKG_PATH_TAG}/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                     ["{BASE_PATH}/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                                      'xsec' : 19.55, # 35.85 * (1.0-((1-0.1086*3)*(1-0.1086*3))) = 19.5 pb
                                      'group' : "Top",
     },
     'SingleTtWTopPostVFP' : { 
                                      'filepaths' : 
-                                     ["{BASE_PATH}/{BKG_PATH_TAG}/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                     ["{BASE_PATH}/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                                      'xsec' : 19.55,
                                      'group' : "Top",
     },
     'SingleTtchanAntitopPostVFP' : { 
                                         'filepaths' : 
-                                        ["{BASE_PATH}/{BKG_PATH_TAG}/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                        ["{BASE_PATH}/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                                         'xsec' : 80.0,
                                         'group' : "Top",
     },
     'SingleTtchanTopPostVFP' : { 
                                     'filepaths' : 
-                                    ["{BASE_PATH}/{BKG_PATH_TAG}/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                    ["{BASE_PATH}/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
                                     'xsec' : 134.2,
                                     'group' : "Top",
     },   
     # inclusive samples, keep for reference
     # 'WWPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/{BKG_PATH_TAG}/WW_TuneCP5_13TeV-pythia8"],
+    #                 ["{BASE_PATH}/BKGV9/WW_TuneCP5_13TeV-pythia8"],
     #                 'xsec' : 118.7,
     #                 'group' : "Diboson",
     # },
     # 'WZPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/{BKG_PATH_TAG}/WZ_TuneCP5_13TeV-pythia8"],
+    #                 ["{BASE_PATH}/BKGV9/WZ_TuneCP5_13TeV-pythia8"],
     #                 'xsec' : 47.026760,  # to check, taken from WZTo1L1Nu2Q dividing by BR: 10.71/(3*0.1086)/(1-3*0.033658-0.2)
     #                 'group' : "Diboson",
     # },
     ##
     'WWTo2L2NuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+        ["{BASE_PATH}/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 12.6, # 118.7*0.1086*0.1086*9
         'group' : "Diboson",
     },
     'WWTo1L1Nu2QPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 52.146, # 118.7*[(3*0.1086)*(1-3*0.1086)]*2 (2 is because one W or the other can go to Q)
         'group' : "Diboson",
     },
     'WZTo3LNuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 4.91, # 4.42965*1.109, 1.109 is the NLO to NNLO kfactor, for this one would need to make sure about the NLO XS, depends a lot on the dilepton mass cut
         'group' : "Diboson",
     },
     'WZTo2Q2LPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 5.4341, # 4.9*1.109
         'group' : "Diboson",
     },
     'WZTo1L1Nu2QPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 11.781, # 10.71*1.10
         'group' : "Diboson",
     },
     'ZZTo2L2NuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8"],
+        ["{BASE_PATH}/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 0.60,
         'group' : "Diboson",
     },
     'ZZTo2Q2LPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 5.1,
         'group' : "Diboson",
     },
     'QCDmuEnrichPt15PostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/{BKG_PATH_TAG}/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8"],
+        ["{BASE_PATH}/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
         'xsec' : 238800,
         'group' : "QCD",
     }

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -25,7 +25,7 @@ dataDictV9 = {
     'DYJetsToMuMuMass10to50PostVFP' : {
                    'filepaths' :
                     ["{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
-                     #"{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
+                     "{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
                    'xsec' : common.xsec_ZmmMass10to50PostVFP,
                    'group': "DYlowMass",
     },

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -25,7 +25,7 @@ dataDictV9 = {
     'DYJetsToMuMuMass10to50PostVFP' : {
                    'filepaths' :
                     ["{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
-                     "{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
+                     #"{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
                    'xsec' : common.xsec_ZmmMass10to50PostVFP,
                    'group': "DYlowMass",
     },

--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -24,8 +24,8 @@ dataDictV9 = {
     },
     'DYJetsToMuMuMass10to50PostVFP' : {
                    'filepaths' :
-                    ["{BASE_PATH}/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
-                     "{BASE_PATH}/BKGV9/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
+                    ["{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos",
+                     "{BASE_PATH}/{BKG_PATH_TAG}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1"],
                    'xsec' : common.xsec_ZmmMass10to50PostVFP,
                    'group': "DYlowMass",
     },
@@ -70,106 +70,106 @@ dataDictV9 = {
     },
     'TTLeptonicPostVFP' : { 
                           'filepaths' : 
-                          ["{BASE_PATH}/BKGV9/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+                          ["{BASE_PATH}/{BKG_PATH_TAG}/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
                           'xsec' : 88.29,
                           'group' : "Top",
     },
 
     'TTSemileptonicPostVFP' : { 
                          'filepaths' : 
-                         ["{BASE_PATH}/BKGV9/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"],
+                         ["{BASE_PATH}/{BKG_PATH_TAG}/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8"],
                          'xsec' : 366.34,
                          'group' : "Top",
     },
     'SingleTschanLepDecaysPostVFP' : { 
                                           'filepaths' : 
-                                          ["{BASE_PATH}/BKGV9/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"],
+                                          ["{BASE_PATH}/{BKG_PATH_TAG}/ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-amcatnlo-pythia8"],
                                           'xsec' : 3.609,
                                           'group' : "Top",
     },
     'SingleTtWAntitopPostVFP' : { 
                                      'filepaths' : 
-                                     ["{BASE_PATH}/BKGV9/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                     ["{BASE_PATH}/{BKG_PATH_TAG}/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
                                      'xsec' : 19.55, # 35.85 * (1.0-((1-0.1086*3)*(1-0.1086*3))) = 19.5 pb
                                      'group' : "Top",
     },
     'SingleTtWTopPostVFP' : { 
                                      'filepaths' : 
-                                     ["{BASE_PATH}/BKGV9/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                     ["{BASE_PATH}/{BKG_PATH_TAG}/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8"],
                                      'xsec' : 19.55,
                                      'group' : "Top",
     },
     'SingleTtchanAntitopPostVFP' : { 
                                         'filepaths' : 
-                                        ["{BASE_PATH}/BKGV9/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                        ["{BASE_PATH}/{BKG_PATH_TAG}/ST_t-channel_antitop_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
                                         'xsec' : 80.0,
                                         'group' : "Top",
     },
     'SingleTtchanTopPostVFP' : { 
                                     'filepaths' : 
-                                    ["{BASE_PATH}/BKGV9/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
+                                    ["{BASE_PATH}/{BKG_PATH_TAG}/ST_t-channel_top_5f_InclusiveDecays_TuneCP5_13TeV-powheg-pythia8"],
                                     'xsec' : 134.2,
                                     'group' : "Top",
     },   
     # inclusive samples, keep for reference
     # 'WWPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/BKGV9/WW_TuneCP5_13TeV-pythia8"],
+    #                 ["{BASE_PATH}/{BKG_PATH_TAG}/WW_TuneCP5_13TeV-pythia8"],
     #                 'xsec' : 118.7,
     #                 'group' : "Diboson",
     # },
     # 'WZPostVFP' : { 
     #                 'filepaths' : 
-    #                 ["{BASE_PATH}/BKGV9/WZ_TuneCP5_13TeV-pythia8"],
+    #                 ["{BASE_PATH}/{BKG_PATH_TAG}/WZ_TuneCP5_13TeV-pythia8"],
     #                 'xsec' : 47.026760,  # to check, taken from WZTo1L1Nu2Q dividing by BR: 10.71/(3*0.1086)/(1-3*0.033658-0.2)
     #                 'group' : "Diboson",
     # },
     ##
     'WWTo2L2NuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8"],
         'xsec' : 12.6, # 118.7*0.1086*0.1086*9
         'group' : "Diboson",
     },
     'WWTo1L1Nu2QPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
         'xsec' : 52.146, # 118.7*[(3*0.1086)*(1-3*0.1086)]*2 (2 is because one W or the other can go to Q)
         'group' : "Diboson",
     },
     'WZTo3LNuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
         'xsec' : 4.91, # 4.42965*1.109, 1.109 is the NLO to NNLO kfactor, for this one would need to make sure about the NLO XS, depends a lot on the dilepton mass cut
         'group' : "Diboson",
     },
     'WZTo2Q2LPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
         'xsec' : 5.4341, # 4.9*1.109
         'group' : "Diboson",
     },
     'WZTo1L1Nu2QPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
         'xsec' : 11.781, # 10.71*1.10
         'group' : "Diboson",
     },
     'ZZTo2L2NuPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8"],
         'xsec' : 0.60,
         'group' : "Diboson",
     },
     'ZZTo2Q2LPostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8"],
         'xsec' : 5.1,
         'group' : "Diboson",
     },
     'QCDmuEnrichPt15PostVFP' : { 
         'filepaths' : 
-        ["{BASE_PATH}/BKGV9/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8"],
+        ["{BASE_PATH}/{BKG_PATH_TAG}/QCD_Pt-20_MuEnrichedPt15_TuneCP5_13TeV-pythia8"],
         'xsec' : 238800,
         'group' : "QCD",
     }

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -92,8 +92,7 @@ def buildFileList(path):
     return buildFileListXrd(path) if path.startswith(xrdprefix) else buildFileListPosix(path)
 
 #TODO add the rest of the samples!
-def makeFilelist(paths, maxFiles=-1, base_path=None, nano_prod_tags=None, is_data=False, oneMCfileEveryN=None,
-                 bkgPathTag=""):
+def makeFilelist(paths, maxFiles=-1, base_path=None, nano_prod_tags=None, is_data=False, oneMCfileEveryN=None):
     filelist = []
     expandedPaths = []
     for orig_path in paths:
@@ -102,7 +101,7 @@ def makeFilelist(paths, maxFiles=-1, base_path=None, nano_prod_tags=None, is_dat
         # try each tag in order until files are found
         fallback = False
         for prod_tag in nano_prod_tags:
-            format_args=dict(BASE_PATH=base_path, NANO_PROD_TAG=prod_tag, BKG_PATH_TAG=bkgPathTag)
+            format_args=dict(BASE_PATH=base_path, NANO_PROD_TAG=prod_tag)
 
             path = orig_path.format(**format_args)
             expandedPaths.append(path)
@@ -213,7 +212,7 @@ def is_zombie(file_path):
 
 def getDatasets(maxFiles=default_nfiles, filt=None, excl=None, mode=None, base_path=None, nanoVersion="v9",
                 data_tags=["TrackFitV722_NanoProdv3", "TrackFitV722_NanoProdv2"],
-                mc_tags=["TrackFitV722_NanoProdv3", "TrackFitV718_NanoProdv1"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True, bkgPathTag=""):
+                mc_tags=["TrackFitV722_NanoProdv3", "TrackFitV718_NanoProdv1"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True):
 
     if maxFiles is None or (isinstance(maxFiles, int) and maxFiles < -1):
         maxFiles=default_nfiles
@@ -253,7 +252,7 @@ def getDatasets(maxFiles=default_nfiles, filt=None, excl=None, mode=None, base_p
         nfiles = maxFiles
         if type(maxFiles) == dict:
             nfiles = maxFiles[sample] if sample in maxFiles else -1
-        paths = makeFilelist(info["filepaths"], nfiles, base_path=base_path, nano_prod_tags=prod_tags, is_data=is_data, oneMCfileEveryN=oneMCfileEveryN, bkgPathTag=bkgPathTag)
+        paths = makeFilelist(info["filepaths"], nfiles, base_path=base_path, nano_prod_tags=prod_tags, is_data=is_data, oneMCfileEveryN=oneMCfileEveryN)
 
         if checkFileForZombie:
             paths = [p for p in paths if not is_zombie(p)]

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -18,10 +18,10 @@ def select_veto_muons(df, nMuons=1):
 
     return df
 
-def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15):
+def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15, noCustomBkgNano=False):
 
     if use_trackerMuons:
-        if datasetGroup in bkgMCprocs:
+        if datasetGroup in bkgMCprocs and noCustomBkgNano:
             df = df.Define("Muon_category", "Muon_isTracker && Muon_highPurity")
         else:
             df = df.Define("Muon_category", "Muon_isTracker && Muon_innerTrackOriginalAlgo != 13 && Muon_innerTrackOriginalAlgo != 14 && Muon_highPurity")
@@ -31,7 +31,7 @@ def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuon
     goodMuonsSelection = f"Muon_correctedPt > {ptLow} && Muon_correctedPt < {ptHigh} && vetoMuons && Muon_mediumId && Muon_category"
     if use_isolation:
         # for w like we directly require isolated muons, for w we need non-isolated for qcd estimation
-        if isoDefinition == "iso04" or datasetGroup in bkgMCprocs: ## FIXME: at some point backgrounds may have all variables
+        if isoDefinition == "iso04" or (datasetGroup in bkgMCprocs and noCustomBkgNano):
             isoBranch = "Muon_pfRelIso04_all"
         elif isoDefinition == "iso04vtxAgn":
             isoBranch = "Muon_vtxAgnPfRelIso04_all"
@@ -100,8 +100,8 @@ def select_z_candidate(df, mass_min=60, mass_max=120):
 
     return df
 
-def apply_triggermatching_muon(df, dataset, muon_eta, muon_phi, otherMuon_eta=None, otherMuon_phi=None):
-    if dataset.group in bkgMCprocs:
+def apply_triggermatching_muon(df, dataset, muon_eta, muon_phi, otherMuon_eta=None, otherMuon_phi=None, noCustomBkgNano=False):
+    if dataset.group in bkgMCprocs and noCustomBkgNano:
         df = df.Define("goodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_pt,TrigObj_l1pt,TrigObj_l2pt,TrigObj_filterBits)")
     else:
         df = df.Define("goodTrigObjs", "wrem::goodMuonTriggerCandidate(TrigObj_id,TrigObj_filterBits)")
@@ -123,12 +123,12 @@ def veto_electrons(df):
     
     return df
 
-def select_standalone_muons(df, dataset, use_trackerMuons=False, muons="goodMuons", idx=0):
+def select_standalone_muons(df, dataset, use_trackerMuons=False, muons="goodMuons", idx=0, noCustomBkgNano=False):
 
     from utilities.common import muonEfficiency_standaloneNumberOfValidHits as nHitsSA
 
-    #standalone quantities, currently only in data and W/Z samples
-    if dataset.group in bkgMCprocs:
+    #standalone quantities, only available in custom NanoAOD
+    if dataset.group in bkgMCprocs and noCustomBkgNano:
         df = df.Alias(f"{muons}_SApt{idx}",  f"{muons}_pt{idx}")
         df = df.Alias(f"{muons}_SAeta{idx}", f"{muons}_eta{idx}")
         df = df.Alias(f"{muons}_SAphi{idx}", f"{muons}_phi{idx}")
@@ -145,7 +145,7 @@ def select_standalone_muons(df, dataset, use_trackerMuons=False, muons="goodMuon
     # the next cuts are mainly needed for consistency with the reco efficiency measurement for the case with global muons
     # note, when SA does not exist this cut is still fine because of how we define these variables
     df = df.Filter(f"{muons}_SApt{idx} > 15.0 && wrem::deltaR2({muons}_SAeta{idx}, {muons}_SAphi{idx}, {muons}_eta{idx}, {muons}_phi{idx}) < 0.09")
-    if nHitsSA > 0 and not use_trackerMuons and not dataset.group in bkgMCprocs:
+    if nHitsSA > 0 and not use_trackerMuons and not (dataset.group in bkgMCprocs and noCustomBkgNano):
         df = df.Filter(f"Muon_standaloneNumberOfValidHits[{muons}][{idx}] >= {nHitsSA}")
 
     return df


### PR DESCRIPTION
There is also an option to use the old central NanoAOD, --noCustomBkgNano.
This PR also builds the path to the background samples accordingly, since the old and new NanoAOD files are kept in separate places. People should copy all the new samples, which are currently on eos here [0] at the same level of the signal samples (old background NanoAODs are in the subfolder BKGV9 instead).

**NOTE**: The extension of low mass DY sample is still being copied on eos from Pisa tier 2 (should be ready in order of tens of minutes). In order to start validating this PR as soon as possible, I am temporarily excluding that part of the sample from the list of input paths. 
It has to be added back when the copy is over before merging this PR

[0] /eos/cms/store/cmst3/group/wmass/w-mass-13TeV/NanoAOD/