### PR TITLE
Set goodMuons pt range for Wmass histmaker

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -318,7 +318,7 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=1)
-    df = muon_selections.select_good_muons(df, 0, 100, dataset.group, nMuons=1, use_trackerMuons=args.trackerMuons, use_isolation=False)
+    df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=1, use_trackerMuons=args.trackerMuons, use_isolation=False)
 
     # the corrected RECO muon kinematics, which is intended to be used as the nominal
     df = muon_calibration.define_corrected_reco_muon_kinematics(df)


### PR DESCRIPTION
Set goodMuons pt range as in the template using option --pt
Because of the veto selection, it is already guaranteed that there can't be more than 1 good muons, so defining goodMuons with the same pt range as the template should have no effect on the physics, but it avoids using magic numbers to define these thresholds, and also avoids having overflow bins filled and integrated over by mistake when doing projection plots.

Note that cuts can match the template range since none of our systematic variations rely on having the events on the other side of the boundary.

I also assume that the unfolding doesn't look at the reco pt overflow bins @davidwalter2 
@jeyserma In the past you had changed this setting the thresholds to 24 and 100 GeV, but I never fully understood why it was needed, please check if there is any reason this change would not work for you.