### PR TITLE
fix copy to eos for subfolders

### DIFF
--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -565,6 +565,8 @@ def createPlotDirAndCopyPhp(outdir, eoscp=True):
     outdir = os.path.realpath(outdir)
     #logger.warning(f"Real output path is {outdir}")
     outdir = output_tools.make_plot_dir(outdir, outfolder=None, eoscp=eoscp, allowCreateLocalFolder=True)
+    if not outdir.endswith("/"):
+        outdir += "/"
     if outdir and not os.path.exists(outdir):
         os.makedirs(outdir)
     htmlpath = f"{os.environ['WREM_BASE']}/scripts/analysisTools/templates/index.php"

--- a/scripts/analysisTools/tests/testFakesVsMt.py
+++ b/scripts/analysisTools/tests/testFakesVsMt.py
@@ -98,7 +98,7 @@ def plotProjection1Dfrom3D(rootHists, datasets, outfolder_dataMC, canvas1Dshapes
     axisProj = "x" if projectAxisToKeep == 0 else "y" if projectAxisToKeep == 1 else "z"
     for d in datasets:
         rootHists[d].GetZaxis().SetRange(chargeBin, chargeBin)
-        logger.warning("In plotProjection1Dfrom3D(): setting pt axis to exclude overflows from projections")
+        # logger.warning("In plotProjection1Dfrom3D(): setting pt axis to exclude overflows from projections")
         rootHists[d].GetYaxis().SetRange(1, rootHists[d].GetNbinsY())
         if d == "Data":
             hdata = rootHists[d].Project3D(f"{axisProj}eo")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -390,7 +390,7 @@ def build_graph(df, dataset):
             weight_expr = "weight_pu*weight_newMuonPrefiringSF*L1PreFiringWeight_ECAL_Nom"
         else:
             weight_expr = "weight_pu*L1PreFiringWeight_Muon_Nom*L1PreFiringWeight_ECAL_Nom"
-            
+
         if not args.noVertexWeight:
             weight_expr += "*weight_vtx"
 
@@ -400,8 +400,8 @@ def build_graph(df, dataset):
         df = muon_selections.define_muon_uT_variable(df, isWorZ, smooth3dsf=args.smooth3dsf, colNamePrefix="goodMuons")
         if not args.smooth3dsf:
             columnsForSF.remove("goodMuons_uT0")
-            
-        if not args.noScaleFactors:
+
+        if not isQCDMC and not args.noScaleFactors:
             df = df.Define("weight_fullMuonSF_withTrackingReco", muon_efficiency_helper, columnsForSF)
             weight_expr += "*weight_fullMuonSF_withTrackingReco"
 
@@ -442,7 +442,7 @@ def build_graph(df, dataset):
         results.append(mTStudyForFakes)
 
     # add filter of deltaPhi(muon,met) before other histograms (but after histogram mTStudyForFakes)
-    if not args.makeMCefficiency:
+    if args.dphiMuonMetCut > 0.0 and not args.makeMCefficiency:
         dphiMuonMetCut = args.dphiMuonMetCut * np.pi
         df = df.Filter(f"deltaPhiMuonMet > {dphiMuonMetCut}") # pi/4 was found to be a good threshold for signal with mT > 40 GeV
         
@@ -515,7 +515,7 @@ def build_graph(df, dataset):
     if not dataset.is_data and not args.onlyMainHistograms:
 
         if not args.onlyTheorySyst:
-            if not args.noScaleFactors:
+            if not isQCDMC and not args.noScaleFactors:
                 df = syst_tools.add_muon_efficiency_unc_hists(results, df, muon_efficiency_helper_stat, muon_efficiency_helper_syst, axes, cols, what_analysis=thisAnalysis, smooth3D=args.smooth3dsf)
             df = syst_tools.add_L1Prefire_unc_hists(results, df, muon_prefiring_helper_stat, muon_prefiring_helper_syst, axes, cols)
             # luminosity, as shape variation despite being a flat scaling to facilitate propagation to fakes


### PR DESCRIPTION
As the title says, since so far the copy was only acting on files, thus ignoring any subfolder in the source path.

In addition, the W histmaker is modified to remove scale factors from the QCD MC by default. This is something we were already enforcing through the noScaleFactors option when running on QCD MC alone to test the fakes. The logic is that the SF should technically apply only to prompt muons, hence not to QCD MC events (this also assumes that the QCD MC is not used for a reliable prediction of this background in the data/MC plots, but mainly to test the fake rate, so that using SF or not is irrelevant).

This PR should change nothing for the analysis (as long as the QCD MC is not used directly for any fit), and the PRvalidation plots should stay exactly the same as before, let's see.