### PR TITLE
Fix pseudodata

### DIFF
--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -239,11 +239,6 @@ class HDF5Writer(object):
 
                     # release memory
                     del chanInfo.pseudodata_datagroups
-                    for proc in chanInfo.datagroups.groups:
-                        for pseudo in chanInfo.pseudoData:
-                            if pseudo in dg.groups[proc].hists:
-                                logger.debug(f"Delete pseudodata histogram {pseudo}")
-                                del dg.groups[proc].hists[pseudo]
 
             # nominal predictions (after pseudodata because some pseudodata changes the nominal model)
             for proc in procs_chan:


### PR DESCRIPTION
In case the pseudodata is taken from an external file with the same histogram name as the nominal model the histogram of the model gets overridden and then deleted. The fix is to not load the histogram if it's already there and don't delete it. 