### PR TITLE
make nMuon selection more flexible

### DIFF
--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -18,7 +18,7 @@ def select_veto_muons(df, nMuons=1, condition="=="):
 
     return df
 
-def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15, condition=""):
+def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15, condition="=="):
 
     if use_trackerMuons:
         df = df.Define("Muon_category", "Muon_isTracker && Muon_innerTrackOriginalAlgo != 13 && Muon_innerTrackOriginalAlgo != 14 && Muon_highPurity")

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -8,17 +8,17 @@ def apply_met_filters(df):
 
     return df
 
-def select_veto_muons(df, nMuons=1):
+def select_veto_muons(df, nMuons=1, condition="=="):
 
     # n.b. charge = -99 is a placeholder for invalid track refit/corrections (mostly just from tracks below
     # the pt threshold of 8 GeV in the nano production)
     df = df.Define("vetoMuonsPre", "Muon_looseId && abs(Muon_dxybs) < 0.05 && Muon_correctedCharge != -99")
     df = df.Define("vetoMuons", "vetoMuonsPre && Muon_correctedPt > 10. && abs(Muon_correctedEta) < 2.4")
-    df = df.Filter(f"Sum(vetoMuons) == {nMuons}")
+    df = df.Filter(f"Sum(vetoMuons) {condition} {nMuons}")
 
     return df
 
-def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15):
+def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuons=False, use_isolation=False, isoDefinition="iso04", isoThreshold=0.15, condition=""):
 
     if use_trackerMuons:
         df = df.Define("Muon_category", "Muon_isTracker && Muon_innerTrackOriginalAlgo != 13 && Muon_innerTrackOriginalAlgo != 14 && Muon_highPurity")
@@ -37,7 +37,7 @@ def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuon
         goodMuonsSelection += f" && {isoBranch} < {isoThreshold}"
 
     df = df.Define("goodMuons", goodMuonsSelection) 
-    df = df.Filter(f"Sum(goodMuons) == {nMuons}")
+    df = df.Filter(f"Sum(goodMuons) {condition} {nMuons}")
 
     return df
 


### PR DESCRIPTION
The default keeps the current behaviour, but at least one can reuse the same functions elsewhere (the annoying part was that defines and filters are mixed, so this change allows one to modify the condition for nMuon counts at will).

It might not be fully consistent with other parts of the code if one reuses the same histmakers, but I am actually trying to use a new one.