### PR TITLE
treat Lambda4 as part of the flavour-decorrelated NP parameters

### DIFF
--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -379,11 +379,6 @@ class TheoryHelper(object):
         var_vals = gamma_vals
         var_names = [f"{gamma_nuisance_name}Down", f"{gamma_nuisance_name}Up"]
 
-        if "Lambda" in self.np_model:
-            Lambda4_nuisance_name = "scetlibNPLambda4"
-            var_vals.extend(["Lambda4.01", "Lambda4.16"])
-            var_names.extend([f"{Lambda4_nuisance_name}Down", f"{Lambda4_nuisance_name}Up"])
-
         logger.debug(f"Adding gamma uncertainties from syst entries {gamma_vals}")
 
 
@@ -437,7 +432,8 @@ class TheoryHelper(object):
     def add_uncorrelated_np_uncertainties(self):
         np_map = {
             "Lambda2" : ["-0.25", "0.25",],
-            "Delta_Lambda2" : ["-0.02", "0.02",]
+            "Delta_Lambda2" : ["-0.02", "0.02",],
+            "Lambda4" : [".01", ".16"],
         } if "Lambda" in self.np_model else {
             "Omega" : ["0.", "0.8"],
             "Delta_Omega" : ["-0.02", "0.02"],

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -624,7 +624,8 @@ def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_cen
             return var_label.startswith("Omega") \
                     or var_label.startswith("Delta_Omega") \
                     or var_label.startswith("Lambda2") \
-                    or var_label.startswith("Delta_Lambda2")
+                    or var_label.startswith("Delta_Lambda2") \
+                    or var_label.startswith("Lambda4")
 
         # special treatment for Lambda2/Omega since they need to be decorrelated in charge and possibly rapidity
         if isinstance(var_axis, hist.axis.StrCategory) and any(is_flavor_dependent_np(var_label) for var_label in var_axis):


### PR DESCRIPTION
Since Lambda4 could in principle be x/flavour dependent, move it to the set of non-perturbative parameters which are decorrelated between W+, W-, and Z

Actual effect is expected to be small and/or negligible.