### PR TITLE
Fix ndof for prefit chisquared in plotting script

### DIFF
--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -248,7 +248,7 @@ if combinetf2:
 
     chi2=None
     if f"chi2_{fittype}" in fitresult:
-        chi2 = fitresult[f"chi2_{fittype}"], fitresult[f"ndf"]
+        chi2 = fitresult[f"chi2_{fittype}"], fitresult[f"ndf_{fittype}"]
 
     for channel, info in meta_input["channel_info"].items():
         hist_data = fitresult["hist_data_obs"][channel].get()

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -195,7 +195,7 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
     hep.cms.label(ax=ax1, lumi=float(f"{lumi:.3g}") if lumi is not None else None, fontsize=20*args.scaleleg*scale, 
         label=args.cmsDecor, data=data)
 
-    plot_tools.addLegend(ax1, ncols=len(h_stack)//3, text_size=20*args.scaleleg*scale)
+    plot_tools.addLegend(ax1, ncols=np.ceil(len(h_stack)/3), text_size=20*args.scaleleg*scale)
     plot_tools.fix_axes(ax1, ax2, yscale=args.yscale)
 
     to_join = [fittype, args.postfix, axis_name, suffix]


### PR DESCRIPTION
The number of degrees of freedom for the prefit chisquared was incorrectly subtracting the number of free parameters (this is correct/necessary for the postfit saturated likelihood, but not for the prefit chisquared)

Fixed now. (plus some minor plot formatting improvement)