### PR TITLE
Add additional symmetrization options and use 'quadratic' mode for PDFs, QCD scales and theory agnostic variations

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -405,7 +405,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                     rename=f"{nuisanceBaseName}{sign}",
                                     **noi_args,
                                     mirror=False,
-                                    symmetrize = "conservative",
+                                    symmetrize = "quadratic",
                                     systAxes=poi_axes+["downUpVar"],
                                     processes=["signal_samples"],
                                     baseName=f"{nuisanceBaseName}{sign}_",

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -372,7 +372,7 @@ class HDF5Writer(object):
                     logger.debug(f"Now at proc {proc}!")
 
                     hvar = dg.groups[proc].hists["syst"]
-                    
+
                     if syst["decorrByBin"]:
                         raise NotImplementedError("By bin decorrelation is not supported for writing output in hdf5")
 
@@ -385,7 +385,7 @@ class HDF5Writer(object):
                     norm_proc = self.dict_norm[chan][proc]
 
                     for var_name in var_names:
-                        kfac = syst["scale"]
+                        kfac=syst["scale"]
 
                         def get_logk(histname, var_type=""):
                             _hist = var_map[histname+var_type]
@@ -394,7 +394,7 @@ class HDF5Writer(object):
 
                             if not np.all(np.isfinite(_syst)):
                                 raise RuntimeError(f"{len(_syst)-sum(np.isfinite(_syst))} NaN or Inf values encountered in systematic {var_name}!")
-                            
+
                             # check if there is a sign flip between systematic and nominal
                             _logk = kfac*np.log(_syst/norm_proc)
                             _logk_view = np.where(np.equal(np.sign(norm_proc*_syst),1), _logk, self.logkepsilon*np.ones_like(_logk))
@@ -407,32 +407,50 @@ class HDF5Writer(object):
 
                             return _logk_view
 
+                        var_name_out = var_name
+
                         if syst["mirror"]:
                             logkavg_proc = get_logk(var_name)
                         elif syst["symmetrize"] is not None:
                             logkup_proc = get_logk(var_name, "Up")
-                            logkdown_proc = get_logk(var_name, "Down")
+                            logkdown_proc = -get_logk(var_name, "Down")
 
                             if syst["symmetrize"] == "conservative":
                                 # symmetrize by largest magnitude of up and down variations
-                                logkavg_proc = np.where(np.abs(logkup_proc) > np.abs(logkdown_proc), logkup_proc, -logkdown_proc)
-                            else:
+                                logkavg_proc = np.where(np.abs(logkup_proc) > np.abs(logkdown_proc), logkup_proc, logkdown_proc)
+                            elif syst["symmetrize"] == "average":
                                 # symmetrize by average of up and down variations
-                                logkavg_proc = 0.5*(logkup_proc - logkdown_proc)
+                                logkavg_proc = 0.5*(logkup_proc + logkdown_proc)
+                            elif syst["symmetrize"] in ["linear", "quadratic"]:
+                                # "linear" corresponds to a piecewise linear dependence of logk on theta
+                                # while "quadratic" corresponds to a quadratic dependence and leads
+                                # to a large variance
+                                diff_fact = np.sqrt(3.) if syst["symmetrize"]=="quadratic" else 1.
+
+                                # split asymmetric variation into two symmetric variations
+                                logkavg_proc = 0.5*(logkup_proc + logkdown_proc)
+                                logkdiffavg_proc = 0.5*diff_fact*(logkup_proc - logkdown_proc)
+
+                                var_name_out = var_name + "SymAvg"
+                                var_name_out_diff = var_name + "SymDiff"
+
+                                #special case, book the extra systematic
+                                self.book_logk_avg(logkdiffavg_proc, chan, proc, var_name_out_diff)
+                                self.book_systematic(syst, var_name_out_diff)
                         else:
                             logkup_proc = get_logk(var_name, "Up")
-                            logkdown_proc = get_logk(var_name, "Down")
+                            logkdown_proc = -get_logk(var_name, "Down")
 
-                            logkavg_proc = 0.5*(logkup_proc - logkdown_proc)
-                            logkhalfdiff_proc = 0.5*(logkup_proc + logkdown_proc)
+                            logkavg_proc = 0.5*(logkup_proc + logkdown_proc)
+                            logkhalfdiff_proc = 0.5*(logkup_proc - logkdown_proc)
 
                             logkup_proc = None
                             logkdown_proc = None
 
-                            self.book_logk_halfdiff(logkhalfdiff_proc, chan, proc, var_name)
+                            self.book_logk_halfdiff(logkhalfdiff_proc, chan, proc, var_name_out)
 
-                        self.book_logk_avg(logkavg_proc, chan, proc, var_name)
-                        self.book_systematic(syst, var_name)
+                        self.book_logk_avg(logkavg_proc, chan, proc, var_name_out)
+                        self.book_systematic(syst, var_name_out)
 
                     # free memory
                     for var in var_map.keys():

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -209,7 +209,7 @@ class TheoryHelper(object):
             self.card_tool.addSystematic(scale_hist,
                 preOpMap=preop_map,
                 preOpArgs=preop_args,
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 processes=[sample_group],
                 group=group_name,
                 splitGroup={"QCDscale": ".*"},
@@ -272,7 +272,7 @@ class TheoryHelper(object):
                 group="resumTransitionFOScale",
                 splitGroup={"resum": ".*"},
                 systAxes=[pt_ax, "vars"],
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 passToFakes=self.propagate_to_fakes,
                 preOp = preop_func,
                 preOpArgs = preop_args,
@@ -489,7 +489,7 @@ class TheoryHelper(object):
         pdfInfo = theory_tools.pdf_info_map("ZmumuPostVFP", pdf)
         pdfName = pdfInfo["name"]
         pdf_hist = pdfName
-        symmetrize = "average"
+        symmetrize = "quadratic"
 
         if from_corr:
             theory_unc = input_tools.args_from_metadata(self.card_tool, "theoryCorr")
@@ -590,7 +590,7 @@ class TheoryHelper(object):
                 group="resumTransitionFOScale",
                 splitGroup={"resum": ".*"},
                 systAxes=["vars"],
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 passToFakes=self.propagate_to_fakes,
                 preOp = lambda h: h[{"vars" : sel_vars}],
                 outNames=outNames,


### PR DESCRIPTION
Additional "linear" and "quadratic" symmetrization modes are added.

These work by splitting a single asymmetric variation into two symmetric variations in a way which preserves the covariance matrix of the event yields.

An assumption has to be made on the intended functional form for the dependence of the event yield on the nuisance parameter for the asymmetric variation.

"linear" assumes that ln(alternate/nominal) is a piecewise linear function with a discontinuity at theta=0, while "quadratic" assumes that it is a parabola passing through 0 at theta=0 and ln(up/nominal) and ln(down/nominal) at theta=+-1

"quadratic" leads to somewhat larger uncertainties for asymmetric variations since values of theta beyond +-1 imply a larger variation of event yields.

If the underlying variation is symmetric then all symmetrization options (including None) are completely equivalent.

The default option for symmetrize in addSystematic remains "average" since the new modes imply doubling the number of nuisance parameters.  The "quadratic" mode is now used for variations which are expected to be asymmetric (non-symmetric pdfs, qcd scales, theory agnostic norm variations)