### PR TITLE
allow histmaker to run only of processes without theory corrections

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -178,9 +178,9 @@ bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibrat
 
 procsWithTheoryCorr = [d.name for d in datasets if d.name in common.vprocs]
 if len(procsWithTheoryCorr):
-    corr_helpers = theory_corrections.load_corr_helpers([d.name for d in datasets if d.name in common.vprocs], args.theoryCorr)
+    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr)
 else:
-    corr_helpers = None
+    corr_helpers = {}
 
 # recoil initialization
 if not args.noRecoil:
@@ -229,10 +229,7 @@ def build_graph(df, dataset):
     # disable auxiliary histograms when unfolding to reduce memory consumptions
     auxiliary_histograms = not args.unfolding and not (args.theoryAgnostic and not args.poiAsNoi) and not args.noAuxiliaryHistograms
 
-    if len(procsWithTheoryCorr):
-        apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
-    else:
-        apply_theory_corr = False
+    apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
 
     cvh_helper = data_calibration_helper if dataset.is_data else mc_calibration_helper
     jpsi_helper = data_jpsi_crctn_helper if dataset.is_data else mc_jpsi_crctn_helper

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -176,7 +176,11 @@ smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing e
 
 bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibration else None
 
-corr_helpers = theory_corrections.load_corr_helpers([d.name for d in datasets if d.name in common.vprocs], args.theoryCorr)
+procsWithTheoryCorr = [d.name for d in datasets if d.name in common.vprocs]
+if len(procsWithTheoryCorr):
+    corr_helpers = theory_corrections.load_corr_helpers([d.name for d in datasets if d.name in common.vprocs], args.theoryCorr)
+else:
+    corr_helpers = None
 
 # recoil initialization
 if not args.noRecoil:
@@ -225,7 +229,10 @@ def build_graph(df, dataset):
     # disable auxiliary histograms when unfolding to reduce memory consumptions
     auxiliary_histograms = not args.unfolding and not (args.theoryAgnostic and not args.poiAsNoi) and not args.noAuxiliaryHistograms
 
-    apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
+    if len(procsWithTheoryCorr):
+        apply_theory_corr = args.theoryCorr and dataset.name in corr_helpers
+    else:
+        apply_theory_corr = False
 
     cvh_helper = data_calibration_helper if dataset.is_data else mc_calibration_helper
     jpsi_helper = data_jpsi_crctn_helper if dataset.is_data else mc_jpsi_crctn_helper

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -416,10 +416,7 @@ def define_nominal_weight(df):
 def define_theory_corr(df, dataset_name, helpers, generators, modify_central_weight):
     df = df.Define(f"nominal_weight_uncorr", build_weight_expr(df, exclude_weights=["theory_corr_weight"]))
 
-    if helpers is not None:
-        dataset_helpers = helpers.get(dataset_name, [])
-    else:
-        dataset_helpers = []
+    dataset_helpers = helpers.get(dataset_name, [])
 
     if not modify_central_weight or not generators or generators[0] not in dataset_helpers:
         df = df.DefinePerSample("theory_corr_weight", "1.0")

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -416,7 +416,10 @@ def define_nominal_weight(df):
 def define_theory_corr(df, dataset_name, helpers, generators, modify_central_weight):
     df = df.Define(f"nominal_weight_uncorr", build_weight_expr(df, exclude_weights=["theory_corr_weight"]))
 
-    dataset_helpers = helpers.get(dataset_name, [])
+    if helpers is not None:
+        dataset_helpers = helpers.get(dataset_name, [])
+    else:
+        dataset_helpers = []
 
     if not modify_central_weight or not generators or generators[0] not in dataset_helpers:
         df = df.DefinePerSample("theory_corr_weight", "1.0")


### PR DESCRIPTION
Just a small fix, the code was trying to produce the theory helpers also if no appropriate process is selected to run on, but this was leading to a crash. 

This fix allows one to run a command like the following 
python scripts/histmakers/mw_with_mu_eta_pt.py  --filterProcs QCD

The change is currently added only to the W histmaker since the use case was to run only on the QCD MC (in principle one may want to run on Top or Diboson but excluding both W and Z to run faster) to get histograms much faster. It may be propagated also to the other histmakers but for them I don't think the fix is needed.