### PR TITLE
implement preliminary veto uncertainty in mW analysis

### DIFF
--- a/scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+
+## make MC efficiency for W vs eta-pt-ut for trigger and isolation
+## Requires event yields made with the W  histmaker, with proper event selection
+## scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+
+# example
+# python scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency3D.py /scratch/mciprian/CombineStudies/testZmumuVeto/WMCtruthVetoEffi/mw_with_mu_eta_pt_VETOEFFI_scetlib_dyturboCorr_maxFiles_m1_genPt0_noRecoPtEta.hdf5 scripts/analysisTools/plots/fromMyWremnants/testZmumuVeto/WMCtruthVetoEffi_genPt0_noRecoPtEta/ -v 4 --rebinPt 2 
+
+from wremnants.datasets.datagroups import Datagroups
+from wremnants import histselections as sel
+#from wremnants import plot_tools,theory_tools,syst_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+
+import narf
+import wremnants
+from wremnants import theory_tools,syst_tools,theory_corrections
+import hist
+
+import numpy as np
+
+import pickle
+import lz4.frame
+
+import argparse
+import os
+import shutil
+import re
+
+## safe batch mode
+import sys
+args = sys.argv[:]
+sys.argv = ['-b']
+import ROOT
+sys.argv = args
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from copy import *
+
+#sys.path.append(os.getcwd() + "/plotUtils/")
+#from utility import *
+from scripts.analysisTools.plotUtils.utility import *
+from scripts.analysisTools.w_mass_13TeV.plotPrefitTemplatesWRemnants import plotPrefitHistograms
+
+sys.path.append(os.getcwd())
+
+def getBoostEff(n_pass, n_tot, integrateVar=[]):
+    s = hist.tag.Slicer()
+    num = n_pass.copy()
+    den = n_tot.copy()
+    if len(integrateVar):
+        num = num[{v: s[::hist.sum] for v in integrateVar}]
+        den = den[ {v: s[::hist.sum] for v in integrateVar}]
+    eff_boost = hh.divideHists(num, den, cutoff=0.1, allowBroadcast=True, createNew=True, cutoff_val=0.0)
+    vals = eff_boost.values()
+    vals[vals < 0.0] = 0.0
+    vals[vals > 1.0] = 1.0
+    eff_boost.values()[...] = vals
+    return eff_boost
+
+def getEtaPtEff(n_pass, n_tot, getRoot=False, rootName="", rootTitle="", integrateVar=[]):
+    eff_boost = getBoostEff(n_pass, n_tot, integrateVar=integrateVar)
+    if getRoot:
+        eff_root = narf.hist_to_root(eff_boost)
+        eff_root.SetName(rootName if len(rootName) else "tmp_root_eff")
+        eff_root.SetTitle(rootTitle)
+        return eff_boost,eff_root
+    else:
+        return eff_boost,None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
+    parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
+    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
+    parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file", default="nominal")
+    parser.add_argument(     '--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
+    parser.add_argument(     '--palette'  , default=87, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
+    parser.add_argument(     '--invertPalette', action='store_true',   help='Inverte color ordering in palette')
+    parser.add_argument('-p','--processes', default=["Wmunu"], nargs='*', type=str,
+                        help='Choose what processes to plot, otherwise all are done')
+    parser.add_argument(     '--rebinPt', default=-1, type=int, help='If positive, rebin yields versus pT by this number before deriving efficiencies (it happens after selecting the pt range)')
+    parser.add_argument(     '--ptRange', default=None, nargs=2, type=float, help='Pt range for plot')
+    args = parser.parse_args()
+
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
+    fname = args.inputfile[0]
+    outdir = args.outdir[0]
+    createPlotDirAndCopyPhp(outdir)
+        
+    ROOT.TH1.SetDefaultSumw2()
+
+    canvas = ROOT.TCanvas("canvas", "", 800, 700)
+    adjustSettings_CMS_lumi()
+    canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+    xAxisName = "PostFSR muon #eta"
+    yAxisName = "PostFSR muon p_{T} (GeV)"
+
+    groups = Datagroups(fname, mode="wmass")
+    datasets = groups.getNames()
+    if args.processes is not None and len(args.processes):
+        datasets = list(filter(lambda x: x in args.processes, datasets))
+    else:
+        datasets = list(filter(lambda x: x != "QCD", datasets))
+
+    logger.debug(f"Using these processes: {datasets}")
+    inputHistName = args.baseName
+    groups.setNominalName(inputHistName)
+    groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+    histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+    s = hist.tag.Slicer()
+    resultDict = {}
+    for d in datasets:
+        logger.info(f"Running on process {d}")
+        hin = histInfo[d].hists[inputHistName]
+        logger.debug(hin.axes)
+        h = hin.copy()
+        hplot = hin.copy()
+
+        if args.ptRange != None:
+            h = h[{"pt" : s[complex(0,args.ptRange[0]):complex(0,args.ptRange[1])]}]
+        if args.rebinPt > 0:
+            h = h[{"pt" : s[::hist.rebin(args.rebinPt)]}]
+            
+        n_veto_pass = h[{"passVeto" : True,
+                         "charge" : s[::hist.sum]}]
+        n_veto_fail = h[{"passVeto" : False,
+                         "charge" : s[::hist.sum]}]
+        n_veto_tot  = h[{"passVeto" : s[::hist.sum],
+                         "charge" : s[::hist.sum]}]
+
+        n_vetoplus_pass = h[{"passVeto" : True,
+                             "charge" : s[complex(0,1)]}]
+        n_vetoplus_fail = h[{"passVeto" : False,
+                             "charge" : s[complex(0,1)]}]
+        n_vetoplus_tot  = h[{"passVeto" : s[::hist.sum],
+                             "charge" : s[complex(0,1)]}]
+
+        n_vetominus_pass = h[{"passVeto" : True,
+                             "charge" : s[complex(0,-1)]}]
+        n_vetominus_fail = h[{"passVeto" : False,
+                             "charge" : s[complex(0,-1)]}]
+        n_vetominus_tot  = h[{"passVeto" : s[::hist.sum],
+                             "charge" : s[complex(0,-1)]}]
+
+
+        # plot yields
+        yields_pass_root = narf.hist_to_root(n_veto_pass)
+        yields_pass_root.SetName("yields_veto_pass")
+        yields_fail_root = narf.hist_to_root(n_veto_fail)
+        yields_fail_root.SetName("yields_veto_fail")
+        yields_tot_root = narf.hist_to_root(n_veto_tot)
+        yields_tot_root.SetName("yields_veto_tot")
+
+        drawCorrelationPlot(yields_pass_root, xAxisName, yAxisName, f"Events passing veto",
+                            f"{yields_pass_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+        drawCorrelationPlot(yields_fail_root, xAxisName, yAxisName, f"Events failing veto",
+                            f"{yields_fail_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+        drawCorrelationPlot(yields_tot_root, xAxisName, yAxisName, f"Events (denominator)",
+                            f"{yields_tot_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+        
+        # NOTE: to simplify our lives, when computing efficiencies as ratio of yields n/N and root is used
+        # then the uncertainty is obtained using option B for TH1::Divide, which uses binomial uncertainties.
+        # However, this implies 0 uncertainty when the efficiency is close to 0 or 1, but we won't really use
+        # these uncertainties, since the 2D smoothing with spline doesn't use them.
+        # otherwise can use eff = npass/(npass+nfail) and use the formula for standard propagation
+        # eff_err = 1./(nTot*nTot) * std::sqrt( nP*nP* e_nF*e_nF + nF*nF * e_nP*e_nP ) with nTot = nP + nF
+        # For now we use boost directly, using n/N but assuming uncorrelated n and N, so the uncertainties are maximally wrong (but we might not use them)
+        
+        eff_veto_boost2D,eff_veto = getEtaPtEff(n_veto_pass, n_veto_tot, getRoot=True, rootName=f"{d}_MC_eff_veto", rootTitle="P(veto | gen)")
+        drawCorrelationPlot(eff_veto, xAxisName, yAxisName, f"MC veto efficiency",
+                            f"{eff_veto.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+
+        eff_vetoplus_boost2D,eff_vetoplus = getEtaPtEff(n_vetoplus_pass, n_vetoplus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetoplus", rootTitle="P(vetoplus | gen)")
+        drawCorrelationPlot(eff_vetoplus, xAxisName, yAxisName, f"MC veto efficiency (charge plus)",
+                            f"{eff_vetoplus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+
+        eff_vetominus_boost2D,eff_vetominus = getEtaPtEff(n_vetominus_pass, n_vetominus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetominus", rootTitle="P(vetominus | gen)")
+        drawCorrelationPlot(eff_vetominus, xAxisName, yAxisName, f"MC veto efficiency (charge minus)",
+                            f"{eff_vetominus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+
+        effRatio_plusOverMinus = copy.deepcopy(eff_vetoplus.Clone("effRatio_plusOverMinus"))
+        effRatio_plusOverMinus.SetTitle("Charge plus / minus")
+        effRatio_plusOverMinus.Divide(eff_vetominus)
+        drawCorrelationPlot(effRatio_plusOverMinus, xAxisName, yAxisName, f"MC veto efficiency ratio",
+                            f"{effRatio_plusOverMinus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                            smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                            draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+
+        eff_veto_boost1Deta,eff_veto_eta = getEtaPtEff(n_veto_pass, n_veto_tot, getRoot=True, rootName=f"{d}_MC_eff_veto_1Deta", rootTitle="P(veto | gen)", integrateVar=["pt"])
+        eff_vetoplus_boost1Deta,eff_vetoplus_eta = getEtaPtEff(n_vetoplus_pass, n_vetoplus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetoplus_1Deta", rootTitle="P(vetoplus | gen)", integrateVar=["pt"])
+        eff_vetominus_boost1Deta,eff_vetominus_eta = getEtaPtEff(n_vetominus_pass, n_vetominus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetominus_1Deta", rootTitle="P(vetominus | gen)", integrateVar=["pt"])
+        drawNTH1([eff_vetoplus_eta, eff_vetominus_eta, eff_veto_eta],
+                 legEntries=["Charge plus", "Charge minus", "Inclusive"],
+                 labelXtmp=xAxisName, labelYtmp="MC veto efficiency",
+                 canvasName="vetoEfficiency_1Deta",
+                 outdir=outdir,
+                 labelRatioTmp="x/plus.::0.995,1.005",
+                 topMargin=0.05,
+                 legendCoords="0.16,0.9,0.84,0.94;3",  # x1,x2,y1,y2
+                 passCanvas=canvas1D, skipLumi=True, transparentLegend=True, onlyLineColor=True, useLineFirstHistogram=True, drawErrorAll=True,
+                 yAxisExtendConstant=1.4)
+
+        eff_veto_boost1Dpt,eff_veto_pt = getEtaPtEff(n_veto_pass, n_veto_tot, getRoot=True, rootName=f"{d}_MC_eff_veto_1Dpt", rootTitle="P(veto | gen)", integrateVar=["eta"])
+        eff_vetoplus_boost1Dpt,eff_vetoplus_pt = getEtaPtEff(n_vetoplus_pass, n_vetoplus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetoplus_1Dpt", rootTitle="P(vetoplus | gen)", integrateVar=["eta"])
+        eff_vetominus_boost1Dpt,eff_vetominus_pt = getEtaPtEff(n_vetominus_pass, n_vetominus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetominus_1Dpt", rootTitle="P(vetominus | gen)", integrateVar=["eta"])
+        minEffi,_ = getMinMaxMultiHisto([eff_vetoplus_pt, eff_vetominus_pt, eff_veto_pt])
+        minPtForRange = min(0.992, minEffi)
+        drawNTH1([eff_vetoplus_pt, eff_vetominus_pt, eff_veto_pt],
+                 legEntries=["Charge plus", "Charge minus", "Inclusive"],
+                 labelXtmp=yAxisName, labelYtmp=f"MC veto efficiency::{minPtForRange},1.002",
+                 canvasName="vetoEfficiency_1Dpt",
+                 outdir=outdir,
+                 labelRatioTmp="x/plus.::0.995,1.005",
+                 topMargin=0.05,
+                 legendCoords="0.16,0.9,0.84,0.94;3",  # x1,x2,y1,y2
+                 passCanvas=canvas1D, skipLumi=True, transparentLegend=True, onlyLineColor=True, useLineFirstHistogram=True, drawErrorAll=True,
+                 yAxisExtendConstant=1.4)
+
+        
+        resultDict[f"{d}_MC_eff_veto_etapt"] = eff_veto_boost2D
+        resultDict[f"{d}_MC_eff_vetoplus_etapt"] = eff_vetoplus_boost2D
+        resultDict[f"{d}_MC_eff_vetominus_etapt"] = eff_vetominus_boost2D
+        
+        # # plot uT distribution for each charge, vs mT (pass or fail, or inclusive), integrate anything else
+        # # do it for events passing trigger and isolation
+        # nPtBins = hTestUt.axes["pt"].size
+        # hTestUt = hTestUt[{"eta" : s[::hist.sum],
+        #                    "pt" :  s[0:nPtBins:hist.sum], # would s[::hist.sum] sum overflow pt bins?
+        #                    "passTrigger" : True,
+        #                    "passIso" : True}]
+        # for charge in [-1, 1]:
+        #     chargeStr = "plus" if charge > 0 else "minus"
+        #     hut = hTestUt[{"charge" : s[complex(0,charge)]}]
+        #     hut_allMt = hut[{"passMT": s[::hist.sum]}]
+        #     hut_passMt = hut[{"passMT": True}]
+        #     hut_failMt = hut[{"passMT": False}]
+        #     allHists = [hut_allMt, hut_passMt, hut_failMt]
+        #     allHistsRoot = []
+        #     hNamesRoot = ["allMT", "passMT", "failMT"]
+        #     for ih,htmp in enumerate(allHists):
+        #         hroot = narf.hist_to_root(htmp)
+        #         hroot.Scale(1./hroot.Integral()) # normalize to unit area to get shape
+        #         hNamesRoot[ih] += f"_{chargeStr}_{d}"
+        #         hroot.SetName(hNamesRoot[ih])
+        #         allHistsRoot.append(hroot)                
+        #     drawNTH1(allHistsRoot, hNamesRoot, "Projected recoil u_{T} (GeV)", "Normalized units", f"ut_{d}_{chargeStr}",
+        #              outdir, draw_both0_noLog1_onlyLog2=1, topMargin=0.05, labelRatioTmp="X / incl.::0.5,1.5",
+        #              legendCoords="0.2,0.8,0.77,0.92;1", passCanvas=canvas1D, skipLumi=True,
+        #              onlyLineColor=True, useLineFirstHistogram=True)
+                
+    postfix = ""
+    #toAppend = []
+    #postfix = "_".join(toAppend)
+    if len(postfix):
+        postfix = "_" + postfix
+
+    resultDict.update({"meta_info" : narf.ioutils.make_meta_info_dict(args=args, wd=common.base_dir)})    
+
+    outfile = outdir + f"vetoEfficienciesEtaPt{postfix}.pkl.lz4"
+    logger.info(f"Going to store 2D histograms {resultDict.keys()} in file {outfile}")
+    with lz4.frame.open(outfile, 'wb') as f:
+        pickle.dump(resultDict, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    outfileRoot = outdir + f"vetoEfficiencies2D{postfix}.root"
+    logger.info(f"Going to store 2D root histograms in file {outfileRoot}")
+    rf = safeOpenFile(outfileRoot, mode="RECREATE")
+    eff_veto.Write()
+    eff_vetoplus.Write()
+    eff_vetominus.Write()
+    rf.Close()

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -72,7 +72,7 @@ def make_parser(parser=None):
     parser.add_argument("--effStatLumiScale", type=float, default=None, help="Rescale equivalent luminosity for efficiency stat uncertainty by this value (e.g. 10 means ten times more data from tag and probe)")
     parser.add_argument("--binnedScaleFactors", action='store_true', help="Use binned scale factors (different helpers and nuisances)")
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
-    parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor")
+    parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor for Wmass")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -132,9 +132,6 @@ def setup(args, inputFile, fitvar, xnorm=False):
 
     simultaneousABCD = wmass and args.ABCD and not xnorm
     constrainMass = (dilepton and not "mll" in fitvar) or args.fitXsec
-
-    if not wmass and args.scaleZmuonVeto:
-        raise ValueError("Option --scaleZmuonVeto was specified, but it only applies to wmass analysis. Please check")
 
     if wmass:
         base_group = "Wenu" if datagroups.flavor == "e" else "Wmunu"
@@ -627,22 +624,24 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                 systAxes=["downUpVar"],
                                 labelsByAxis=["downUpVar"],
                                 passToFakes=passSystToFakes)
-        decorrVetoDict = {
-            "x" : {
-                "label" : "eta",
-                "edges": [round(-2.4+i*0.1,1) for i in range(49)]
+        ## TODO: implement second lepton veto for low PU (both electrons and muons)
+        if not lowPU:
+            decorrVetoDict = {
+                "x" : {
+                    "label" : "eta",
+                    "edges": [round(-2.4+i*0.1,1) for i in range(49)]
+                }
             }
-        }
-        cardTool.addSystematic("ZmuonVeto",
-                               processes=['Zveto_samples'],
-                               group="ZmuonVeto",
-                               mirror=True,
-                               systAxes=[],
-                               outNames=["ZmuonVetoDown", "ZmuonVetoUp"],
-                               passToFakes=passSystToFakes,
-                               scale=args.scaleZmuonVeto,
-                               decorrelateByBin=decorrVetoDict
-                               )
+            cardTool.addSystematic("ZmuonVeto",
+                                   processes=['Zveto_samples'],
+                                   group="ZmuonVeto",
+                                   mirror=True,
+                                   systAxes=[],
+                                   outNames=["ZmuonVetoDown", "ZmuonVetoUp"],
+                                   passToFakes=passSystToFakes,
+                                   scale=args.scaleZmuonVeto,
+                                   decorrelateByBin=decorrVetoDict
+                                   )
     else:
         cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15, group="CMS_background")
         cardTool.addLnNSystematic("luminosity", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -640,7 +640,9 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                    actionRequiresNomi=True,
                                    action=syst_tools.decorrelateByAxis,
                                    actionArgs=dict(axisToDecorrName="eta",
-                                                   decorrEdges=[round(-2.4+i*0.1,1) for i in range(49)],
+                                                   # empty array automatically uses all edges of the axis named "axisToDecorrName"
+                                                   # decorrEdges=[round(-2.4+i*0.1,1) for i in range(49)],
+                                                   decorrEdges=[], 
                                                    newDecorrAxisName="decorrEta"
                                                    )
                                    )

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -72,6 +72,7 @@ def make_parser(parser=None):
     parser.add_argument("--effStatLumiScale", type=float, default=None, help="Rescale equivalent luminosity for efficiency stat uncertainty by this value (e.g. 10 means ten times more data from tag and probe)")
     parser.add_argument("--binnedScaleFactors", action='store_true', help="Use binned scale factors (different helpers and nuisances)")
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
+    parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -130,8 +131,11 @@ def setup(args, inputFile, fitvar, xnorm=False):
     dilepton = "dilepton" in datagroups.mode or any(x in ["ptll", "mll"] for x in fitvar)
 
     simultaneousABCD = wmass and args.ABCD and not xnorm
-    constrainMass = (dilepton and not "mll" in fitvar) or args.fitXsec 
-    
+    constrainMass = (dilepton and not "mll" in fitvar) or args.fitXsec
+
+    if not wmass and args.scaleZmuonVeto:
+        raise ValueError("Option --scaleZmuonVeto was specified, but it only applies to wmass analysis. Please check")
+
     if wmass:
         base_group = "Wenu" if datagroups.flavor == "e" else "Wmunu"
     else:
@@ -623,6 +627,22 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                 systAxes=["downUpVar"],
                                 labelsByAxis=["downUpVar"],
                                 passToFakes=passSystToFakes)
+        decorrVetoDict = {
+            "x" : {
+                "label" : "eta",
+                "edges": [round(-2.4+i*0.1,1) for i in range(49)]
+            }
+        }
+        cardTool.addSystematic("ZmuonVeto",
+                               processes=['Zveto_samples'],
+                               group="ZmuonVeto",
+                               mirror=True,
+                               systAxes=[],
+                               outNames=["ZmuonVetoDown", "ZmuonVetoUp"],
+                               passToFakes=passSystToFakes,
+                               scale=args.scaleZmuonVeto,
+                               decorrelateByBin=decorrVetoDict
+                               )
     else:
         cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15, group="CMS_background")
         cardTool.addLnNSystematic("luminosity", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -285,6 +285,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
     if wmass:
         cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
+        cardTool.addProcessGroup("Zveto_samples", lambda x: assertSample(x, startsWith=[*ZMatch, "DYlowMass"], excludeMatch=dibosonMatch))
         cardTool.addProcessGroup("wtau_samples", lambda x: assertSample(x, startsWith=["Wtaunu"]))
         if not xnorm:
             cardTool.addProcessGroup("single_v_nonsig_samples", lambda x: assertSample(x, startsWith=ZMatch, excludeMatch=dibosonMatch))

--- a/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
@@ -1,0 +1,160 @@
+import argparse
+from utilities import common, rdf_tools, logging, differential
+from utilities.io_tools import output_tools
+from utilities.common import background_MCprocs as bkgMCprocs
+from wremnants.datasets.datagroups import Datagroups
+
+parser,initargs = common.common_parser(True)
+
+import ROOT
+import narf
+import wremnants
+from wremnants import theory_tools,syst_tools,theory_corrections, muon_calibration, muon_selections, muon_validation, unfolding_tools, theoryAgnostic_tools, helicity_utils
+from wremnants.histmaker_tools import scale_to_data, aggregate_groups
+from wremnants.datasets.dataset_tools import getDatasets
+import hist
+import lz4.frame
+import math
+import time
+from utilities import boostHistHelpers as hh
+import pathlib
+import os
+import numpy as np
+
+data_dir = common.data_dir
+parser.add_argument("--oneMCfileEveryN", type=int, default=None, help="Use 1 MC file every N, where N is given by this option. Mainly for tests")
+parser.add_argument("--vetoGenPartPt", type=float, default=0.0, help="Minimum pT for the postFSR gen muon when defining the variation of the veto efficiency")
+args = parser.parse_args()
+logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
+
+args = parser.parse_args()
+    
+thisAnalysis = ROOT.wrem.AnalysisType.Wmass
+
+era = args.era
+datasets = getDatasets(maxFiles=args.maxFiles,
+                       filt=args.filterProcs,
+                       excl=args.excludeProcs, 
+                       nanoVersion="v9", base_path=args.dataPath, oneMCfileEveryN=args.oneMCfileEveryN,
+                       extended = "msht20an3lo" not in args.pdfs,
+                       era=era)
+
+# custom template binning
+template_neta = int(args.eta[0])
+template_mineta = args.eta[1]
+template_maxeta = args.eta[2]
+logger.info(f"Eta binning: {template_neta} bins from {template_mineta} to {template_maxeta}")
+template_npt = int(args.pt[0])
+template_minpt = args.pt[1]
+template_maxpt = args.pt[2]
+logger.info(f"Pt binning: {template_npt} bins from {template_minpt} to {template_maxpt}")
+
+# standard regular axes
+axis_eta = hist.axis.Regular(template_neta, template_mineta, template_maxeta, name = "eta", overflow=False, underflow=False)
+axis_pt = hist.axis.Regular(template_npt, template_minpt, template_maxpt, name = "pt", overflow=False, underflow=False)
+axis_charge = common.axis_charge
+axis_passVeto = hist.axis.Boolean(name = "passVeto")
+
+nominal_axes = [axis_eta, axis_pt, axis_charge, axis_passVeto]
+nominal_cols = ["postFSRmuon_eta0", "postFSRmuon_pt0", "postFSRmuon_charge0", "passVeto"]
+
+# sum those groups up in post processing
+groups_to_aggregate = args.aggregateGroups
+
+#qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
+
+logger.info("Running with no scale factors")
+
+pileup_helper = wremnants.make_pileup_helper(era = era)
+vertex_helper = wremnants.make_vertex_helper(era = era)
+
+calib_filepaths = common.calib_filepaths
+closure_filepaths = common.closure_filepaths
+
+diff_weights_helper = ROOT.wrem.SplinesDifferentialWeightsHelper(calib_filepaths['tflite_file']) if (args.muonScaleVariation == 'smearingWeightsSplines' or args.validationHists) else None
+
+mc_jpsi_crctn_helper, data_jpsi_crctn_helper, jpsi_crctn_MC_unc_helper, jpsi_crctn_data_unc_helper = muon_calibration.make_jpsi_crctn_helpers(args, calib_filepaths, make_uncertainty_helper=True)
+
+z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibration.make_Z_non_closure_helpers(args, calib_filepaths, closure_filepaths)
+
+mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args)
+
+smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+
+bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibration else None
+
+procsWithTheoryCorr = [d.name for d in datasets if d.name in common.vprocs]
+if len(procsWithTheoryCorr):
+    corr_helpers = theory_corrections.load_corr_helpers(procsWithTheoryCorr, args.theoryCorr, allowMissingTheoryCorr=args.allowMissingTheoryCorr)
+else:
+    corr_helpers = {}
+
+smearing_weights_procs = []
+
+def build_graph(df, dataset):
+    logger.info(f"build graph for dataset: {dataset.name}")
+    results = []
+    isW = dataset.name in common.wprocs
+    isWmunu = dataset.name in ["WplusmunuPostVFP", "WminusmunuPostVFP"]
+    isZ = dataset.name in common.zprocs
+    isWorZ = isW or isZ
+    isTop = dataset.group == "Top"
+
+    cvh_helper = data_calibration_helper if dataset.is_data else mc_calibration_helper
+    jpsi_helper = data_jpsi_crctn_helper if dataset.is_data else mc_jpsi_crctn_helper
+
+    df = df.Define("weight", "std::copysign(1.0, genWeight)")
+    weightsum = df.SumAndCount("weight")
+
+    axes = nominal_axes
+    cols = nominal_cols
+
+    df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
+
+    # gen match to bare muons to select only prompt muons from MC processes, but also including tau decays
+    # status flags in NanoAOD: https://cms-nanoaod-integration.web.cern.ch/autoDoc/NanoAODv9/2016ULpostVFP/doc_TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL16NanoAODv9-106X_mcRun2_asymptotic_v17-v1.html
+    postFSRmuonDef = f"GenPart_status == 1 && (GenPart_statusFlags & 1 || GenPart_statusFlags & (1 << 5)) && abs(GenPart_pdgId) == 13 && GenPart_pt > {args.vetoGenPartPt}"
+    df = df.Define("postFSRmuons", postFSRmuonDef)
+
+    # restrict to one gen muon for simplicity
+    df = df.Filter("Sum(postFSRmuons) == 1")
+    df = muon_selections.veto_electrons(df)
+    df = muon_selections.apply_met_filters(df)
+
+    ########################################################################
+    # define event weights here since they are needed below for some helpers
+    df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
+    df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
+
+    weight_expr = "weight_pu*L1PreFiringWeight_ECAL_Nom"
+    if not args.noVertexWeight:
+        weight_expr += "*weight_vtx"
+
+    logger.debug(f"Exp weight defined: {weight_expr}")
+    df = df.Define("exp_weight", weight_expr)
+    df = theory_tools.define_theory_weights_and_corrs(df, dataset.name, corr_helpers, args)
+
+    ########################################################################
+
+    df = df.Define("postFSRmuon_pt0", "GenPart_pt[postFSRmuons][0]")
+    df = df.Define("postFSRmuon_eta0", "GenPart_eta[postFSRmuons][0]")
+    df = df.Define("postFSRmuon_phi0", "GenPart_phi[postFSRmuons][0]")
+    df = df.Define("postFSRmuon_charge0", "-1 * std::copysign(1.0, GenPart_pdgId[postFSRmuons][0])")
+
+    df = muon_selections.select_veto_muons(df, nMuons=0, condition=">=", ptCut=0.0, etaCut=3.0)
+    # might have more veto muons, but will look for at least one gen matched to the only gen muon
+    df = df.Define("oneOrMoreVetoMuons", "Sum(vetoMuons) > 0")
+    df = df.Define("passVeto", "oneOrMoreVetoMuons && wrem::hasMatchDR2(postFSRmuon_eta0,postFSRmuon_phi0,Muon_eta[vetoMuons],Muon_phi[vetoMuons],0.09)")
+
+    nominal = df.HistoBoost("nominal", axes, [*cols, "nominal_weight"])
+    results.append(nominal)
+
+    return results, weightsum
+
+resultdict = narf.build_and_run(datasets, build_graph)
+
+if not args.noScaleToData:
+    scale_to_data(resultdict)
+    aggregate_groups(datasets, resultdict, groups_to_aggregate)
+
+output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args)

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -211,8 +211,8 @@ def extendHistByMirror(hvar, hnom, downAsUp=False, downAsNomi=False):
 def addGenChargeAxis(h, idx):
     return addGenericAxis(h, hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "qGen"), idx, add_trailing=False, flow=True)
     
-def addSystAxis(h, size=1, offset=0):
-    return addGenericAxis(h, hist.axis.Regular(size,offset,size+offset, name="systIdx"))
+def addSystAxis(h, size=1, offset=0, axname="systIdx"):
+    return addGenericAxis(h, hist.axis.Regular(size,offset,size+offset, name=axName))
 
 def addGenericAxis(h, axis, idx=None, add_trailing=True, flow=True):
     axes = [*h.axes, axis] if add_trailing else [axis, *h.axes]

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -292,13 +292,12 @@ class CardTool(object):
     # preOp is a function to apply per process, preOpMap can be used with a dict for a speratate function for each process, 
     #   it is executed before summing the processes. Arguments can be specified with preOpArgs 
     # action will be applied to the sum of all the individual samples contributing, arguments can be specified with actionArgs
-    # decorrelateByBin is to customize eta-pt decorrelation: pass dictionary with {axisName: [bin edges]}
     def addSystematic(self, name, systAxes=[], systAxesFlow=[], outNames=None, skipEntries=None, labelsByAxis=None, 
                       baseName="", mirror=False, mirrorDownVarEqualToUp=False, mirrorDownVarEqualToNomi=False, symmetrize = "average",
                       scale=1, processes=None, group=None, noi=False, noConstraint=False, noProfile=False,
-                      preOp=None, preOpMap=None, preOpArgs={}, action=None, actionArgs={}, 
+                      preOp=None, preOpMap=None, preOpArgs={}, action=None, actionArgs={}, actionRequiresNomi=False,
                       systNameReplace=[], systNamePrepend=None, groupFilter=None, passToFakes=False,
-                      rename=None, splitGroup={}, decorrelateByBin={}, formatWithValue=None,
+                      rename=None, splitGroup={}, formatWithValue=None,
                       customizeNuisanceAttributes={},
                       ):
         # note: setting Up=Down seems to be pathological for the moment, it might be due to the interpolation in the fit
@@ -362,12 +361,12 @@ class CardTool(object):
                 "preOpArgs" : preOpArgs,
                 "action" : action,
                 "actionArgs" : actionArgs,
+                "actionRequiresNomi" : actionRequiresNomi,
                 "systNameReplace" : systNameReplace,
                 "noConstraint" : noConstraint,
                 "noProfile" : noProfile,
                 "skipEntries" : [] if not skipEntries else skipEntries,
                 "name" : name,
-                "decorrByBin": decorrelateByBin,
                 "systNamePrepend" : systNamePrepend,
                 "formatWithValue" : formatWithValue,
             }
@@ -503,7 +502,7 @@ class CardTool(object):
 
         return updated_skip
 
-    def systHists(self, hvar, syst):
+    def systHists(self, hvar, syst, hnom):
         if syst == self.nominalName:
             return {self.nominalName : hvar}
 
@@ -513,7 +512,10 @@ class CardTool(object):
 
         # Jan: moved above the mirror action, as this action can cause mirroring
         if systInfo["action"]:
-            hvar = systInfo["action"](hvar, **systInfo["actionArgs"])
+            if systInfo["actionRequiresNomi"]:
+               hvar = systInfo["action"](hvar, hnom, **systInfo["actionArgs"])
+            else:
+                hvar = systInfo["action"](hvar, **systInfo["actionArgs"])
         if self.outfile:
             self.outfile.cd() # needed to restore the current directory in case the action opens a new root file
 
@@ -706,87 +708,9 @@ class CardTool(object):
             if up_nBinsSystSameAsNomi >= varEqNomiThreshold or down_nBinsSystSameAsNomi >= varEqNomiThreshold:
                 if not skipOneAsNomi or (up_nBinsSystSameAsNomi >= varEqNomiThreshold and down_nBinsSystSameAsNomi >= varEqNomiThreshold):
                     logger.warning(f"syst {name} has Up/Down variation with {up_nBinsSystSameAsNomi:.1%}/{down_nBinsSystSameAsNomi:.1%} of bins equal to nominal")
-                    
-    def makeDecorrelatedSystNuisances(self, systNames, dcbb={}):
-        # NOTE: the dictionary is supposed to have only a single key
-        for k in dcbb.keys():
-            systNamesTmp = []
-            decorrSystLabel = dcbb[k]["label"]
-            if k == "xy":
-                for ix in range(len(dcbb[k]["edges"][0])-1):
-                    for iy in range(len(dcbb[k]["edges"][1])-1):
-                        systNamesTmp.extend([f"{x}_{decorrSystLabel[0]}{ix}{decorrSystLabel[1]}{iy}" for x in systNames])
-            else:
-                for ik in range(len(dcbb[k]["edges"])-1):
-                    systNamesTmp.extend([f"{x}_{decorrSystLabel}{ik}" for x in systNames])
-            return systNamesTmp
-            #logger.error(f"systNames = {systNames}")
 
-    def makeDecorrelatedSystHistograms(self, h, hnomi, name, decorrByBinDict):
-        # s = hist.tag.Slicer()
-        # TODO: using an alternative version using boost directly may be faster, but for now this is just for testing
-        # decorrByBinDict is a dictionary as
-        # decorrByBinDict = {"x": {"label" : "eta",
-        #                          "edges" : [round(-2.4+i*0.4,1) for i in range(13)],}
-        #                   }
-        # for a 2D decorrelation the values of each key are arrays of size 2
-        # decorrByBinDict = {"xy": {"label" : ["eta", "pt"],
-        #                          "edges" : [ [etaEdges], [ptEdges] ]}
-        #                   }
-        # TODO: could also do charge decorrelation by using the z axis if present
-        ret = {}
-        hnomiroot = narf.hist_to_root(hnomi)
-        hsystroot = narf.hist_to_root(h)
-        for ax in decorrByBinDict.keys():
-            decorrDict = decorrByBinDict[ax]
-            decorrSystLabel = decorrDict["label"]
-            logger.info(f"Decorrelating syst {name} by {ax} bins using {decorrSystLabel}")
-            if ax != "xy":
-                for ibin in range(len(decorrDict["edges"]) -1):
-                    upDown = "Up" if name.endswith("Up") else "Down" if name.endswith("Down") else ""
-                    newname = name[:-len(upDown)] if len(upDown) else name[:]
-                    newname = f"{newname}_{decorrSystLabel}{ibin}{upDown}"
-                    logger.debug(f"Decorrelating syst {name} by {ax} bins: preparing new histogram {newname}")
-                    # FIXME: do not assume we can only have eta and pt axes (or eta-pt when implemented)
-                    # bin ID are retrieved adding some small constants to bin edges, low/high edge is increased/decreased
-                    if ax == "x":
-                        xbinLow = hnomiroot.GetXaxis().FindFixBin(decorrDict["edges"][ibin]+0.001)
-                        xbinHigh = hnomiroot.GetXaxis().FindFixBin(decorrDict["edges"][ibin+1]-0.001)
-                        ybinLow = 1
-                        ybinHigh = hnomiroot.GetNbinsY()
-                    elif ax == "y":
-                        xbinLow = 1
-                        xbinHigh = hnomiroot.GetNbinsX()
-                        ybinLow = hnomiroot.GetYaxis().FindFixBin(decorrDict["edges"][ibin]+0.001)
-                        ybinHigh = hnomiroot.GetYaxis().FindFixBin(decorrDict["edges"][ibin+1]-0.001)
-                    hsystrootDecorr = copy.deepcopy(hnomiroot.Clone(newname))
-                    ROOT.wrem.fillTH3fromTH3part(hsystrootDecorr, hsystroot,
-                                                 xbinLow, ybinLow, 1,
-                                                 xbinHigh, ybinHigh, hnomiroot.GetNbinsZ())
-                    ret[newname] = narf.root_to_hist(hsystrootDecorr, axis_names = hnomi.axes.name)
-            else:
-                edgesX = decorrDict["edges"][0]
-                edgesY = decorrDict["edges"][1]
-                for ix in range(len(edgesX)-1):
-                    for iy in range(len(edgesY)-1):
-                        xbinLow = hnomiroot.GetXaxis().FindFixBin(edgesX[ix]+0.001)
-                        xbinHigh = hnomiroot.GetXaxis().FindFixBin(edgesX[ix+1]-0.001)
-                        ybinLow = hnomiroot.GetYaxis().FindFixBin(edgesY[iy]+0.001)
-                        ybinHigh = hnomiroot.GetYaxis().FindFixBin(edgesY[iy+1]-0.001)
-                        upDown = "Up" if name.endswith("Up") else "Down" if name.endswith("Down") else ""
-                        newname = name[:-len(upDown)] if len(upDown) else name[:]
-                        newname = f"{newname}_{decorrSystLabel[0]}{ix}{decorrSystLabel[1]}{iy}{upDown}"
-                        logger.warning(f"Decorrelating syst {name} by {ax} bins: preparing new histogram {newname}")
-                        hsystrootDecorr = copy.deepcopy(hnomiroot.Clone(newname))
-                        ROOT.wrem.fillTH3fromTH3part(hsystrootDecorr, hsystroot,
-                                                     xbinLow, ybinLow, 1,
-                                                     xbinHigh, ybinHigh, hnomiroot.GetNbinsZ())
-                        ret[newname] = narf.root_to_hist(hsystrootDecorr, axis_names = hnomi.axes.name)
-        return ret
 
-                
     def writeForProcess(self, h, proc, syst, check_systs=True):
-        decorrelateByBin = {}
         hnom = None
         systInfo = None
         if syst != self.nominalName:
@@ -797,11 +721,9 @@ class CardTool(object):
                 h = hh.extendHistByMirror(h, hnom,
                                           downAsUp=systInfo["mirrorDownVarEqualToUp"],
                                           downAsNomi=systInfo["mirrorDownVarEqualToNomi"])            
-            if systInfo["decorrByBin"]:
-                decorrelateByBin = systInfo["decorrByBin"]
 
         logger.info(f"   {syst} for process {proc}")
-        var_map = self.systHists(h, syst)
+        var_map = self.systHists(h, syst, hnom)
 
         if syst != self.nominalName:
             if not systInfo["mirror"] and systInfo["symmetrize"] is not None:
@@ -823,8 +745,7 @@ class CardTool(object):
         # this is a big loop a bit slow, but it might be mainly the hist->root conversion and writing into the root file
         for name, var in var_map.items():
             if name != "":
-                self.writeHist(var, proc, name, setZeroStatUnc=setZeroStatUnc,
-                               decorrByBin=decorrelateByBin, hnomi=hnom)
+                self.writeHist(var, proc, name, setZeroStatUnc=setZeroStatUnc, hnomi=hnom)
 
     def loadPseudodata(self, forceNonzero=True):
         datagroups = self.pseudodata_datagroups
@@ -1086,11 +1007,6 @@ class CardTool(object):
         # Deduplicate while keeping order
         systNames = list(dict.fromkeys(names))
 
-        # if decorrelating by bin, define new nuisances
-        if systInfo["decorrByBin"]:
-            systNamesTmp = self.makeDecorrelatedSystNuisances(systNames, systInfo["decorrByBin"])
-            systNames = systNamesTmp[:]
-                
         systnamesPruned = [s for s in systNames if not self.isExcludedNuisance(s)]
         systNames = systnamesPruned[:]
         for chan in self.channels:
@@ -1167,7 +1083,7 @@ class CardTool(object):
         hout.SetName(f"{name}_{self.channels[0]}" if self.channels else name)
         hout.Write()
     
-    def writeHist(self, h, proc, syst, setZeroStatUnc=False, decorrByBin={}, hnomi=None):
+    def writeHist(self, h, proc, syst, setZeroStatUnc=False, hnomi=None):
         if self.skipHist:
             return
         if self.fit_axes:
@@ -1207,8 +1123,6 @@ class CardTool(object):
         name = self.variationName(proc, syst)
 
         hists = {name: h} # always keep original variation in output file for checks
-        if decorrByBin:
-            hists.update(self.makeDecorrelatedSystHistograms(h, hnomi, syst, decorrByBin))
 
         for hname, histo in hists.items():
             if self.writeByCharge:

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -190,12 +190,14 @@ class HDF5Writer(object):
             hist_nominal = dg.groups[procs_chan[0]].hists[chanInfo.nominalName] 
             hist_axes[chan] = [hist_nominal.axes[a] for a in axes]
 
+            hist_nominal_perProc = {}
             # nominal predictions
             for proc in procs_chan:
                 logger.debug(f"Now  in channel {chan} at process {proc}")
-                
+
                 # nominal histograms of prediction
                 norm_proc_hist = dg.groups[proc].hists[chanInfo.nominalName]
+                hist_nominal_perProc[proc] = norm_proc_hist.copy()
 
                 if not masked:                
                     norm_proc, sumw2_proc = self.get_flat_values(norm_proc_hist, chanInfo, axes)
@@ -372,11 +374,12 @@ class HDF5Writer(object):
                     logger.debug(f"Now at proc {proc}!")
 
                     hvar = dg.groups[proc].hists["syst"]
+                    #hnom = dg.groups[proc].hists[chanInfo.nominalName] ## this doesn't work here for some reason, perhaps I should reload the datagroups
 
                     if syst["decorrByBin"]:
                         raise NotImplementedError("By bin decorrelation is not supported for writing output in hdf5")
 
-                    var_map = chanInfo.systHists(hvar, systKey)
+                    var_map = chanInfo.systHists(hvar, systKey, hist_nominal_perProc[proc])
 
                     var_names = [x[:-2] if "Up" in x[-2:] else (x[:-4] if "Down" in x[-4:] else x) 
                         for x in filter(lambda x: x != "", var_map.keys())]

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -190,14 +190,12 @@ class HDF5Writer(object):
             hist_nominal = dg.groups[procs_chan[0]].hists[chanInfo.nominalName] 
             hist_axes[chan] = [hist_nominal.axes[a] for a in axes]
 
-            hist_nominal_perProc = {}
             # nominal predictions
             for proc in procs_chan:
                 logger.debug(f"Now  in channel {chan} at process {proc}")
 
                 # nominal histograms of prediction
                 norm_proc_hist = dg.groups[proc].hists[chanInfo.nominalName]
-                #hist_nominal_perProc[proc] = norm_proc_hist.copy()
 
                 if not masked:                
                     norm_proc, sumw2_proc = self.get_flat_values(norm_proc_hist, chanInfo, axes)

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -197,7 +197,7 @@ class HDF5Writer(object):
 
                 # nominal histograms of prediction
                 norm_proc_hist = dg.groups[proc].hists[chanInfo.nominalName]
-                hist_nominal_perProc[proc] = norm_proc_hist.copy()
+                #hist_nominal_perProc[proc] = norm_proc_hist.copy()
 
                 if not masked:                
                     norm_proc, sumw2_proc = self.get_flat_values(norm_proc_hist, chanInfo, axes)
@@ -287,9 +287,7 @@ class HDF5Writer(object):
             # free memory
             if dg.dataName in dg.groups:
                 del dg.groups[dg.dataName].hists[chanInfo.nominalName]
-            for proc in procs_chan:
-                del dg.groups[proc].hists[chanInfo.nominalName]
-            
+
             # release original histograms in the proxy objects
             if chanInfo.pseudoData:
                 for pseudoData in chanInfo.pseudoData:
@@ -374,12 +372,9 @@ class HDF5Writer(object):
                     logger.debug(f"Now at proc {proc}!")
 
                     hvar = dg.groups[proc].hists["syst"]
-                    #hnom = dg.groups[proc].hists[chanInfo.nominalName] ## this doesn't work here for some reason, perhaps I should reload the datagroups
+                    hnom = dg.groups[proc].hists[chanInfo.nominalName]
 
-                    if syst["decorrByBin"]:
-                        raise NotImplementedError("By bin decorrelation is not supported for writing output in hdf5")
-
-                    var_map = chanInfo.systHists(hvar, systKey, hist_nominal_perProc[proc])
+                    var_map = chanInfo.systHists(hvar, systKey, hnom)
 
                     var_names = [x[:-2] if "Up" in x[-2:] else (x[:-4] if "Down" in x[-4:] else x) 
                         for x in filter(lambda x: x != "", var_map.keys())]

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -8,12 +8,12 @@ def apply_met_filters(df):
 
     return df
 
-def select_veto_muons(df, nMuons=1, condition="=="):
+def select_veto_muons(df, nMuons=1, condition="==", ptCut=10.0, etaCut=2.4):
 
     # n.b. charge = -99 is a placeholder for invalid track refit/corrections (mostly just from tracks below
     # the pt threshold of 8 GeV in the nano production)
     df = df.Define("vetoMuonsPre", "Muon_looseId && abs(Muon_dxybs) < 0.05 && Muon_correctedCharge != -99")
-    df = df.Define("vetoMuons", "vetoMuonsPre && Muon_correctedPt > 10. && abs(Muon_correctedEta) < 2.4")
+    df = df.Define("vetoMuons", f"vetoMuonsPre && Muon_correctedPt > {ptCut} && abs(Muon_correctedEta) < {etaCut}")
     df = df.Filter(f"Sum(vetoMuons) {condition} {nMuons}")
 
     return df

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -217,13 +217,13 @@ def scale_helicity_hist_to_variations(scale_hist, sum_axes=[], pt_ax="ptVgen", g
     scale_variation_hist = hist.Hist(*scale_hist.axes, 
                                      name = out_name, data = systhist)
 
-    return scale_variation_hist 
+    return scale_variation_hist
 
 def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisName=None):
 
     if axisToDecorrName not in hnom.axes.name:
         raise ValueError(f"Requested to decorrelate uncertainty in histogram {hvar.name} by {axisToDecorrName} axis, but available axes for nominal histogram are {hnom.axes.name}")
-
+    
     # for convenience, broadcast the nominal into the same shape as hvar
     # hvar may often have the same dimension as hnom, but sometimes it might have been mirrored and thus have at least the mirror axis
     hnomAsVar = hh.broadcastSystHist(hnom, hvar)
@@ -231,14 +231,28 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
     ax = hnomAsVar.axes[axisToDecorrName]
     axisToDecorrIndex = list(hnomAsVar.axes).index(ax)
     logger.debug(f"Decorrelating versus axis {axisToDecorrName} with index {axisToDecorrIndex}")
+
+    # check that the edges in decorrEdges correspond to a subset of the edges of axis names axisToDecorrName
+    badEdges = []
+    for edge in decorrEdges:
+        if all(not np.isclose(edge, j, atol=0.0001) for j in ax.edges):
+            badEdges.append(edge)
+    if len(badEdges):
+        raise ValueError(f"Inconsistent edges specified to decorrelate uncertainty versus axis {axisToDecorrName}\n"
+                         f"Original axis edges: {ax.edges}\n"
+                         f"Decorrelation edges: {decorrEdges}\n"
+                         f"Inconsistent edges:  {badEdges}")
+
     # add new axis to the broadcasted nominal (then we will copy the syst in the relevant bins)
     axis_decorr_name = newDecorrAxisName if newDecorrAxisName != None else f"{axisToDecorrName}_decorr"
     axis_decorr = hist.axis.Variable(decorrEdges, underflow=False, overflow=False, name=axis_decorr_name)
     hvarnew = hh.addGenericAxis(hnomAsVar, axis_decorr)
 
     for isyst in range(len(decorrEdges)-1):
-        indexLow = ax.index(decorrEdges[isyst] + 0.001) # add epsilon to ensure picking the bin on the right of the edge
-        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001)
+        indexLow = ax.index(decorrEdges[isyst] + 0.001) # add epsilon to ensure picking the bin on the right of the edge (note that the second bin index is excluded from the slice selection below)
+        # for the upper edge add an additional protection for the very last edge in case the axis doesn't have the overflow bin, since the edge lookup might be undefined in that case
+        # since the upper edge is no longer associated to the following bin, which would be the overflow bin, but to the inner bin (adding epsilon seems to work nonetheless, but it is probably by chance)
+        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001) if decorrEdges[isyst+1] < ax.edges[-1] else ax.size
         slices = [slice(None) if n != axisToDecorrIndex else slice(indexLow,indexHigh) for n in range(len(hnomAsVar.axes.name))]
         hvarnew.values(flow=False)[*slices, isyst] = hvar.values(flow=False)[*slices] # use values instead of view, because hvar has storage=Double(), while hnom (and hence hvarnew) has storage=Weight
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -221,8 +221,9 @@ def scale_helicity_hist_to_variations(scale_hist, sum_axes=[], pt_ax="ptVgen", g
 
 def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisName=None):
 
+    commonMessage = f"Requested to decorrelate uncertainty in histogram {hvar.name} by {axisToDecorrName} axis"
     if axisToDecorrName not in hnom.axes.name:
-        raise ValueError(f"Requested to decorrelate uncertainty in histogram {hvar.name} by {axisToDecorrName} axis, but available axes for nominal histogram are {hnom.axes.name}")
+        raise ValueError(f"{commonMessage}, but available axes for nominal histogram are {hnom.axes.name}")
     
     # for convenience, broadcast the nominal into the same shape as hvar
     # hvar may often have the same dimension as hnom, but sometimes it might have been mirrored and thus have at least the mirror axis
@@ -232,16 +233,22 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
     axisToDecorrIndex = list(hnomAsVar.axes).index(ax)
     logger.debug(f"Decorrelating versus axis {axisToDecorrName} with index {axisToDecorrIndex}")
 
-    # check that the edges in decorrEdges correspond to a subset of the edges of axis names axisToDecorrName
-    badEdges = []
-    for edge in decorrEdges:
-        if all(not np.isclose(edge, j, atol=0.0001) for j in ax.edges):
-            badEdges.append(edge)
-    if len(badEdges):
-        raise ValueError(f"Inconsistent edges specified to decorrelate uncertainty versus axis {axisToDecorrName}\n"
-                         f"Original axis edges: {ax.edges}\n"
-                         f"Decorrelation edges: {decorrEdges}\n"
-                         f"Inconsistent edges:  {badEdges}")
+    if len(decorrEdges):
+        if len(decorrEdges) < 3:
+            raise ValueError(f"{commonMessage}, but less than 3 edges (thus 2 bins) were specified.")
+        # check that the edges in decorrEdges correspond to a subset of the edges of axis names axisToDecorrName
+        badEdges = []
+        for edge in decorrEdges:
+            if all(not np.isclose(edge, j, atol=0.0001) for j in ax.edges):
+                badEdges.append(edge)
+        if len(badEdges):
+            raise ValueError(f"Inconsistent edges specified to decorrelate uncertainty versus axis {axisToDecorrName}\n"
+                             f"Original axis edges: {ax.edges}\n"
+                             f"Decorrelation edges: {decorrEdges}\n"
+                             f"Inconsistent edges:  {badEdges}")
+    else:
+        # empty array automatically uses all edges of the chosen axis
+        decorrEdges = [x for x in ax.edges]
 
     # add new axis to the broadcasted nominal (then we will copy the syst in the relevant bins)
     axis_decorr_name = newDecorrAxisName if newDecorrAxisName != None else f"{axisToDecorrName}_decorr"

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -252,7 +252,7 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
         indexLow = ax.index(decorrEdges[isyst] + 0.001) # add epsilon to ensure picking the bin on the right of the edge (note that the second bin index is excluded from the slice selection below)
         # for the upper edge add an additional protection for the very last edge in case the axis doesn't have the overflow bin, since the edge lookup might be undefined in that case
         # since the upper edge is no longer associated to the following bin, which would be the overflow bin, but to the inner bin (adding epsilon seems to work nonetheless, but it is probably by chance)
-        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001) if decorrEdges[isyst+1] < ax.edges[-1] else ax.size
+        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001) if decorrEdges[isyst+1] < ax.edges[-1] else hist.overflow
         slices = [slice(None) if n != axisToDecorrIndex else slice(indexLow,indexHigh) for n in range(len(hnomAsVar.axes.name))]
         hvarnew.values(flow=False)[*slices, isyst] = hvar.values(flow=False)[*slices] # use values instead of view, because hvar has storage=Double(), while hnom (and hence hvarnew) has storage=Weight
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -252,7 +252,7 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
         indexLow = ax.index(decorrEdges[isyst] + 0.001) # add epsilon to ensure picking the bin on the right of the edge (note that the second bin index is excluded from the slice selection below)
         # for the upper edge add an additional protection for the very last edge in case the axis doesn't have the overflow bin, since the edge lookup might be undefined in that case
         # since the upper edge is no longer associated to the following bin, which would be the overflow bin, but to the inner bin (adding epsilon seems to work nonetheless, but it is probably by chance)
-        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001) if decorrEdges[isyst+1] < ax.edges[-1] else hist.overflow
+        indexHigh = ax.index(decorrEdges[isyst+1] + 0.001) if decorrEdges[isyst+1] < ax.edges[-1] else ax.size # it seems hist.overflow doesn't work inside slice()
         slices = [slice(None) if n != axisToDecorrIndex else slice(indexLow,indexHigh) for n in range(len(hnomAsVar.axes.name))]
         hvarnew.values(flow=False)[*slices, isyst] = hvar.values(flow=False)[*slices] # use values instead of view, because hvar has storage=Double(), while hnom (and hence hvarnew) has storage=Weight
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -458,7 +458,17 @@ def add_luminosity_unc_hists(results, df, args, axes, cols, addhelicity=False):
         luminosity = df.HistoBoost("nominal_luminosity", axes, [*cols, "luminosityScaling"], tensor_axes = [common.down_up_axis], storage=hist.storage.Double())
         results.append(luminosity)
     return df
-    
+
+# TODO: generalize to non-constant scaling if needed
+def add_scaledByCondition_unc_hists(results, df, args, axes, cols, newWeightName, histName, condition, scale):
+    # scale represents the scaling factor of the nominal weight, 1.1 means +10%, 2.0 means + 100% and so on
+    df = df.Define(newWeightName, f"({condition}) ? ({scale}*nominal_weight) : nominal_weight")
+    # df = df.Filter(f"wrem::printVar({newWeightName})")
+    # df = df.Filter(f"wrem::printVar(nominal_weight)")
+    scaledHist = df.HistoBoost(f"nominal_{histName}", axes, [*cols, newWeightName], storage=hist.storage.Double())
+    results.append(scaledHist)
+    return df
+
 def add_muon_efficiency_unc_hists(results, df, helper_stat, helper_syst, axes, cols, base_name="nominal", what_analysis=ROOT.wrem.AnalysisType.Wmass, smooth3D=False, addhelicity=False):
     # TODO: update for dilepton
     if what_analysis == ROOT.wrem.AnalysisType.Wmass:

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -263,7 +263,7 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
         hvarnew = hvarnew.project(*sortedAxes)
 
     return hvarnew
-        
+
 def make_fakerate_variation(href, fakerate_axes, fakerate_axes_syst, variation_fakerate=0.5, flow=False):
     # 1) calculate fakerate in bins of fakerate axes
     nameMT, failMT, passMT = sel.get_mt_selection(href)

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -222,12 +222,12 @@ def scale_helicity_hist_to_variations(scale_hist, sum_axes=[], pt_ax="ptVgen", g
 def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisName=None):
 
     if axisToDecorrName not in hnom.axes.name:
-        raise ValueError("Requested to decorrelate uncertainty in histogram {hvar.name} by {axisToDecorrName} axis, but available axes for nominal histogram are {hnom.axes.name}")
+        raise ValueError(f"Requested to decorrelate uncertainty in histogram {hvar.name} by {axisToDecorrName} axis, but available axes for nominal histogram are {hnom.axes.name}")
 
     # for convenience, broadcast the nominal into the same shape as hvar
     # hvar may often have the same dimension as hnom, but sometimes it might have been mirrored and thus have at least the mirror axis
     hnomAsVar = hh.broadcastSystHist(hnom, hvar)
-    
+
     ax = hnomAsVar.axes[axisToDecorrName]
     axisToDecorrIndex = list(hnomAsVar.axes).index(ax)
     logger.debug(f"Decorrelating versus axis {axisToDecorrName} with index {axisToDecorrIndex}")
@@ -235,7 +235,7 @@ def decorrelateByAxis(hvar, hnom, axisToDecorrName, decorrEdges, newDecorrAxisNa
     axis_decorr_name = newDecorrAxisName if newDecorrAxisName != None else f"{axisToDecorrName}_decorr"
     axis_decorr = hist.axis.Variable(decorrEdges, underflow=False, overflow=False, name=axis_decorr_name)
     hvarnew = hh.addGenericAxis(hnomAsVar, axis_decorr)
-        
+
     for isyst in range(len(decorrEdges)-1):
         indexLow = ax.index(decorrEdges[isyst] + 0.001) # add epsilon to ensure picking the bin on the right of the edge
         indexHigh = ax.index(decorrEdges[isyst+1] + 0.001)


### PR DESCRIPTION
This is a preliminary implementation, which will be discussed tomorrow at the mW working meeting. **Until then this PR should not be merged.**

The mW histomaker will produce a new histogram where the fraction of the Z backgrounds where one muon fails the veto is scaled up by 100% (equivalent to assuming that the scale factor for the failed veto is 1.0, namely no change in the central value, with a 100% uncertainty.
The definition of this fraction requires selecting at least 2 postFSR muons inside the eta acceptance. It is possible to apply a minimum gen pT selection as well, but based on some studies to be shown tomorrow I would recommend applying no gen pT cut.

In setupCombine.py this uncertainty is mirrored, and further decorrelated vs eta.
**NOTE**: the eta decorrelation is currently implemented in CardTool.py and might not work for the hdf5 based setup. Decorrelating at the histmaker level requires a dedicated helper (and a little waste of resources).

In principle one should modify the central value of the Z nominal histograms too, but doing it properly requires knowledge of a reasonable range of the actual anti-veto scale factors, since the shift may not be negligible.

Finally, a new histomaker **scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py** is added, specifically to study MC truth veto efficiencies using W events. Doing it from the main histmaker was not practical, since a lot of things had to be changed, customised, or moved away. This is accompanied by a new plotting script **scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency.py** 