### PR TITLE
Fix tracking alt bkg systematics

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -114,6 +114,7 @@ def make_parser(parser=None):
     parser.add_argument("--binnedScaleFactors", action='store_true', help="Use binned scale factors (different helpers and nuisances)")
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
     parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor for Wmass")
+    parser.add_argument("--logNormalWmunu", default=None, type=float, help="Add lnN uncertainty for W signal (mainly for tests with fakes in control regions, where W is a subdominant background")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -686,6 +687,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
     # Below: experimental uncertainties
     cardTool.addLnNSystematic("CMS_PhotonInduced", processes=["PhotonInduced"], size=2.0, group="CMS_background")
     if wmass:
+        if args.logNormalWmunu:            
+            cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background")
         cardTool.addLnNSystematic(f"CMS_{cardTool.getFakeName()}", processes=[cardTool.getFakeName()], size=1.15, group="Fake")
         cardTool.addLnNSystematic("CMS_Top", processes=["Top"], size=1.06, group="CMS_background")
         cardTool.addLnNSystematic("CMS_VV", processes=["Diboson"], size=1.16, group="CMS_background")
@@ -696,43 +699,6 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                 systAxes=["downUpVar"],
                                 labelsByAxis=["downUpVar"],
                                 passToFakes=passSystToFakes)
-        ## TODO: implement second lepton veto for low PU (both electrons and muons)
-        if not lowPU:
-            pass
-            '''
-            # eta decorrelated nuisances
-            decorrVarAxis = "eta"
-            if "abseta" in fitvar:
-                decorrVarAxis = "abseta"
-            cardTool.addSystematic("ZmuonVeto",
-                                   processes=['Zveto_samples'],
-                                   group="ZmuonVeto",
-                                   mirror=True,
-                                   passToFakes=passSystToFakes,
-                                   scale=args.scaleZmuonVeto,
-                                   baseName="ZmuonVeto_",
-                                   systAxes=["decorrEta"],
-                                   labelsByAxis=["decorrEta"],
-                                   actionRequiresNomi=True,
-                                   action=syst_tools.decorrelateByAxis,
-                                   actionArgs=dict(axisToDecorrName=decorrVarAxis,
-                                                   # empty array automatically uses all edges of the axis named "axisToDecorrName"
-                                                #    rebin=[round(-2.4+i*0.2,1) for i in range(25)],
-                                                   newDecorrAxisName="decorrEta"
-                                                   )
-                                   )
-            # add also the fully inclusive systematic uncertainty, which is not kept in the previous step
-            cardTool.addSystematic("ZmuonVeto",
-                                   processes=['Zveto_samples'],
-                                   group="ZmuonVeto",
-                                   rename=f"ZmuonVeto_inclusive",
-                                   baseName="ZmuonVeto_inclusive",
-                                   mirror=True,
-                                   passToFakes=passSystToFakes,
-                                   scale=args.scaleZmuonVeto,
-                                   )
-            '''
-
     else:
         cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15, group="CMS_background")
         cardTool.addLnNSystematic("lumi", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity")
@@ -759,6 +725,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                     mirrorDownVarEqualToNomi=False
                     groupName = "muon_eff_syst"
                     splitGroupDict = {f"{groupName}_{x}" : f".*effSyst.*{x}" for x in list(effTypesNoIso + ["iso"])}
+                    splitGroupDict["muon_eff_all"] = ".*"
                 else:
                     nameReplace = [] if any(x in name for x in chargeDependentSteps) else [("q0", "qall")] # for iso change the tag id with another sensible label
                     mirror = True
@@ -772,6 +739,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
                     scale = 1
                     groupName = "muon_eff_stat"
                     splitGroupDict = {f"{groupName}_{x}" : f".*effStat.*{x}" for x in effStatTypes}
+                    splitGroupDict["muon_eff_all"] = ".*"
                 if args.effStatLumiScale and "Syst" not in name:
                     scale /= math.sqrt(args.effStatLumiScale)
 
@@ -804,7 +772,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
                             passToFakes=passSystToFakes,
                             systNameReplace=[("effSystTnP", "effSyst"), ("etaDecorr0", "fullyCorr")],
                             scale=scale,
-                            splitGroup={groupName: ".*"},
+                            splitGroup={groupName: ".*",
+                                        "muon_eff_all" : ".*"},
                         )
 
             if wmass:
@@ -817,8 +786,9 @@ def setup(args, inputFile, fitvar, xnorm=False):
                         scale = 1.0
                         mirror = True
                         mirrorDownVarEqualToNomi=False
-                        groupName = "muon_eff_veto_syst"
-                        splitGroupDict = {f"{groupName}_{x}" : f".*effSyst_veto.*{x}" for x in list(["reco","tracking","idip"])}
+                        groupName = "muon_eff_syst_veto"
+                        splitGroupDict = {f"{groupName}{x}" : f".*effSyst_veto.*{x}" for x in list(["reco","tracking","idip"])}
+                        splitGroupDict["muon_eff_all"] = ".*"
                     else:
                         nameReplace = []
                         mirror = True
@@ -830,8 +800,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
                         axlabels = ["eta", "pt", "q"]
                         nameReplace = nameReplace + [("effStatTnP_veto_sf_", "effStat_veto_")]           
                         scale = 1.0
-                        groupName = "muon_eff_veto_stat"
-                        splitGroupDict = {}
+                        groupName = "muon_eff_stat_veto"
+                        splitGroupDict = {"muon_eff_all" : ".*"}
                     if args.effStatLumiScale and "Syst" not in name:
                         scale /= math.sqrt(args.effStatLumiScale)
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -277,11 +277,28 @@ def build_graph(df, dataset):
     results.append(df.HistoBoost("WlikeMET", [hist.axis.Regular(20, 0, 100, name="Wlike-MET")], ["met_wlike_TV2_pt", "nominal_weight"]))
     ###########
 
+    df = df.Define("passWlikeMT", f"transverseMass >= {mtw_min}")
+
+    if not args.onlyMainHistograms:
+        axis_mt_coarse = hist.axis.Variable([0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 120.0], name = "mt", underflow=False, overflow=True)
+        axis_trigPassIso = hist.axis.Boolean(name = f"trig_passIso")
+        axis_nonTrigPassIso = hist.axis.Boolean(name = f"nonTrig_passIso")
+
+        nominal_bin = df.HistoBoost("nominal_isoMtBins", [*axes, axis_trigPassIso, axis_nonTrigPassIso, axis_mt_coarse], [*cols, "trigMuons_passIso0", "nonTrigMuons_passIso0", "transverseMass", "nominal_weight"])
+        results.append(nominal_bin)
+
+        axis_eta_nonTrig = hist.axis.Regular(template_neta, template_mineta, template_maxeta, name = "etaNonTrig", overflow=False, underflow=False)
+        axis_pt_nonTrig = hist.axis.Regular(template_npt, template_minpt, template_maxpt, name = "ptNonTrig", overflow=False, underflow=False)
+        # nonTriggering muon charge can be assumed to be opposite of triggering one
+        nominal_bothMuons = df.HistoBoost("nominal_bothMuons", [*axes, axis_eta_nonTrig, axis_pt_nonTrig, common.axis_passMT], [*cols, "nonTrigMuons_eta0", "nonTrigMuons_pt0", "passWlikeMT", "nominal_weight"])
+        results.append(nominal_bothMuons)
+
     # cutting after storing mt distributions for plotting, since the cut is only on corrected met
     if args.dphiMuonMetCut > 0.0:
         df = df.Define("deltaPhiMuonMet", "std::abs(wrem::deltaPhi(trigMuons_phi0,met_wlike_TV2.Phi()))")
         df = df.Filter(f"deltaPhiMuonMet > {args.dphiMuonMetCut*np.pi}")
-    df = df.Filter(f"transverseMass >= {mtw_min}")
+
+    df = df.Filter("passWlikeMT")
 
     if not args.onlyMainHistograms:
         # plot reco vertex distribution before and after PU reweigthing

--- a/wremnants/include/muon_efficiencies_smooth.h
+++ b/wremnants/include/muon_efficiencies_smooth.h
@@ -1178,14 +1178,18 @@ namespace wrem {
             sf_type_(std::make_shared<const HIST_SF>(std::move(sf_type))) {
         }
 
+        double scale_factor_byCell(int pt_idx, int eta_idx, int charge_idx, int idx_nom_alt) const {
+            const double sf = sf_type_->at(eta_idx, pt_idx, charge_idx, idx_nom_alt);
+            // std::cout << "Scale factor " << sf << std::endl;
+            return sf;
+        }
+
         double scale_factor(float pt, float eta, int charge, int idx_nom_alt) const {
 
             auto const eta_idx = sf_type_->template axis<0>().index(eta);
             auto const pt_idx = sf_type_->template axis<1>().index(pt);
             auto const charge_idx = sf_type_->template axis<2>().index(charge);
-            const double sf = sf_type_->at(eta_idx, pt_idx, charge_idx, idx_nom_alt);
-            // std::cout << "Scale factor " << sf << std::endl;
-            return sf;
+            return scale_factor_byCell(pt_idx, eta_idx, charge_idx, idx_nom_alt);
 
         }
 
@@ -1199,11 +1203,11 @@ namespace wrem {
             auto const pt_idx =      sf_type_->template axis<1>().index(pt);
             auto const charge_idx =  sf_type_->template axis<2>().index(charge);
 
-            double sf_nomi = scale_factor(pt_idx, eta_idx, charge_idx, idx_nom_);
+            double sf_nomi = scale_factor_byCell(pt_idx, eta_idx, charge_idx, idx_nom_);
 
             for(int ns = 0; ns < NSysts; ns++) {
                 
-                double sf_alt  = scale_factor(pt_idx, eta_idx, charge_idx, sf_type_->template axis<3>().index(ns+1) ); // 0 is the nominal, systs starts from 1
+                double sf_alt  = scale_factor_byCell(pt_idx, eta_idx, charge_idx, sf_type_->template axis<3>().index(ns+1) ); // 0 is the nominal, systs starts from 1
                 res(ns) = sf_alt / sf_nomi; 
 
             }

--- a/wremnants/muon_efficiencies_smooth.py
+++ b/wremnants/muon_efficiencies_smooth.py
@@ -540,6 +540,33 @@ def make_muon_efficiency_helpers_smooth_altSyst(filename = data_dir + "/muonSF/a
     sf_syst_2D.values(flow=True)[:, 0, ...] = sf_syst_2D.values(flow=True)[:, 1, ...]
     sf_syst_2D.values(flow=True)[:, axis_pt_eff.extent-1, ...] = sf_syst_2D.values(flow=True)[:, axis_pt_eff.extent-2, ...]
 
+    # ### TEST
+    # s = hist.tag.Slicer()
+    # from scripts.analysisTools.plotUtils.utility import createPlotDirAndCopyPhp, adjustSettings_CMS_lumi, drawCorrelationPlot, copyOutputToEos
+    # outdir_original = "scripts/analysisTools/plots/TESTPLOTS/altBkgSF/"
+    # outdir_local = createPlotDirAndCopyPhp(outdir_original, eoscp=True)
+    # adjustSettings_CMS_lumi()
+    # canvas = ROOT.TCanvas("canvas","",800,800)
+    # for js in range(1+Nsyst):
+    #     hplot = sf_syst_2D[{2: s[1],
+    #                         3: s[js],
+    #                         }] # take syst js (0 is the nominal), and charge plus for now
+    #     logger.error(f"hplot.axes.name = {hplot.axes.name}")
+    #     hroot = narf.hist_to_root(hplot)
+    #     hroot.SetName(f"hroot_plus_js_{js}")
+    #     hroot.SetTitle("Nominal" if js == 0 else "Inclusive syst" if js == 1 else f"Syst #eta bin {js-1}")
+    #     drawCorrelationPlot(hroot,
+    #                         "Standalone muon #eta",
+    #                         "Standalone muon p_{T} (GeV)",
+    #                         "Scale factor",
+    #                         hroot.GetName(), plotLabel="ForceTitle", outdir=outdir_local,
+    #                         draw_both0_noLog1_onlyLog2=1, nContours=51, palette=87,
+    #                         invertPalette=False, passCanvas=canvas, skipLumi=True)
+    # copyOutputToEos(outdir_original, eoscp=True)
+    # logger.warning("STOP HERE")
+    # quit()
+    # ####
+
     # case with only 2D histograms
     sf_syst_2D_pyroot = narf.hist_to_pyroot_boost(sf_syst_2D)
     helper_syst = ROOT.wrem.muon_efficiency_smooth_helper_syst_oneStep[templateAnalysisArg, Nsyst, type(sf_syst_2D_pyroot)]( ROOT.std.move(sf_syst_2D_pyroot) )
@@ -549,7 +576,7 @@ def make_muon_efficiency_helpers_smooth_altSyst(filename = data_dir + "/muonSF/a
     axis_nsyst = hist.axis.Integer(0, Nsyst, underflow = False, overflow = False, name = "n_syst_variations")
     helper_syst.tensor_axes = [axis_nsyst]
     #
-    
+
     fin.Close()
 
     logger.debug(f"Return efficiency helper for altBkg systematics!")

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -658,7 +658,7 @@ def add_muon_efficiency_unc_hists(results, df, helper_stat, helper_syst, axes, c
             muon_columns_syst = [*muon_columns_syst_trig, "trigMuons_passTrigger0", *muon_columns_syst_nonTrig, "nonTrigMuons_passTrigger0"]
         else:
             raise NotImplementedError(f"add_muon_efficiency_unc_hists: analysis {what_analysis} not implemented.")            
-        
+
     if not smooth3D:
         # will use different helpers and member functions
         muon_columns_stat = [x for x in muon_columns_stat if "_uT0" not in x]
@@ -718,7 +718,7 @@ def add_muon_efficiency_unc_hists_altBkg(results, df, helper_syst, axes, cols, b
         if what_analysis == ROOT.wrem.AnalysisType.Wlike:
             muon_columns_syst = [*muon_columns_syst_trig, *muon_columns_syst_nonTrig]
         elif what_analysis == ROOT.wrem.AnalysisType.Dilepton:
-            muon_columns_syst = [*muon_columns_syst_trig, "trigMuons_passTrigger0", *muon_columns_syst_nonTrig, "nonTrigMuons_passTrigger0"]
+            muon_columns_syst = [*muon_columns_syst_trig, *muon_columns_syst_nonTrig]
         else:
             raise NotImplementedError(f"add_muon_efficiency_unc_hists_altBkg: analysis {what_analysis} not implemented.")            
     


### PR DESCRIPTION
Fixing the helper, and updating setupCombine.py to use again this systematics.
I am slightly changing the name of groups for the veto nuisances to facilitate gathering later on, and also adding a group that includes all efficiency systematics (both stat and syst together, also with veto).

I am including a few minor changes also in the histmakers for W and Z to add some utility plots (although this mainly relate to another PR which will add some scripts to make plots with them)