### PR TITLE
Fix asymmetric HDF5 writing and AlphaS for CT18

### DIFF
--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -377,6 +377,7 @@ class HDF5Writer(object):
                         raise NotImplementedError("By bin decorrelation is not supported for writing output in hdf5")
 
                     var_map = chanInfo.systHists(hvar, systKey)
+
                     var_names = [x[:-2] if "Up" in x[-2:] else (x[:-4] if "Down" in x[-4:] else x) 
                         for x in filter(lambda x: x != "", var_map.keys())]
                     # Deduplicate while keeping order
@@ -788,7 +789,7 @@ class HDF5Writer(object):
         self.book_logk(self.dict_logkavg, self.dict_logkavg_indices, self.dict_logkavg_values, *args)
     
     def book_logk_halfdiff(self, *args):
-        self.book_logk(self.dict_logkhalfdiff, self.dict_logkavg_indices, self.dict_logkavg_values, *args)
+        self.book_logk(self.dict_logkhalfdiff, self.dict_logkhalfdiff_indices, self.dict_logkhalfdiff_values, *args)
 
     def book_logk(self, dict_logk, dict_logk_indices, dict_logk_values, logk, chan, proc, syst_name):
         norm_proc = self.dict_norm[chan][proc]

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -788,7 +788,7 @@ class HDF5Writer(object):
         self.book_logk(self.dict_logkavg, self.dict_logkavg_indices, self.dict_logkavg_values, *args)
     
     def book_logk_halfdiff(self, *args):
-        self.book_logk(self.dict_logkavg, self.dict_logkavg_indices, self.dict_logkavg_values, *args)
+        self.book_logk(self.dict_logkhalfdiff, self.dict_logkavg_indices, self.dict_logkavg_values, *args)
 
     def book_logk(self, dict_logk, dict_logk_indices, dict_logk_values, logk, chan, proc, syst_name):
         norm_proc = self.dict_norm[chan][proc]

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -489,7 +489,7 @@ class TheoryHelper(object):
         pdfInfo = theory_tools.pdf_info_map("ZmumuPostVFP", pdf)
         pdfName = pdfInfo["name"]
         pdf_hist = pdfName
-        symmetrize = None
+        symmetrize = "average"
 
         if from_corr:
             theory_unc = input_tools.args_from_metadata(self.card_tool, "theoryCorr")

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -489,6 +489,7 @@ class TheoryHelper(object):
         pdfInfo = theory_tools.pdf_info_map("ZmumuPostVFP", pdf)
         pdfName = pdfInfo["name"]
         pdf_hist = pdfName
+        symmetrize = None
 
         if from_corr:
             theory_unc = input_tools.args_from_metadata(self.card_tool, "theoryCorr")
@@ -512,6 +513,7 @@ class TheoryHelper(object):
             passToFakes=self.propagate_to_fakes,
             preOpMap=operation,
             scale=pdfInfo.get("scale", 1)*scale,
+            symmetrize=symmetrize,
             systAxes=[pdf_ax],
         )
         if from_corr:
@@ -534,6 +536,7 @@ class TheoryHelper(object):
                     passToFakes=self.propagate_to_fakes,
                     preOpMap=operation,
                     scale=pdfInfo.get("scale", 1)*scale,
+                    symmetrize=symmetrize,
                     systAxes=[pdf_ax],
                 )
 
@@ -547,6 +550,7 @@ class TheoryHelper(object):
             splitGroup={f"{pdfName}AlphaS": '.*'},
             systAxes=["vars" if from_corr else "alphasVar"],
             scale=0.75 if asRange == "002" else 1.5,
+            symmetrize=symmetrize,
             passToFakes=self.propagate_to_fakes,
         )
         if from_corr:

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -46,7 +46,7 @@ pdfMap = {
         "branch" : "LHEPdfWeightAltSet11",
         "combine" : "asymHessian",
         "entries" : 59,
-        "alphas" : ["LHEPdfWeightAltSet11[0]", "LHEPdfWeightAltSet11[59]", "LHEPdfWeightAltSet18[62]"],
+        "alphas" : ["LHEPdfWeightAltSet11[0]", "LHEPdfWeightAltSet11[59]", "LHEPdfWeightAltSet11[62]"],
         "alphasRange" : "002",
         "scale" : 1/1.645 # Convert from 90% CL to 68%
     },


### PR DESCRIPTION
As in the title:

- Fix asymmetric writing in HDF5Writer (bug recently introduced in PR#357)
- Corrected the branch for AlphaS down variation for CT18
- Default average symmetrizing for PDFs

No impact on Asimov is expected, but this should fix asymmetric uncertainties in the bias tests.