### PR TITLE
Update muon calibration scale and resolution corrections

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -68,7 +68,7 @@ def make_parser(parser=None):
     parser.add_argument("--muonScaleVariation", choices=["smearingWeights", "massWeights", "manualShift"], default="smearingWeights", help="the method with which the muon scale variation histograms are derived")
     parser.add_argument("--scaleMuonCorr", type=float, default=1.0, help="Scale up/down dummy muon scale uncertainty by this factor")
     parser.add_argument("--correlatedNonClosureNuisances", action='store_true', help="get systematics from histograms for the Z non-closure nuisances without decorrelation in eta and pt")
-    parser.add_argument("--calibrationStatScaling", type=float, default=1.7, help="scaling of calibration statistical uncertainty")
+    parser.add_argument("--calibrationStatScaling", type=float, default=2.2, help="scaling of calibration statistical uncertainty")
     parser.add_argument("--correlatedAdHocA", type=float, default=0.0, help="fully correlated ad-hoc uncertainty on b-field term A (in addition to Z pdg mass)")
     parser.add_argument("--correlatedAdHocM", type=float, default=3.5e-6, help="fully correlated ad-hoc uncertainty on alignment term M")
     parser.add_argument("--noEfficiencyUnc", action='store_true', help="Skip efficiency uncertainty (useful for tests, because it's slow). Equivalent to --excludeNuisances '.*effSystTnP|.*effStatTnP' ")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -94,6 +94,7 @@ def make_parser(parser=None):
     # utility options to deal with charge when relevant, mainly for theory agnostic but also unfolding
     parser.add_argument("--recoCharge", type=str, default=["plus", "minus"], nargs="+", choices=["plus", "minus"], help="Specify reco charge to use, default uses both. This is a workaround for unfolding/theory-agnostic fit when running a single reco charge, as gen bins with opposite gen charge have to be filtered out")
     parser.add_argument("--forceRecoChargeAsGen", action="store_true", help="Force gen charge to match reco charge in CardTool, this only works when the reco charge is used to define the channel")
+    parser.add_argument("--forceConstrainMass", action='store_true', help="force mass to be constrained in fit")
     # TODO: some options that should exist only for a specific case, can implement a subparser to substitute --unfolding and --theoryAgnostic
     # some options are actually in common between them, so an intermediate subparser might be used
     ##parsers = parser.add_subparsers(dest='analysisFitSetup')
@@ -134,8 +135,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
     dilepton = "dilepton" in datagroups.mode or any(x in ["ptll", "mll"] for x in fitvar)
 
     simultaneousABCD = wmass and args.ABCD and not xnorm
-    # constrainMass = (dilepton and not "mll" in fitvar) or args.fitXsec
-    constrainMass = dilepton or args.fitXsec
+    constrainMass = (dilepton and not "mll" in fitvar) or args.fitXsec
+    constrainMass = constrainMass or args.forceConstrainMass
 
     print("constrainMass", constrainMass)
 

--- a/scripts/corrections/make_muon_response_maps.py
+++ b/scripts/corrections/make_muon_response_maps.py
@@ -29,11 +29,11 @@ procs.append("WminustaunuPostVFP")
 
 
 with h5py.File(infile, 'r') as f:
-    results = narf.ioutils.pickle_load_h5py(f["results"])
     for proc in procs:
-        hist_response_proc = results[proc]["output"]["hist_qopr"].get()
-        hist_response_scaled_proc = results[proc]["output"]["hist_qopr_shifted"].get()
-        hist_response_smeared_proc = results[proc]["output"]["hist_qopr_smearedmulti"].get()
+        results = narf.ioutils.pickle_load_h5py(f[proc])
+        hist_response_proc = results["output"]["hist_qopr"].get()
+        hist_response_scaled_proc = results["output"]["hist_qopr_shifted"].get()
+        hist_response_smeared_proc = results["output"]["hist_qopr_smearedmulti"].get()
         if hist_response is None:
             hist_response = hist_response_proc
             hist_response_scaled = hist_response_scaled_proc

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -501,17 +501,17 @@ def build_graph(df, dataset):
             ####################################################
             # nuisances from the muon momemtum scale calibration 
             if (args.muonCorrData in ["massfit", "lbl_massfit"]):
+                input_kinematics = [
+                    f"{reco_sel_GF}_recoPt",
+                    f"{reco_sel_GF}_recoEta",
+                    f"{reco_sel_GF}_recoCharge",
+                    f"{reco_sel_GF}_genPt",
+                    f"{reco_sel_GF}_genEta",
+                    f"{reco_sel_GF}_genCharge"
+                ]
                 if diff_weights_helper:
-                    df = df.Define(f'{reco_sel_GF}_response_weight', diff_weights_helper,
-                        [
-                            f"{reco_sel_GF}_recoPt",
-                            f"{reco_sel_GF}_recoEta",
-                            f"{reco_sel_GF}_recoCharge",
-                            f"{reco_sel_GF}_genPt",
-                            f"{reco_sel_GF}_genEta",
-                            f"{reco_sel_GF}_genCharge"
-                        ]
-                    )
+                    df = df.Define(f'{reco_sel_GF}_response_weight', diff_weights_helper, [*input_kinematics])
+                    input_kinematics.append(f'{reco_sel_GF}_response_weight')
 
                 # muon scale variation from stats. uncertainty on the jpsi massfit
                 df = muon_calibration.add_jpsi_crctn_stats_unc_hists(

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -533,20 +533,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties from non-closure stats
                 df = df.Define("muonScaleClosSyst_responseWeights_tensor_splines", closure_unc_helper,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -554,20 +545,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for A (fully correlated)
                 df = df.Define("muonScaleClosASyst_responseWeights_tensor_splines", closure_unc_helper_A,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_A.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -575,20 +557,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for M (fully correlated)
                 df = df.Define("muonScaleClosMSyst_responseWeights_tensor_splines", closure_unc_helper_M,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_M.tensor_axes,
                     storage = hist.storage.Double()
                 )

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -419,20 +419,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties from non-closure stats
                 df = df.Define("muonScaleClosSyst_responseWeights_tensor_splines", closure_unc_helper,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -440,20 +431,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for A (fully correlated)
                 df = df.Define("muonScaleClosASyst_responseWeights_tensor_splines", closure_unc_helper_A,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_A.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -461,20 +443,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for M (fully correlated)
                 df = df.Define("muonScaleClosMSyst_responseWeights_tensor_splines", closure_unc_helper_M,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_M.tensor_axes,
                     storage = hist.storage.Double()
                 )

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -410,7 +410,7 @@ def build_graph(df, dataset):
                     )
                     hist_Z_non_closure_parametrized = df.HistoBoost(
                         "Z_non_closure_parametrized_gaus" if args.muonScaleVariation == 'smearingWeightsGaus' else "nominal_Z_non_closure_parametrized",
-                        nominal_axes,
+                        axes,
                         [*cols, "Z_non_closure_parametrized"],
                         tensor_axes = z_non_closure_parametrized_helper.tensor_axes,
                         storage=hist.storage.Double()

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -71,6 +71,10 @@ all_axes = {
     "ewMll": hist.axis.Variable(ewMassBins, name = "ewMll", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
     "ewMlly": hist.axis.Variable(ewMassBins, name = "ewMlly", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
     "ewLogDeltaM": hist.axis.Regular(100, -10, 4, name = "ewLogDeltaM", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
+    "trigMuons_abseta0" : hist.axis.Regular(3, 0., 2.4, name = "trigMuons_abseta0", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
+    "nonTrigMuons_eta0" : hist.axis.Regular(24, -2.4, 2.4, name = "nonTrigMuons_eta0", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
+    "nonTrigMuons_pt0" : hist.axis.Regular(int(args.pt[0]), args.pt[1], args.pt[2], name = "nonTrigMuons_pt0"),
+    "nonTrigMuons_charge0" : hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "nonTrigMuons_charge0"),
 }
 
 auxiliary_gen_axes = ["massVgen", # preFSR variables
@@ -132,6 +136,10 @@ mc_jpsi_crctn_helper, data_jpsi_crctn_helper, mc_jpsi_crctn_unc_helper, data_jps
 z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibration.make_Z_non_closure_helpers(args, calib_filepaths, closure_filepaths)
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args)
+
+closure_unc_helper = wremnants.muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
+closure_unc_helper_A = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
+closure_unc_helper_M = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
 
 smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
 
@@ -227,6 +235,10 @@ def build_graph(df, dataset):
     
         df = df.Define("cosThetaStarll", "csSineCosThetaPhill.costheta")
         df = df.Define("phiStarll", "std::atan2(csSineCosThetaPhill.sinphi, csSineCosThetaPhill.cosphi)")
+
+    # TODO might need to add an explicit cut on trigMuons_pt0 in case nominal pt range
+    # extends below 26 GeV e.g. for calibration test purposes
+    df = df.Define("trigMuons_abseta0", "std::fabs(trigMuons_eta0)")
 
     logger.debug(f"Define weights and store nominal histograms")
 
@@ -386,6 +398,88 @@ def build_graph(df, dataset):
                         storage=hist.storage.Double()
                     )
                     results.append(hist_Z_non_closure_parametrized_M)
+
+                if args.nonClosureScheme == "A-M-combined":
+                    df = df.DefinePerSample("AMFlag", "0x01 | 0x04")
+                    df = df.Define("Z_non_closure_parametrized", z_non_closure_parametrized_helper,
+                        [
+                            *input_kinematics,
+                            "nominal_weight",
+                            "AMFlag"
+                        ]
+                    )
+                    hist_Z_non_closure_parametrized = df.HistoBoost(
+                        "Z_non_closure_parametrized_gaus" if args.muonScaleVariation == 'smearingWeightsGaus' else "nominal_Z_non_closure_parametrized",
+                        nominal_axes,
+                        [*cols, "Z_non_closure_parametrized"],
+                        tensor_axes = z_non_closure_parametrized_helper.tensor_axes,
+                        storage=hist.storage.Double()
+                    )
+                    results.append(hist_Z_non_closure_parametrized)
+
+                # extra uncertainties from non-closure stats
+                df = df.Define("muonScaleClosSyst_responseWeights_tensor_splines", closure_unc_helper,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosSyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosSyst_responseWeights)
+
+                # extra uncertainties for A (fully correlated)
+                df = df.Define("muonScaleClosASyst_responseWeights_tensor_splines", closure_unc_helper_A,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosASyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper_A.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosASyst_responseWeights)
+
+                # extra uncertainties for M (fully correlated)
+                df = df.Define("muonScaleClosMSyst_responseWeights_tensor_splines", closure_unc_helper_M,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosMSyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper_M.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosMSyst_responseWeights)
+
             ####################################################
 
             # Don't think it makes sense to apply the mass weights to scale leptons from tau decays

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -344,20 +344,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties from non-closure stats
                 df = df.Define("muonScaleClosSyst_responseWeights_tensor_splines", closure_unc_helper,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -365,20 +356,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for A (fully correlated)
                 df = df.Define("muonScaleClosASyst_responseWeights_tensor_splines", closure_unc_helper_A,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_A.tensor_axes,
                     storage = hist.storage.Double()
                 )
@@ -386,20 +368,11 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for M (fully correlated)
                 df = df.Define("muonScaleClosMSyst_responseWeights_tensor_splines", closure_unc_helper_M,
-                    [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_response_weight",
-                        "nominal_weight"
-                    ]
+                    [*input_kinematics, "nominal_weight"]
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights", axes,
-                    [*nominal_cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
+                    [*cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
                     tensor_axes = closure_unc_helper_M.tensor_axes,
                     storage = hist.storage.Double()
                 )

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -104,6 +104,10 @@ z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibratio
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args)
 
+closure_unc_helper = wremnants.muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
+closure_unc_helper_A = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
+closure_unc_helper_M = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
+
 smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
 
 bias_helper = muon_calibration.make_muon_bias_helpers(args) if args.biasCalibration else None
@@ -318,6 +322,89 @@ def build_graph(df, dataset):
                         storage=hist.storage.Double()
                     )
                     results.append(hist_Z_non_closure_parametrized_M)
+
+                if args.nonClosureScheme == "A-M-combined":
+                    df = df.DefinePerSample("AMFlag", "0x01 | 0x04")
+                    df = df.Define("Z_non_closure_parametrized", z_non_closure_parametrized_helper,
+                        [
+                            *input_kinematics,
+                            "nominal_weight",
+                            "AMFlag"
+                        ]
+                    )
+                    hist_Z_non_closure_parametrized = df.HistoBoost(
+                        "Z_non_closure_parametrized_gaus" if args.muonScaleVariation == 'smearingWeightsGaus' else "nominal_Z_non_closure_parametrized",
+                        nominal_axes,
+                        [*cols, "Z_non_closure_parametrized"],
+                        tensor_axes = z_non_closure_parametrized_helper.tensor_axes,
+                        storage=hist.storage.Double()
+                    )
+                    results.append(hist_Z_non_closure_parametrized)
+
+
+                # extra uncertainties from non-closure stats
+                df = df.Define("muonScaleClosSyst_responseWeights_tensor_splines", closure_unc_helper,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosSyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosSyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosSyst_responseWeights)
+
+                # extra uncertainties for A (fully correlated)
+                df = df.Define("muonScaleClosASyst_responseWeights_tensor_splines", closure_unc_helper_A,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosASyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosASyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper_A.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosASyst_responseWeights)
+
+                # extra uncertainties for M (fully correlated)
+                df = df.Define("muonScaleClosMSyst_responseWeights_tensor_splines", closure_unc_helper_M,
+                    [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_response_weight",
+                        "nominal_weight"
+                    ]
+                )
+                nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
+                    "nominal_muonScaleClosMSyst_responseWeights", axes,
+                    [*nominal_cols, "muonScaleClosMSyst_responseWeights_tensor_splines"],
+                    tensor_axes = closure_unc_helper_M.tensor_axes,
+                    storage = hist.storage.Double()
+                )
+                results.append(nominal_muonScaleClosMSyst_responseWeights)
+
             ####################################################
 
     if hasattr(dataset, "out_of_acceptance"):

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -334,7 +334,7 @@ def build_graph(df, dataset):
                     )
                     hist_Z_non_closure_parametrized = df.HistoBoost(
                         "Z_non_closure_parametrized_gaus" if args.muonScaleVariation == 'smearingWeightsGaus' else "nominal_Z_non_closure_parametrized",
-                        nominal_axes,
+                        axes,
                         [*cols, "Z_non_closure_parametrized"],
                         tensor_axes = z_non_closure_parametrized_helper.tensor_axes,
                         storage=hist.storage.Double()

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -57,14 +57,17 @@ calib_filepaths = {
     },
     'data_corrfile': {
         'massfit': f"{calib_dir}/calibrationJDATA_ideal.root",
-        'lbl_massfit': f"{calib_dir}/calibrationJDATA_MCstat_inclusive_smeared.root"
+        'lbl_massfit': f"{calib_dir}/calibrationJDATA_MCstat_inclusive_binsel.root"
+        # 'lbl_massfit': f"{calib_dir}/calibrationJZ_DATA_MCstat_binsel.root"
     },
     'mc_resofile': f"{calib_dir}/sigmaMC_LBL_JYZ.root",
     'data_resofile': f"{calib_dir}/sigmaDATA_LBL_JYZ.root",
     'tflite_file': f"{calib_dir}/muon_response.tflite"
+    # 'tflite_file': f"{calib_dir}/muon_response_nosmearing.tflite"
 }
 closure_filepaths = {
-    'parametrized': f"{closure_dir}/parametrizedClosureZ_inclusive_smeared.root",
+    'parametrized': f"{closure_dir}/parametrizedClosureZ_ORkinweight_binsel_newres_MCstat_new.root",
+    # 'parametrized': f"{closure_dir}/parametrizedClosureZ_ORkinweight_binsel_MCstat_simul.root",
     'binned': f"{closure_dir}/closureZ_LBL_smeared_v721.root"
 }
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -64,7 +64,7 @@ calib_filepaths = {
     'tflite_file': f"{calib_dir}/muon_response.tflite"
 }
 closure_filepaths = {
-    'parametrized': f"{closure_dir}/calibrationAlignmentZ_after_LBL_v721.root",
+    'parametrized': f"{closure_dir}/parametrizedClosureZ_inclusive_smeared.root",
     'binned': f"{closure_dir}/closureZ_LBL_smeared_v721.root"
 }
 
@@ -180,9 +180,12 @@ def common_parser(for_reco_highPU=False):
     parser.add_argument("-o", "--outfolder", type=str, default="", help="Output folder")
     parser.add_argument("--appendOutputFile", type=str, default="", help="Append analysis output to specified output file")
     parser.add_argument("-e", "--era", type=str, choices=["2016PreVFP","2016PostVFP", "2017", "2018"], help="Data set to process", default="2016PostVFP")
-    parser.add_argument("--nonClosureScheme", type=str, default = "A-only", choices=["none", "A-M-separated", "A-M-combined", "binned", "binned-plus-M", "A-only", "M-only"], help = "source of the Z non-closure nuisances")
+    parser.add_argument("--scale_A", default=1.0, type=float, help="scaling of the uncertainty on the b-field scale parameter A")
+    parser.add_argument("--scale_e", default=1.0, type=float, help="scaling of the uncertainty on the material scale parameter e")
+    parser.add_argument("--scale_M", default=1.0, type=float, help="scaling of the uncertainty on the alignment scale parameter M")
+    parser.add_argument("--nonClosureScheme", type=str, default = "A-M-combined", choices=["none", "A-M-separated", "A-M-combined", "binned", "binned-plus-M", "A-only", "M-only"], help = "source of the Z non-closure nuisances")
     parser.add_argument("--correlatedNonClosureNP", action="store_false", help="disable the de-correlation of Z non-closure nuisance parameters after the jpsi massfit")
-    parser.add_argument("--dummyNonClosureA", action="store_false", help="read values for the magnetic part of the Z non-closure from a file")
+    parser.add_argument("--dummyNonClosureA", action="store_true", help="read values for the magnetic part of the Z non-closure from a file")
     parser.add_argument("--dummyNonClosureAMag", default=6.8e-5, type=float, help="magnitude of the dummy value for the magnetic part of the Z non-closure")
     parser.add_argument("--dummyNonClosureM", action="store_true", help="use a dummy value for the alignment part of the Z non-closure")
     parser.add_argument("--dummyNonClosureMMag", default=0., type=float, help="magnitude of the dummy value for the alignment part of the Z non-closure")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -57,7 +57,7 @@ calib_filepaths = {
     },
     'data_corrfile': {
         'massfit': f"{calib_dir}/calibrationJDATA_ideal.root",
-        'lbl_massfit': f"{calib_dir}/calibrationJDATA_rewtgr_3dmap_LBL_MCstat.root"
+        'lbl_massfit': f"{calib_dir}/calibrationJDATA_MCstat_inclusive_smeared.root"
     },
     'mc_resofile': f"{calib_dir}/sigmaMC_LBL_JYZ.root",
     'data_resofile': f"{calib_dir}/sigmaDATA_LBL_JYZ.root",

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -71,6 +71,12 @@ closure_filepaths = {
     'binned': f"{closure_dir}/closureZ_LBL_smeared_v721.root"
 }
 
+# some constants for momentum scale uncertainties
+correlated_variation_base_size = {
+    "A" : 1e-5,
+    "M" : 1e-6,
+    }
+
 ## 5% quantiles from aMC@NLO used in SMP-18-012
 #ptV_5quantiles_binning = [0.0, 1.971, 2.949, 3.838, 4.733, 5.674, 6.684, 7.781, 8.979, 10.303, 11.777, 13.435, 15.332, 17.525, 20.115, 23.245, 27.173, 32.414, 40.151, 53.858, 13000.0]
 ## 10% quantiles from aMC@NLO used in SMP-18-012 with some rounding <== This one worked fine with toys

--- a/wremnants/include/muon_calibration.h
+++ b/wremnants/include/muon_calibration.h
@@ -1222,7 +1222,7 @@ public:
     static constexpr auto nUnc = sizes[sizes.size() - 1];
     using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nUnc, 2>>;
 
-    JpsiCorrectionsUncHelperSplines(const std::string &filename, T&& corrections) : 
+    JpsiCorrectionsUncHelperSplines(T&& corrections) :
         correctionHist_(std::make_shared<const T>(std::move(corrections))) {
     }
 

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -193,8 +193,10 @@ def make_muon_smearing_helpers_binned(filename = f"{data_dir}/calibration/smeari
 
     return helper, helper_var
 
-def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutionDATA_LBL_JZ_seagulls.root",
-                               filenamemc = f"{data_dir}/calibration/resolutionMC_LBL_JZ_seagulls.root"):
+def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutionDATA_LBL_JZ_deltaphim_d50.root",
+                               filenamemc = f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_d50.root",
+                               override_d = None,
+                               dummary_vars = False):
     # this helper smears muon pT to match the resolution in data
 
     def load_res(filename):
@@ -218,15 +220,19 @@ def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutio
     adata, cdata, bdata, ddata, covdata = load_res(filenamedata)
     amc, cmc, bmc, dmc, covmc = load_res(filenamemc)
 
-    # d^2 values are fixed to 100 and not written in the root files so set them by hand
-    ddata.values()[...] = 100.
-    ddata.variances()[...] = 0.
+    if override_d is not None:
+        ddata.values()[...] = override_d
+        ddata.variances()[...] = 0.
 
-    dmc.values()[...] = 100.
-    dmc.variances()[...] = 0.
+        dmc.values()[...] = override_d
+        dmc.variances()[...] = 0.
+
+    if np.any(np.isclose(ddata.values(), 0.)) or np.any(np.isclose(dmc.values(), 0.)):
+        raise ValueError("d^2 values of 0 are invalid for the resolution parameterization")
 
     axis_res_eta = adata.axes["res_eta"]
     axis_res_parm = hist.axis.StrCategory(["a", "c", "b", "d"], name = "res_parm")
+    # ordering is different here because the covariance matrix is ordered a, b, c
     axis_res_parm_reduced = hist.axis.StrCategory(["a", "b", "c"], name = "res_parm_reduced")
     axis_data_mc = hist.axis.StrCategory(["data", "mc"], name = "data_mc")
 
@@ -270,6 +276,18 @@ def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutio
 
     dparms = np.sqrt(e[None, :])*v
     dparms = np.reshape(dparms, (neta, -1, nvar))
+
+    if dummy_vars:
+        # replace eigenvector variations with dummy variations (intended to be used to e.g. determine the resolution corrections in-situ)
+        varsizes = [1e-5, 1e-5, 1e-9]
+
+        dparms = np.zeros((neta, nparmsreduced, nvar), dtype=np.float64)
+        ivar = 0
+        for ieta in range(neta):
+            for iparm in range(nparmsreduced):
+                varsize = varsizes[iparm]
+                dparms[ieta, iparm, ivar] = varsize
+                ivar += 1
 
     axis_res_var = hist.axis.Integer(0, nvar, name = "smearing_variation")
 
@@ -381,17 +399,11 @@ def make_jpsi_crctn_unc_helper(
     n_scale_params = 3
     nvars = neta*n_scale_params
 
-    # check only the first two parameters now because the variances stored in the histograms are not fully consistent (but the covariance matrix is fine)
-    is_consistent = False
-    if is_consistent:
-        variances_ref = np.stack([A.variances(), e.variances(), M.variances()], axis=-1)
-        variances = np.reshape(np.diag(cov), (neta, nparmscov))[:, :n_scale_params]
-    else:
-        variances_ref = np.stack([A.variances(), e.variances()], axis=-1)
-        variances = np.reshape(np.diag(cov), (neta, nparmscov))[:, :2]
+    variances_ref = np.stack([A.variances(), e.variances(), M.variances()], axis=-1)
+    variances = np.reshape(np.diag(cov), (neta, nparmscov))[:, :n_scale_params]
 
-    # if not np.all(np.isclose(variances, variances_ref, atol=0.)):
-        # raise ValueError("Covariance matrix is not consistent with parameter uncertainties or parameters are not in the expected order.")
+    if not np.all(np.isclose(variances, variances_ref, atol=0.)):
+        raise ValueError("Covariance matrix is not consistent with parameter uncertainties or parameters are not in the expected order.")
 
     cov = np.reshape(cov, (neta, nparmscov, neta, nparmscov))
     cov = cov[:, :n_scale_params, :, :n_scale_params]
@@ -430,6 +442,137 @@ def make_jpsi_crctn_unc_helper(
     )
     helper.tensor_axes = (hist_scale_params_unc.axes['unc'], common.down_up_axis)
     return helper
+
+def make_dummy_closure_uncertainty_helper(neta=24, etalow=-2.4, etahigh=2.4):
+
+    n_scale_params = 3
+    n_var_params = 2
+
+    nvars = n_var_params*neta
+
+    axis_eta = hist.axis.Regular(neta, etalow, etahigh, name="scale_eta")
+    axis_scale_params = hist.axis.Integer(0, n_scale_params, underflow=False, overflow = False, name = 'scale_params')
+    axis_scale_params_unc = hist.axis.Integer(0, nvars, underflow=False, overflow = False, name = 'unc')
+
+    hist_scale_params_unc = hist.Hist(axis_eta, axis_scale_params, axis_scale_params_unc)
+
+    ivar = 0
+    for ieta in range(neta):
+        for iparm in [0, 2]:
+            if iparm == 0:
+                var_size = 1e-4
+            elif iparm == 2:
+                var_size = 1e-4/50.
+
+            hist_scale_params_unc.values()[ieta, iparm, ivar] = var_size
+
+            ivar += 1
+
+    print(hist_scale_params_unc.values())
+
+    hist_scale_params_unc_cpp = narf.hist_to_pyroot_boost(hist_scale_params_unc, tensor_rank = 2)
+
+    helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[type(hist_scale_params_unc_cpp).__cpp_name__](
+        ROOT.std.move(hist_scale_params_unc_cpp)
+    )
+
+    helper.tensor_axes = (hist_scale_params_unc.axes['unc'], common.down_up_axis)
+    return helper
+
+def make_closure_uncertainty_helper(filepath_correction):
+
+    f = ROOT.TFile.Open(filepath_correction)
+    A = f.Get("AZ")
+    M = f.Get("MZ")
+    cov = f.Get("covariance_matrix")
+
+    A = narf.root_to_hist(A, axis_names = ["scale_eta"])
+    M = narf.root_to_hist(M, axis_names = ["scale_eta"])
+    cov = narf.root_to_hist(cov)
+
+    f.Close()
+
+    axis_eta = A.axes["scale_eta"]
+    neta = axis_eta.size
+
+    cov = cov.values()
+    nparmscov = cov.shape[0]//neta
+    n_scale_params = 3
+    nvars = neta*n_scale_params
+
+    variances_ref = np.stack([A.variances(), M.variances()], axis=-1)
+    variances = np.reshape(np.diag(cov), (neta, nparmscov))[:, :n_scale_params]
+
+    if not np.all(np.isclose(variances, variances_ref, atol=0.)):
+        raise ValueError("Covariance matrix is not consistent with parameter uncertainties or parameters are not in the expected order.")
+
+    cov = np.reshape(cov, (neta, nparmscov, neta, nparmscov))
+    covin = cov
+    cov = np.zeros((neta, n_scale_params, neta, n_scale_params), dtype=np.float64)
+
+    cov[:, 0, :, 0] = covin[:, 0, :, 0]
+    cov[:, 2, :, 2] = covin[:, 1, :, 1]
+    cov[:, 0, :, 2] = covin[:, 0, :, 1]
+    cov[:, 2, :, 0] = covin[:, 1, :, 0]
+
+    cov = np.reshape(cov, (nvars, nvars))
+
+    # mz = 91.1876
+    # mzerr = 2.1e-3
+    # zvarsize = np.sqrt((mzerr/mz)**2 + 2e-5**2)
+    # zvar = np.zeros((neta, n_scale_params), dtype=np.float64)
+    # zvar[:, 0] = zvarsize
+    # zvar = np.reshape(zvar, (nvars, 1))
+    # cov += zvar @ zvar.T
+    #
+    # alignment_var = np.zeros((neta, n_scale_params), dtype=np.float64)
+    # alignment_var[:, 2] = 3.5e-6
+    # alignment_var = np.reshape(alignment_var, (nvars, 1))
+    # cov += alignment_var @ alignment_var.T
+
+    e, v = np.linalg.eigh(cov)
+    e = np.maximum(e, 0.)
+    var_mat = np.sqrt(e[None, :]) * v
+    var_mat = np.reshape(var_mat, (neta, n_scale_params, nvars))
+
+    if not np.all(np.isfinite(var_mat)):
+        raise ValueError("Variations not finite")
+
+    axis_scale_params = hist.axis.Integer(0, n_scale_params, underflow=False, overflow = False, name = 'scale_params')
+    axis_scale_params_unc = hist.axis.Integer(0, nvars, underflow=False, overflow = False, name = 'unc')
+
+    hist_scale_params_unc = hist.Hist(axis_eta, axis_scale_params, axis_scale_params_unc)
+    hist_scale_params_unc[...] = var_mat
+
+    hist_scale_params_unc_cpp = narf.hist_to_pyroot_boost(hist_scale_params_unc, tensor_rank = 2)
+
+    helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[type(hist_scale_params_unc_cpp).__cpp_name__](
+        ROOT.std.move(hist_scale_params_unc_cpp)
+    )
+
+    helper.tensor_axes = (hist_scale_params_unc.axes['unc'], common.down_up_axis)
+    return helper
+
+def make_uniform_closure_uncertainty_helper(iparm = 0, val = 1e-5):
+    nvars = 1
+    n_scale_params = 3
+
+    axis_eta = hist.axis.Regular(1, -2.4, 2.4, name = "scale_eta")
+    axis_scale_params = hist.axis.Integer(0, n_scale_params, underflow=False, overflow = False, name = 'scale_params')
+    axis_scale_params_unc = hist.axis.Integer(0, nvars, underflow=False, overflow = False, name = 'unc')
+
+    hist_scale_params_unc = hist.Hist(axis_eta, axis_scale_params, axis_scale_params_unc)
+    hist_scale_params_unc.values()[:, iparm, 0] = val
+
+    hist_scale_params_unc_cpp = narf.hist_to_pyroot_boost(hist_scale_params_unc, tensor_rank = 2)
+
+    helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[type(hist_scale_params_unc_cpp).__cpp_name__](
+        ROOT.std.move(hist_scale_params_unc_cpp)
+    )
+
+    helper.tensor_axes = (hist_scale_params_unc.axes['unc'], common.down_up_axis)
+    return helper
+
 
 def make_Z_non_closure_parametrized_helper(
     filepath_correction, filepath_tflite,

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -196,7 +196,7 @@ def make_muon_smearing_helpers_binned(filename = f"{data_dir}/calibration/smeari
 def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutionDATA_LBL_JZ_deltaphim_d50.root",
                                filenamemc = f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_d50.root",
                                override_d = None,
-                               dummary_vars = False):
+                               dummy_vars = False):
     # this helper smears muon pT to match the resolution in data
 
     def load_res(filename):


### PR DESCRIPTION
Muon scale and resolution corrections are updated to the latest inputs from @emanca


For the resolution corrections these are now applied binned in eta and using the four-parameter acbd model in pt (as opposed to the previous version which was binned in both eta and pt and smoothed in two dimensions)

New helpers are added to accommodate this and are used by default.

The central value and uncertainty scheme implemented for the moment is:

scale:
central value for data: track refit + lbl corrections + J/psi parametrized calibration (no change in procedure, parametrized calibration updated)
central value for mc: track refit + truth-assisted lbl corrections (no change in procedure or inputs)

uncertainties:
J/psi calibration statistical uncertainty with ad-hoc scaling of 2.2x
statistical uncertainty from parametrized non-closure on the Z
Z pdg mass uncertainty implicit from non-closure (propagated as 2.1e-3/91.18 fully correlated variation on the b-field term A)
Fully correlated ad-hoc uncertainty of 3.5e-6 on the alignment term M

resolution:

central value:  simultaneous J/psi + Z determination of resolution for Data and MC separately using gen-kernel fits and parameterized model (updated procedure and inputs)

statistical uncertainty from simultaneous J/psi+Z resolution determination (updated procedure and inputs)