### PR TITLE
Update calibration inputs and uncertainties

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -98,9 +98,9 @@ def make_parser(parser=None):
     parser.add_argument("--muonScaleVariation", choices=["smearingWeights", "massWeights", "manualShift"], default="smearingWeights", help="the method with which the muon scale variation histograms are derived")
     parser.add_argument("--scaleMuonCorr", type=float, default=1.0, help="Scale up/down dummy muon scale uncertainty by this factor")
     parser.add_argument("--correlatedNonClosureNuisances", action='store_true', help="get systematics from histograms for the Z non-closure nuisances without decorrelation in eta and pt")
-    parser.add_argument("--calibrationStatScaling", type=float, default=2.2, help="scaling of calibration statistical uncertainty")
+    parser.add_argument("--calibrationStatScaling", type=float, default=2.0, help="scaling of calibration statistical uncertainty")
     parser.add_argument("--correlatedAdHocA", type=float, default=0.0, help="fully correlated ad-hoc uncertainty on b-field term A (in addition to Z pdg mass)")
-    parser.add_argument("--correlatedAdHocM", type=float, default=3.5e-6, help="fully correlated ad-hoc uncertainty on alignment term M")
+    parser.add_argument("--correlatedAdHocM", type=float, default=0.0, help="fully correlated ad-hoc uncertainty on alignment term M")
     parser.add_argument("--noEfficiencyUnc", action='store_true', help="Skip efficiency uncertainty (useful for tests, because it's slow). Equivalent to --excludeNuisances '.*effSystTnP|.*effStatTnP' ")
     parser.add_argument("--effStatLumiScale", type=float, default=None, help="Rescale equivalent luminosity for efficiency stat uncertainty by this value (e.g. 10 means ten times more data from tag and probe)")
     parser.add_argument("--binnedScaleFactors", action='store_true', help="Use binned scale factors (different helpers and nuisances)")
@@ -829,15 +829,16 @@ def setup(args, inputFile, fitvar, xnorm=False):
         passToFakes=passSystToFakes,
         scale = scaleA,
     )
-    cardTool.addSystematic("muonScaleClosMSyst_responseWeights",
-        processes=['single_v_samples'],
-        group="scaleClosMCrctn",
-        splitGroup={f"muonCalibration" : f".*"},
-        baseName="ScaleClosM_correction_",
-        systAxes=["unc", "downUpVar"],
-        passToFakes=passSystToFakes,
-        scale = scaleM,
-    )
+    if abs(scaleM) > 0.:
+        cardTool.addSystematic("muonScaleClosMSyst_responseWeights",
+            processes=['single_v_samples'],
+            group="scaleClosMCrctn",
+            splitGroup={f"muonCalibration" : f".*"},
+            baseName="ScaleClosM_correction_",
+            systAxes=["unc", "downUpVar"],
+            passToFakes=passSystToFakes,
+            scale = scaleM,
+        )
     if not input_tools.args_from_metadata(cardTool, "noSmearing"):
         cardTool.addSystematic("muonResolutionSyst_responseWeights", 
             mirror = True,

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -66,7 +66,7 @@ calib_filepaths = {
     # 'tflite_file': f"{calib_dir}/muon_response_nosmearing.tflite"
 }
 closure_filepaths = {
-    'parametrized': f"{closure_dir}/parametrizedClosureZ_ORkinweight_binsel_newres_MCstat_new.root",
+    'parametrized': f"{closure_dir}/parametrizedClosureZ_ORkinweight_binsel_MCstat_fullres.root",
     # 'parametrized': f"{closure_dir}/parametrizedClosureZ_ORkinweight_binsel_MCstat_simul.root",
     'binned': f"{closure_dir}/closureZ_LBL_smeared_v721.root"
 }

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -193,8 +193,8 @@ def make_muon_smearing_helpers_binned(filename = f"{data_dir}/calibration/smeari
 
     return helper, helper_var
 
-def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutionDATA_LBL_JZ_deltaphim_d50.root",
-                               filenamemc = f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_d50.root",
+def make_muon_smearing_helpers(filenamedata = f"{data_dir}/calibration/resolutionDATA_LBL_JZ_deltaphim_Apr3.root",
+                               filenamemc = f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_Apr3.root",
                                override_d = None,
                                dummy_vars = False):
     # this helper smears muon pT to match the resolution in data


### PR DESCRIPTION
Resolution corrections were slightly updated, leading to a small change in the closure parameters.

The default calibration uncertainties have been updated accordingly (J/psi calibration statistical uncertainty scaling reduced from 2.2 to 2.0 and the additional ad-hoc fully correlated M uncertainty removed since it can now be covered by the scaled statistical uncertainties)

The muon response maps have also been updated since these depend on the resolution corrections.