### PR TITLE
PDF inflation factors, fix lumi uncertainty correlation between W/Z

### DIFF
--- a/scripts/analysisTools/templates/index.php
+++ b/scripts/analysisTools/templates/index.php
@@ -107,7 +107,7 @@ if ($_GET['noplots']) {
 <div style="display: block; clear:both;">
 <h2><a name="files">Other files</a></h2>
 <ul>
-<?
+<?php
 foreach (glob("*") as $filename) {
     if ($_GET['noplots'] || !in_array($filename, $displayed)) {
         if (isset($_GET['match'])) {

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -51,7 +51,7 @@ def make_parser(parser=None):
     parser.add_argument("--npUnc", default="Delta_Lambda", type=str, choices=combine_theory_helper.TheoryHelper.valid_np_models, help="Nonperturbative uncertainty model")
     parser.add_argument("--tnpMagnitude", default=1, type=float, help="Variation size for the TNP")
     parser.add_argument("--scaleTNP", default=12, type=float, help="Scale the TNP uncertainties by this factor")
-    parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
+    parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor (overrides the inflation factor)")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--massVariation", type=float, default=100, help="Variation of boson mass")
     parser.add_argument("--ewUnc", type=str, nargs="*", default=["default"], choices=["default","horacenloew", "winhacnloew", "virtual_ew", "virtual_ew_wlike"], help="Include EW uncertainty")
@@ -405,7 +405,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                     rename=f"{nuisanceBaseName}{sign}",
                                     **noi_args,
                                     mirror=False,
-                                    symmetrize = "conservative",
+                                    symmetrize = "quadratic",
                                     systAxes=poi_axes+["downUpVar"],
                                     processes=["signal_samples"],
                                     baseName=f"{nuisanceBaseName}{sign}_",
@@ -642,7 +642,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                 passToFakes=passSystToFakes)
     else:
         cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15, group="CMS_background")
-        cardTool.addLnNSystematic("luminosity", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity")
+        cardTool.addLnNSystematic("lumi", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity")
 
     if not args.noEfficiencyUnc:
 

--- a/utilities/styles/nuisance_translate.json
+++ b/utilities/styles/nuisance_translate.json
@@ -39,7 +39,7 @@
     "muonPrefire": "L1 muon prefire",
     "ecalPrefire": "L1 ecal prefire",
     "stat": "Data stat.",
-    "luminosity": "Luminosity",
+    "lumi": "Luminosity",
     "theory_ew": "EW"
 }
 

--- a/wremnants/Templates/index.php
+++ b/wremnants/Templates/index.php
@@ -107,7 +107,7 @@ if ($_GET['noplots']) {
 <div style="display: block; clear:both;">
 <h2><a name="files">Other files</a></h2>
 <ul>
-<?
+<?php
 foreach (glob("*") as $filename) {
     if ($_GET['noplots'] || !in_array($filename, $displayed)) {
         if (isset($_GET['match'])) {

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -209,7 +209,7 @@ class TheoryHelper(object):
             self.card_tool.addSystematic(scale_hist,
                 preOpMap=preop_map,
                 preOpArgs=preop_args,
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 processes=[sample_group],
                 group=group_name,
                 splitGroup={"QCDscale": ".*"},
@@ -272,7 +272,7 @@ class TheoryHelper(object):
                 group="resumTransitionFOScale",
                 splitGroup={"resum": ".*"},
                 systAxes=[pt_ax, "vars"],
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 passToFakes=self.propagate_to_fakes,
                 preOp = preop_func,
                 preOpArgs = preop_args,
@@ -488,8 +488,9 @@ class TheoryHelper(object):
         pdf = input_tools.args_from_metadata(self.card_tool, "pdfs")[0]
         pdfInfo = theory_tools.pdf_info_map("ZmumuPostVFP", pdf)
         pdfName = pdfInfo["name"]
+        scale = scale if scale != 1.0 else pdfInfo["inflationFactor"]
         pdf_hist = pdfName
-        symmetrize = "average"
+        symmetrize = "quadratic"
 
         if from_corr:
             theory_unc = input_tools.args_from_metadata(self.card_tool, "theoryCorr")
@@ -501,7 +502,7 @@ class TheoryHelper(object):
                 logger.error(f"Did not find {pdf_hist} correction in file! Cannot use SCETlib+DYTurbo PDF uncertainties")
             pdf_hist += "Corr"
 
-        logger.info(f"Using PDF hist {pdf_hist}")
+        logger.info(f"Using PDF hist {pdf_hist}, apply scaling of {scale}")
 
         pdf_ax = self.syst_ax if from_corr else "pdfVar"
         symHessian = pdfInfo["combine"] == "symHessian"
@@ -549,7 +550,7 @@ class TheoryHelper(object):
             group=pdfName,
             splitGroup={f"{pdfName}AlphaS": '.*'},
             systAxes=["vars" if from_corr else "alphasVar"],
-            scale=0.75 if asRange == "002" else 1.5,
+            scale=(0.75 if asRange == "002" else 1.5)*scale,
             symmetrize=symmetrize,
             passToFakes=self.propagate_to_fakes,
         )
@@ -558,7 +559,6 @@ class TheoryHelper(object):
         else:
             as_args["systNameReplace"] = as_replace
             as_args['skipEntries'] = [{"alphasVar" : "as0118"}]
-            
         self.card_tool.addSystematic(**as_args)
 
     def add_transition_fo_scale_uncertainties(self, transition = True, scale=True):
@@ -590,7 +590,7 @@ class TheoryHelper(object):
                 group="resumTransitionFOScale",
                 splitGroup={"resum": ".*"},
                 systAxes=["vars"],
-                symmetrize = "conservative",
+                symmetrize = "quadratic",
                 passToFakes=self.propagate_to_fakes,
                 preOp = lambda h: h[{"vars" : sel_vars}],
                 outNames=outNames,

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -39,6 +39,7 @@ pdfMap = {
         "entries" : 101,
         "alphas" : ["LHEPdfWeight[0]", "LHEPdfWeight[101]", "LHEPdfWeight[102]"],
         "alphasRange" : "002",
+        "inflationFactor": 2.5,
     },
     "ct18" : {
         "name" : "pdfCT18",
@@ -47,7 +48,8 @@ pdfMap = {
         "entries" : 59,
         "alphas" : ["LHEPdfWeightAltSet11[0]", "LHEPdfWeightAltSet11[59]", "LHEPdfWeightAltSet11[62]"],
         "alphasRange" : "002",
-        "scale" : 1/1.645 # Convert from 90% CL to 68%
+        "scale" : 1/1.645, # Convert from 90% CL to 68%
+        "inflationFactor": 1.0,
     },
     "nnpdf30" : {
         "name" : "pdfNNPDF30",
@@ -56,6 +58,7 @@ pdfMap = {
         "entries" : 101,
         "alphas" : ["LHEPdfWeightAltSet13[0]", "LHEPdfWeightAltSet15[0]", "LHEPdfWeightAltSet16[0]"],
         "alphasRange" : "001",
+        "inflationFactor": 1.0, # not determined
     },
     "nnpdf40" : {
         "name" : "pdfNNPDF40",
@@ -64,6 +67,7 @@ pdfMap = {
         "entries" : 51,
         "alphas" : ["LHEPdfWeightAltSet3[0]", "LHEPdfWeightAltSet3[51]", "LHEPdfWeightAltSet3[52]"],
         "alphasRange" : "001",
+        "inflationFactor": 4.0,
     },
     "pdf4lhc21" : {
         "name" : "pdfPDF4LHC21",
@@ -72,6 +76,7 @@ pdfMap = {
         "entries" : 41,
         "alphas" : ["LHEPdfWeightAltSet10[0]", "LHEPdfWeightAltSet10[41]", "LHEPdfWeightAltSet10[42]"],
         "alphasRange" : "001",
+        "inflationFactor": 1.0,
     },
     "msht20" : {
         "name" : "pdfMSHT20",
@@ -80,6 +85,7 @@ pdfMap = {
         "entries" : 65,
         "alphas" : ["LHEPdfWeightAltSet12[0]", "LHEPdfWeightAltSet12[67]", "LHEPdfWeightAltSet12[70]"],
         "alphasRange" : "002",
+        "inflationFactor": 1.5,
     },
     "msht20an3lo" : {
         "name" : "pdfMSHT20an3lo",
@@ -88,6 +94,7 @@ pdfMap = {
         "entries" : 105,
         "alphas" : ["LHEPdfWeightAltSet24[0]", "LHEPdfWeightAltSet24[108]", "LHEPdfWeightAltSet24[111]"],
         "alphasRange" : "002",
+        "inflationFactor": 1.5,
     },
     "ct18z" : {
         "name" : "pdfCT18Z",
@@ -97,7 +104,8 @@ pdfMap = {
         "first_entry" : 63,
         "alphas" : ["LHEPdfWeightAltSet11[63]", "LHEPdfWeightAltSet11[122]", "LHEPdfWeightAltSet11[125]"],
         "alphasRange" : "002",
-        "scale" : 1/1.645 # Convert from 90% CL to 68%
+        "scale" : 1/1.645, # Convert from 90% CL to 68%
+        "inflationFactor": 1.0,
     },
     "atlasWZj20" : {
         "name" : "pdfATLASWZJ20",
@@ -106,6 +114,7 @@ pdfMap = {
         "entries" : 60,
         "alphas" : ["LHEPdfWeight[0]", "LHEPdfWeight[41]", "LHEPdfWeight[42]"],
         "alphasRange" : "002",
+        "inflationFactor": 1.0,  # not determined
     },
     "herapdf20" : {
         "name" : "pdfHERAPDF20",
@@ -114,6 +123,7 @@ pdfMap = {
         "entries" : 29,
         "alphas" : ["LHEPdfWeightAltSet20[0]", "LHEPdfWeightAltSet22[0]", "LHEPdfWeightAltSet23[0]"], # alphas 116-120
         "alphasRange" : "002",
+        "inflationFactor": 4.0,
     },
     "herapdf20ext" : {
         "name" : "pdfHERAPDF20ext",
@@ -122,6 +132,7 @@ pdfMap = {
         "entries" : 14,
         "alphas" : ["LHEPdfWeightAltSet20[0]", "LHEPdfWeightAltSet22[0]", "LHEPdfWeightAltSet23[0]"], # dummy AS
         "alphasRange" : "002",
+        "inflationFactor": 4.0,
     },
 }
 


### PR DESCRIPTION
Include the PDF inflation factors and add them by default to the fit. For our default CT18Z, the inflation factor is 1.0, so this PR will not change the result.

Also fixed the luminosity to be correlated between Z and W fits, by naming them identical to "lumi".
