### PR TITLE
updates to use xrdcp to create plots on eos

### DIFF
--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -4,6 +4,7 @@ import re, sys, os, os.path, subprocess, json, ROOT, copy, math
 import numpy as np
 from utilities import common, logging
 from functools import partial
+from utilities.io_tools import output_tools
 
 from array import array
 import shutil
@@ -48,6 +49,16 @@ legEntries_plots_ = {"Wmunu"      : "W#rightarrow#mu#nu",
                      "Fake"       : "Nonprompt", # or "Multijet"
                      "QCD"        : "QCD MC",
                      "Other"      : "Other"}   
+
+#########################################################################
+
+def common_plot_parser():
+    parser = common.base_parser()
+    parser.add_argument('--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
+    parser.add_argument('--palette'  , default=87, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
+    parser.add_argument('--invertPalette', action='store_true',   help='Inverte color ordering in palette')
+    parser.add_argument('--eosMount', dest="eoscp", action='store_false', help="(Deprecated!) Do not use xrdcp to copy to eos, exploit the eos mount when using an eos path for output (without this option the code will create a temporary local folder and then copy plots to eos through xrdcp at the end")
+    return parser
 
 #########################################################################
 
@@ -549,12 +560,17 @@ def getTH2morePtBins(h2, newname, nPt):
             
 #########################################################################
 
-def createPlotDirAndCopyPhp(outdir):
+def createPlotDirAndCopyPhp(outdir, eoscp=True):
+    # when passing an eos path it will create a temporary local folder, to avoid exploiting the mount
+    outdir = os.path.realpath(outdir)
+    #logger.warning(f"Real output path is {outdir}")
+    outdir = output_tools.make_plot_dir(outdir, outfolder=None, eoscp=eoscp, allowCreateLocalFolder=True)
     if outdir and not os.path.exists(outdir):
         os.makedirs(outdir)
     htmlpath = f"{os.environ['WREM_BASE']}/scripts/analysisTools/templates/index.php"
     shutil.copy(htmlpath, outdir)
-
+    #logger.warning(f"exiting createPlotDirAndCopyPhp: outdir = {outdir}")
+    return outdir
 
 #########################################################################
 
@@ -618,7 +634,7 @@ def drawTH1(htmp,
 
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     labelX,setXAxisRangeFromUser,xmin,xmax = getAxisRangeFromUser(labelXtmp)
     labelY,setYAxisRangeFromUser,ymin,ymax = getAxisRangeFromUser(labelYtmp)
@@ -800,7 +816,7 @@ def drawCorrelationPlot(h2D_tmp,
     canvas.cd()
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
     # normalize to 1
     if (scaleToUnitArea): h2D.Scale(1./h2D.Integral())
 
@@ -947,7 +963,7 @@ def drawSingleTH1(h1,
     yAxisTitleOffset = 1.45 if leftMargin > 0.1 else 0.5
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)
@@ -1264,7 +1280,7 @@ def drawSingleTH1withFit(h1,
     yAxisTitleOffset = 1.45 if leftMargin > 0.1 else 0.6
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)
@@ -1584,8 +1600,7 @@ def drawNTH1(hists=[],
 
     adjustSettings_CMS_lumi()
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
-    
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)
@@ -2009,7 +2024,7 @@ def drawDataAndMC(h1, h2,
     yAxisTitleOffset = 1.45 if leftMargin > 0.1 else 0.6
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)
@@ -2402,7 +2417,7 @@ def drawTH1dataMCstack(h1, thestack,
     canvas.cd()
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     dataNorm = h1.Integral()
     stackNorm = 0.0
@@ -2754,7 +2769,7 @@ def drawCheckTheoryBand(h1, h2, h3,
     yAxisTitleOffset = 1.45 if leftMargin > 0.1 else 0.6
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)
@@ -3175,7 +3190,7 @@ def drawXsecAndTheoryband(h1, h2,  # h1 is data, h2 is total uncertainty band
     yAxisTitleOffset = 1.45 if leftMargin > 0.1 else 0.6
 
     addStringToEnd(outdir,"/",notAddIfEndswithMatch=True)
-    createPlotDirAndCopyPhp(outdir)
+    outdir = createPlotDirAndCopyPhp(outdir)
 
     cw,ch = canvasSize.split(',')
     #canvas = ROOT.TCanvas("canvas",h2D.GetTitle() if plotLabel == "ForceTitle" else "",700,625)

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -572,6 +572,12 @@ def createPlotDirAndCopyPhp(outdir, eoscp=True):
     #logger.warning(f"exiting createPlotDirAndCopyPhp: outdir = {outdir}")
     return outdir
 
+def copyOutputToEos(eosPathToCopy, eoscp=True, deleteFullTmp=True):
+    if output_tools.is_eosuser_path(folderToCopy) and eoscp:
+        output_tools.copy_to_eos(copyOutputToEos, deleteFullTmp=deleteFullTmp)
+    else:
+        pass
+
 #########################################################################
 
 def getAxisRangeFromUser(axisNameTmp="", 

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -573,8 +573,12 @@ def createPlotDirAndCopyPhp(outdir, eoscp=True):
     return outdir
 
 def copyOutputToEos(eosPathToCopy, eoscp=True, deleteFullTmp=True):
-    if output_tools.is_eosuser_path(folderToCopy) and eoscp:
-        output_tools.copy_to_eos(copyOutputToEos, deleteFullTmp=deleteFullTmp)
+    # this part copies the plots to eos in the path specified by eosPathToCopy
+    # and then delete the local folder that was automatially created by output_tools.make_plot_dir in createPlotDirAndCopyPhp
+    # unless deleteFullTmp=False, in which case the local folder is kept
+    # When the output path was a local folder (without exploiting the eos mount), this function does not have to do anything
+    if output_tools.is_eosuser_path(eosPathToCopy) and eoscp:
+        output_tools.copy_to_eos(eosPathToCopy, deleteFullTmp=deleteFullTmp)
     else:
         pass
 
@@ -748,7 +752,7 @@ def drawCorrelationPlot(h2D_tmp,
                         rightMargin=0.20,
                         nContours=51,
                         palette=55,
-                        invertePalette=False,
+                        invertPalette=False,
                         canvasSize="700,625",
                         passCanvas=None,
                         bottomMargin=0.1,
@@ -804,7 +808,7 @@ def drawCorrelationPlot(h2D_tmp,
     if palette > 0:
         ROOT.gStyle.SetPalette(palette)  # 55:raibow palette ; 57: kBird (blue to yellow, default) ; 107 kVisibleSpectrum ; 77 kDarkRainBow 
     ROOT.gStyle.SetNumberContours(nContours) # default is 20 
-    if invertePalette:
+    if invertPalette:
         ROOT.TColor.InvertPalette()
 
     labelX,setXAxisRangeFromUser,xmin,xmax = getAxisRangeFromUser(labelXtmp)

--- a/scripts/analysisTools/tests/makeMtEfficiency.py
+++ b/scripts/analysisTools/tests/makeMtEfficiency.py
@@ -51,8 +51,8 @@ if __name__ == "__main__":
            
     fname = args.rootfile[0]
     postfix = f"_{args.postfix}" if args.postfix else ""
-    outdir = f"{args.outputfolder[0]}/mtCutEfficiency{postfix}/"
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = f"{args.outputfolder[0]}/mtCutEfficiency{postfix}/"
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
     
     ROOT.TH1.SetDefaultSumw2()
     
@@ -193,3 +193,5 @@ def getHistograms(inputfile):
         drawGraphCMS([grSoverB[imt] for imt in grSoverB.keys()], "Transverse mass threshold (GeV)", f"QCD/{denLabel} yields for m_{{T}} {signCut} threshold::{miny},{maxy}",
                      f"QCDover{denLabel}_yieldRatio", outdir, grLeg2, legendCoords="0.6,0.48,0.9,0.64;1",
                      passCanvas=canvas1D, graphDrawStyle="pl", legEntryStyle="PL", useOriginalGraphStyle=True)
+
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/tests/testFakesVsMt.py
+++ b/scripts/analysisTools/tests/testFakesVsMt.py
@@ -861,14 +861,14 @@ def runStudy(fname, charges, mainOutputFolder, args):
                             "Fakerate factor",
                             FRF_jetInclusive_vsEtaPt.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                             draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                            invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                            invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
         drawCorrelationPlot(FRF_1orMoreJet_vsEtaPt,
                             xAxisName,
                             yAxisName,
                             "Fakerate factor",
                             FRF_1orMoreJet_vsEtaPt.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                             draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                            invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                            invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
         # and also the ratio between jet inclusive and >=1 jet
         FRF_ratioJet_vsEtaPt = copy.deepcopy(FRF_jetInclusive_vsEtaPt.Clone(f"FRF_ratioJet_vsEtaPt_{charge}"))
         FRF_ratioJet_vsEtaPt.SetTitle(f"jetInclusive/1orMoreJet, mT < {mtThreshold} GeV")
@@ -879,7 +879,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                             "Ratio of fakerate factors::0.8,1.6",
                             FRF_ratioJet_vsEtaPt.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                             draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                            invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                            invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
         # don't rebin mT here (default is 1 GeV),
         # otherwise the new binning might no longer be consistent with the one passed to --mt-bin-edges
@@ -907,14 +907,14 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                     "Events (data - MC)",
                                     h2PassIso.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                     draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                    invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                    invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
                 drawCorrelationPlot(h2FailIso,
                                     xAxisName,
                                     yAxisName,
                                     "Events (data - MC)",
                                     h2FailIso.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                     draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                    invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                    invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
             ratio.append(h2PassIso.Clone(f"fakerateFactor_mt{lowEdge}to{highEdge}"))
             ratio[imt].SetTitle("%s m_{T} #in [%d, %d]" % (args.met, lowEdge, highEdge))
@@ -926,7 +926,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                     "fakerate factor: N(iso) / N(not-iso)::0,3",
                                     ratio[imt].GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                     draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                    invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                    invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
 
         if args.mtNominalRange:
@@ -951,7 +951,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                 "fakerate factor: N(iso) / N(not-iso)",
                                 nominalFakerateFactor.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                 draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
             # plot also at high mt, including overflow
             h2PassIso_highMt = getTH2fromTH3(histoPassIso, f"pt_eta_mt{highEdge}toInf_passIso", binEnd, 1+histoPassIso.GetNbinsZ())
             h2FailIso_highMt = getTH2fromTH3(histoFailIso, f"pt_eta_mt{highEdge}toInf_failIso", binEnd, 1+histoFailIso.GetNbinsZ())
@@ -966,7 +966,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                 "fakerate factor: N(iso) / N(not-iso)",
                                 highMtFakerateFactor.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                 draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
             nomiFRF_unrolled = unroll2Dto1D(nominalFakerateFactor, newname=f"unrolled_{nominalFakerateFactor.GetName()}", cropNegativeBins=False)
             highMtFRF_unrolled = unroll2Dto1D(highMtFakerateFactor, newname=f"unrolled_{highMtFakerateFactor.GetName()}", cropNegativeBins=False)
             ptBinRanges = []
@@ -1105,7 +1105,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                     "fakerate factor: N(iso) / N(not-iso)",
                                     fakerateFactor_vs_etaMt.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                     draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                    invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                    invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
         if args.integralMtMethod == "sideband":
             if args.jetCut:
@@ -1125,7 +1125,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                             f"QCD template correction::{corrRange}",
                             hFRFcorr.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                             draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                            invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                            invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
         if args.fitPolDegree:
             drawTH1(histoChi2diffTest,
@@ -1232,7 +1232,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
         #                         f"QCD template correction::{corrRange}",
         #                         hFRFcorrTestCap.GetName(), plotLabel="ForceTitle", outdir=outfolder,
         #                         draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-        #                         invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+        #                         invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
         if hFRFcorr.GetNbinsX() == 1 or hFRFcorr.GetNbinsY() == 1:
             if hFRFcorr.GetNbinsY() == 1:
@@ -1289,7 +1289,7 @@ def runStudy(fname, charges, mainOutputFolder, args):
                                 f"FRF correction uncertainty (quadrature sum)",
                                 etaPtTemplate.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                 draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-                                invertePalette=args.invertePalette, passCanvas=canvas, skipLumi=True)
+                                invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
             ROOT.wrem.broadCastTH2intoTH3(etaPtChargeTemplate, etaPtTemplate, chargeBin, chargeBin, True)
             etaPtChargeTemplate.Write()
 
@@ -1441,7 +1441,7 @@ def runStudyVsDphi(fname, charges, mainOutputFolder, args):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1)
     parser.add_argument("outputfolder",   type=str, nargs=1)
     parser.add_argument("-x", "--xAxisName", default="Muon #eta", help="x axis name")
@@ -1459,13 +1459,9 @@ if __name__ == "__main__":
     parser.add_argument("--jetCut", action="store_true",   help="Use jet cut to derive the FRF (sample will be more QCD enriched but might bias the FRF)")
     parser.add_argument("--rebinx", dest="rebinEta", default=1, type=int, help="To rebin x axis (eta)")
     parser.add_argument("--rebiny", dest="rebinPt", default=1, type=int, help="To rebin y axis (pt)")
-    parser.add_argument("--nContours", dest="nContours",    default=51, type=int, help="Number of contours in palette. Default is 51 (let it be odd, so the central strip is white if the range is symmetric)")
-    parser.add_argument("--palette"  , dest="palette",      default=87, type=int, help="Set palette: default is a built-in one, 55 is kRainbow")
-    parser.add_argument("--invertPalette", dest="invertePalette" , action="store_true",   help="Inverte color ordering in palette")
     parser.add_argument("--absEta", dest="absEta" , action="store_true",   help="Do study using histograms folded into absolute value of pseudorapidity")
     parser.add_argument("--allPlot2D", dest="skipPlot2D" , action="store_false",   help="Do some 2D plots with FRF vs eta-Mt, pt-mT, and so on")
     parser.add_argument("--postfix", default="", type=str, help="Postfix for folder name")
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument("--useQCDMC", action="store_true",   help="Make study using QCD MC instead of data-driven fakes, as a cross check")
     parser.add_argument("--dphiMuonMetCut", type=float, help="Threshold to cut |deltaPhi| > thr*np.pi between muon and met", default=-1.0)
     parser.add_argument("--dphiStudy", action="store_true",   help="Only do some plots for dphi study skipping the rest")
@@ -1499,8 +1495,10 @@ if __name__ == "__main__":
     if args.postfix:
         subFolder += f"_{args.postfix}"
     subFolder += "/"
-    mainOutputFolder = args.outputfolder[0] + subFolder
-
+    outdir_original = args.outputfolder[0] + subFolder
+    
+    mainOutputFolder = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+    
     fname = "fakerateFactorMtBasedCorrection_vsEtaPt.root"
 
     filesToMerge = []
@@ -1521,3 +1519,5 @@ if __name__ == "__main__":
         print()
         print(f"Saving all FRF corrections vs eta-pt in file {outFile}")
         print()
+
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/tests/testPlots1D.py
+++ b/scripts/analysisTools/tests/testPlots1D.py
@@ -97,10 +97,9 @@ def plotDistribution1D(hdata, hmc, datasets, outfolder_dataMC, canvas1Dshapes=No
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1)
     parser.add_argument("outputfolder",   type=str, nargs=1)
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument('-p','--processes', default=None, nargs='*', type=str,
                         help='Choose what processes to plot, otherwise all are done')
     parser.add_argument('--plot', nargs='+', type=str,
@@ -116,8 +115,8 @@ if __name__ == "__main__":
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     
     fname = args.inputfile[0]
-    outdir = args.outputfolder[0]
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = args.outputfolder[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
         
     ROOT.TH1.SetDefaultSumw2()
 
@@ -163,3 +162,4 @@ if __name__ == "__main__":
         plotDistribution1D(hdata, hmc, datasets, outdir, canvas1Dshapes=canvas1D,
                            xAxisName=args.xAxisName[ip], plotName=p, ratioPadYaxisTitle=ratioPadYaxisTitle)
 
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/tests/testQCDisoMtCorr.py
+++ b/scripts/analysisTools/tests/testQCDisoMtCorr.py
@@ -32,16 +32,12 @@ from scripts.analysisTools.tests.testPlots1D import plotDistribution1D
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1)
     parser.add_argument("outputfolder",   type=str, nargs=1)
     parser.add_argument("-c", "--charge", default="plus", choices=["plus", "minus", "both"], help="charge")
     parser.add_argument("-x", "--x-axis-name", dest="xAxisName", default="RawPF m_{T} (GeV)", help="x axis name")
     parser.add_argument("-y", "--y-axis-name", dest="yAxisName", default="PFrelIso04", help="y axis name")
-    parser.add_argument(     '--nContours', dest='nContours',    default=51, type=int, help='Number of contours in palette. Default is 51 (let it be odd, so the central strip is white if not using --abs-value and the range is symmetric)')
-    parser.add_argument(     '--palette'  , dest='palette',      default=55, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
-    parser.add_argument(     '--invertPalette', dest='invertePalette' , default=False , action='store_true',   help='Inverte color ordering in palette')
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     args = parser.parse_args()
     
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
@@ -76,9 +72,13 @@ if __name__ == "__main__":
     canvas1D = ROOT.TCanvas("canvas1D","",800,800)
 
     jetLabels = ["jetInclusive", "1orMoreJet"]
+
+    outdir_original = args.outputfolder[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
     for charge in charges:
 
-        outfolder = f"{args.outputfolder[0]}/{charge}/"
+        outfolder = f"{outdir}/{charge}/"
         createPlotDirAndCopyPhp(outfolder)
         # bin number from root histogram
         chargeBin = 1 if charge == "minus" else 2
@@ -125,7 +125,7 @@ if __name__ == "__main__":
                                     "Events",
                                     h2mtIso.GetName(), plotLabel="ForceTitle", outdir=outfolder,
                                     draw_both0_noLog1_onlyLog2=1, drawProfileX=True,
-                                    nContours=args.nContours, palette=args.palette, invertePalette=args.invertePalette,
+                                    nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette,
                                     passCanvas=canvas, skipLumi=True)
 
         grList = [fakeRateVsMt[jetLabel][d] for d in datasetsNoFake for jetLabel in jetLabels]
@@ -165,3 +165,6 @@ if __name__ == "__main__":
                                datasetsAllNoFake, outfolder, canvas1Dshapes=canvas1D, xAxisName="PF rel. isolation (#DeltaR = 0.4)",
                                plotName=f"isolation_{jetLabel}", draw_both0_noLog1_onlyLog2=0,
                                ratioPadYaxisTitle="Data/pred::0.7,1.1")
+
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)
+

--- a/scripts/analysisTools/tests/testShapesIsoMtRegions.py
+++ b/scripts/analysisTools/tests/testShapesIsoMtRegions.py
@@ -40,14 +40,10 @@ from scripts.analysisTools.w_mass_13TeV.plotPrefitTemplatesWRemnants import plot
 sys.path.append(os.getcwd())
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
     parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file (e.g., 'nominal')", default="nominal")
-    parser.add_argument(     '--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
-    parser.add_argument(     '--palette'  , default=87, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
-    parser.add_argument(     '--invertPalette', action='store_true',   help='Inverte color ordering in palette')
     parser.add_argument('-p','--processes', default=None, nargs='*', type=str,
                         help='Choose what processes to plot, otherwise all are done')
     parser.add_argument('-c','--charges', default="both", choices=["plus", "minus", "both"], type=str,
@@ -58,18 +54,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
-    # if 0:
-    #     logger.critical("TEST LOGGER CRITICAL")
-    #     logger.error("TEST LOGGER ERROR")
-    #     logger.warning("TEST LOGGER WARNING")
-    #     logger.info("TEST LOGGER INFO")
-    #     logger.debug("TEST LOGGER DEBUG")
-    #     quit()
 
     fname = args.inputfile[0]
-    outdir = args.outdir[0]
-    createPlotDirAndCopyPhp(outdir)
-        
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
     ROOT.TH1.SetDefaultSumw2()
 
     canvas = ROOT.TCanvas("canvas", "", 800, 700)
@@ -146,7 +135,7 @@ if __name__ == "__main__":
                                         f"{h.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                                         smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                                         draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                                        nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                                        nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
                 hist2D[charge][f"{d}_{charge}"] = h
         print()
 
@@ -190,7 +179,7 @@ if __name__ == "__main__":
                                     f"{hFRF.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                                     smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                                     draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                                    nContours=args.nContours, palette=args.palette, invertePalette=args.invertePalette)
+                                    nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
                 # plot unrolled FRF to better see how it looks like
                 hFRF_unrolled = unroll2Dto1D(hFRF, newname=f"{hFRF.GetName()}_unrolled")
                 drawSingleTH1(hFRF_unrolled, XlabelUnroll, f"Fake rate factor ({c})", f"{hFRF.GetName()}_unrolled",
@@ -216,10 +205,4 @@ if __name__ == "__main__":
                                   drawVertLines="{a},{b}".format(a=hFakeYields.GetNbinsY(),b=hFakeYields.GetNbinsX()),
                                   textForLines=ptBinRanges, ytextOffsetFromTop=0.3, textSize=0.04, textAngle=0)
 
-
-    # processes = ["WplusmunuPostVFP"]
-    # hnomi = {}
-    # for p in processes:
-    #     hnomi[p] = input_tools.read_and_scale(fname, p, args.baseName, True)
-    #     print(hnomi[p].axes)
-    # quit()
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
+++ b/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
@@ -74,7 +74,7 @@ def sortParameters(params):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument('infile', nargs=1, type=str, help='file with the fitresult')
     parser.add_argument(      '--expected-infile'        , dest='expInfile'     , default=''        , type=str, help='file with the fitresult for expected, to plot together with observed (still to be implemented)')
     parser.add_argument('-o','--outdir', dest='outdir', default=None, type=str, help='If given, plot the pulls of the nuisances in this output directory')
@@ -112,12 +112,12 @@ if __name__ == "__main__":
     if len(infile_exp):
         plotObsWithExp = True
 
-    if args.outdir:
-        createPlotDirAndCopyPhp(args.outdir)
-    else:
+    if not args.outdir:
         print("You must pass an output folder with option -o")
         quit()
-        
+
+    outdir_original = args.outdir:
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
     #valuesPrefit = dict((k,v) for k,v in valuesAndErrorsAll.items() if k.endswith('_gen'))
     pois_regexps = list(args.pois.split(','))
 
@@ -213,7 +213,7 @@ if __name__ == "__main__":
                 if sigShift >= args.upperLimitSigma: continue
             numberRankedNuisances += 1
 
-        if args.outdir: 
+        if outdir: 
             nuis_p_i+=1
             hist_fit_s.SetBinContent(nuis_p_i, val_f)
             hist_fit_s.SetBinError(nuis_p_i,err_f)
@@ -259,7 +259,7 @@ if __name__ == "__main__":
         else:
             args.postfix = addPostfix
             
-    outnameNoExt = "{od}/nuisances_{ps}_{suff}".format(od=args.outdir, ps=args.uniqueString, suff=args.postfix)
+    outnameNoExt = "{od}/nuisances_{ps}_{suff}".format(od=outdir, ps=args.uniqueString, suff=args.postfix)
 
     for ext in args.format.split(','):
         txtfilename = "{noext}.{ext}".format(noext=outnameNoExt, ext=ext)
@@ -343,7 +343,7 @@ if __name__ == "__main__":
         txtfile.close()
         print(f"Info: {ext} file {txtfilename} has been created")
 
-    if args.outdir:
+    if outdir:
         line = ROOT.TLine()
         lat  = ROOT.TLatex(); lat.SetNDC(); lat.SetTextFont(42); lat.SetTextSize(0.04)
         ROOT.gStyle.SetOptStat(0)
@@ -568,5 +568,5 @@ if __name__ == "__main__":
             for ext in ['png', 'pdf']:
                 canvas_nuis.SaveAs("{noext}.{ext}".format(noext=outnameNoExt, ext=ext))
 
-        
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)
 

--- a/scripts/analysisTools/w_mass_13TeV/getCorrelationLine.py
+++ b/scripts/analysisTools/w_mass_13TeV/getCorrelationLine.py
@@ -37,9 +37,9 @@ if __name__ == "__main__":
 
     #date = datetime.date.today().isoformat()
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument('fitresult', type=str, nargs=1, help="fitresult.root file from combinetf")
-    parser.add_argument('-o','--outdir', default='', type=str, help='outdput directory to save the matrix')
+    parser.add_argument('-o','--outdir', default=None, type=str, help='outdput directory to save the plot')
     parser.add_argument('-p','--param',  default='', type=str, help='parameter for which you want to show the correlation matrix. Must be a single object')
     parser.add_argument('-t','--type',   default='hessian', type=str, choices=['toys', 'hessian'], help='which type of input file: toys or hessian (default)')
     parser.add_argument('-m','--matrix', default='', type=str, help='matrix to be used (name is correlation_matrix_channel<matrix>)')
@@ -68,8 +68,10 @@ if __name__ == "__main__":
         print("Need to specify a parameter with option -p")
         quit()
 
-    if args.outdir:
-        createPlotDirAndCopyPhp(args.outdir)
+    outdir_original = args.outdir:
+    outdir = None
+    if outdir_original:
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
 
     param = args.param
     print(f"Will do parameter with the following name: {param}")
@@ -149,9 +151,10 @@ if __name__ == "__main__":
     c.SetGridy(1)
     c.RedrawAxis("sameaxis")
 
-    if args.outdir:
+    if outdir:
         for i in ['pdf', 'png']:
             suff = '' if not args.postfix else '_'+args.postfix
-            c.SaveAs(args.outdir+'/corrLine{suff}_{pn}_{ch}.{i}'.format(suff=suff,i=i,pn=param, ch=args.matrix.replace("channel","")))
+            c.SaveAs(outdir+'/corrLine{suff}_{pn}_{ch}.{i}'.format(suff=suff,i=i,pn=param, ch=args.matrix.replace("channel","")))
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)
 
 

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     ROOT.gStyle.SetOptStat(0)
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("rootfile", type=str, nargs=1)
     parser.add_argument('-o','--outdir',     default='./makeImpactsOnMW/',   type=str, help='output directory to save the plot (not needed with --justPrint)')    
     parser.add_argument(     '--nuisgroups', default='ALL',   type=str, help='nuis groups for which you want to show the impacts (can pass comma-separated list to make all of them one after the other). Use full name, no regular expressions. By default, all are made')
@@ -112,9 +112,6 @@ if __name__ == "__main__":
     parser.add_argument(     '--canvasSize', default='800,1200', type=str, help='Pass canvas dimensions as "width,height" ')
     # parser.add_argument(     '--draw-option', dest='drawOption', default='COLZ TEXT', type=str, help='Options for drawing TH2')
     parser.add_argument(     '--margin',   default='', type=str, help='Pass canvas margin as "left,right,top,bottom" ')
-    parser.add_argument(     '--nContours',    default=51, type=int, help='Number of contours in palette. Default is 51 (let it be odd, so the central strip is white if not using --abs-value and the range is symmetric)')
-    parser.add_argument(     '--palette',      default=0, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
-    parser.add_argument(     '--invertPalette', default=False , action='store_true',   help='Inverte color ordering in palette')
     parser.add_argument(     '--scaleToMeV', default=False , action='store_true',   help='Report numbers in terms of uncertainty on mW in MeV (default is to report percentage of prefit uncertainty)')
     parser.add_argument(     '--showTotal', default=False , action='store_true',   help='Show total uncertainty in plot')
     parser.add_argument(     '--prefitUncertainty',      default=100.0, type=float, help='prefit uncertainty on mW in MeV')
@@ -315,6 +312,8 @@ if __name__ == "__main__":
     if len(postfix) and  not postfix.startswith("_"):
         postfix = "_" + postfix
     smallBoson = "z" if args.isWlike else "w"
-    createPlotDirAndCopyPhp(args.outdir)
+    outdir_original = args.outdir
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
     for ext in ["pdf", "png"]:
-        c1.SaveAs(f"{args.outdir}/impactsOnM{smallBoson}{postfix}.{ext}")
+        c1.SaveAs(f"{outdir}/impactsOnM{smallBoson}{postfix}.{ext}")
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/makeQCDMCstudy.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeQCDMCstudy.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+
+## make study using a histogram created specifically for QCD MC (but in principle it can be used for other processes too if the histograms exist
+## axes should be these ones ('eta', 'pt', 'charge', 'mt', 'passIso', 'Njets', 'leadjetPt', 'DphiMuonMet')
+
+# example
+# python scripts/analysisTools/w_mass_13TeV/makeQCDMCstudy.py /scratch/mciprian/CombineStudies/TRASHTEST/mw_with_mu_eta_pt_scetlib_dyturboCorr_maxFiles_m1_extMC_noSF.hdf5 scripts/analysisTools/plots/fromMyWremnants/testFakes_studies/  -v 4
+
+from wremnants.datasets.datagroups import Datagroups
+from wremnants import histselections as sel
+#from wremnants import plot_tools,theory_tools,syst_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+
+import narf
+import wremnants
+from wremnants import theory_tools,syst_tools
+import hist
+
+import numpy as np
+
+import pickle
+import lz4.frame
+
+import argparse
+import os
+import shutil
+import re
+
+## safe batch mode
+import sys
+args = sys.argv[:]
+sys.argv = ['-b']
+import ROOT
+sys.argv = args
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from copy import *
+
+from scripts.analysisTools.plotUtils.utility import *
+
+if __name__ == "__main__":
+    parser = common_plot_parser()
+    parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
+    parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
+    parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file (it depends on what study you run)", default="otherStudyForFakes")
+    parser.add_argument('-p','--processes', default=["QCD"], nargs='*', type=str,
+                        help='Choose what processes to plot, otherwise all are done')
+    parser.add_argument("-r", "--runStudy", type=int, default=0, choices=range(4), help="What to run");
+    args = parser.parse_args()
+
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
+
+    ###############################################################################################
+    
+    def runKinematics(args):
+
+        fname = args.inputfile[0]
+        outdir_original = args.outdir[0]
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
+        ROOT.TH1.SetDefaultSumw2()
+
+        canvas = ROOT.TCanvas("canvas", "", 800, 700)
+        adjustSettings_CMS_lumi()
+        canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+
+        groups = Datagroups(fname, mode="wmass")
+        datasets = groups.getNames()
+        if args.processes is not None and len(args.processes):
+            datasets = list(filter(lambda x: x in args.processes, datasets))
+        else:
+            datasets = list(filter(lambda x: x == "QCD", datasets))
+
+        logger.debug(f"Using these processes: {datasets}")
+        inputHistName = args.baseName
+        groups.setNominalName(inputHistName)
+        groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+        histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+        s = hist.tag.Slicer()
+        for d in datasets:
+            logger.info(f"Running on process {d}")
+            hin = histInfo[d].hists[inputHistName]
+            logger.debug(hin.axes)
+            # ('eta', 'pt', 'charge', 'mt', 'passIso', 'Njets', 'leadjetPt', 'DphiMuonMet')
+            hin = hin[{"charge" : s[::hist.sum]}] # integrate charges for now
+            # make eta inot abseta for now
+            makeAbsEta = True # make an option for this
+            etaAxisName = "eta"
+            if makeAbsEta:
+                hin = hh.makeAbsHist(hin, "eta")
+                etaAxisName = "abseta"
+            hpass = hin[{"passIso": True}]
+            hfail = hin[{"passIso": False}]
+            htest = hin.copy()
+
+            h_njets_mt = hin[{"pt"          : s[::hist.sum],
+                              "leadjetPt"   : s[::hist.sum],
+                              "DphiMuonMet" : s[::hist.sum],
+                              etaAxisName: s[::hist.sum],
+                              }]
+            h_njets_mt_pass = h_njets_mt[{"passIso": True}]
+            h_njets_mt_fail = h_njets_mt[{"passIso": False}]
+
+            hroot_njets_mt_pass = narf.hist_to_root(h_njets_mt_pass)
+            hroot_njets_mt_pass.SetName("njets_mt_pass")
+            hroot_njets_mt_pass.SetTitle("Pass isolation")
+            drawCorrelationPlot(hroot_njets_mt_pass, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_pass.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_fail = narf.hist_to_root(h_njets_mt_fail)
+            hroot_njets_mt_fail.SetName("njets_mt_fail")
+            hroot_njets_mt_fail.SetTitle("Fail isolation")
+            drawCorrelationPlot(hroot_njets_mt_fail, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_fail.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_FRF = copy.deepcopy(hroot_njets_mt_pass.Clone("njets_mt_FRF"))
+            hroot_njets_mt_FRF.Divide(hroot_njets_mt_fail)
+            hroot_njets_mt_FRF.SetTitle("")
+            drawCorrelationPlot(hroot_njets_mt_FRF, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Fakerate factor::0,1.5",
+                                f"{hroot_njets_mt_FRF.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            h_njets_mt_ptLow_pass = hpass[{"pt"          : s[0:1:hist.sum],
+                                        "leadjetPt"   : s[::hist.sum],
+                                        "DphiMuonMet" : s[::hist.sum],
+                                        etaAxisName: s[::hist.sum],
+                                        }]
+            h_njets_mt_ptLow_fail = hfail[{"pt"          : s[0:1:hist.sum],
+                                        "leadjetPt"   : s[::hist.sum],
+                                        "DphiMuonMet" : s[::hist.sum],
+                                        etaAxisName: s[::hist.sum],
+                                        }]
+            h_njets_mt_ptHigh_pass = hpass[{"pt"          : s[2::hist.sum],
+                                        "leadjetPt"   : s[::hist.sum],
+                                        "DphiMuonMet" : s[::hist.sum],
+                                        etaAxisName: s[::hist.sum],
+                                        }]
+            h_njets_mt_ptHigh_fail = hfail[{"pt"          : s[2::hist.sum],
+                                         "leadjetPt"   : s[::hist.sum],
+                                         "DphiMuonMet" : s[::hist.sum],
+                                         etaAxisName: s[::hist.sum],
+                                         }]
+
+            hroot_njets_mt_ptLow_pass = narf.hist_to_root(h_njets_mt_ptLow_pass)
+            hroot_njets_mt_ptLow_pass.SetName("njets_mt_ptLow_pass")
+            ptLow_leftEdge = int(hin.axes["pt"].edges[0])
+            ptLow_rightEdge = int(hin.axes["pt"].edges[1])
+            ptLowRange_text = f"{ptLow_leftEdge} < p_{{T}} < {ptLow_rightEdge} GeV"
+            hroot_njets_mt_ptLow_pass.SetTitle(f"Pass isolation, {ptLowRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptLow_pass, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_ptLow_pass.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_ptLow_fail = narf.hist_to_root(h_njets_mt_ptLow_fail)
+            hroot_njets_mt_ptLow_fail.SetName("njets_mt_ptLow_fail")
+            hroot_njets_mt_ptLow_fail.SetTitle(f"Fail isolation, {ptLowRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptLow_fail, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_ptLow_fail.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_ptLow_FRF = copy.deepcopy(hroot_njets_mt_ptLow_pass.Clone("njets_mt_ptLow_FRF"))
+            hroot_njets_mt_ptLow_FRF.Divide(hroot_njets_mt_ptLow_fail)
+            hroot_njets_mt_ptLow_FRF.SetTitle(f"{ptLowRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptLow_FRF, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Fakerate factor::0,1.5",
+                                f"{hroot_njets_mt_ptLow_FRF.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            ### now pt high
+            hroot_njets_mt_ptHigh_pass = narf.hist_to_root(h_njets_mt_ptHigh_pass)
+            hroot_njets_mt_ptHigh_pass.SetName("njets_mt_ptHigh_pass")
+            ptHigh_leftEdge = int(hin.axes["pt"].edges[2])
+            ptHigh_rightEdge = int(hin.axes["pt"].edges[-1])
+            ptHighRange_text = f"{ptHigh_leftEdge} < p_{{T}} < {ptHigh_rightEdge} GeV"
+            hroot_njets_mt_ptHigh_pass.SetTitle(f"Pass isolation, {ptHighRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptHigh_pass, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_ptHigh_pass.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_ptHigh_fail = narf.hist_to_root(h_njets_mt_ptHigh_fail)
+            hroot_njets_mt_ptHigh_fail.SetName("njets_mt_ptHigh_fail")
+            hroot_njets_mt_ptHigh_fail.SetTitle(f"Fail isolation, {ptHighRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptHigh_fail, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Events",
+                                f"{hroot_njets_mt_ptHigh_fail.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            hroot_njets_mt_ptHigh_FRF = copy.deepcopy(hroot_njets_mt_ptHigh_pass.Clone("njets_mt_ptHigh_FRF"))
+            hroot_njets_mt_ptHigh_FRF.Divide(hroot_njets_mt_ptHigh_fail)
+            hroot_njets_mt_ptHigh_FRF.SetTitle(f"{ptHighRange_text}")
+            drawCorrelationPlot(hroot_njets_mt_ptHigh_FRF, "DeepMET m_{T} (GeV)", "Number of jets (p_{T} > 15 GeV)", f"Fakerate factor::0,1.5",
+                                f"{hroot_njets_mt_ptHigh_FRF.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            outdirTest = outdir + "/testShapes/"
+            createPlotDirAndCopyPhp(outdirTest)
+
+            newMtEdges = [i * 5 for i in range(12)] + [60, 80, 120]
+            htest = hh.rebinHist(htest, "mt", newMtEdges)
+
+            ptEdges = htest.axes["pt"].edges
+            newPtEdges = [ptEdges[0], ptEdges[1], *ptEdges[2::3]]
+            logger.warning(f"For test with Njets, rebinning pt to {newPtEdges}")
+            htest = hh.rebinHist(htest, "pt", newPtEdges)
+
+            etaEdges = htest.axes[etaAxisName].edges
+            ptEdges = htest.axes["pt"].edges
+            etaLatex = "|#eta|" if makeAbsEta else "#eta"
+            for ieta in range(htest.axes[etaAxisName].size):
+                for ipt in range(htest.axes["pt"].size):
+                    etaRangeText = f"{round(etaEdges[ieta],1)} < {etaLatex} < {round(etaEdges[ieta+1],1)}"
+                    ptRangeText = f"{ptEdges[ipt]} < p_{{T}} < {ptEdges[ipt+1]} GeV"
+                    htestReduced = htest[{"pt"        : s[ipt:ipt+1:hist.sum],
+                                          etaAxisName : s[ieta:ieta+1:hist.sum],
+                                          "leadjetPt" : s[::hist.sum],
+                                          "DphiMuonMet" : s[::hist.sum],
+                                      }]
+
+                    h_0jet_pass = htestReduced[{"Njets" : s[0],
+                                                "passIso": True,
+                                                }]
+                    h_1orMoreJet_pass = htestReduced[{"Njets" : s[1::hist.sum],
+                                                      "passIso": True,
+                                                      }]
+                    h_2orMoreJet_pass = htestReduced[{"Njets" : s[2::hist.sum],
+                                                      "passIso": True,
+                                                      }]
+                    h_0jet_fail = htestReduced[{"Njets" : s[0],
+                                                "passIso": False,
+                                                }]
+                    h_1orMoreJet_fail = htestReduced[{"Njets" : s[1::hist.sum],
+                                                      "passIso": False,
+                                                      }]
+                    h_2orMoreJet_fail = htestReduced[{"Njets" : s[2::hist.sum],
+                                                      "passIso": False,
+                                                      }]
+
+                    h_0jet_FRF = hh.divideHists(h_0jet_pass, h_0jet_fail)
+                    hroot_0jet_FRF  = narf.hist_to_root(h_0jet_FRF)
+                    hroot_0jet_FRF.SetName(f"h_0jet_FRF_ipt{ipt}_ieta{ieta}")
+
+                    h_1orMoreJet_FRF = hh.divideHists(h_1orMoreJet_pass, h_1orMoreJet_fail)
+                    hroot_1orMoreJet_FRF  = narf.hist_to_root(h_1orMoreJet_FRF)
+                    hroot_1orMoreJet_FRF.SetName(f"h_1orMoreJet_FRF_ipt{ipt}_ieta{ieta}")
+
+                    h_2orMoreJet_FRF = hh.divideHists(h_2orMoreJet_pass, h_2orMoreJet_fail)
+                    hroot_2orMoreJet_FRF  = narf.hist_to_root(h_2orMoreJet_FRF)
+                    hroot_2orMoreJet_FRF.SetName(f"h_2orMoreJet_FRF_ipt{ipt}_ieta{ieta}")
+
+                    drawNTH1([hroot_0jet_FRF, hroot_1orMoreJet_FRF, hroot_2orMoreJet_FRF],
+                             ["0 jets", ">= 1 jets", ">= 2 jets"],
+                             "DeepMet m_{T} (GeV)", "Fakerate factor",
+                             f"FRFvsNjets_ipt{ipt}_ieta{ieta}", outdirTest,
+                             topMargin=0.05, leftMargin=0.16, rightMargin=0.05, labelRatioTmp=">= N-j / 0-jet::0.5,1.5",
+                             legendCoords="0.7,0.94,0.76,0.94;1", transparentLegend=True,
+                             lowerPanelHeight=0.4, skipLumi=True, passCanvas=canvas1D,
+                             noErrorRatioDen=False, drawErrorAll=True,
+                             onlyLineColor=True, useLineFirstHistogram=True,
+                             setOnlyLineRatio=True, lineWidth=2,
+                             moreTextLatex=f"{etaRangeText}      {ptRangeText}::0.18,0.97,0.05,0.035")
+
+        copyOutputToEos(outdir_original, eoscp=args.eoscp)
+
+    ###############################################################################################
+
+    def runGenMatching(args):
+
+        fname = args.inputfile[0]
+        outdir_original = args.outdir[0] + "/genMatchStudy/"
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
+        ROOT.TH1.SetDefaultSumw2()
+
+        canvas = ROOT.TCanvas("canvas", "", 800, 700)
+        adjustSettings_CMS_lumi()
+        canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+
+        groups = Datagroups(fname, mode="wmass")
+        datasets = groups.getNames()
+        if args.processes is not None and len(args.processes):
+            datasets = list(filter(lambda x: x in args.processes, datasets))
+        else:
+            datasets = list(filter(lambda x: x == "QCD", datasets))
+
+        logger.debug(f"Using these processes: {datasets}")
+        inputHistName = args.baseName
+        groups.setNominalName(inputHistName)
+        groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+        histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+        s = hist.tag.Slicer()
+
+        for d in datasets:
+            logger.info(f"Running on process {d}")
+            hin = histInfo[d].hists[inputHistName]
+            logger.debug(hin.axes)
+
+            makeAbsEta = True # make an option for this
+            etaAxisName = "eta"
+            etaAxisTitle = "Reco muon #eta"
+            if makeAbsEta:
+                hin = hh.makeAbsHist(hin, "eta")
+                etaAxisName = "abseta"
+                etaAxisTitle = "Reco muon |#eta|"
+                
+            hin = hin[{etaAxisName : s[::hist.rebin(4)],
+                       "pt" : s[::hist.rebin(4)]}]
+            hpass = hin[{"hasMatch" : True}]
+            htotal = hin[{"hasMatch" : s[::hist.sum]}]
+            
+            hfrac = hh.divideHists(hpass, htotal)
+            hfrac_root  = narf.hist_to_root(hfrac)
+            hfrac_root.SetName(f"hfrac_{inputHistName}")
+            hfrac_root.SetTitle(inputHistName)
+            
+            drawCorrelationPlot(hfrac_root, etaAxisTitle, "Reco muon p_{T} (GeV)", f"Fraction of events with gen match",
+                                f"{hfrac_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+        copyOutputToEos(outdir_original, eoscp=args.eoscp)
+
+    ###############################################################################################
+
+    def runGenMt(args):
+
+        useMet = False
+        if "Met" in args.baseName:
+            useMet = True
+
+        fname = args.inputfile[0]
+        outdir_original = args.outdir[0] + ("/genMetStudy/" if useMet else "/genMtStudy/")
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
+        ROOT.TH1.SetDefaultSumw2()
+
+        canvas = ROOT.TCanvas("canvas", "", 800, 700)
+        adjustSettings_CMS_lumi()
+        canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+
+        groups = Datagroups(fname, mode="wmass")
+        datasets = groups.getNames()
+        if args.processes is not None and len(args.processes):
+            datasets = list(filter(lambda x: x in args.processes, datasets))
+        else:
+            datasets = list(filter(lambda x: x == "QCD", datasets))
+
+        logger.debug(f"Using these processes: {datasets}")
+        inputHistName = args.baseName
+        groups.setNominalName(inputHistName)
+        groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+        histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+        s = hist.tag.Slicer()
+
+        for d in datasets:
+            logger.info(f"Running on process {d}")
+            hin = histInfo[d].hists[inputHistName]
+            logger.debug(hin.axes)
+
+            makeAbsEta = True # make an option for this
+            etaAxisName = "eta"
+            etaAxisTitle = "Reco muon #eta"
+            if makeAbsEta:
+                hin = hh.makeAbsHist(hin, "eta")
+                etaAxisName = "abseta"
+                etaAxisTitle = "Reco muon |#eta|"
+                
+            hin = hin[{etaAxisName : s[::hist.rebin(8)],
+                       "pt" : s[::hist.rebin(8)],
+                       "recoMet" if useMet else "mt": s[::hist.rebin(5)],
+                       "genMet" if useMet else "genMt": s[::hist.rebin(5)],
+                       }]
+
+            hpass = hin[{"passIso" : True}]
+            hfail = hin[{"passIso" : False}]
+            htotal = hin[{"passIso" : s[::hist.sum]}]
+
+            etaEdges = hin.axes[etaAxisName].edges
+            ptEdges = hin.axes["pt"].edges
+            etaLatex = "|#eta|" if makeAbsEta else "#eta"
+
+            xAxisName = "Reco m_{T} (GeV)"
+            yAxisName = "Gen m_{T} with reco muon (GeV)"
+            if useMet:
+                xAxisName = "Reco MET (GeV)"
+                yAxisName = "Gen MET (GeV)"
+
+            for ieta in range(hin.axes[etaAxisName].size):
+                for ipt in range(hin.axes["pt"].size):
+                    etaRangeText = f"{round(etaEdges[ieta],1)} < {etaLatex} < {round(etaEdges[ieta+1],1)}"
+                    ptRangeText = f"{ptEdges[ipt]} < p_{{T}} < {ptEdges[ipt+1]} GeV"
+
+                    hp = hpass[{"pt": s[ipt],
+                                etaAxisName : s[ieta]
+                                }]
+                    hf = hfail[{"pt": s[ipt],
+                                etaAxisName : s[ieta]
+                                }]
+                    ht = htotal[{"pt": s[ipt],
+                                etaAxisName : s[ieta]
+                                }]
+
+                    hpr  = narf.hist_to_root(hp)
+                    hpr.SetName(f"mtVsGenMt_passIso_ipt{ipt}_ieta{ieta}")
+                    hpr.SetTitle(f"passIso {etaRangeText}     {ptRangeText}")
+                    drawCorrelationPlot(hpr, xAxisName, yAxisName, f"Events",
+                                        f"{hpr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                        smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                        draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                        nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+                    
+                    hfr  = narf.hist_to_root(hf)
+                    hfr.SetName(f"mtVsGenMt_failIso_ipt{ipt}_ieta{ieta}")
+                    hfr.SetTitle(f"failIso {etaRangeText}     {ptRangeText}")
+                    drawCorrelationPlot(hfr, xAxisName, yAxisName, f"Events",
+                                        f"{hfr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                        smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                        draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                        nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+                    htr  = narf.hist_to_root(ht)
+                    htr.SetName(f"mtVsGenMt_anyIso_ipt{ipt}_ieta{ieta}")
+                    htr.SetTitle(f"AnyIso {etaRangeText}     {ptRangeText}")
+                    drawCorrelationPlot(htr, xAxisName, yAxisName, f"Events",
+                                        f"{htr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                        smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                        draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                        nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+        copyOutputToEos(outdir_original, eoscp=args.eoscp)
+
+    ###############################################################################################
+
+    def runJetMuon(args):
+
+        useMet = False
+        if "Met" in args.baseName:
+            useMet = True
+
+        fname = args.inputfile[0]
+        outdir_original = args.outdir[0] + "/jetAndMuon/"
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
+        ROOT.TH1.SetDefaultSumw2()
+
+        canvas = ROOT.TCanvas("canvas", "", 800, 700)
+        adjustSettings_CMS_lumi()
+        canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+
+        groups = Datagroups(fname, mode="wmass")
+        datasets = groups.getNames()
+        if args.processes is not None and len(args.processes):
+            datasets = list(filter(lambda x: x in args.processes, datasets))
+        else:
+            datasets = list(filter(lambda x: x == "QCD", datasets))
+
+        logger.debug(f"Using these processes: {datasets}")
+        inputHistName = args.baseName
+        groups.setNominalName(inputHistName)
+        groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+        histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+        s = hist.tag.Slicer()
+
+        for d in datasets:
+            logger.info(f"Running on process {d}")
+            hin = histInfo[d].hists[inputHistName]
+            logger.debug(hin.axes)
+                
+            hp = hin[{"passIso" : True}]
+            hf = hin[{"passIso" : False}]
+            ht = hin[{"passIso" : s[::hist.sum]}]
+
+            xAxisName = "Muon p_{T} (GeV)"
+            yAxisName = "Jet p_{T} with #DeltaR(jet,muon)<0.4 (GeV)"
+
+            hpr  = narf.hist_to_root(hp)
+            hpr.SetName(f"jetMuonPt_passIso")
+            hpr.SetTitle(f"passIso")
+            drawCorrelationPlot(hpr, xAxisName, yAxisName, f"Events",
+                                f"{hpr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+                    
+            hfr  = narf.hist_to_root(hf)
+            hfr.SetName(f"jetMuonPt_failIso")
+            hfr.SetTitle(f"failIso")
+            drawCorrelationPlot(hfr, xAxisName, yAxisName, f"Events",
+                                f"{hfr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+            htr  = narf.hist_to_root(ht)
+            htr.SetName(f"jetMuonPt_anyIso")
+            htr.SetTitle(f"AnyIso")
+            drawCorrelationPlot(htr, xAxisName, yAxisName, f"Events",
+                                f"{htr.GetName()}", plotLabel="ForceTitle", outdir=outdir,
+                                smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
+                                draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
+                                nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
+
+        copyOutputToEos(outdir_original, eoscp=args.eoscp)
+
+    ###############################################################################################
+    ###############################################################################################
+    ###############################################################################################
+
+    if args.runStudy == 0:
+        runKinematics(args)
+    elif args.runStudy == 1:
+        runGenMatching(args)
+    elif args.runStudy == 2:
+        runGenMt(args)
+    elif args.runStudy == 3:
+        runJetMuon(args)
+        

--- a/scripts/analysisTools/w_mass_13TeV/makeQCDMCstudy.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeQCDMCstudy.py
@@ -535,4 +535,3 @@ if __name__ == "__main__":
         runGenMt(args)
     elif args.runStudy == 3:
         runJetMuon(args)
-        

--- a/scripts/analysisTools/w_mass_13TeV/makeVertexPileupWeights.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeVertexPileupWeights.py
@@ -31,18 +31,19 @@ outputfile = data_dir + "/vertex/vertexPileupWeights.root"
 plotFolder = "plots/testNanoAOD/testvertexPileupWeights/"
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    
+    parser = common_plot_parser()
     args = parser.parse_args()
 
     adjustSettings_CMS_lumi()
     canvas = ROOT.TCanvas("canvas", "", 800, 800) 
 
     outfile = safeOpenFile(outputfile, mode="RECREATE")
-    
+    outdir_original = plotFolder
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
     for f in inputfiles:
         era = "preVFP" if "preVFP" in f else "postVFP" if "postVFP" in f else "full2016"
-        outFolder = f"{plotFolder}/{era}/"
+        outFolder = f"{outdir}/{era}/"
         createPlotDirAndCopyPhp(outFolder)
         infile = safeOpenFile(f)
         # get vertex binning from file (although it should be 55 bins from -15 to 15 cm)
@@ -88,4 +89,5 @@ if __name__ == "__main__":
         infile.Close()
 
     outfile.Close()
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)
     

--- a/scripts/analysisTools/w_mass_13TeV/makeVertexStudy.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeVertexStudy.py
@@ -77,10 +77,9 @@ if __name__ == "__main__":
 
     workingPoints = ["noCut", "vetoMuon", "goodMuon", "goodMuonAndSA", "fullSelNoMT"]
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
     parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument("-n", "--baseName", type=str, nargs="+", help="Histogram name in the file", default=["vertexStudyHisto_vetoMuon"], choices=[f"vertexStudyHisto_{wp}" for wp in workingPoints])
     parser.add_argument(     '--dzCut', default=0.1, type=float, help='Vertex dz(gen,reco) threshold in cm to calculate the efficiency')
     parser.add_argument('-p','--process', default="WplusmunuPostVFP", choices=["WplusmunuPostVFP", "WminusmunuPostVFP", "ZmumuPostVFP"], type=str, help='Choose what process to plot')
@@ -89,8 +88,8 @@ if __name__ == "__main__":
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     fname = args.inputfile[0]
-    outdir = args.outdir[0]
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
 
     ROOT.TH1.SetDefaultSumw2()
 
@@ -101,7 +100,7 @@ if __name__ == "__main__":
     yAxisName = "Muon p_{T} (GeV)"
 
     h5file = h5py.File(fname, "r")
-    results = narf.ioutils.pickle_load_h5py(h5file["results"])
+    results = input_tools.load_results_h5py(h5file)
 
     s = hist.tag.Slicer()
 
@@ -179,4 +178,4 @@ if __name__ == "__main__":
     drawGraphCMS([gr_vpts[wp] for wp in wps], xAxisName, f"{yAxisName}::{ymin},1.0", f"vtxEff_genBosonPt_multiWP_{postfixForCanvasName}", outdir,
                  leg_roc=wps[:], legendCoords = "0.55,0.30,0.95,0.58;1",
                  passCanvas=canvas, etabinText=f"{textForPlot}::0.18,0.15", skipLumi=True)
-    
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/makeWMCefficiency3D.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeWMCefficiency3D.py
@@ -72,14 +72,10 @@ def getEtaPtEff(n_pass, n_tot, getRoot=False, rootName="", rootTitle=""):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
     parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file", default="yieldsForWeffMC")
-    parser.add_argument(     '--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
-    parser.add_argument(     '--palette'  , default=87, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
-    parser.add_argument(     '--invertPalette', action='store_true',   help='Inverte color ordering in palette')
     parser.add_argument(     '--passMt', action='store_true',   help='Measure efficiencies only for events passing mT, otherwise stay inclusive')
     parser.add_argument('-p','--processes', default=["Wmunu"], nargs='*', type=str,
                         help='Choose what processes to plot, otherwise all are done')
@@ -88,8 +84,8 @@ if __name__ == "__main__":
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     fname = args.inputfile[0]
-    outdir = args.outdir[0]
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original)
         
     ROOT.TH1.SetDefaultSumw2()
 
@@ -174,35 +170,35 @@ if __name__ == "__main__":
                             f"{eff_iso.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_isonotrig_boost2D,eff_isonotrig = getEtaPtEff(n_isonotrig_pass, n_isonotrig_tot, getRoot=True, rootName=f"{d}_MC_eff_isonotrig", rootTitle="P(iso | ID+IP)")
         drawCorrelationPlot(eff_isonotrig, xAxisName, yAxisName, f"MC isolation efficiency",
                             f"{eff_isonotrig.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_isoantitrig_boost2D,eff_isoantitrig = getEtaPtEff(n_isoantitrig_pass, n_isoantitrig_tot, getRoot=True, rootName=f"{d}_MC_eff_isoantitrig", rootTitle="P(iso | ID+IP & fail trig)")
         drawCorrelationPlot(eff_isoantitrig, xAxisName, yAxisName, f"MC isolation efficiency",
                             f"{eff_isoantitrig.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_triggerplus_boost2D,eff_triggerplus = getEtaPtEff(n_triggerplus_pass, n_triggerplus_tot, getRoot=True, rootName=f"{d}_MC_eff_triggerplus", rootTitle="P(trig | ID+IP)")
         drawCorrelationPlot(eff_triggerplus, xAxisName, yAxisName, f"MC trigger plus efficiency",
                             f"{eff_triggerplus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_triggerminus_boost2D,eff_triggerminus = getEtaPtEff(n_triggerminus_pass, n_triggerminus_tot, getRoot=True, rootName=f"{d}_MC_eff_triggerminus", rootTitle="P(trig | ID+IP)")
         drawCorrelationPlot(eff_triggerminus, xAxisName, yAxisName, f"MC trigger minus efficiency",
                             f"{eff_triggerminus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_iso_3D = getBoostEff(n_iso_pass, n_iso_tot, rebinUt=args.rebinUt)
         #eff_isonotrig_3D = getBoostEff(n_isonotrig_pass, n_isonotrig_tot, rebinUt=args.rebinUt)
@@ -276,3 +272,4 @@ if __name__ == "__main__":
     eff_triggerplus.Write()
     eff_triggerminus.Write()
     rf.Close()
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeWMCvetoEfficiency.py
@@ -73,14 +73,10 @@ def getEtaPtEff(n_pass, n_tot, getRoot=False, rootName="", rootTitle="", integra
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
     parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
-    parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4], help="Set verbosity level with logging, the larger the more verbose");
     parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file", default="nominal")
-    parser.add_argument(     '--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
-    parser.add_argument(     '--palette'  , default=87, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
-    parser.add_argument(     '--invertPalette', action='store_true',   help='Inverte color ordering in palette')
     parser.add_argument('-p','--processes', default=["Wmunu"], nargs='*', type=str,
                         help='Choose what processes to plot, otherwise all are done')
     parser.add_argument(     '--rebinPt', default=-1, type=int, help='If positive, rebin yields versus pT by this number before deriving efficiencies (it happens after selecting the pt range)')
@@ -89,8 +85,8 @@ if __name__ == "__main__":
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
     fname = args.inputfile[0]
-    outdir = args.outdir[0]
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original)
         
     ROOT.TH1.SetDefaultSumw2()
 
@@ -160,17 +156,17 @@ if __name__ == "__main__":
                             f"{yields_pass_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
         drawCorrelationPlot(yields_fail_root, xAxisName, yAxisName, f"Events failing veto",
                             f"{yields_fail_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
         drawCorrelationPlot(yields_tot_root, xAxisName, yAxisName, f"Events (denominator)",
                             f"{yields_tot_root.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
         
         # NOTE: to simplify our lives, when computing efficiencies as ratio of yields n/N and root is used
         # then the uncertainty is obtained using option B for TH1::Divide, which uses binomial uncertainties.
@@ -185,21 +181,21 @@ if __name__ == "__main__":
                             f"{eff_veto.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_vetoplus_boost2D,eff_vetoplus = getEtaPtEff(n_vetoplus_pass, n_vetoplus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetoplus", rootTitle="P(vetoplus | gen)")
         drawCorrelationPlot(eff_vetoplus, xAxisName, yAxisName, f"MC veto efficiency (charge plus)",
                             f"{eff_vetoplus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_vetominus_boost2D,eff_vetominus = getEtaPtEff(n_vetominus_pass, n_vetominus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetominus", rootTitle="P(vetominus | gen)")
         drawCorrelationPlot(eff_vetominus, xAxisName, yAxisName, f"MC veto efficiency (charge minus)",
                             f"{eff_vetominus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         effRatio_plusOverMinus = copy.deepcopy(eff_vetoplus.Clone("effRatio_plusOverMinus"))
         effRatio_plusOverMinus.SetTitle("Charge plus / minus")
@@ -208,7 +204,7 @@ if __name__ == "__main__":
                             f"{effRatio_plusOverMinus.GetName()}", plotLabel="ForceTitle", outdir=outdir,
                             smoothPlot=False, drawProfileX=False, scaleToUnitArea=False,
                             draw_both0_noLog1_onlyLog2=1, passCanvas=canvas,
-                            nContours=args.nContours, palette=args.palette, invertePalette=args.invertPalette)
+                            nContours=args.nContours, palette=args.palette, invertPalette=args.invertPalette)
 
         eff_veto_boost1Deta,eff_veto_eta = getEtaPtEff(n_veto_pass, n_veto_tot, getRoot=True, rootName=f"{d}_MC_eff_veto_1Deta", rootTitle="P(veto | gen)", integrateVar=["pt"])
         eff_vetoplus_boost1Deta,eff_vetoplus_eta = getEtaPtEff(n_vetoplus_pass, n_vetoplus_tot, getRoot=True, rootName=f"{d}_MC_eff_vetoplus_1Deta", rootTitle="P(vetoplus | gen)", integrateVar=["pt"])
@@ -265,3 +261,4 @@ if __name__ == "__main__":
     eff_vetoplus.Write()
     eff_vetominus.Write()
     rf.Close()
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/mergeFilesSF2D.py
+++ b/scripts/analysisTools/w_mass_13TeV/mergeFilesSF2D.py
@@ -45,7 +45,7 @@ import wremnants
 
 if __name__ == "__main__":
             
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument('inputfile',  type=str, nargs=1,   help='Input root file with TH2')
     parser.add_argument('outputfile', type=str, nargs=1,   help='Output file absolute path')
     parser.add_argument('mergefiles', type=str, nargs='+', help='List of files to merge to inputfile into outputfile, keys already in inputfile are overridden, unless --noOverwriteDuplicate is specified')
@@ -62,12 +62,13 @@ if __name__ == "__main__":
         raise ValueError(f"Invalid outputfile name {args.outputfile[0]}, it would overwrite the input file {args.inputfile[0]}")
 
     #allSmooth_GtoHout.root
-    outdir = os.path.dirname(os.path.abspath(args.outputfile[0])) + "/"
-    createPlotDirAndCopyPhp(outdir)
+    outdir_original = os.path.dirname(os.path.abspath(args.outputfile[0])) + "/"
+    outdir = createPlotDirAndCopyPhp(outdir_original)
 
-    outfile = safeOpenFile(args.outputfile[0], mode="RECREATE")
+    outfilenameLocal = outdir + "/" + os.path.basename(args.outputfile[0]) 
+    outfile = safeOpenFile(outfilenameLocal, mode="RECREATE")
     
-    infile = safeOpenFile(args.inputfile[0])
+    infile = safeOpenFile(args.inputfile[0]) # might not work if the input is on eos and one uses the mount
     inputHistnames = []
     for k in infile.GetListOfKeys():
         name = k.GetName()
@@ -96,5 +97,6 @@ if __name__ == "__main__":
                     h.Write(name)
         infile.Close()
                     
-    logger.info(f"Done, closing file {args.outputfile[0]}")
+    logger.info(f"Done, closing file {outfile.GetName()}")
     outfile.Close()
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
+++ b/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
@@ -227,7 +227,7 @@ def plotPrefitHistograms(hdata2D, hmc2D, outdir_dataMC, xAxisName, yAxisName,
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument("rootfile", type=str, nargs=1, help="Input file with TH2 histograms")
     parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
     parser.add_argument("-l", "--lumi",     type=str, default=None, help="Luminosity to print on canvas, by default it is not printed")
@@ -244,11 +244,11 @@ if __name__ == "__main__":
     parser.add_argument('-c','--charges', dest='charges', choices=['plus', 'minus', 'both'], default='both', type=str, help='Charges to process')
     parser.add_argument("--rr", "--ratio-range", dest="ratioRange", default=(0.92,1.08), type=float, nargs=2, help="Range for ratio plot")
     args = parser.parse_args()
-           
+
     fname = args.rootfile[0]
-    outdir = args.outdir[0]
-    createPlotDirAndCopyPhp(outdir)
-    
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
     ROOT.TH1.SetDefaultSumw2()
 
     canvas = ROOT.TCanvas("canvas", "", 800, 700)
@@ -260,13 +260,13 @@ if __name__ == "__main__":
     if not args.pseudodata:
         processes = ["Data"] + processes
     charges = ["plus", "minus"] if args.charges == "both" else [args.charges]
-    
+
     xAxisName = "Muon #eta"
     yAxisName = "Muon p_{T} (GeV)"
 
     colors = colors_plots_
     legEntries = legEntries_plots_
-    
+
     for charge in charges:
 
         # read histograms
@@ -291,3 +291,4 @@ if __name__ == "__main__":
                              colors=colors, legEntries=legEntries, isPseudoData=True if args.pseudodata else False,
                              ratioRange=args.ratioRange)
 
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/run2Dsmoothing.py
+++ b/scripts/analysisTools/w_mass_13TeV/run2Dsmoothing.py
@@ -456,7 +456,7 @@ if __name__ == "__main__":
                      "triggerminus" : f"{sfFolder}triggerminus3DSFVQTextended.root",
                      }
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument('outdir', type=str, nargs=1, help='output directory to save things')
     parser.add_argument('-n', '--outfilename', type=str, default='smoothSF3D.pkl.lz4', help='Output file name, extension must be pkl.lz4, which is automatically added if no extension is given')
     parser.add_argument('--eta', type=int, nargs="*", default=[], help='Select some eta bins (ID goes from 1 to Neta')
@@ -504,8 +504,9 @@ if __name__ == "__main__":
     work.append([inputRootFile["triggerplus"],  "SF3D_nominal_trigger_plus",  "triggerplus", effHist["triggerplus"]])
     work.append([inputRootFile["triggerminus"], "SF3D_nominal_trigger_minus", "triggerminus", effHist["triggerminus"]])
 
-    outdir = args.outdir[0]
-    
+    outdir_original = args.outdir[0]
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+
     resultDict = {}
     for w in work:
         inputfile, histname, step, eff = w
@@ -515,9 +516,9 @@ if __name__ == "__main__":
         for ret in rets:
             if ret != None:
                 resultDict[ret.name] = ret
-                
+
     resultDict.update({"meta_info" : narf.ioutils.make_meta_info_dict(args=args, wd=common.base_dir)})
-    
+
     outfile = outdir + args.outfilename
     logger.info(f"Going to store histograms in file {outfile}")
     logger.info(f"All keys: {resultDict.keys()}")
@@ -525,3 +526,4 @@ if __name__ == "__main__":
     with lz4.frame.open(outfile, 'wb') as f:
         pickle.dump(resultDict, f, protocol=pickle.HIGHEST_PROTOCOL)
     logger.info(f"Output saved: {time.time()-time0}")
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)

--- a/scripts/analysisTools/w_mass_13TeV/subMatrix.py
+++ b/scripts/analysisTools/w_mass_13TeV/subMatrix.py
@@ -275,15 +275,13 @@ if __name__ == "__main__":
                                     "channelmu"             : "mu",
     }
 
-    parser = argparse.ArgumentParser()
+    parser = common_plot_parser()
     parser.add_argument('fitresult', type=str, nargs=1, help="fitresult.root file from combinetf")
     parser.add_argument('-o','--outdir', default='', type=str, help='output directory to save the matrix')
     parser.add_argument('-p','--params', default='', type=str, help='parameters for which you want to show the correlation matrix. comma separated list of regexps')
     parser.add_argument('-t','--type'  , default='hessian', choices=['toys', 'scans', 'hessian'], type=str, help='which type of input file: toys(default),scans, or hessian')
     parser.add_argument(     '--postfix', default='', type=str, help='Postfix for the correlation matrix')
     parser.add_argument(     '--uniqueString',  default=None, required=True, type=str, help='Keyword for canvas name to uniquely identify the output plot')
-    parser.add_argument(     '--nContours', default=51, type=int, help='Number of contours in palette. Default is 51 (keep it odd: no correlation is white with our palette)')
-    parser.add_argument(     '--palette'  , default=0, type=int, help='Set palette: default is a built-in one, 55 is kRainbow')
     parser.add_argument(     '--vertical-labels-X', dest='verticalLabelsX', action='store_true', help='Set labels on X axis vertically (sometimes they overlap if rotated)')
     parser.add_argument(     '--noTextMatrix', action='store_true', help='Do not print text with values on the matrix')
     parser.add_argument(     '--title'  , default='', type=str, help='Title for matrix ')
@@ -318,9 +316,10 @@ if __name__ == "__main__":
                                          array ("d", [1.00, 1.00, 0.00]),
                                          255,  0.95)
 
-
-    if args.outdir:
-        createPlotDirAndCopyPhp(args.outdir)
+    outdir_original = args.outdir:
+    outdir = None
+    if outdir_original:
+        outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
     else:
         print("You must pass an output folder with option -o")
         quit()
@@ -535,7 +534,7 @@ if __name__ == "__main__":
                        
             args.skipLatexOnTop = True
             
-        if args.outdir:
+        if outdir:
             ROOT.gStyle.SetPaintTextFormat('1.2f')
             if len(params) < 30 and not args.noTextMatrix: tmp_mat.Draw('colz text45')
             else: tmp_mat.Draw('colz')
@@ -554,7 +553,7 @@ if __name__ == "__main__":
             paramsName = args.uniqueString
 
             suff = '' if not args.postfix else '_'+args.postfix
-            outfname = args.outdir+'/small{corcov}_{pn}{suff}'.format(suff=suff,pn=paramsName,corcov=corcov)
+            outfname = outdir+'/small{corcov}_{pn}{suff}'.format(suff=suff,pn=paramsName,corcov=corcov)
             for i in ['pdf', 'png']:
                 c.SaveAs('{ofn}.{i}'.format(ofn=outfname,i=i))
             # save matrix in root file
@@ -567,3 +566,6 @@ if __name__ == "__main__":
     if args.showMoreCorrelated:
         print("Option --show-more-correlated is not yet implemented")
         pass
+
+    copyOutputToEos(outdir_original, eoscp=args.eoscp)
+


### PR DESCRIPTION
This PR tries to modify all plotting scripts in scripts/analysisTools/ to avoid using the eos mount for storing plots on eos. For now it only touches the functions to create folders and copy files.

It reuses the utility functions in **[utilities/io_tools/output_tools.py](https://github.com/WMass/WRemnants/compare/main...cippy:eoscp4plots?expand=1#diff-9db85a6d3c6388cfa13bb4fd910de29a1437e0b4bff0608c80b5eb1c7f921bff)**, with some slight modifications to comply with some requirements of stuff in scripts/analysisTools/ (although I tried to maintain the original behaviour when adding new flags).

One thing I noticed: when the temporary folder "temp" is created to store files locally before copying to eos, only the final subfolder inside it is eventually deleted, but I actually think one would like to delete the whole "temp" folder when the copy to eos happens. If one does it, we might want to call this temporary folder with a more specific name to avoid potential mistakes when deleting (for example, "tempLocalFolderBeforeEosCp", in case one already has a temp folder for other purposes)

Updates for this PR concerning specific plotting scripts will follow.