### PR TITLE
Update treatment of width uncertainty

### DIFF
--- a/utilities/common.py
+++ b/utilities/common.py
@@ -164,7 +164,6 @@ def common_parser(for_reco_highPU=False):
         default=["scetlib_dyturbo", "winhacnloew", "virtual_ew_wlike", "horaceqedew_FSR", "horacelophotosmecoffew_FSR"], choices=theory_corrections.valid_theory_corrections(), 
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
-    parser.add_argument("--widthVariations", action='store_true', help="Store variations of W and Z widths.")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--eta", nargs=3, type=float, help="Eta binning as 'nbins min max' (only uniform for now)", default=[48,-2.4,2.4])
     parser.add_argument("--pt", nargs=3, type=float, help="Pt binning as 'nbins,min,max' (only uniform for now)", default=[30,26.,56.])

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -368,11 +368,8 @@ def widthWeightNames(matches=None, proc=""):
     else:
         raise RuntimeError(f"No width found for process {proc}")
     # 0 and 1 are Up, Down from mass uncertainty EW fit (already accounted for in mass variations)
-    names = [f"width{proc[0]}{str(widths[i]).replace('.','p')}GeV" for i in (0, 1)]
     # 2, 3, and 4 are PDG width Down, Central, Up
-    names.append(f"widthShift{proc[0]}{str(2.3 if proc[0] == 'Z' else 42).replace('.','p')}MeVDown")
-    names.append(f"width{proc[0]}{str(widths[central]).replace('.','p')}GeV")
-    names.append(f"widthShift{proc[0]}{str(2.3 if proc[0] == 'Z' else 42).replace('.','p')}MeVUp")
+    names = [f"width{proc[0]}{str(width).replace('.','p')}GeV" for width in widths]
 
     return [x if not matches or any(y in x for y in matches) else "" for x in names]
 
@@ -632,8 +629,7 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
     df = theory_tools.define_scale_tensor(df)
     df = define_mass_weights(df, dataset_name)
-    if args.widthVariations:
-        df = define_width_weights(df, dataset_name)
+    df = define_width_weights(df, dataset_name)
 
     add_pdf_hists(results, df, dataset_name, axes, cols, args.pdfs, base_name=base_name, addhelicity=addhelicity)
     add_qcdScale_hist(results, df, scale_axes, scale_cols, base_name=base_name, addhelicity=addhelicity)
@@ -655,7 +651,6 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
 
         # TODO: Should have consistent order here with the scetlib correction function
         add_massweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name, addhelicity=addhelicity)
-        if args.widthVariations:
-            add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
+        add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name)
 
     return df


### PR DESCRIPTION
- Get rid of arguments to run width unc, just include it by default (W in W case and Z in Z case, not both)
- Use EW fit variation as nominal. Can be swapped out for the experimental ones, but currently not as an option (would need to modify the code)

The impact of the variations is 0.02 MeV, so totally negligible. I've still included it. If the experimental range is used instead, the impact is 1.3 MeV. You can see the variations here:


![](https://kelong.web.cern.ch/kelong/WMassAnalysis/AN2023Nov/W/pt_widthW2p09053GeV.png)
