### PR TITLE
Updating mass difference and supporting width fits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -542,7 +542,7 @@ jobs:
           lfs: 'true'
 
       - name: dilepton mll analysis
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_dilepton.py -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll cosThetaStarll --useDileptonTriggerSelection --forceDefaultName --postfix mll
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/histmakers/mz_dilepton.py -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll cosThetaStarll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'virtual_ewCorr' --selectEntries 2 --varLabel 'EW(virtual)' --selectAxis systIdx --color blue

--- a/scripts/combine/pullsAndImpacts.py
+++ b/scripts/combine/pullsAndImpacts.py
@@ -338,7 +338,7 @@ app = dash.Dash(__name__)
 def producePlots(fitresult, args, poi, group=False, normalize=False, fitresult_ref=None):
     poi_type = poi.split("_")[-1] if poi else None
 
-    if "MeV" in poi:
+    if poi is not None and "MeV" in poi:
         scale = float(re.search(r'\d+(\.\d+)?', poi.split("MeV")[0].replace("p",".")).group())
         if "Diff" in poi:
             scale *= 2 # take diffs by 2 as up and down pull in opposite directions
@@ -352,6 +352,8 @@ def producePlots(fitresult, args, poi, group=False, normalize=False, fitresult_r
             impact_title = "Impact on mass diff. (charge) (MeV)"
         elif poi.startswith("massDiffEta"):
             impact_title = "$\\mathrm{Impact\\ on\\ mass\\ diff. }(\\eta)\\ (\\mathrm{MeV})$"
+        else:
+            impact_title = "Impact on mass diff. (MeV)"
     elif poi and poi.startswith("Width"):
         impact_title = "Impact on width (MeV)"
     else:

--- a/scripts/combine/pullsAndImpacts.py
+++ b/scripts/combine/pullsAndImpacts.py
@@ -66,18 +66,7 @@ def get_marker(filled=True, color='#377eb8', opacity=1.0):
         }
     return marker
 
-def plotImpacts(df, poi, pulls=False, normalize=False, oneSidedImpacts=False):
-    poi_type = poi.split("_")[-1] if poi else None
-
-    if poi and poi.startswith("massShift"):
-        impact_title = "Impact on mass (MeV)"
-    elif poi and poi.startswith("massDiffCharge"):
-        impact_title = "Impact on mass diff. (charge) (MeV)"
-    elif poi and poi.startswith("massDiffEta"):
-        impact_title = "$\\mathrm{Impact\\ on\\ mass\\ diff. }(\\eta)\\ (\\mathrm{MeV})$"
-    else:
-        impact_title=poi
-
+def plotImpacts(df, impact_title="", pulls=False, normalize=False, oneSidedImpacts=False):
     impacts = bool(np.count_nonzero(df['absimpact'])) and not args.noImpacts
     ncols = pulls+impacts
     fig = make_subplots(rows=1,cols=ncols,
@@ -267,7 +256,7 @@ def plotImpacts(df, poi, pulls=False, normalize=False, oneSidedImpacts=False):
 
     return fig
 
-def readFitInfoFromFile(rf, filename, poi, group=False, stat=0.0, normalize=False, scale=100):    
+def readFitInfoFromFile(rf, filename, poi, group=False, stat=0.0, normalize=False, scale=1):    
     impacts, labels, _ = combinetf_input.read_impacts_poi(rf, group, add_total=group, stat=stat, poi=poi, normalize=normalize)
     
     if (group and grouping) or args.filters:
@@ -346,7 +335,27 @@ app = dash.Dash(__name__)
     [Input("groups", "on")],
 )
 
-def producePlots(fitresult, args, poi, group=False, normalize=False, fitresult_ref=None, scale=100):
+def producePlots(fitresult, args, poi, group=False, normalize=False, fitresult_ref=None):
+    poi_type = poi.split("_")[-1] if poi else None
+
+    if "MeV" in poi:
+        scale = float(re.search(r'\d+(\.\d+)?', poi.split("MeV")[0].replace("p",".")).group())
+        if "Diff" in poi:
+            scale *= 2 # take diffs by 2 as up and down pull in opposite directions
+    else:
+        scale = 1
+
+    if poi and poi.startswith("massShift"):
+        impact_title = "Impact on mass (MeV)"
+    elif poi and poi.startswith("massDiff"):
+        if poi.startswith("massDiffCharge"):
+            impact_title = "Impact on mass diff. (charge) (MeV)"
+        elif poi.startswith("massDiffEta"):
+            impact_title = "$\\mathrm{Impact\\ on\\ mass\\ diff. }(\\eta)\\ (\\mathrm{MeV})$"
+    elif poi and poi.startswith("Width"):
+        impact_title = "Impact on width (MeV)"
+    else:
+        impact_title=poi
 
     if not (group and args.output_mode == 'output'):
         df = readFitInfoFromFile(fitresult, args.inputFile, poi, False, stat=args.stat/100., normalize=normalize, scale=scale)
@@ -446,14 +455,14 @@ def producePlots(fitresult, args, poi, group=False, normalize=False, fitresult_r
         if args.num and args.num < df.size:
             # in case multiple extensions are given including html, don't do the skimming on html but all other formats
             if "html" in extensions and len(extensions)>1:
-                fig = plotImpacts(df, pulls=not args.noPulls and not group, poi=poi, normalize=not args.absolute, oneSidedImpacts=args.oneSidedImpacts)
+                fig = plotImpacts(df, pulls=not args.noPulls and not group, impact_title=impact_title, normalize=not args.absolute, oneSidedImpacts=args.oneSidedImpacts)
                 outfile_html = outfile.replace(outfile.split(".")[-1], "html")
                 writeOutput(fig, outfile_html, postfix=postfix)
                 extensions = [e for e in extensions if e != "html"]
                 outfile = outfile.replace(outfile.split(".")[-1], extensions[0])
             df = df[-args.num:]
 
-        fig = plotImpacts(df, pulls=not args.noPulls and not group, poi=poi, normalize=not args.absolute, oneSidedImpacts=args.oneSidedImpacts)
+        fig = plotImpacts(df, pulls=not args.noPulls and not group, impact_title=impact_title, normalize=not args.absolute, oneSidedImpacts=args.oneSidedImpacts)
         writeOutput(fig, outfile, extensions[0:], postfix=postfix, args=args, meta_info=meta)      
         if args.eoscp and output_tools.is_eosuser_path(args.outFolder):
             output_tools.copy_to_eos(args.outFolder, "")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -40,6 +40,7 @@ def make_parser(parser=None):
     parser.add_argument("--lumiScale", type=float, default=1.0, help="Rescale equivalent luminosity by this value (e.g. 10 means ten times more data and MC)")
     parser.add_argument("--sumChannels", action='store_true', help="Only use one channel")
     parser.add_argument("--fitXsec", action='store_true', help="Fit signal inclusive cross section")
+    parser.add_argument("--fitWidth", action='store_true', help="Fit boson width")
     parser.add_argument("--fitMassDiff", type=str, default=None, choices=["charge", "cosThetaStarll", "eta-sign", "eta-range", "etaRegion", "etaRegionSign", "etaRegionRange"], help="Fit an additional POI for the difference in the boson mass")
     parser.add_argument("--fitMassDecorr", type=str, default=None, help="Decorrelate POI for given axis, fit multiple POIs for the different POIs")
     parser.add_argument("--fitresult", type=str, default=None ,help="Use data and covariance matrix from fitresult (for making a theory fit)")
@@ -517,14 +518,17 @@ def setup(args, inputFile, fitvar, xnorm=False):
         )
 
     # Experimental range
-    #widthVars = ['widthW2p043GeV', 'widthW2p127GeV'] if wmass else ['widthZ2p4929GeV', 'widthZ2p4975GeV']
+    #widthVars = (42, ['widthW2p043GeV', 'widthW2p127GeV']) if wmass else (2.3, ['widthZ2p4929GeV', 'widthZ2p4975GeV'])
     # Variation from EW fit (mostly driven by alphas unc.)
-    widthVars = ['widthW2p09053GeV', 'widthW2p09173GeV'] if wmass else ['widthZ2p49333GeV', 'widthZ2p49493GeV']
+    widthVars = (0.6, ['widthW2p09053GeV', 'widthW2p09173GeV']) if wmass else (0.8, ['widthZ2p49333GeV', 'widthZ2p49493GeV'])
     cardTool.addSystematic(f"widthWeight{label}",
+                            rename=f"Width{label}{str(widthVars[0]).replace('.','p')}MeV",
                             processes=["signal_samples_inctau"],
-                            action=lambda h: h[{"width" : widthVars}],
+                            action=lambda h: h[{"width" : widthVars[1]}],
                             group=f"width{label}",
                             mirror=False,
+                            noi=args.fitWidth,
+                            noConstraint=args.fitWidth,
                             systAxes=["width"],
                             outNames=[f"width{label}Down", f"width{label}Up"],
                             passToFakes=passSystToFakes,

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -815,6 +815,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     if not input_tools.args_from_metadata(cardTool, "noSmearing"):
         cardTool.addSystematic("muonResolutionSyst_responseWeights", 
             mirror = True,
+            # scale=10,
             processes=['single_v_samples'],
             group="resolutionCrctn",
             splitGroup={f"muonCalibration" : f".*"},

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -62,19 +62,20 @@ translate_selection = {
 
 def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suffix="", chi2=None, meta=None, saturated_chi2=False):
     axes_names = [a.name for a in axes]
-    axis_name = "_".join([a for a in axes_names])
     if len(h_data.axes) > 1:
         # make unrolled 1D histograms
-        if "eta" in axes_names: # convention is to plot eta-pt 
+        if "eta" in axes_names or "etaAbsEta" in axes_names: # convention is to plot eta-pt 
             axes_names = axes_names[::-1]
         h_data = sel.unrolledHist(h_data, binwnorm=1, obs=axes_names)
         h_inclusive = sel.unrolledHist(h_inclusive, binwnorm=1, obs=axes_names)
         h_stack = [sel.unrolledHist(h, binwnorm=1, obs=axes_names) for h in h_stack]
 
+    axis_name = "_".join([a for a in axes_names])
+    xlabel=f"{'-'.join([styles.xlabels.get(s,s).replace('(GeV)','') for s in axes_names])} bin"
     if ratio:
-        fig, ax1, ax2 = plot_tools.figureWithRatio(h_data, styles.xlabels.get(axis_name, "Bin number"), "Entries/bin", args.ylim, "Data/Pred.", args.rrange)
+        fig, ax1, ax2 = plot_tools.figureWithRatio(h_data, xlabel, "Entries/bin", args.ylim, "Data/Pred.", args.rrange)
     else:
-        fig, ax1 = plot_tools.figure(h_data, styles.xlabels.get(axis_name, "Bin number"), "Entries/bin", args.ylim)
+        fig, ax1 = plot_tools.figure(h_data, xlabel, "Entries/bin", args.ylim)
 
     hep.histplot(
         h_stack,
@@ -166,7 +167,7 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
     hep.cms.label(ax=ax1, lumi=float(f"{args.lumi:.3g}"), fontsize=20*args.scaleleg*scale, 
         label=args.cmsDecor, data=data)
 
-    plot_tools.addLegend(ax1, ncols=2, text_size=20*args.scaleleg)
+    plot_tools.addLegend(ax1, ncols=2, text_size=20*args.scaleleg*scale)
     plot_tools.fix_axes(ax1, ax2, yscale=args.yscale)
 
     to_join = [fittype, args.postfix, axis_name, suffix]

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -64,7 +64,7 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
     axes_names = [a.name for a in axes]
     if len(h_data.axes) > 1:
         # make unrolled 1D histograms
-        if "eta" in axes_names or "etaAbsEta" in axes_names: # convention is to plot eta-pt 
+        if axes_names[-1].startswith("eta"): # convention is to plot eta-pt 
             axes_names = axes_names[::-1]
         h_data = sel.unrolledHist(h_data, binwnorm=1, obs=axes_names)
         h_inclusive = sel.unrolledHist(h_inclusive, binwnorm=1, obs=axes_names)
@@ -158,8 +158,14 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
             chi2_name = "\chi_{\mathrm{sat.}}^2/ndf"
         else:
             chi2_name = "\chi^2/ndf"
-        plt.text(0.05, 0.94, f"${chi2_name} = {round(chi2[0],1)}/{chi2[1]}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
-            fontsize=20*args.scaleleg*scale)
+        if len(h_data.values())<100:
+            plt.text(0.05, 0.94, f"${chi2_name}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
+                fontsize=20*args.scaleleg*scale)  
+            plt.text(0.05, 0.86, f"$= {round(chi2[0],1)}/{chi2[1]}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
+                fontsize=20*args.scaleleg*scale)  
+        else:
+            plt.text(0.05, 0.94, f"${chi2_name} = {round(chi2[0],1)}/{chi2[1]}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
+                fontsize=20*args.scaleleg*scale)
 
     plot_tools.redo_axis_ticks(ax1, "x")
     plot_tools.redo_axis_ticks(ax2, "x")

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -76,8 +76,6 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
     axes_names = [a.name for a in axes]
     if len(h_data.axes) > 1:
         # make unrolled 1D histograms
-        if axes_names[-1].startswith("eta"): # convention is to plot eta-pt 
-            axes_names = axes_names[::-1]
         h_data = sel.unrolledHist(h_data, binwnorm=1, obs=axes_names)
         h_inclusive = sel.unrolledHist(h_inclusive, binwnorm=1, obs=axes_names)
         h_stack = [sel.unrolledHist(h, binwnorm=1, obs=axes_names) for h in h_stack]

--- a/utilities/styles/styles.py
+++ b/utilities/styles/styles.py
@@ -48,7 +48,7 @@ process_labels = {
     "Wenu": r"W$^{\pm}\to e\nu$",
     "Wtaunu": r"W$^{\pm}\to\tau\nu$",
     "DYlowMass": r"Z$\to\mu\mu$, $10<m<50$ GeV",
-    "PhotonInduced": "Photon-induced EW",
+    "PhotonInduced": r"$\gamma$-induced",
     "Top": "Top",
     "Diboson": "Diboson",
     "QCD": "QCD MC",

--- a/wremnants/plot_tools.py
+++ b/wremnants/plot_tools.py
@@ -107,6 +107,7 @@ def addLegend(ax, ncols=2, extra_text=None, extra_text_loc=(0.8, 0.7), text_size
     if len(handles) % 2 and ncols == 2:
         handles.insert(math.floor(len(handles)/2), patches.Patch(color='none', label = ' '))
         labels.insert(math.floor(len(labels)/2), ' ')
+    text_size = text_size*(0.7 if shape == 1 else 1.3)
     leg = ax.legend(handles=handles, labels=labels, prop={'size' : text_size}, ncol=ncols, loc=loc)
 
     if extra_text:

--- a/wremnants/plot_tools.py
+++ b/wremnants/plot_tools.py
@@ -107,7 +107,6 @@ def addLegend(ax, ncols=2, extra_text=None, extra_text_loc=(0.8, 0.7), text_size
     if len(handles) % 2 and ncols == 2:
         handles.insert(math.floor(len(handles)/2), patches.Patch(color='none', label = ' '))
         labels.insert(math.floor(len(labels)/2), ' ')
-    text_size = text_size*(0.7 if shape == 1 else 1.3)
     leg = ax.legend(handles=handles, labels=labels, prop={'size' : text_size}, ncol=ncols, loc=loc)
 
     if extra_text:

--- a/wremnants/unfolding_tools.py
+++ b/wremnants/unfolding_tools.py
@@ -55,7 +55,7 @@ def define_gen_level(df, gen_level, dataset_name, mode="wmass"):
             df = df.Define("ptGen", "event % 2 == 0 ? genl.pt() : genlanti.pt()")
             df = df.Define("absEtaGen", "event % 2 == 0 ? fabs(genl.eta()) : fabs(genlanti.eta())")
             df = df.Define("ptOtherGen", "event % 2 == 0 ? genlanti.pt() : genl.pt()")
-            df = df.Define("absEtaOtherGen", "event % 2 == 0 ? genlanti.pt() : genl.pt()")
+            df = df.Define("absEtaOtherGen", "event % 2 == 0 ? fabs(genlanti.eta()) : fabs(genl.eta())")
 
     elif gen_level == "postFSR":
         df = theory_tools.define_postfsr_vars(df, mode=mode)


### PR DESCRIPTION
- In case the mass is fit in 3 regions, e.g. BB, BE, EE, two mass differences are fit. The mass can be fit together with mass differences of the extreme regions i.e. mBB-mEE and between the middle region and the extreme regions i.e. mBB+mEE-mBE. 
- using wlike trigger strategy for the wlike and dilepton analyses
- Supporting the fit with the w/z width and also generalizing the impact plotting scipt to scale the size of variations into MeV
- Fixing a typo in the preFSR definition for the unfolding
- Some smaller updates on the plotting