### PR TITLE
add updated nano production version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,8 @@ env:
   OUTFILE_LOWPU_MU: "mw_lowPU_mu.hdf5"
   OUTFILE_LOWPU_EE: "mz_lowPU_ee.hdf5"
   OUTFILE_LOWPU_MUMU: "mz_lowPU_mumu.hdf5"
-  DATAPATH: "/scratch/shared/NanoAOD/"
+  # DATAPATH: "/scratch/shared/NanoAOD/"
+  DATAPATH: "root://eoscms.cern.ch//store/cmst3/group/wmass/w-mass-13TeV/NanoAOD/"
   DATAPATH_LOWPU: "/scratch/shared/NanoAOD/LowPU/"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,7 @@ env:
   OUTFILE_LOWPU_MU: "mw_lowPU_mu.hdf5"
   OUTFILE_LOWPU_EE: "mz_lowPU_ee.hdf5"
   OUTFILE_LOWPU_MUMU: "mz_lowPU_mumu.hdf5"
-  # DATAPATH: "/scratch/shared/NanoAOD/"
-  DATAPATH: "root://eoscms.cern.ch//store/cmst3/group/wmass/w-mass-13TeV/NanoAOD/"
+  DATAPATH: "/scratch/shared/NanoAOD/"
   DATAPATH_LOWPU: "/scratch/shared/NanoAOD/LowPU/"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/wremnants/datasets/dataset_tools.py
+++ b/wremnants/datasets/dataset_tools.py
@@ -168,8 +168,8 @@ def is_zombie(file_path):
     return False
 
 def getDatasets(maxFiles=default_nfiles, filt=None, excl=None, mode=None, base_path=None, nanoVersion="v9",
-                data_tags=["TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv3"],
-                mc_tags=["TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv4", "TrackFitV722_NanoProdv3"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True):
+                data_tags=["TrackFitV722_NanoProdv6", "TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv3"],
+                mc_tags=["TrackFitV722_NanoProdv6", "TrackFitV722_NanoProdv5", "TrackFitV722_NanoProdv4", "TrackFitV722_NanoProdv3"], oneMCfileEveryN=None, checkFileForZombie=False, era="2016PostVFP", extended=True):
 
     if maxFiles is None or (isinstance(maxFiles, int) and maxFiles < -1):
         maxFiles=default_nfiles


### PR DESCRIPTION
NanoProdv6 contains the extra hit count information for the muons.  Keep the old versions as fallback for the moment since the new variables are not actually used/required yet.