### PR TITLE
make possible to customize iso cuts for each lepton in Z histmakers

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -72,6 +72,7 @@ if args.makeMCefficiency:
 args = parser.parse_args()
 
 thisAnalysis = ROOT.wrem.AnalysisType.Wmass
+isoBranch = muon_selections.getIsoBranch(args.isolationDefinition)
 
 era = args.era
 
@@ -381,20 +382,8 @@ def build_graph(df, dataset):
 
     df = df.Define("goodMuons_ptJet0", "Jet_pt[Muon_jetIdx[goodMuons][0]]")
 
-    if args.isolationDefinition == "iso04":
-        df = df.Define("goodMuons_relIso0", "Muon_pfRelIso04_all[goodMuons][0]")
-        df = df.Define("goodMuons_iso0", "Muon_pfRelIso04_all[goodMuons][0]*Muon_pt[goodMuons][0]")
-    elif args.isolationDefinition == "iso04vtxAgn":
-        df = df.Define("goodMuons_relIso0", "Muon_vtxAgnPfRelIso04_all[goodMuons][0]")
-        df = df.Define("goodMuons_iso0", "Muon_vtxAgnPfRelIso04_all[goodMuons][0]*Muon_pt[goodMuons][0]")
-    elif args.isolationDefinition == "iso04chg":
-        df = df.Define("goodMuons_relIso0", "Muon_pfRelIso04_chg[goodMuons][0]")
-        df = df.Define("goodMuons_iso0", "Muon_pfRelIso04_chg[goodMuons][0]*Muon_pt[goodMuons][0]")
-    elif args.isolationDefinition == "iso04chgvtxAgn":
-        df = df.Define("goodMuons_relIso0", "Muon_vtxAgnPfRelIso04_chg[goodMuons][0]")
-        df = df.Define("goodMuons_iso0", "Muon_vtxAgnPfRelIso04_chg[goodMuons][0]*Muon_pt[goodMuons][0]")
-    else:
-        raise NotImplementedError(f"Isolation definition {args.isolationDefinition} not implemented")
+    df = df.Define("goodMuons_relIso0", f"{isoBranch}[goodMuons][0]")
+    df = df.Define("goodMuons_iso0", "goodMuons_relIso0*Muon_pt[goodMuons][0]")
 
     # Jet collection actually has a pt threshold of 15 GeV in MiniAOD 
     df = df.Define("goodCleanJetsNoPt", "Jet_jetId >= 6 && (Jet_pt > 50 || Jet_puId >= 4) && abs(Jet_eta) < 2.4 && wrem::cleanJetsFromLeptons(Jet_eta,Jet_phi,Muon_correctedEta[vetoMuons],Muon_correctedPhi[vetoMuons],Electron_eta[vetoElectrons],Electron_phi[vetoElectrons])")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -387,7 +387,7 @@ def build_graph(df, dataset):
 
     # Jet collection actually has a pt threshold of 15 GeV in MiniAOD 
     df = df.Define("goodCleanJetsNoPt", "Jet_jetId >= 6 && (Jet_pt > 50 || Jet_puId >= 4) && abs(Jet_eta) < 2.4 && wrem::cleanJetsFromLeptons(Jet_eta,Jet_phi,Muon_correctedEta[vetoMuons],Muon_correctedPhi[vetoMuons],Electron_eta[vetoElectrons],Electron_phi[vetoElectrons])")
-    df = df.Define("passIso", "goodMuons_relIso0 < 0.15")
+    df = df.Define("passIso", f"goodMuons_relIso0 < {args.isolationThreshold}")
 
     ########################################################################
     # define event weights here since they are needed below for some helpers

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -208,7 +208,7 @@ def build_graph(df, dataset):
     df = muon_calibration.define_corrected_muons(df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper)
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
-    isoThreshold = 0.15
+    isoThreshold = args.isolationThreshold
     passIsoBoth = (args.muonIsolation[0] + args.muonIsolation[1] == 2)
     df = muon_selections.select_good_muons(df, args.pt[1], args.pt[2], dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=passIsoBoth, isoBranch=isoBranch, isoThreshold=isoThreshold)
 
@@ -216,12 +216,7 @@ def build_graph(df, dataset):
 
     # iso cut applied here, if requested, because it needs the definition of trigMuons and nonTrigMuons from muon_selections.define_trigger_muons
     if not passIsoBoth:
-        if args.muonIsolation[0]:
-            isoCondTrig0 = "<" if args.muonIsolation[0] == 1 else ">"
-            df = df.Filter(f"{isoBranch}[trigMuons][0] {isoCondTrig0} {isoThreshold}")
-        if args.muonIsolation[1]:
-            isoCondTrig1 = "<" if args.muonIsolation[1] == 1 else ">"
-            df = df.Filter(f"{isoBranch}[nonTrigMuons][0] {isoCondTrig0} {isoThreshold}")
+        df = muon_selections.apply_iso_muons(df, args.muonIsolation[0], args.muonIsolation[1], isoBranch, isoThreshold)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -175,7 +175,7 @@ def build_graph(df, dataset):
 
     df = muon_selections.select_veto_muons(df, nMuons=2)
 
-    isoThreshold = 0.15
+    isoThreshold = args.isolationThreshold
     passIsoBoth = (args.muonIsolation[0] + args.muonIsolation[1] == 2)
     df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=2, use_trackerMuons=args.trackerMuons, use_isolation=passIsoBoth, isoBranch=isoBranch, isoThreshold=isoThreshold)
     
@@ -183,12 +183,7 @@ def build_graph(df, dataset):
 
     # iso cut applied here, if requested, because it needs the definition of trigMuons and nonTrigMuons from muon_selections.define_trigger_muons
     if not passIsoBoth:
-        if args.muonIsolation[0]:
-            isoCondTrig0 = "<" if args.muonIsolation[0] == 1 else ">"
-            df = df.Filter(f"{isoBranch}[trigMuons][0] {isoCondTrig0} {isoThreshold}")
-        if args.muonIsolation[1]:
-            isoCondTrig1 = "<" if args.muonIsolation[1] == 1 else ">"
-            df = df.Filter(f"{isoBranch}[nonTrigMuons][0] {isoCondTrig0} {isoThreshold}")
+        df = muon_selections.apply_iso_muons(df, args.muonIsolation[0], args.muonIsolation[1], isoBranch, isoThreshold)
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -305,7 +305,7 @@ def common_parser(for_reco_highPU=False):
         parser.add_argument("--noSmooth3dsf", dest="smooth3dsf", action='store_false', help="If true (default) use smooth 3D scale factors instead of the original 2D ones (but eff. systs are still obtained from 2D version)")
         parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing") 
         parser.add_argument("--noScaleFactors", action="store_true", help="Don't use scale factors for efficiency (legacy option for tests)")
-        parser.add_argument("--isolationDefinition", choices=["iso04vtxAgn", "iso04", "iso03chg", "iso04chgvtxAgn"], default="iso04vtxAgn",  help="Isolation type (and corresponding scale factors)")
+        parser.add_argument("--isolationDefinition", choices=["iso04vtxAgn", "iso04", "iso04chg", "iso04chgvtxAgn"], default="iso04vtxAgn",  help="Isolation type (and corresponding scale factors)")
 
     commonargs,_ = parser.parse_known_args()
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -306,6 +306,7 @@ def common_parser(for_reco_highPU=False):
         parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing") 
         parser.add_argument("--noScaleFactors", action="store_true", help="Don't use scale factors for efficiency (legacy option for tests)")
         parser.add_argument("--isolationDefinition", choices=["iso04vtxAgn", "iso04", "iso04chg", "iso04chgvtxAgn"], default="iso04vtxAgn",  help="Isolation type (and corresponding scale factors)")
+        parser.add_argument("--isolationThreshold", default=0.15, type=float, help="Threshold for isolation cut")
 
     commonargs,_ = parser.parse_known_args()
 

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -23,6 +23,16 @@ def getIsoBranch(isoDefinition == "iso04vtxAgn"):
     else:
         raise NotImplementedError(f"Isolation definition {isoDefinition} not implemented")
 
+def apply_iso_muons(df, iso_first, iso_second, isoBranch, isoThreshold=0.15, name_first="trigMuons", name_second="nonTrigMuons"):
+    # iso_first/iso_second are integers with values -1/1 for fail/pass isolation, or 0 if not cut has to be applied 
+    if iso_first:
+        isoCond0 = "<" if iso_first == 1 else ">"
+        df = df.Filter(f"{isoBranch}[{name_first}][0] {isoCond0} {isoThreshold}")
+    if iso_second:
+        isoCond1 = "<" if iso_second == 1 else ">"
+        df = df.Filter(f"{isoBranch}[{name_second}][0] {isoCond1} {isoThreshold}")
+    return df
+    
 def apply_met_filters(df):
     df = df.Filter("Flag_globalSuperTightHalo2016Filter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_goodVertices && Flag_HBHENoiseIsoFilter && Flag_HBHENoiseFilter && Flag_BadPFMuonFilter")
 


### PR DESCRIPTION
For some applications it is desirable to be able to invert or remove the isolation cut on one or both leptons in the Z analysis, so this PR tries to implement that in a clean way (the default behaviour with isolation applied to both muons is preserved).
I am also trying to improve the way the isolation variables (namely the branches in the NanoAOD) are read depending on the user choice, moving common pieces of code from different scripts into a single function in muon_selections.

This PR has to be complemented by changes in the efficiency helpers, since at the moment the Wlike/dilepton analysis are expected to have both leptons passing isolation, so the SF are always for passing isolation.