### PR TITLE
Some customisation for the fakes, augment W histmaker to run fake enriched control region, and miscellaneous

### DIFF
--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -15,22 +15,39 @@ logger = logging.child_logger(__name__)
 
 #########################################################################
 # trying to use same colors as mathplotlib in wremnants
-colors_plots_ = {"Wmunu"      : ROOT.TColor.GetColor("#8B0000"), #ROOT.kRed+2,
-                 "Zmumu"      : ROOT.TColor.GetColor("#87CEFA"), #lightskyblue, #ADD8E6 is lightblue #ROOT.kAzure+2,
-                 "ZmumuVeto"  : ROOT.TColor.GetColor("#ADD8E6"),
-                 "DYlowMass"  : ROOT.TColor.GetColor("#00BFFF"), #deepskyblue,
-                 "DYlowMassVeto" : ROOT.TColor.GetColor("#00FFFF"), # cyan
-                 "Wtau"       : ROOT.TColor.GetColor("#FFA500"), #ROOT.kCyan+1, #backward compatibility
-                 "Wtaunu"     : ROOT.TColor.GetColor("#FFA500"), # orange, use #FF8C00 for darkOrange #ROOT.kCyan+1,
-                 "WmunuOOA"   : ROOT.TColor.GetColor("#FF8C00"), # dark orange
-                 "Ztautau"    : ROOT.TColor.GetColor("#00008B"), #green
-                 "ZtautauVeto" : ROOT.TColor.GetColor("#90EE90"), #lightgreen
-                 "Top"        : ROOT.TColor.GetColor("#008000"), #ROOT.kGreen+2,
-                 "Diboson"    : ROOT.TColor.GetColor("#FFC0CB"), #ROOT.kViolet,
+# colors_plots_ = {"Wmunu"      : ROOT.TColor.GetColor("#8B0000"), #ROOT.kRed+2,
+#                  "Zmumu"      : ROOT.TColor.GetColor("#87CEFA"), #lightskyblue, #ADD8E6 is lightblue #ROOT.kAzure+2,
+#                  "ZmumuVeto"  : ROOT.TColor.GetColor("#ADD8E6"),
+#                  "DYlowMass"  : ROOT.TColor.GetColor("#00BFFF"), #deepskyblue,
+#                  "DYlowMassVeto" : ROOT.TColor.GetColor("#00FFFF"), # cyan
+#                  "Wtau"       : ROOT.TColor.GetColor("#FFA500"), #ROOT.kCyan+1, #backward compatibility
+#                  "Wtaunu"     : ROOT.TColor.GetColor("#FFA500"), # orange, use #FF8C00 for darkOrange #ROOT.kCyan+1,
+#                  "WmunuOOA"   : ROOT.TColor.GetColor("#FF8C00"), # dark orange
+#                  "Ztautau"    : ROOT.TColor.GetColor("#00008B"), #green
+#                  "ZtautauVeto" : ROOT.TColor.GetColor("#90EE90"), #lightgreen
+#                  "Top"        : ROOT.TColor.GetColor("#008000"), #ROOT.kGreen+2,
+#                  "Diboson"    : ROOT.TColor.GetColor("#FFC0CB"), #ROOT.kViolet,
+#                  "PhotonInduced" : ROOT.TColor.GetColor("#FFFF99"),
+#                  "Fake"       : ROOT.TColor.GetColor("#D3D3D3"), # dimgray is "#696969" #ROOT.kGray,
+#                  "QCD"        : ROOT.TColor.GetColor("#D3D3D3"), # light grey #ROOT.kGray,
+#                  "Other"      : ROOT.TColor.GetColor("#808080"), # grey #ROOT.kGray}
+# }
+colors_plots_ = {"Wmunu"      : ROOT.TColor.GetColor("#e42536"),
+                 "Zmumu"      : ROOT.TColor.GetColor("#5790fc"),
+                 "ZmumuVeto"  : ROOT.TColor.GetColor("#5790fc"),
+                 "DYlowMass"  : ROOT.TColor.GetColor("#00BFFF"),
+                 "DYlowMassVeto" : ROOT.TColor.GetColor("#00FFFF"),
+                 "Wtau"       : ROOT.TColor.GetColor("#f89c20"),
+                 "Wtaunu"     : ROOT.TColor.GetColor("#f89c20"),
+                 "WmunuOOA"   : ROOT.TColor.GetColor("#FF8C00"),
+                 "Ztautau"    : ROOT.TColor.GetColor("#7a21dd"),
+                 "ZtautauVeto" : ROOT.TColor.GetColor("#7a21dd"),
+                 "Top"        : ROOT.TColor.GetColor("#008000"),
+                 "Diboson"    : ROOT.TColor.GetColor("#964a8b"),
                  "PhotonInduced" : ROOT.TColor.GetColor("#FFFF99"),
-                 "Fake"       : ROOT.TColor.GetColor("#D3D3D3"), # dimgray is "#696969" #ROOT.kGray,
-                 "QCD"        : ROOT.TColor.GetColor("#D3D3D3"), # light grey #ROOT.kGray,
-                 "Other"      : ROOT.TColor.GetColor("#808080"), # grey #ROOT.kGray}
+                 "Fake"       : ROOT.TColor.GetColor("#9c9ca1"),
+                 "QCD"        : ROOT.TColor.GetColor("#9c9ca1"),
+                 "Other"      : ROOT.TColor.GetColor("#808080"),
 }
 
 legEntries_plots_ = {"Wmunu"      : "W#rightarrow#mu#nu",
@@ -43,9 +60,9 @@ legEntries_plots_ = {"Wmunu"      : "W#rightarrow#mu#nu",
                      "WmunuOOA"   : "W#rightarrow#mu#nu OOA",
                      "Ztautau"    : "Z#rightarrow#tau#tau",
                      "ZtautauVeto": "veto Z#rightarrow#tau#tau",
-                     "Top"        : "t quark",
+                     "Top"        : "Top",
                      "Diboson"    : "Diboson",
-                     "PhotonInduced" : "Photon-induced",
+                     "PhotonInduced" : "#gamma-induced",
                      "Fake"       : "Nonprompt", # or "Multijet"
                      "QCD"        : "QCD MC",
                      "Other"      : "Other"}   
@@ -55,7 +72,7 @@ legEntries_plots_ = {"Wmunu"      : "W#rightarrow#mu#nu",
 def common_plot_parser():
     parser = common.base_parser()
     parser.add_argument('--nContours', default=51, type=int, help='Number of contours in palette. Default is 51')
-    parser.add_argument('--palette'  , default=112, type=int, help='Set palette: 55 is kRainbow, 112 is kViridis, 87 is kLightTemperature')
+    parser.add_argument('--palette'  , default=112, type=int, help='Set palette: 55 is kRainbow, 112 is kViridis, 113 is kCividis, 87 is kLightTemperature')
     parser.add_argument('--invertPalette', action='store_true',   help='Inverte color ordering in palette')
     parser.add_argument('--eosMount', dest="eoscp", action='store_false', help="(Deprecated!) Do not use xrdcp to copy to eos, exploit the eos mount when using an eos path for output (without this option the code will create a temporary local folder and then copy plots to eos through xrdcp at the end")
     return parser
@@ -1776,10 +1793,12 @@ def drawNTH1(hists=[],
         sliceLabelOffset = 6. if "#eta" in textForLines[0] else 6.
         for i in range(1,nptBins): # do not need line at canvas borders 
             vertline.DrawLine(etarange*i-offsetXaxisHist,ymin,etarange*i-offsetXaxisHist,ymax)
-        if len(textForLines):
-            for i in range(0,len(textForLines)):
-                ytext = ymax - ytextOffsetFromTop*(ymax - ymin)
-                bintext.DrawLatex(etarange*i + etarange/sliceLabelOffset, ytext, textForLines[i])
+        nLines = len(textForLines)
+        if nLines:
+            for i in range(0,nLines):
+                if nLines < 31 or not (i % 5): # only print 5 labels                                    
+                    ytext = ymax - ytextOffsetFromTop*(ymax - ymin)
+                    bintext.DrawLatex(etarange*i + etarange/sliceLabelOffset, ytext, textForLines[i])
 
     # redraw legend, or vertical lines appear on top of it
     leg.Draw("same")
@@ -2515,10 +2534,12 @@ def drawTH1dataMCstack(h1, thestack,
         for i in range(1,nptBins): # do not need line at canvas borders
             #vertline.DrawLine(etarange*i,0,etarange*i,canvas.GetUymax())
             vertline.DrawLine(etarange*i,0,etarange*i,ymaxBackup)
-        if len(textForLines):
+        nLines = len(textForLines)
+        if nLines:
             offsetText = etarange / (6. if len(textForLines) > 15 else 4.)
-            for i in range(0,len(textForLines)): # we need nptBins texts
-                bintext.DrawLatex(etarange*i + offsetText, textYheightOffset*ymaxBackup, textForLines[i])
+            for i in range(0,nLines): # we need nptBins texts
+                if nLines < 31 or not (i % 5): # only print 5 labels                                    
+                    bintext.DrawLatex(etarange*i + offsetText, textYheightOffset*ymaxBackup, textForLines[i])
 
     # legend.SetFillColor(0)
     # legend.SetFillStyle(0)

--- a/scripts/analysisTools/runFit_theoryAgnosticPoisAsNoi_polVar.py
+++ b/scripts/analysisTools/runFit_theoryAgnosticPoisAsNoi_polVar.py
@@ -1,7 +1,7 @@
 import os
 
 # for setup and fit
-skipSetup = 1
+skipSetup = 0
 skipFit = 1
 # for plots
 skipImpacts = 1
@@ -9,7 +9,7 @@ skipCorrelation = 1
 skipCorrLine = 1
 skipDiffnuis = 1
 skipCompareDiffnuis = 1
-skipTemplates = 0 # check settings
+skipTemplates = 1 # check settings
 #
 justPrint = 1
 
@@ -25,7 +25,7 @@ onlySignalAndOOA = False # (requires onlySignal=True to be effective) signal onl
 doStatOnly = False
 noFake = False # irrelevant when onlySignal=True
 noPDFandQCDtheorySystOnSignal = False # irrelevant when doStatOnly=True
-tag = "x0p30_y3p00_V7"  # "x0p40_y3p50_V6" # "x0p40_y3p50_V6" # "x0p40_y3p50_V4" # "x0p30_y3p00_V4"
+tag = "x0p30_y3p00_V9"  # "x0p40_y3p50_V6" # "x0p40_y3p50_V6" # "x0p40_y3p50_V4" # "x0p30_y3p00_V4"
 oneMCfileEveryN = 1
 testFolder = f"oneMCfileEvery{oneMCfileEveryN}" if oneMCfileEveryN > 1 else "fullStat"
 projectToNewLumi = -1.0 # set negative to skip it.
@@ -58,9 +58,9 @@ else:
 baseOutdir = f"/scratch/mciprian/CombineStudies/theoryAgnostic_pol/{tag}/"
 basePlotDir = "scripts/analysisTools/plots/fromMyWremnants/fitResults/theoryAgnostic_polVar/pdfCT18Z_April2024/"
 
-inputFileHDF5 = f"{baseOutdir}/mw_with_mu_eta_pt_scetlib_dyturboCorr_maxFiles_m1_testTApolvar_{tag}.hdf5"
+inputFileHDF5 = f"{baseOutdir}/mw_with_mu_eta_pt_scetlib_dyturboCorr_maxFiles_m1_{tag}.hdf5"
 if oneMCfileEveryN > 1:
-    inputFileHDF5 = f"{baseOutdir}/mw_with_mu_eta_pt_scetlib_dyturboCorr_maxFiles_m1_testTApolvar_{tag}_oneMCfileEvery{oneMCfileEveryN}.hdf5"
+    inputFileHDF5 = f"{baseOutdir}/mw_with_mu_eta_pt_scetlib_dyturboCorr_maxFiles_m1_{tag}_oneMCfileEvery{oneMCfileEveryN}.hdf5"
 
 if noPDFandQCDtheorySystOnSignal and not doStatOnly:
     testFolder += "/noPDFandQCDtheorySystOnSignal/"
@@ -69,7 +69,7 @@ procFolder = "onlySignal" if onlySignal else "allProcsNoFake" if noFake else "al
 if onlySignal and onlySignalAndOOA:
     procFolder = "onlySignalAndOOA"
     
-outdir = f"{baseOutdir}/{testFolder}/{procFolder}/"
+    outdir = f"{baseOutdir}/{testFolder}/{procFolder}/"
 
 theoryAgnosticOptions = " --analysisMode theoryAgnosticPolVar --poiAsNoi"
 

--- a/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
+++ b/scripts/analysisTools/w_mass_13TeV/diffNuisances.py
@@ -42,6 +42,9 @@ def sortEffSyst(name):
             return v
     return -1
 
+def sortByCharge(name):
+    return 0 if "minus" in name else 1 if "plus" in name else 2
+
 def sortParameters(params):
     
     params = sorted(params)
@@ -66,8 +69,7 @@ def sortParameters(params):
         params = sorted(params, key = lambda x: utilities.getNFromString(x,chooseIndex=0))
         params = sorted(params, key = lambda x: 0 if "_A_" in x else 1)
     elif any(re.match('.*polVar.*',x) for x in params):
-        #params = sorted(params, key = lambda x: (-1,utilities.getNFromString(x,chooseIndex=0)) if "_UL_" else (utilities.getNFromString(x,chooseIndex=0), utilities.getNFromString(x,chooseIndex=1)))
-        pass
+        params = sorted(params, key = lambda x: (sortByCharge(x), 8, utilities.getNFromString(x,chooseIndex=0)) if "_UL_" in x else (sortByCharge(x), utilities.getNFromString(x,chooseIndex=0), utilities.getNFromString(x,chooseIndex=1)))
     elif any(re.match('.*ZmuonVeto.*',x) for x in params):
         params = sorted(params, key= lambda x: utilities.getNFromString(x), reverse=False)
     return params

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python3
 
 # plot impacts on mW or mZ from groups of nuisance parameters
 
@@ -103,7 +103,7 @@ if __name__ == "__main__":
 
     parser = common_plot_parser()
     parser.add_argument("rootfile", type=str, nargs=1)
-    parser.add_argument('-o','--outdir',     default='./makeImpactsOnMW/',   type=str, help='output directory to save the plot (not needed with --justPrint)')    
+    parser.add_argument('-o','--outdir',     default='./makeImpactsOnMW/',   type=str, help='output directory to save the plot (not needed with --justPrint)')
     parser.add_argument(     '--nuisgroups', default='ALL',   type=str, help='nuis groups for which you want to show the impacts (can pass comma-separated list to make all of them one after the other). Use full name, no regular expressions. By default, all are made')
     parser.add_argument('-k',  '--keepNuisgroups', default=None,   type=str, help='nuis groups for which you want to show the impacts, using regular expressions')
     parser.add_argument('-x', '--excludeNuisgroups', default=None,   type=str, help='Regular expression for nuisances to be excluded (note that it wins against --keepNuisgroups since evaluated before it')
@@ -231,17 +231,17 @@ if __name__ == "__main__":
 
     h1.SetBarWidth(0.8);
     h1.SetBarOffset(0.1);
-    h1.SetFillColor(ROOT.kGreen-5)
+    h1.SetFillColor(ROOT.TColor.GetColor("#5790fc"))   # used to be ROOT.kGreen-5
     h1.SetLineColor(ROOT.kBlack)
     #h1.SetFillStyle(3001)
-    h1.SetFillColorAlpha(ROOT.kGreen-5, 0.5)
+    #h1.SetFillColorAlpha(ROOT.TColor.GetColor("#5790fc"), 0.5)
     if compare:
         h2.SetBarWidth(0.4);
         h2.SetBarOffset(0.2);
-        h2.SetFillColor(ROOT.kPink-6)
+        h2.SetFillColor(ROOT.TColor.GetColor("#bd1f01")) # "#f89c20" is orange, used to be ROOT.kPink-6
         h2.SetLineColor(ROOT.kBlack)
         #h2.SetFillStyle(3001)
-        h2.SetFillColorAlpha(ROOT.kPink-6, 0.5)
+        h2.SetFillColorAlpha(ROOT.TColor.GetColor("#f89c20"), 0.9)
         h1.GetYaxis().SetRangeUser(0.0, 1.1* max(totalUncertainty_mW_alt, totalUncertainty_mW))
         
     cw,ch = args.canvasSize.split(',')

--- a/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
+++ b/scripts/analysisTools/w_mass_13TeV/plotPrefitTemplatesWRemnants.py
@@ -240,12 +240,13 @@ if __name__ == "__main__":
     # defaultProcs = ["Zmumu", "Ztautau", "Other"] if commonargs.isWlike else ["Wmunu", "Wtaunu", "Zmumu", "DYlowMass", "Ztautau", "Fake", "Top", "Diboson", "PhotonInduced", "ZmumuVeto", "DYlowMassVeto", "ZtautauVeto"]
 
     defaultProcs = []
-    fname = args.rootfile[0]
+    fname = commonargs.rootfile[0]
     tmpf = safeOpenFile(fname)
     for k in tmpf.GetListOfKeys():
         name = k.GetName()
-        if k.ClassName() == "TDirectoryFile" and name not in ["Data", "meta_info"]
-        defaultProcs.append(name)
+        # print(f"{name}   {k.ClassName()}")
+        if name not in ["Data", "meta_info"]:
+            defaultProcs.append(name)
     tmpf.Close()
 
     parser.add_argument("--pp", "--predicted-processes", dest="predictedProcesses", type=str, nargs="*", help="Use these names for predicted processes to make plots", default=defaultProcs)
@@ -253,6 +254,8 @@ if __name__ == "__main__":
     parser.add_argument('-c','--charges', dest='charges', choices=['plus', 'minus', 'both'], default='both', type=str, help='Charges to process')
     parser.add_argument("--rr", "--ratio-range", dest="ratioRange", default=(0.92,1.08), type=float, nargs=2, help="Range for ratio plot")
     args = parser.parse_args()
+
+    print(f"Predicted processes = {args.predictedProcesses}")
 
     outdir_original = args.outdir[0]
     outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
@@ -281,7 +284,7 @@ if __name__ == "__main__":
         nomihists = {}
         infile = safeOpenFile(fname)
         for proc in processes:
-            print(f"{charge}   {proc}")
+            # print(f"{charge}   {proc}")
             nomihists[proc] = safeGetObject(infile, f"{proc}/nominal_{proc}_{charge}", detach=True) # process name as subfolder
         if args.pseudodata:
             nomihists["Data"] = safeGetObject(infile, f"Data/{args.pseudodata}_{charge}", detach=True)

--- a/scripts/analysisTools/w_mass_13TeV/postFitHistograms.py
+++ b/scripts/analysisTools/w_mass_13TeV/postFitHistograms.py
@@ -105,6 +105,9 @@ if __name__ == "__main__":
     parser.add_argument('-l','--lumi', default=16.8, type=float, help='Integrated luminosity to print in the plot')
     parser.add_argument('--fp','--filter-processes', dest="filterProcesses", default="", type=str, help='If given, regexp to filter some processes')
     parser.add_argument('--dt','--data-title', dest="dataTitle", default="Data", type=str, help='Title for data in legend (usually Data but could be Pseudodata)')
+    parser.add_argument("--rrPre", dest="ratioRangePrefit", default=(0.9,1.1), type=float, nargs=2, help="Range for ratio plot prefit")
+    parser.add_argument("--rrPost", dest="ratioRangePostfit", default=(0.99,1.01), type=float, nargs=2, help="Range for ratio plot postfit")
+    parser.add_argument(     '--unrolledRatioRangeAsPrefit', action='store_true', help="For unrolled stack plot use same ratio range as prefit also in the postfit")
     args = parser.parse_args()
 
     logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
@@ -183,6 +186,10 @@ if __name__ == "__main__":
         #ptBinRanges.append("p_{{T}} #in [{ptmin:3g}, {ptmax:.3g}]".format(ptmin=recoBins.ptBins[ipt], ptmax=recoBins.ptBins[ipt+1]))
         ptBinRanges.append("#splitline{{[{ptmin},{ptmax}]}}{{GeV}}".format(ptmin=int(recoBins.ptBins[ipt]), ptmax=int(recoBins.ptBins[ipt+1])))
 
+    etaBinRanges = []
+    for ieta in range(0,recoBins.Neta):
+        etaBinRanges.append("[{etamin},{etamax}]".format(etamin=round(recoBins.etaBins[ieta],1), etamax=round(recoBins.etaBins[ieta+1],1)))
+        
 
     for charge in charges:
         binshift = shifts[charge]
@@ -195,6 +202,11 @@ if __name__ == "__main__":
         ratios_unrolled = {}
         ratios_unc_unrolled = {}
         unc_unrolled = {}
+        #
+        all_procs_unrolled_y = {}
+        ratios_unrolled_y = {}
+        ratios_unc_unrolled_y = {}
+        unc_unrolled_y = {}
 
         # keep this order
         for prepost in ['postfit', 'prefit']:
@@ -224,13 +236,17 @@ if __name__ == "__main__":
                 h2_backrolled = dressed2DfromFit(h1_1, binning, pname, titles[i], binshift, nMaskedCha=nMaskedChanPerCharge,
                                                    nRecoBins=nRecoBins)
                 h1_unrolled = unroll2Dto1D(h2_backrolled, newname=f"unroll_{pname}", cropNegativeBins=False)
+                h1_unrolled_y = unroll2Dto1D(h2_backrolled, newname=f"unroll_y_{pname}", cropNegativeBins=False, invertUnroll=True)
 
                 if args.normWidth:
-                    normalizeTH1unrolledSingleChargebyBinWidth(h1_unrolled, h2_backrolled)
-                all_procs[keyplot] = h2_backrolled;  
+                    normalizeTH1unrolledSingleChargebyBinWidth(h1_unrolled, h2_backrolled, unrollAlongX=True)
+                    normalizeTH1unrolledSingleChargebyBinWidth(h1_unrolled_y, h2_backrolled, unrollAlongX=False)
+                all_procs[keyplot] = h2_backrolled;
                 all_procs_unrolled[keyplot] = h1_unrolled
+                all_procs_unrolled_y[keyplot] = h1_unrolled_y
                 all_procs[keyplot].SetDirectory(0); 
                 all_procs_unrolled[keyplot].SetDirectory(0)
+                all_procs_unrolled_y[keyplot].SetDirectory(0)
                 if prepost == 'prefit' and p != 'obs':
                     postfitkey = keyplot.replace("prefit", "postfit")
                     if all_procs_unrolled[postfitkey] != None and all_procs_unrolled[keyplot] != None:
@@ -240,9 +256,18 @@ if __name__ == "__main__":
                         ratios_unrolled[keyratio].SetDirectory(0)
                         ratios_unrolled[keyratio].Divide(all_procs_unrolled[keyplot])
                         ratios_unrolled[keyratio].SetFillColor(process_features[p]["color"])
+                        #
+                        ratios_unrolled_y[keyratio] = copy.deepcopy(all_procs_unrolled_y[postfitkey].Clone(keyratio+"_y"))
+                        ratios_unrolled_y[keyratio].SetDirectory(0)
+                        ratios_unrolled_y[keyratio].Divide(all_procs_unrolled_y[keyplot])
+                        ratios_unrolled_y[keyratio].SetFillColor(process_features[p]["color"])
+
                         for ibin in range(1,ratios_unrolled[keyratio].GetNbinsX()+1):
                             unc = 0.0 if all_procs_unrolled[keyplot].GetBinContent(ibin) == 0.0 else (all_procs_unrolled[postfitkey].GetBinError(ibin) / all_procs_unrolled[keyplot].GetBinContent(ibin))
                             ratios_unrolled[keyratio].SetBinError(ibin, unc)
+                            #
+                            unc = 0.0 if all_procs_unrolled_y[keyplot].GetBinContent(ibin) == 0.0 else (all_procs_unrolled_y[postfitkey].GetBinError(ibin) / all_procs_unrolled_y[keyplot].GetBinContent(ibin))
+                            ratios_unrolled_y[keyratio].SetBinError(ibin, unc)
                         # uncertainties
                         ratios_unc_unrolled[keyratio] = copy.deepcopy(all_procs_unrolled[postfitkey].Clone(keyratio+"_unc"))
                         ratios_unc_unrolled[keyratio].SetDirectory(0)
@@ -251,22 +276,49 @@ if __name__ == "__main__":
                         unc_unrolled[keyplot] = copy.deepcopy(all_procs_unrolled[keyplot].Clone(keyplot+"_unc"))
                         unc_unrolled[postfitkey].Reset("ICESM")
                         unc_unrolled[keyplot].Reset("ICESM")
+                        #
+                        ratios_unc_unrolled_y[keyratio] = copy.deepcopy(all_procs_unrolled_y[postfitkey].Clone(keyratio+"_unc_y"))
+                        ratios_unc_unrolled_y[keyratio].SetDirectory(0)
+                        ratios_unc_unrolled_y[keyratio].SetFillColor(process_features[p]["color"])
+                        unc_unrolled_y[postfitkey] = copy.deepcopy(all_procs_unrolled_y[postfitkey].Clone(postfitkey+"_unc_y"))
+                        unc_unrolled_y[keyplot] = copy.deepcopy(all_procs_unrolled_y[keyplot].Clone(keyplot+"_unc_y"))
+                        unc_unrolled_y[postfitkey].Reset("ICESM")
+                        unc_unrolled_y[keyplot].Reset("ICESM")
+
                         for ibin in range(1,ratios_unc_unrolled[keyratio].GetNbinsX()+1):
                             val = 0.0 if all_procs_unrolled[keyplot].GetBinError(ibin) == 0.0 else (all_procs_unrolled[postfitkey].GetBinError(ibin) / all_procs_unrolled[keyplot].GetBinError(ibin))
                             ratios_unc_unrolled[keyratio].SetBinContent(ibin, val)
                             ratios_unc_unrolled[keyratio].SetBinError(ibin, 0.0)
                             unc_unrolled[postfitkey].SetBinContent(ibin, all_procs_unrolled[postfitkey].GetBinError(ibin))
                             unc_unrolled[keyplot].SetBinContent(ibin, all_procs_unrolled[keyplot].GetBinError(ibin))
+                            #
+                            val = 0.0 if all_procs_unrolled_y[keyplot].GetBinError(ibin) == 0.0 else (all_procs_unrolled_y[postfitkey].GetBinError(ibin) / all_procs_unrolled_y[keyplot].GetBinError(ibin))
+                            ratios_unc_unrolled_y[keyratio].SetBinContent(ibin, val)
+                            ratios_unc_unrolled_y[keyratio].SetBinError(ibin, 0.0)
+                            unc_unrolled_y[postfitkey].SetBinContent(ibin, all_procs_unrolled_y[postfitkey].GetBinError(ibin))
+                            unc_unrolled_y[keyplot].SetBinContent(ibin, all_procs_unrolled_y[keyplot].GetBinError(ibin))
+
                         # try plotting both
                         hists = [copy.deepcopy(all_procs_unrolled[postfitkey].Clone(f"postfit_{chfl}_{p}")),
                                  copy.deepcopy(all_procs_unrolled[keyplot].Clone(f"prefit_{chfl}_{p}"))]
                         vertLines="{a},{b}".format(a=recoBins.Npt,b=recoBins.Neta)
                         legs = ["postfit","prefit"]
                         # yields
-                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Events", f"postfitAndprefit_yields_chan{chfl}_{p}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit::0.8,1.2", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=ptBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055")
+                        unrollPfx = ""
+                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Events", f"postfitAndprefit_yields_chan{chfl}_{p}{unrollPfx}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit::0.8,1.2", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=ptBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055")
                         # uncertainties
                         hists = [unc_unrolled[postfitkey], unc_unrolled[keyplot]]
-                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Uncertainty", f"postfitAndprefit_uncertainty_chan{chfl}_{p}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=ptBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055", setRatioRangeFromHisto=True, setOnlyLineRatio=True)
+                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Uncertainty", f"postfitAndprefit_uncertainty_chan{chfl}_{p}{unrollPfx}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=ptBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055", setRatioRangeFromHisto=True, setOnlyLineRatio=True)
+                        #
+                        hists = [copy.deepcopy(all_procs_unrolled_y[postfitkey].Clone(f"postfit_{chfl}_{p}_y")),
+                                 copy.deepcopy(all_procs_unrolled_y[keyplot].Clone(f"prefit_{chfl}_{p}_y"))]
+                        unrollPfx = "_unrollY"
+                        vertLines="{a},{b}".format(a=recoBins.Neta,b=recoBins.Npt)
+                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Events", f"postfitAndprefit_yields_chan{chfl}_{p}{unrollPfx}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit::0.8,1.2", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=etaBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055")
+                        # uncertainties
+                        hists = [unc_unrolled_y[postfitkey], unc_unrolled_y[keyplot]]
+                        drawNTH1(hists, legs, "unrolled lepton (#eta, p_{T}) bin", "Uncertainty", f"postfitAndprefit_uncertainty_chan{chfl}_{p}{unrollPfx}", outdirsub, leftMargin=0.06, rightMargin=0.02, labelRatioTmp="postfit/prefit", legendCoords="0.45,0.8,0.92,1.0;2", passCanvas=cwide, drawLumiLatex=True, lumi=args.lumi, drawVertLines=vertLines, textForLines=etaBinRanges, yAxisExtendConstant=1.25, markerStyleFirstHistogram=1, fillStyleSecondHistogram=1001, colorVec=[ROOT.kGray], moreTextLatex=f"{process_features[p]['title']}::0.3,0.95,0.08,0.055", setRatioRangeFromHisto=True, setOnlyLineRatio=True)
+
 
 
                     else:
@@ -290,11 +342,13 @@ if __name__ == "__main__":
                                                      nMaskedCha=nMaskedChanPerCharge,
                                                      nRecoBins=nRecoBins)
             h1_expfull_unrolled = unroll2Dto1D(h2_expfull_backrolled, newname=f"unroll_{expfullName2D}", cropNegativeBins=False)
+            h1_expfull_unrolled_y = unroll2Dto1D(h2_expfull_backrolled, newname=f"unroll_y_{expfullName2D}", cropNegativeBins=False, invertUnroll=True)
 
             h2_expfull_backrolled.Write(f"expfull_{prepost}_{charge}")
             # can normalize the unrolled, not the 2D
             if args.normWidth:
-                normalizeTH1unrolledSingleChargebyBinWidth(h1_expfull_unrolled, h2_expfull_backrolled)
+                normalizeTH1unrolledSingleChargebyBinWidth(h1_expfull_unrolled, h2_expfull_backrolled, unrollAlongX=True)
+                normalizeTH1unrolledSingleChargebyBinWidth(h1_expfull_unrolled_y, h2_expfull_backrolled, unrollAlongX=False)
 
             for projection in ['X', 'Y']:
                 if projection=='X':
@@ -348,7 +402,7 @@ if __name__ == "__main__":
 
                 xaxisProj = xaxisname2D if projection == "X" else yaxisname2D
                 cnameProj = f"projection{projection}_{chfl}{suffix}"
-                ratioYlabel = "data/pred::" + ("0.9,1.1" if prepost == "prefit" else "0.99,1.01")
+                ratioYlabel = "data/pred::" + (f"{args.ratioRangePrefit[0]},{args.ratioRangePrefit[1]}" if prepost == "prefit" else f"{args.ratioRangePostfit[0]},{args.ratioRangePostfit[1]}")
                 verticalAxisNameProj = verticalAxisNameProjX if projection == "X" else verticalAxisNameProjY
                 drawTH1dataMCstack(hdata, stack, xaxisProj, verticalAxisNameProj, cnameProj, outdir, leg, ratioYlabel,
                                    1, passCanvas=cnarrow, hErrStack=hexpfull, lumi=args.lumi)
@@ -362,16 +416,23 @@ if __name__ == "__main__":
                                                   nMaskedCha=nMaskedChanPerCharge,
                                                   nRecoBins=nRecoBins)
             hdata_unrolled = unroll2Dto1D(h2_data_backrolled, newname=f"unrolled_{charge}_data", cropNegativeBins=False)
-
+            hdata_unrolled_y = unroll2Dto1D(h2_data_backrolled, newname=f"unrolled_{charge}_data", cropNegativeBins=False, invertUnroll=True)
 
             if args.normWidth:
-                normalizeTH1unrolledSingleChargebyBinWidth(hdata_unrolled, h2_data_backrolled)
+                normalizeTH1unrolledSingleChargebyBinWidth(hdata_unrolled, h2_data_backrolled, unrollAlongX=True)
+                normalizeTH1unrolledSingleChargebyBinWidth(hdata_unrolled_y, h2_data_backrolled, unrollAlongX=False)
             hdata_unrolled.SetDirectory(0)
             htot_unrolled  = hdata_unrolled.Clone(f"unrolled_{charge}_full")
             htot_unrolled.Reset("ICES")
             htot_unrolled.Sumw2()
             htot_unrolled.SetDirectory(0)
+            hdata_unrolled_y.SetDirectory(0)
+            htot_unrolled_y  = hdata_unrolled_y.Clone(f"unrolled_y_{charge}_full")
+            htot_unrolled_y.Reset("ICES")
+            htot_unrolled_y.Sumw2()
+            htot_unrolled_y.SetDirectory(0)
             stack_unrolled = ROOT.THStack(f"stack_unrolled_{prepost}_{charge}", "")
+            stack_unrolled_y = ROOT.THStack(f"stack_unrolled_y_{prepost}_{charge}", "")
             leg_unrolled = prepareLegend(0.08, 0.81, 0.95, 0.90, textSize=0.045, nColumns=min(9, len(predictedProcessNames)+1))
             listOfProj = []
             for key in sortedKeys:
@@ -386,24 +447,37 @@ if __name__ == "__main__":
                 stack_unrolled.Add(proc_unrolled)
                 htot_unrolled.Add(proc_unrolled)
                 listOfProj.append([proc_unrolled, procsAndTitles[keycolor]])
+                #
+                proc_unrolled_y = all_procs_unrolled_y[key]
+                proc_unrolled_y.SetFillColor(process_features[keycolor]["color"])
+                stack_unrolled_y.Add(proc_unrolled_y)
+                htot_unrolled_y.Add(proc_unrolled_y)
 
+                
             leg_unrolled.AddEntry(hdata_unrolled, args.dataTitle, 'PE')
             for pair in reversed(listOfProj):
                 leg_unrolled.AddEntry(pair[0], pair[1], 'F')
 
-            #print("Integral data  = " + str(hdata_unrolled.Integral()))
-            #print("Integral stack = " + str(stack_unrolled.GetStack().Last().Integral()))
-            #print("Integral htot  = " + str(htot_unrolled.Integral()))
-
+            YlabelUnroll = verticalAxisName + "::%.2f,%.2f" % (0, 2.*hdata_unrolled.GetBinContent(hdata_unrolled.GetMaximumBin()))
+            # for unrolled may use always the prefit ratio for better comparison
+            ratioYlabel = "data/pred::" + (f"{args.ratioRangePrefit[0]},{args.ratioRangePrefit[1]}" if prepost == "prefit" or args.unrolledRatioRangeAsPrefit else f"{args.ratioRangePostfit[0]},{args.ratioRangePostfit[1]}")
+            
             cnameUnroll = f"unrolled_{chfl}{suffix}"
             XlabelUnroll = "unrolled template along #eta:  #eta #in [%.1f, %.1f]" % (recoBins.etaBins[0], recoBins.etaBins[-1])
-            YlabelUnroll = verticalAxisName + "::%.2f,%.2f" % (0, 2.*hdata_unrolled.GetBinContent(hdata_unrolled.GetMaximumBin()))
-            ratioYlabel = "data/pred::" + ("0.9,1.1" if prepost == "prefit" else "0.99,1.01")
             drawTH1dataMCstack(hdata_unrolled, stack_unrolled, XlabelUnroll, YlabelUnroll, cnameUnroll, outdir,
                                leg_unrolled, ratioYlabel, 1, passCanvas=cwide, hErrStack=h1_expfull_unrolled, lumi=args.lumi,
                                wideCanvas=True, leftMargin=0.05,rightMargin=0.02, 
                                drawVertLines="{a},{b}".format(a=recoBins.Npt,b=recoBins.Neta),
                                textForLines=ptBinRanges, etaptbinning=binning,
+                               textSize=0.04, textAngle=0, textYheightOffset=0.65)
+            #
+            cnameUnroll = f"unrolled_{chfl}{suffix}_unrollY"
+            XlabelUnroll = "unrolled template along p_{T}:  p_{T} #in [%.1f, %.1f]" % (recoBins.ptBins[0], recoBins.ptBins[-1])
+            drawTH1dataMCstack(hdata_unrolled_y, stack_unrolled_y, XlabelUnroll, YlabelUnroll, cnameUnroll, outdir,
+                               leg_unrolled, ratioYlabel, 1, passCanvas=cwide, hErrStack=h1_expfull_unrolled_y, lumi=args.lumi,
+                               wideCanvas=True, leftMargin=0.05,rightMargin=0.02, 
+                               drawVertLines="{a},{b}".format(a=recoBins.Neta,b=recoBins.Npt),
+                               textForLines=etaBinRanges, etaptbinning=binning,
                                textSize=0.04, textAngle=0, textYheightOffset=0.65)
 
     outfile.Close()

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -80,7 +80,7 @@ def make_parser(parser=None):
     parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--binnedFakeEstimation", action='store_true', help="Compute fakerate factor (and shaperate factor) without smooting in pT (and mT)")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
-    parser.add_argument("--smoothingOrderFakerate", type=int, default=1, help="Order of the polynomial for the smoothing of the fake rate ")
+    parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
     parser.add_argument("--simultaneousABCD", action="store_true", help="Produce datacard for simultaneous fit of ABCD regions")
     # settings on the nuisances itself
     parser.add_argument("--doStatOnly", action="store_true", default=False, help="Set up fit to get stat-only uncertainty (currently combinetf with -S 0 doesn't work)")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -79,6 +79,8 @@ def make_parser(parser=None):
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
     parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--binnedFakeEstimation", action='store_true', help="Compute fakerate factor (and shaperate factor) without smooting in pT (and mT)")
+    parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
+    parser.add_argument("--smoothingOrderFakerate", type=int, default=1, help="Order of the polynomial for the smoothing of the fake rate ")
     parser.add_argument("--simultaneousABCD", action="store_true", help="Produce datacard for simultaneous fit of ABCD regions")
     # settings on the nuisances itself
     parser.add_argument("--doStatOnly", action="store_true", default=False, help="Set up fit to get stat-only uncertainty (currently combinetf with -S 0 doesn't work)")
@@ -246,7 +248,9 @@ def setup(args, inputFile, fitvar, xnorm=False):
     if wmass and not xnorm:
         datagroups.fakerate_axes=args.fakerateAxes
         datagroups.set_histselectors(datagroups.getNames(), args.baseName, mode=args.fakeEstimation,
-            smoothen=not args.binnedFakeEstimation, integrate_x="mt" not in fitvar, simultaneousABCD=simultaneousABCD)
+                                     smoothen=not args.binnedFakeEstimation, smoothingOrderFakerate=args.smoothingOrderFakerate,
+                                     integrate_x="mt" not in fitvar,
+                                     simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
 
     # Start to create the CardTool object, customizing everything
     cardTool = CardTool.CardTool(xnorm=xnorm, simultaneousABCD=simultaneousABCD, real_data=args.realData)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -33,6 +33,7 @@ parser.add_argument("--noAuxiliaryHistograms", action="store_true", help="Remove
 parser.add_argument("--mtCut", type=int, default=40, help="Value for the transverse mass cut in the event selection")
 parser.add_argument("--vetoGenPartPt", type=float, default=0.0, help="Minimum pT for the postFSR gen muon when defining the variation of the veto efficiency")
 parser.add_argument("--noTrigger", action="store_true", help="Just for test: remove trigger HLT bit selection and trigger matching (should also remove scale factors with --noScaleFactors for it to make sense)")
+parser.add_argument("--selectNonPromptFromSV", action="store_true", help="Test: define a non-prompt muon enriched control region")
 #
 
 args = parser.parse_args()
@@ -343,6 +344,11 @@ def build_graph(df, dataset):
 
     df = muon_selections.veto_electrons(df)
     df = muon_selections.apply_met_filters(df)
+
+    if args.selectNonPromptFromSV:
+        df = muon_selections.select_good_secondary_vertices(df)
+        df = df.Filter("Muon_sip3d[goodMuons][0] > 4.0 && wrem::hasMatchDR2(goodMuons_eta0,goodMuons_phi0,SV_eta[goodSV],SV_phi[goodSV], 0.01)")
+
     if args.makeMCefficiency:
         df = df.Define("GoodTrigObjs", f"wrem::goodMuonTriggerCandidate<wrem::Era::Era_{era}>(TrigObj_id,TrigObj_filterBits)")
         hltString = muon_selections.hlt_string(era)

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -45,6 +45,8 @@ parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify c
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
 parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
 parser.add_argument("--binnedFakeEstimation", action='store_true', help="Compute fakerate factor (and shaperate factor) without smooting in pT (and mT)")
+parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
+parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
 parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
 parser.add_argument("--fineGroups", action='store_true', help="Plot each group as a separate process, otherwise combine groups based on predefined dictionary")
 
@@ -131,7 +133,7 @@ else:
 
 groups.fakerate_axes=args.fakerateAxes
 if applySelection:
-    groups.set_histselectors(datasets, args.baseName, smoothen=not args.binnedFakeEstimation, integrate_x=all("mt" not in x.split("-") for x in args.hists), mode=args.fakeEstimation)
+    groups.set_histselectors(datasets, args.baseName, smoothen=not args.binnedFakeEstimation, smoothingOrderFakerate=args.smoothingOrderFakerate, integrate_x=all("mt" not in x.split("-") for x in args.hists), mode=args.fakeEstimation, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
 
 if not args.nominalRef:
     nominalName = args.baseName.rsplit("_", 1)[0]

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -312,9 +312,9 @@ else:
             }
         elif analysis=="WMass":
             all_axes = {
-                # "pt": hist.axis.Regular(30, 26, 56, name = "pt", overflow=False, underflow=False),
+                "pt": hist.axis.Regular(30, 26, 56, name = "pt", overflow=False, underflow=False),
                 # "pt": hist.axis.Regular(31, 26, 57, name = "pt", overflow=False, underflow=False),
-                "pt": hist.axis.Regular(29, 27, 56, name = "ptGen", overflow=False, underflow=False),
+                #"pt": hist.axis.Regular(29, 27, 56, name = "ptGen", overflow=False, underflow=False),
                 "eta": hist.axis.Regular(48, -2.4, 2.4, name = "eta", overflow=False, underflow=False),
                 "charge": common.axis_charge,
                 "passIso": common.axis_passIso,
@@ -323,6 +323,9 @@ else:
                 "absEtaGen": hist.axis.Variable(differential.eta_binning, name = "absEtaGen", overflow=False, underflow=False),
                 "qGen": common.axis_charge,
             }
+        else:
+            raise ValueError(f"Unknown analysis {analysis}, can't set the axes")
+
         axes = [all_axes[part] for part in filename_parts[-2].split("_") if part in all_axes.keys()]
         if args.axlim:
             nv = len(args.axlim)

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -171,7 +171,7 @@ def set_subparsers(subparser, name):
         if name == "theoryAgnosticPolVar":
             subparser.add_argument("--theoryAgnosticFilePath", type=str, default=".",
                                    help="Path where input files are stored")
-            subparser.add_argument("--theoryAgnosticFileTag", type=str, default="x0p30_y3p00_V8", choices=["x0p30_y3p00_V4", "x0p30_y3p00_V5", "x0p40_y3p50_V6", "x0p30_y3p00_V7", "x0p30_y3p00_V8"],
+            subparser.add_argument("--theoryAgnosticFileTag", type=str, default="x0p30_y3p00_V9", choices=["x0p30_y3p00_V4", "x0p30_y3p00_V5", "x0p40_y3p50_V6", "x0p30_y3p00_V7", "x0p30_y3p00_V8", "x0p30_y3p00_V9"],
                                    help="Tag for input files")
             subparser.add_argument("--theoryAgnosticSplitOOA", action='store_true',
                                    help="Define out-of-acceptance signal template as an independent process")

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -198,7 +198,7 @@ class Datagroups(object):
             logger.warning(f"Excluded all groups using '{excludes}'. Continue without any group.")
 
     def set_histselectors(self, 
-                          group_names, histToRead="nominal", fake_processes=None, mode="extended2D", smoothen=False, smoothingOrderFakerate=1, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
+                          group_names, histToRead="nominal", fake_processes=None, mode="extended1D", smoothen=False, smoothingOrderFakerate=2, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
     ):
         logger.info(f"Set histselector")
         if self.mode not in ["wmass", "lowpu_w"]:

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -198,7 +198,7 @@ class Datagroups(object):
             logger.warning(f"Excluded all groups using '{excludes}'. Continue without any group.")
 
     def set_histselectors(self, 
-                          group_names, histToRead="nominal", fake_processes=None, mode="extended1D", smoothen=False, smoothingOrderFakerate=2, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
+                          group_names, histToRead="nominal", fake_processes=None, mode="extended1D", smoothen=True, smoothingOrderFakerate=2, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
     ):
         logger.info(f"Set histselector")
         if self.mode not in ["wmass", "lowpu_w"]:

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -198,7 +198,7 @@ class Datagroups(object):
             logger.warning(f"Excluded all groups using '{excludes}'. Continue without any group.")
 
     def set_histselectors(self, 
-        group_names, histToRead="nominal", fake_processes=None, mode="extended2D", smoothen=False, simultaneousABCD=False, **kwargs
+                          group_names, histToRead="nominal", fake_processes=None, mode="extended2D", smoothen=False, smoothingOrderFakerate=1, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
     ):
         logger.info(f"Set histselector")
         if self.mode not in ["wmass", "lowpu_w"]:
@@ -222,6 +222,8 @@ class Datagroups(object):
                 fakeselector = sel.FakeSelectorSimpleABCD
         else:
             raise RuntimeError(f"Unknown mode {mode} for fakerate estimation")
+        if forceGlobalScaleFakes is not None:
+            scale = forceGlobalScaleFakes
         fake_processes = [self.fakeName] if fake_processes is None else fake_processes
         for i, g in enumerate(group_names):
             members = self.groups[g].members[:]
@@ -230,7 +232,7 @@ class Datagroups(object):
             base_member = members[0].name
             h = self.results[base_member]["output"][histToRead].get()
             if g in fake_processes:
-                self.groups[g].histselector = fakeselector(h[{"charge": hist.sum}], global_scalefactor=scale, fakerate_axes=self.fakerate_axes, smooth_fakerate=smoothen, **auxiliary_info, **kwargs)
+                self.groups[g].histselector = fakeselector(h[{"charge": hist.sum}], global_scalefactor=scale, fakerate_axes=self.fakerate_axes, smooth_fakerate=smoothen, smoothing_order_fakerate=smoothingOrderFakerate, **auxiliary_info, **kwargs)
             else:
                 self.groups[g].histselector = signalselector(h[{"charge": hist.sum}], fakerate_axes=self.fakerate_axes, **kwargs)
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -357,7 +357,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
     # simple ABCD method
     def __init__(self, h, *args, 
         smooth_fakerate=False, 
-        smoothing_order_fakerate=1,
+        smoothing_order_fakerate=2,
         polynomial="bernstein", # "power",
         throw_toys=None,#"normal", # None, 'normal' or 'poisson'
         global_scalefactor=1, # apply global correction factor on prediction

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -356,7 +356,7 @@ class SignalSelectorABCD(HistselectorABCD):
 class FakeSelectorSimpleABCD(HistselectorABCD):
     # simple ABCD method
     def __init__(self, h, *args, 
-        smooth_fakerate=False, 
+        smooth_fakerate=True, 
         smoothing_order_fakerate=2,
         polynomial="bernstein", # "power",
         throw_toys=None,#"normal", # None, 'normal' or 'poisson'
@@ -614,9 +614,9 @@ class FakeSelectorSimultaneousABCD(FakeSelectorSimpleABCD):
         return h
 
 class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
-    # extrapolate the fakerate in the abcd x axis by finding a analytic description in the dx region
+    # extrapolate the fakerate in the abcd x axis by finding an analytic description in the dx region
     def __init__(self, h, *args, 
-        smooth_fakerate=False,
+        smooth_fakerate=True,
         polynomial="power",
         extrapolation_order=1,
         rebin_x="automatic", # can be a list of bin edges, "automatic", or None
@@ -656,7 +656,7 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
             logger.debug("Integrate abcd x-axis, treat uncertainty as bin by bin stat")
             y_frf, y_frf_variation = self.compute_fakeratefactor(h, syst_variations=is_nominal)
             d = c * y_frf
-            # sum up abcd-x axis (sum up variatoins to treat uncertainty fully correlated across abcd-x axis bins)
+            # sum up abcd-x axis (sum up variations to treat uncertainty fully correlated across abcd-x axis bins)
             idx_x = h[{self.name_y: self.sel_dy}].axes.name.index(self.name_x)
             d = d.sum(axis=idx_x)
             if is_nominal:

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -357,7 +357,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
     # simple ABCD method
     def __init__(self, h, *args, 
         smooth_fakerate=False, 
-        smoothing_order_fakerate=1, 
+        smoothing_order_fakerate=1,
         polynomial="bernstein", # "power",
         throw_toys=None,#"normal", # None, 'normal' or 'poisson'
         global_scalefactor=1, # apply global correction factor on prediction
@@ -380,6 +380,8 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         # fakerate factor
         self.smooth_fakerate = smooth_fakerate
         self.smoothing_order_fakerate = smoothing_order_fakerate
+        if self.smooth_fakerate:
+            logger.info(f"Fakerate smoothing order is {self.smoothing_order_fakerate}")
 
         # solve with non negative least squares
         if self.polynomial=="bernstein":

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -10,6 +10,10 @@ def apply_met_filters(df):
 
     return df
 
+def select_good_secondary_vertices(df, dlenSig=4.0, ntracks=0):
+    df = df.Define(f"goodSV", f"SV_dlenSig > {dlenSig} && SV_ntracks >= {ntracks}")
+    return df
+
 def select_veto_muons(df, nMuons=1, condition="==", ptCut=10.0, etaCut=2.4):
 
     # n.b. charge = -99 is a placeholder for invalid track refit/corrections (mostly just from tracks below


### PR DESCRIPTION
Add a couple of options in setupCombine.py to customise the fake method to use
- choose smoothing_order, default modified to 2 (was 1) because it performs better
- override hardcoded scaling factor for the normalization of the fakes in the signal region, mainly for tests (allowing to change it or set it to 1.0, namely no scaling)

Augment the W histmaker to run a fake enriched region with muons from secondary vertices (the current selection might be improved when ntuples are reproduced, some variables for the proper matching have been added in recent NanoAOD versions, and Josh recently backported these changes to our custom NanoAOD producer)

The rest is mainly a set of updates for plotting scripts for which I might be the only user at the moment. Among other things I am trying to comply with the color scheme recommended by the CMS CAT group.