### PR TITLE
Remove dphi cut between muon and met by default

### DIFF
--- a/scripts/analysisTools/tests/testFakesVsMt.py
+++ b/scripts/analysisTools/tests/testFakesVsMt.py
@@ -488,7 +488,6 @@ def runStudy(fname, charges, mainOutputFolder, args):
 
     hFRFcorr = None
     hFRFcorrUnc = None
-    #hFRFcorrTestCap = None
     hFRF_proj = None
     histoChi2diffTest = None
     histoPullsPol1Slope = None
@@ -990,12 +989,11 @@ def runStudy(fname, charges, mainOutputFolder, args):
         ptHigh = round(0.01 + h2PassIso.GetYaxis().GetBinLowEdge(1+h2PassIso.GetNbinsY()), 1)
 
         nPtBins = h2PassIso.GetNbinsY()
-        logger.warning(f"hFRFcorr defined with {nPtBins} pt bins from {round(ptLow,1)} to pt = {round(ptLow,1)}")
+        logger.warning(f"hFRFcorr defined with {nPtBins} pt bins from {round(ptLow,1)} to pt = {round(ptHigh,1)}")
 
         hFRFcorr = ROOT.TH2D(f"fakerateFactorCorrection_{charge}", "%s m_{T} > %d GeV" % (args.met, int(args.mtNominalRange.split(',')[1])),
                                      h2PassIso.GetNbinsX(), round(etaLow,1), round(etaHigh,1),
-                                     nPtBins, round(ptLow,1), round(ptLow,1))
-        #hFRFcorrTestCap = copy.deepcopy(hFRFcorr.Clone(f"fakerateFactorCorrTestCap_{charge}"))
+                                     nPtBins, round(ptLow,1), round(ptHigh,1))
         if args.fitPolDegree == 1:
             histoChi2diffTest = ROOT.TH1D(f"histoChi2diffTest_{charge}", "Probability(#chi^{2}_{0} - #chi^{2}_{1})", 10, 0, 1)
             histoPullsPol1Slope = ROOT.TH1D(f"histoPullsPol1Slope_{charge}", "Pulls for slope parameter in pol1 fits", 20, -5, 5)
@@ -1079,7 +1077,6 @@ def runStudy(fname, charges, mainOutputFolder, args):
                         binContent = 0.05
                     inverseNomiFRF = 1.0/binContent
                     hFRFcorr.SetBinContent(ieta, ipt, valFRF * inverseNomiFRF)
-                    #hFRFcorrTestCap.SetBinContent(ieta, ipt, valFRFCap * inverseNomiFRF)
                     if hFRFcorrUnc == None:
                         hFRFcorrUnc = {}
                         for key in uncFRF.keys():
@@ -1147,16 +1144,11 @@ def runStudy(fname, charges, mainOutputFolder, args):
                         ROOT.kAzure+2, ROOT.kAzure+1,
                         ROOT.kOrange+2, ROOT.kOrange+1,
                         ROOT.kGreen+2, ROOT.kGreen+1] # colors only passed for variations
-            # if hFRFcorrTestCap:
-            #     hList.append( unroll2Dto1D(hFRFcorrTestCap,
-            #                                newname=f"unrolled_{hFRFcorrTestCap.GetName()}",
-            #                                cropNegativeBins=False) )
-            #     legEntries.append( "syst(cap FRF)" )
-            #     colorVec = [ROOT.kGreen+3] + colorVec
             ptBinRanges = []
             for ipt in range(hFRFcorr.GetNbinsY()):
-                ptBinRanges.append("[{ptmin},{ptmax}] GeV".format(ptmin=int(hFRFcorr.GetYaxis().GetBinLowEdge(ipt+1)),
-                                                                  ptmax=int(hFRFcorr.GetYaxis().GetBinLowEdge(ipt+2))))
+                ptmin = int(hFRFcorr.GetYaxis().GetBinLowEdge(ipt+1))
+                ptmax = int(hFRFcorr.GetYaxis().GetBinLowEdge(ipt+2))
+                ptBinRanges.append("[{ptmin},{ptmax}] GeV".format(ptmin=ptmin, ptmax=ptmax))
 
             for ivar in uncFRF.keys():
                 if ivar == "quadsum":
@@ -1224,15 +1216,6 @@ def runStudy(fname, charges, mainOutputFolder, args):
                  textForLines=ptBinRanges, transparentLegend=False,
                  onlyLineColor=True, noErrorRatioDen=False, useLineFirstHistogram=True, setOnlyLineRatio=False,
                  drawErrorAll=True)
-
-        # if hFRFcorrTestCap is not None:
-        #     drawCorrelationPlot(hFRFcorrTestCap,
-        #                         xAxisName,
-        #                         yAxisName,
-        #                         f"QCD template correction::{corrRange}",
-        #                         hFRFcorrTestCap.GetName(), plotLabel="ForceTitle", outdir=outfolder,
-        #                         draw_both0_noLog1_onlyLog2=1, nContours=args.nContours, palette=args.palette,
-        #                         invertPalette=args.invertPalette, passCanvas=canvas, skipLumi=True)
 
         if hFRFcorr.GetNbinsX() == 1 or hFRFcorr.GetNbinsY() == 1:
             if hFRFcorr.GetNbinsY() == 1:

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -239,10 +239,11 @@ def build_graph(df, dataset):
     df = df.Define("met_wlike_TV2_pt", "met_wlike_TV2.Mod()")
     results.append(df.HistoBoost("WlikeMET", [hist.axis.Regular(20, 0, 100, name="Wlike-MET")], ["met_wlike_TV2_pt", "nominal_weight"]))
     ###########
-    
+
     # cutting after storing mt distributions for plotting, since the cut is only on corrected met
-    df = df.Define("deltaPhiMuonMet", "std::abs(wrem::deltaPhi(trigMuons_phi0,met_wlike_TV2.Phi()))")
-    df = df.Filter(f"deltaPhiMuonMet > {args.dphiMuonMetCut*np.pi}")
+    if args.dphiMuonMetCut > 0.0:
+        df = df.Define("deltaPhiMuonMet", "std::abs(wrem::deltaPhi(trigMuons_phi0,met_wlike_TV2.Phi()))")
+        df = df.Filter(f"deltaPhiMuonMet > {args.dphiMuonMetCut*np.pi}")
     df = df.Filter(f"transverseMass >= {mtw_min}")
 
     if not args.onlyMainHistograms:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -254,7 +254,7 @@ def common_parser(for_reco_highPU=False):
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)
-        parser.add_argument("--dphiMuonMetCut", type=float, help="Threshold to cut |deltaPhi| > thr*np.pi between muon and met", default=0.25)
+        parser.add_argument("--dphiMuonMetCut", type=float, help="Threshold to cut |deltaPhi| > thr*np.pi between muon and met", default=0.0)
         parser.add_argument("--muonCorrMC", type=str, default="idealMC_lbltruth", 
             choices=["none", "trackfit_only", "trackfit_only_idealMC", "lbl", "idealMC_lbltruth", "idealMC_massfit", "idealMC_lbltruth_massfit"], 
             help="Type of correction to apply to the muons in simulation")


### PR DESCRIPTION
The cut dphi(mu, met) > pi/4 was originally motivated by the mitigation of the fake rate dependence on mT, but after moving to the vertex agnostic isolation it seems this is no longer happening, and apparently the dependence remains regardless of this cut, so this PR sets the default threshold to 0 (namely no cut on dphi any longer).

The signal component in the signal region for W events should only be mildly affected by this change, and the difference on the total yields should mainly come from the variation of the fake background (which should be around 10-20% depending on pt).

Small differences in the Wlike analysis can be expected since the cut was also used there for consistency with the Wmass space.
Instead, the dilepton and low PU workflows should not be affected at all, since the cut was apparently not applied.