### PR TITLE
Add correction that takes ptll MC/data ratio and applies this as ptVgen corr

### DIFF
--- a/scripts/corrections/make_ptv_corr.py
+++ b/scripts/corrections/make_ptv_corr.py
@@ -1,0 +1,52 @@
+from wremnants.datasets.datagroups import Datagroups
+from utilities import boostHistHelpers as hh, common, logging
+from utilities.io_tools import input_tools, output_tools
+import numpy as np
+import hist
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inputFile", type=str, required=True)
+parser.add_argument("--outpath", type=str, default=f"{common.data_dir}/TheoryCorrections", help="Output path")
+parser.add_argument("--debug", action='store_true', help="Print debug output")
+parser.add_argument("-p", "--postfix", type=str, help="Postfix for output file name", default=None)
+parser.add_argument("--proc", type=str, required=True, choices=["z", "w", ], help="Process")
+args = parser.parse_args()
+
+logger = logging.setup_logger("make_ptv_corr", 4 if args.debug else 3)
+
+nominalName = "nominal"
+syst = "uncorr"
+hist_name = syst
+datagroups = Datagroups(args.inputFile)
+
+if datagroups.mode != "dilepton":
+    raise ValueError("Expected input is the output from the dilepton histmaker")
+
+datagroups.setNominalName(nominalName)
+datagroups.loadHistsForDatagroups(nominalName, syst=syst)
+datagroups.addSummedProc(syst, name=syst, rename="MC_sum")
+
+groups = datagroups.getDatagroups()
+ratio = hh.divideHists(*[groups[x].hists[hist_name].project("ptll") for x in ['Data', 'MC_sum']])
+
+pt_ax = ratio.axes["ptll"]
+pt_ax._ax.metadata['name'] = "ptVgen"
+charge_ax = hist.axis.Regular(*(1, -1, 1) if args.proc == 'z' else (2, -2, 2), name="chargeVgen", flow=False)
+
+corrh = hist.Hist(hist.axis.Regular(1, 0, 13000, name="massVgen", flow=False), 
+                  hist.axis.Regular(1, 0, 10, name="absYVgen", underflow=False, overflow=True), 
+                  pt_ax, charge_ax, hist.axis.Regular(1, 0, 1, name="vars"))
+
+corrh[...] = ratio.values(flow=True)[np.newaxis,np.newaxis,:,np.newaxis, np.newaxis]
+
+output_dict = {
+    "MC_data_ratio" : corrh,
+    "data_hist" : groups['Data'].hists[hist_name],
+    "MC_sum_hist" : groups['MC_sum'].hists[hist_name],
+}
+
+meta_dict = input_tools.get_metadata(args.inputFile)
+outfile = args.outpath+"/dataPtll"
+output_tools.write_theory_corr_hist(outfile, args.proc.upper(), output_dict, args, meta_dict)
+logger.info(f"Average correction is {np.mean(corrh.values())}")

--- a/scripts/corrections/make_theory_corr.py
+++ b/scripts/corrections/make_theory_corr.py
@@ -135,6 +135,7 @@ logger.info(f"Minnlo norm in corr region is {nom_sum(minnloh)}, corrh norm is {n
 
 corrh = hist.Hist(*corrh_unc.axes, name=corrh_unc.name, storage=hist.storage.Double(), data=corrh_unc.values(flow=True))
 
+# Do it like this so name is modified in the output dict
 if args.postfix:
     args.generator += args.postfix
 outfile = f"{args.outpath}/{args.generator}"
@@ -170,7 +171,6 @@ norm_ratio = to_val(num_yield)/to_val(denom_yield)
 
 logger.info(f"Average correction is {np.average(corrh.values())}")
 logger.info(f"Normalization change (corr/minnlo) is {norm_ratio}")
-logger.info(f"Wrote file {outfile}")
 
 if args.plotdir:
     colors = {

--- a/scripts/corrections/make_theory_corr.py
+++ b/scripts/corrections/make_theory_corr.py
@@ -135,10 +135,10 @@ logger.info(f"Minnlo norm in corr region is {nom_sum(minnloh)}, corrh norm is {n
 
 corrh = hist.Hist(*corrh_unc.axes, name=corrh_unc.name, storage=hist.storage.Double(), data=corrh_unc.values(flow=True))
 
-# Do it like this so name is modified in the output dict
+generator = args.generator
 if args.postfix:
-    args.generator += args.postfix
-outfile = f"{args.outpath}/{args.generator}"
+    generator += args.postfix
+outfile = f"{args.outpath}/{generator}"
 
 meta_dict = {}
 for f in [args.minnlo_file]+args.corr_files:
@@ -153,8 +153,8 @@ for f in [args.minnlo_file]+args.corr_files:
         pass
 
 output_dict = {
-    f"{args.generator}_minnlo_ratio" : corrh,
-    f"{args.generator}_hist" : numh,
+    f"{generator}_minnlo_ratio" : corrh,
+    f"{generator}_hist" : numh,
     "minnlo_ref_hist" : minnloh,
 }
 
@@ -194,7 +194,7 @@ if args.plotdir:
         final_state = "\\ell\\ell" if args.proc == 'z' else ("\\ell^{+}\\nu" if charge.imag > 0 else "\\ell^{-}\\nu")
 
         outdir = output_tools.make_plot_dir(*args.plotdir.rsplit("/", 1), eoscp=args.eoscp)
-        plot_name = f"corr2D_{args.generator}_MiNNLO_{proc}"
+        plot_name = f"corr2D_{generator}_MiNNLO_{proc}"
         plot_tools.save_pdf_and_png(outdir, plot_name)
         plot_tools.write_index_and_log(outdir, plot_name, args=args, analysis_meta_info=meta_dict)
         
@@ -203,7 +203,7 @@ if args.plotdir:
                 [minnloh[{"charge" : charge}].project(varm),
                     numh[{"vars" : 0, "charge" : charge}].project(varn),
                 ],
-                ["MiNNLO", args.generator, 
+                ["MiNNLO", generator, 
                 ],
                 colors=["orange", "mediumpurple"], 
                 linestyles=["solid", "dashed", ],
@@ -215,7 +215,7 @@ if args.plotdir:
                 yscale=1.1,
                 xlim=None, binwnorm=1.0, baseline=True
             )
-            plot_name = f"{varm}_{args.generator}_MiNNLO_{proc}"
+            plot_name = f"{varm}_{generator}_MiNNLO_{proc}"
             plot_tools.save_pdf_and_png(outdir, plot_name)
             plot_tools.write_index_and_log(outdir, plot_name, args=args,
                 analysis_meta_info=meta_dict)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -69,6 +69,7 @@ args = parser.parse_args()
 thisAnalysis = ROOT.wrem.AnalysisType.Wmass
 
 era = args.era
+
 datasets = getDatasets(maxFiles=args.maxFiles,
                        filt=args.filterProcs,
                        excl=args.excludeProcs, 

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -16,7 +16,7 @@ import re
 import numpy as np
 
 parser = common.plot_parser()
-parser.add_argument("infile", help="Output file of the analysis stage, containing ND boost histogrdams")
+parser.add_argument("infile", help="Output file of the analysis stage, containing ND boost histograms")
 parser.add_argument("--ratioToData", action='store_true', help="Use data as denominator in ratio")
 parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file (e.g., 'nominal')", default="nominal")
 parser.add_argument("--nominalRef", type=str, help="Specify the nominal his if baseName is a variation hist (for plotting alt hists)")

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -297,3 +297,6 @@ else:
         chi2 = None
 
     make_plots(hist_data, hist_inclusive, hist_stack, axes, colors=colors, labels=labels, chi2=chi2, saturated_chi2=True)
+
+if output_tools.is_eosuser_path(args.outpath) and args.eoscp:
+    output_tools.copy_to_eos(args.outpath, args.outfolder)

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -83,7 +83,6 @@ def divideHists(h1, h2, cutoff=1e-5, allowBroadcast=True, rel_unc=False, cutoff_
     else:
         outh.values(flow=flow)[...] = val
 
-
     return outh
 
 def relVariance(hvals, hvars, cutoff=1e-5, fillOnes=False):

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -83,6 +83,7 @@ def divideHists(h1, h2, cutoff=1e-5, allowBroadcast=True, rel_unc=False, cutoff_
     else:
         outh.values(flow=flow)[...] = val
 
+
     return outh
 
 def relVariance(hvals, hvars, cutoff=1e-5, fillOnes=False):

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -630,3 +630,17 @@ def rescaleBandVariation(histo, factor):
 
         histo[...]= np.stack([new_lower,new_upper],axis=-1)
         return histo
+
+def rssHist(h, syst_axis, scale=1.):
+    s = hist.tag.Slicer()
+
+    hnom = h[{syst_axis : 0}]
+    hdiff = addHists(h, hnom, scale2=-1.)*scale
+    hss = multiplyHists(hdiff, hdiff)
+
+    hrss = sqrtHist(hss[{syst_axis : s[0:hist.overflow:hist.sum]}])
+    hUp = addHists(hnom, hrss)
+    hDown = addHists(hnom, hrss, scale2=-1.)
+
+    return hUp, hDown
+

--- a/utilities/io_tools/input_tools.py
+++ b/utilities/io_tools/input_tools.py
@@ -141,7 +141,7 @@ def flip_hist_y_sign(h, yaxis="Y"):
     h.values()[...] = h.values()*scale[(None if ax.name != yaxis else slice(0, ax.size) for ax in h.axes)]
     return h 
 
-def read_dyturbo_vars_hist(base_name, var_axis, axes, charge=None):
+def read_dyturbo_vars_hist(base_name, var_axis=None, axes=("Y", "qT"), charge=None):
 
     # map from scetlib fo variations naming to dyturbo naming
     # *FIXME* this is sensitive to presence or absence of trailing zeros for kappas
@@ -155,6 +155,8 @@ def read_dyturbo_vars_hist(base_name, var_axis, axes, charge=None):
         }
 
     var_hist = None
+    if var_axis is None:
+        var_axis=hist.axis.StrCategory(list(scales_map.keys()), name="vars")
 
     for i, var in enumerate(var_axis):
         if var.startswith("pdf"):
@@ -351,8 +353,6 @@ def read_matched_scetlib_dyturbo_hist(scetlib_resum, scetlib_fo_sing, dyturbo_fo
     htotal = hh.addHists(hresum, hnonsing, by_ax_name=False)
 
     return htotal
-
-
 
 def read_json(fIn):
 

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -134,7 +134,9 @@ def copy_to_eos(outpath, outfolder=None):
 def write_theory_corr_hist(output_name, process, output_dict, args=None, file_meta_data=None): 
     outname = output_name
     if args is not None and args.postfix is not None:
-        outname += f"_{args.postfix}"
+        # Don't add if the generator name is already modified
+        if args.postfix not in args.generator:
+            outname += f"{args.postfix}"
     output_filename = f"{outname}Corr{process}.pkl.lz4"
     logger.info(f"Write correction file {output_filename}")
     result_dict = {process : output_dict, "meta_data" : narf.ioutils.make_meta_info_dict(args, wd=common.base_dir)}

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -133,10 +133,6 @@ def copy_to_eos(outpath, outfolder=None):
 
 def write_theory_corr_hist(output_name, process, output_dict, args=None, file_meta_data=None): 
     outname = output_name
-    if args is not None and args.postfix is not None:
-        # Don't add if the generator name is already modified
-        if args.postfix not in args.generator:
-            outname += f"{args.postfix}"
     output_filename = f"{outname}Corr{process}.pkl.lz4"
     logger.info(f"Write correction file {output_filename}")
     result_dict = {process : output_dict, "meta_data" : narf.ioutils.make_meta_info_dict(args, wd=common.base_dir)}

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -55,6 +55,8 @@ def syst_transform_map(base_hist, hist_name):
     def projAx(hname):
         return hname.split("-")
 
+    resum_tnps = ['pdf0', 'gamma_cusp+1', 'gamma_mu_q+1', 'gamma_nu+1', 'h_qqV-0.5', 's+1', 'b_qqV+1', 'b_qqbarV+1', 'b_qqS+1', 'b_qqDS+1', 'b_qg+1']
+
     transforms.update({
         "resumFOScaleUp" : {
             "action" : lambda h: scetlibIdx(h, 2)},
@@ -74,21 +76,39 @@ def syst_transform_map(base_hist, hist_name):
                 ["transition_points0.2_0.65_1.1", "transition_points0.4_0.55_0.7", 
                 "transition_points0.2_0.45_0.7", "transition_points0.4_0.75_1.1", ],
                  no_flow=["ptVgen"], do_min=True)},
-       "resumTNPAllUp" : {
-           "action" : lambda h: h if "vars" not in h.axes.name else theory_tools.hessianPdfUnc(h[{"vars" :
-                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^gamma_", "^q_", "b_", "^s+", "^s-", "^h_"])]}], 
-                "vars", uncType="asymHessian")[0]},
-       "resumTNPAllDown" : {
-           "action" : lambda h: h if "vars" not in h.axes.name else theory_tools.hessianPdfUnc(h[{"vars" :
-                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^gamma_", "^q_", "b_", "^s+", "^s-", "^h_"])]}], 
-                "vars", uncType="asymHessian")[1]},
+       "resumTNPUp" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars")[0]
+        },
+       "resumTNPDown" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars")[1]
+        },
+       "resumTNPx5Up" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars", scale=5)[0]
+        },
+       "resumTNPx5Down" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars", scale=5)[1]
+        },
+       "resumTNPx12Up" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars", scale=12)[0]
+        },
+       "resumTNPx12Down" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.rssHist(h[{"vars" : resum_tnps}], "vars", scale=12)[1]
+        },
        "resumScaleAllUp" : {
            "action" : lambda h: h if "vars" not in h.axes.name else hh.syst_min_or_max_env_hist(h, projAx(hist_name), "vars",
-                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*",])],
+                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*", 'kappa.*', 'muf.*', ])],
                     do_min=False)},
        "resumScaleAllDown" : {
            "action" : lambda h: h if "vars" not in h.axes.name else hh.syst_min_or_max_env_hist(h, projAx(hist_name), "vars",
-                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*",])],
+                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*", 'kappa.*', 'muf.*', ])],
+                    do_min=True)},
+       "resumScaleUp" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.syst_min_or_max_env_hist(h, projAx(hist_name), "vars",
+                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*"])],
+                    do_min=False)},
+       "resumScaleDown" : {
+           "action" : lambda h: h if "vars" not in h.axes.name else hh.syst_min_or_max_env_hist(h, projAx(hist_name), "vars",
+                 [x for x in h.axes["vars"] if any(re.match(y, x) for y in ["pdf0", "^nuB.*", "nuS.*", "^muB.*", "^muS.*"])],
                     do_min=True)},
        "resumNPUp" : {
             "action" : lambda h: hh.syst_min_or_max_env_hist(h, projAx(hist_name), "vars", 

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -130,10 +130,6 @@ def postprocess_corr_hist(corrh):
 
     renorm_fact_resum_transition_scale_vars = renorm_fact_resum_scale_vars + transition_vars_exclusive
 
-    # avoid mucking with other correction hists...
-    if not all(x in corrh.axes["vars"] for x in renorm_fact_resum_scale_vars):
-        return corrh
-
     if all(var in corrh.axes["vars"] for var in renorm_scale_vars):
         additional_var_hists.update(compute_envelope(corrh, "renorm_scale_envelope", renorm_scale_vars))
 

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -130,6 +130,10 @@ def postprocess_corr_hist(corrh):
 
     renorm_fact_resum_transition_scale_vars = renorm_fact_resum_scale_vars + transition_vars_exclusive
 
+    # avoid mucking with other correction hists...
+    if not all(x in corrh.axes["vars"] for x in renorm_fact_resum_scale_vars):
+        return corrh
+
     if all(var in corrh.axes["vars"] for var in renorm_scale_vars):
         additional_var_hists.update(compute_envelope(corrh, "renorm_scale_envelope", renorm_scale_vars))
 
@@ -345,8 +349,6 @@ def make_helicity_test_corrector(is_w_like = False, filename = None):
     corr_coeffs.values()[..., 6, 1, 2] *= 1.7
     corr_coeffs.values()[..., 7, 1, 2] *= 1.8
     corr_coeffs.values()[..., 8, 1, 2] *= 1.9
-
-    print("corr_coeffs", corr_coeffs)
 
     helper = makeCorrectionsTensor(corr_coeffs, ROOT.wrem.CentralCorrByHelicityHelper, tensor_rank=3)
 

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -174,6 +174,8 @@ def postprocess_corr_hist(corrh):
 def get_corr_name(generator):
     # Hack for now
     label = generator.replace("1D", "")
+    if "dataPtll" in generator:
+        return "MC_data_ratio"
     return f"{label}_minnlo_ratio" if "Helicity" not in generator else f"{label.replace('Helicity', '')}_minnlo_coeffs"
 
 def rebin_corr_hists(hists, ndim=-1, binning=None):


### PR DESCRIPTION
* New corrector that can roughly be seen as reweighing the ptV to the data (more accurate would be to use the unfolded results). This is useful for studies of the bias from the ptV modeling
* Small plotting improvements (eoscp for postfix, ignore unc. in ratio if they don't exist in hist, TNPs added to syst map)
* Function to calculate sqrt(SS) of variations (useful for plotting)