### PR TITLE
Update to latest NanoAOD samples

### DIFF
--- a/wremnants/datasets/datasetDict_v9.py
+++ b/wremnants/datasets/datasetDict_v9.py
@@ -25,7 +25,7 @@ dataDictV9 = {
     'DYJetsToMuMuMass10to50PostVFP' : {
                    'filepaths' :
                     ["{BASE_PATH}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/NanoV9MCPostVFP_{NANO_PROD_TAG}",
-                     "{BASE_PATH}/DYJetsToMuMu_M-10to50_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos_ext1/NanoV9MCPostVFP_{NANO_PROD_TAG}"],
+                     ],
                    'xsec' : common.xsec_ZmmMass10to50PostVFP,
                    'group': "DYlowMass",
     },

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -212,8 +212,8 @@ def is_zombie(file_path):
     return False
 
 def getDatasets(maxFiles=default_nfiles, filt=None, excl=None, mode=None, base_path=None, nanoVersion="v9",
-                data_tags=["TrackFitV722_NanoProdv3", "TrackFitV722_NanoProdv2"],
-                mc_tags=["TrackFitV722_NanoProdv3", "TrackFitV718_NanoProdv1"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True):
+                data_tags=["TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv3"],
+                mc_tags=["TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv4", "TrackFitV722_NanoProdv3"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True):
 
     if maxFiles is None or (isinstance(maxFiles, int) and maxFiles < -1):
         maxFiles=default_nfiles


### PR DESCRIPTION
n.b. TrackFitV722_NanoProdv5 and TrackFitV722_NanoProdv4 are equivalent for the standard analysis cuts.

(v5 just relaxes the pt cut for the track refit to facilitate some calibration related cross checks)