### PR TITLE
Fix for missing processes with theory corrections, and fix for threads

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -178,7 +178,7 @@ bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibrat
 
 procsWithTheoryCorr = [d.name for d in datasets if d.name in common.vprocs]
 if len(procsWithTheoryCorr):
-    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr, allowMissingTheoryCorr=args.allowMissingTheoryCorr)
+    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr)
 else:
     corr_helpers = {}
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -178,7 +178,7 @@ bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibrat
 
 procsWithTheoryCorr = [d.name for d in datasets if d.name in common.vprocs]
 if len(procsWithTheoryCorr):
-    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr)
+    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr, allowMissingTheoryCorr=args.allowMissingTheoryCorr)
 else:
     corr_helpers = {}
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -119,7 +119,7 @@ def set_parser_default(parser, argument, newDefault):
 def common_parser(for_reco_highPU=False):
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-j", "--nThreads", type=int, help="number of threads")
+    parser.add_argument("-j", "--nThreads", type=int, default=0, help="number of threads")
     parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4],
                         help="Set verbosity level with logging, the larger the more verbose")
     parser.add_argument("--noColorLogger", action="store_true", help="Do not use logging with colors")
@@ -130,10 +130,7 @@ def common_parser(for_reco_highPU=False):
     common_logger = logging.setup_logger(__file__, initargs.verbose, initargs.noColorLogger, initName="common_logger_wremnants")
     
     import ROOT
-    if not initargs.nThreads:
-        ROOT.ROOT.EnableImplicitMT()
-    elif initargs.nThreads != 1:
-        ROOT.ROOT.EnableImplicitMT(initargs.nThreads)
+    ROOT.ROOT.EnableImplicitMT(initargs.nThreads)
     import narf
     import wremnants
     from wremnants import theory_corrections,theory_tools
@@ -163,6 +160,7 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--theoryCorr", nargs="*", type=str, action=NoneFilterAction,
         default=["scetlib_dyturbo", "winhacnloew", "virtual_ew_wlike", "horaceqedew_FSR", "horacelophotosmecoffew_FSR"], choices=theory_corrections.valid_theory_corrections(), 
         help="Apply corrections from indicated generator. First will be nominal correction.")
+    parser.add_argument("--allowMissingTheoryCorr", action='store_true', help="To allow the histmaker to run on subset of processes, for which some generators passed to --theoryCorr may not exist (to avoid having to specify --theoryCorr to change the default)")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -119,7 +119,7 @@ def set_parser_default(parser, argument, newDefault):
 def common_parser(for_reco_highPU=False):
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-j", "--nThreads", type=int, default=0, help="number of threads")
+    parser.add_argument("-j", "--nThreads", type=int, default=0, help="number of threads (0 or negative values use all available threads)")
     parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4],
                         help="Set verbosity level with logging, the larger the more verbose")
     parser.add_argument("--noColorLogger", action="store_true", help="Do not use logging with colors")
@@ -130,7 +130,7 @@ def common_parser(for_reco_highPU=False):
     common_logger = logging.setup_logger(__file__, initargs.verbose, initargs.noColorLogger, initName="common_logger_wremnants")
     
     import ROOT
-    ROOT.ROOT.EnableImplicitMT(initargs.nThreads)
+    ROOT.ROOT.EnableImplicitMT(max(0,initargs.nThreads))
     import narf
     import wremnants
     from wremnants import theory_corrections,theory_tools
@@ -160,7 +160,6 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("--theoryCorr", nargs="*", type=str, action=NoneFilterAction,
         default=["scetlib_dyturbo", "winhacnloew", "virtual_ew_wlike", "horaceqedew_FSR", "horacelophotosmecoffew_FSR"], choices=theory_corrections.valid_theory_corrections(), 
         help="Apply corrections from indicated generator. First will be nominal correction.")
-    parser.add_argument("--allowMissingTheoryCorr", action='store_true', help="To allow the histmaker to run on subset of processes, for which some generators passed to --theoryCorr may not exist (to avoid having to specify --theoryCorr to change the default)")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -21,7 +21,7 @@ def valid_theory_corrections():
     matches = [re.match("(^.*)Corr[W|Z]\.pkl\.lz4", os.path.basename(c)) for c in corr_files]
     return [m[1] for m in matches if m]+["none"]
 
-def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.data_dir}/TheoryCorrections/"):
+def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.data_dir}/TheoryCorrections/", allowMissingTheoryCorr=False):
     corr_helpers = {}
     for proc in procs:
         corr_helpers[proc] = {}
@@ -41,7 +41,11 @@ def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.da
                 corr_helpers[proc][generator] = makeCorrectionsTensor(corrh, weighted_corr=generator in theory_tools.theory_corr_weight_map)
     for generator in generators:
         if not any([generator in corr_helpers[proc] for proc in procs]):
-            raise ValueError(f"Did not find correction for generator {generator} for any processes!")
+            err_msg = f"Did not find correction for generator {generator} for any processes!"
+            if allowMissingTheoryCorr:
+                logger.warning(f"{err_msg} Execution will continue since --allowMissingTheoryCorr was requested")
+            else:
+                raise ValueError(err_msg)
     return corr_helpers
 
 def make_corr_helper_fromnp(filename=f"{common.data_dir}/N3LLCorrections/inclusive_{{process}}_pT.npz", isW=True):

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -21,7 +21,7 @@ def valid_theory_corrections():
     matches = [re.match("(^.*)Corr[W|Z]\.pkl\.lz4", os.path.basename(c)) for c in corr_files]
     return [m[1] for m in matches if m]+["none"]
 
-def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.data_dir}/TheoryCorrections/", allowMissingTheoryCorr=False):
+def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.data_dir}/TheoryCorrections/"):
     corr_helpers = {}
     for proc in procs:
         corr_helpers[proc] = {}
@@ -41,11 +41,7 @@ def load_corr_helpers(procs, generators, make_tensor=True, base_dir=f"{common.da
                 corr_helpers[proc][generator] = makeCorrectionsTensor(corrh, weighted_corr=generator in theory_tools.theory_corr_weight_map)
     for generator in generators:
         if not any([generator in corr_helpers[proc] for proc in procs]):
-            err_msg = f"Did not find correction for generator {generator} for any processes!"
-            if allowMissingTheoryCorr:
-                logger.warning(f"{err_msg} Execution will continue since --allowMissingTheoryCorr was requested")
-            else:
-                raise ValueError(err_msg)
+            logger.warning(f"Did not find correction for generator {generator} for any processes!")
     return corr_helpers
 
 def make_corr_helper_fromnp(filename=f"{common.data_dir}/N3LLCorrections/inclusive_{{process}}_pT.npz", isW=True):


### PR DESCRIPTION
This PR does two independent things:

1) it complements previously merged PR #380, which was not dealing with cases where one runs on at least one process with theory corrections (which activates their usage in the W histomaker) but at the same time there are generators for which no valid process is selected.
A new option is defined to bypass the error message and avoid that the code throws the error. 
One could also use --theoryCorr to remove the offending generators, but it is often less convenient that just bypassing the safety check.

2) In addition, it updates the way the number of cores is selected with option -j. The default is now 0, which makes ROOT use all the available cores, but at the same time one can select a single thread passing 1 (while in the previous case the selection on nThreads was made only for nThreads > 1). I added this change here since opening a new PR only for it seemed a waste