### PR TITLE
Add Virtual EW corrections for Z from Powheg Fixed Order and add sin2theta variation for Z

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel 'without EW virtual' --selectAxis weak --color blue
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel "no EW virtual" --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel "no EW virtual" --selectAxis weak --color blue
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel no_EW_virtual --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'virtual_ewCorr' --selectEntries 2 --varLabel 'EW(virtual)' --selectAxis systIdx --color blue 
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel 'without EW virtual' --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWHelicityCorr' --selectEntries weak_no_ew --varLabel no_EW_virtual --selectAxis weak --color blue
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWCorr' --selectEntries weak_no_ew --varLabel no_EW_virtual --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -93,7 +93,7 @@ def make_parser(parser=None):
     parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--massVariation", type=float, default=100, help="Variation of boson mass")
-    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default"], help="Include EW uncertainty (other than pure ISR or FSR)", 
+    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default", "powhegFOEWHelicity"], help="Include EW uncertainty (other than pure ISR or FSR)",
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" not in x and "FSR" not in x])
     parser.add_argument("--isrUnc", type=str, nargs="*", default=["pythiaew_ISR",], help="Include ISR uncertainty", 
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" in x])

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -93,7 +93,7 @@ def make_parser(parser=None):
     parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--massVariation", type=float, default=100, help="Variation of boson mass")
-    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default", "powhegFOEWHelicity"], help="Include EW uncertainty (other than pure ISR or FSR)",
+    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default", "powhegFOEW"], help="Include EW uncertainty (other than pure ISR or FSR)",
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" not in x and "FSR" not in x])
     parser.add_argument("--isrUnc", type=str, nargs="*", default=["pythiaew_ISR",], help="Include ISR uncertainty", 
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" in x])

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -393,6 +393,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     signalMatch = WMatch if wmass else ZMatch
 
     cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
+    cardTool.addProcessGroup("z_samples", lambda x: assertSample(x, startsWith=[*ZMatch, "DYlowMass"], excludeMatch=dibosonMatch))
     if wmass:
         cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
         cardTool.addProcessGroup("Zveto_samples", lambda x: assertSample(x, startsWith=[*ZMatch, "DYlowMass"], excludeMatch=dibosonMatch))
@@ -685,6 +686,17 @@ def setup(args, inputFile, fitvar, xnorm=False):
                                 outNames=["widthWDown", "widthWUp"],
                                 passToFakes=passSystToFakes,
         )
+
+    cardTool.addSystematic(f"sin2thetaWeightZ",
+                            rename=f"Sin2thetaZ0p00003",
+                            processes= ['z_samples'],
+                            action=lambda h: h[{"sin2theta" : ['sin2thetaZ0p23151', 'sin2thetaZ0p23157']}],
+                            group=f"sin2thetaZ",
+                            mirror=False,
+                            systAxes=["sin2theta"],
+                            outNames=[f"sin2thetaZDown", f"sin2thetaZUp"],
+                            passToFakes=passSystToFakes,
+    )
 
     combine_helpers.add_electroweak_uncertainty(cardTool, [*args.ewUnc, *args.fsrUnc, *args.isrUnc], 
         samples="single_v_samples", flavor=datagroups.flavor, passSystToFakes=passSystToFakes)

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -393,7 +393,8 @@ def setup(args, inputFile, fitvar, xnorm=False):
     signalMatch = WMatch if wmass else ZMatch
 
     cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
-    cardTool.addProcessGroup("z_samples", lambda x: assertSample(x, startsWith=[*ZMatch, "DYlowMass"], excludeMatch=dibosonMatch))
+    # TODO consistently treat low mass drell yan as signal across full analysis
+    cardTool.addProcessGroup("z_samples", lambda x: assertSample(x, startsWith=ZMatch, excludeMatch=dibosonMatch))
     if wmass:
         cardTool.addProcessGroup("w_samples", lambda x: assertSample(x, startsWith=WMatch, excludeMatch=dibosonMatch))
         cardTool.addProcessGroup("Zveto_samples", lambda x: assertSample(x, startsWith=[*ZMatch, "DYlowMass"], excludeMatch=dibosonMatch))

--- a/scripts/corrections/make_theory_corr_ew_powhegFO.py
+++ b/scripts/corrections/make_theory_corr_ew_powhegFO.py
@@ -1,0 +1,99 @@
+import numpy as np
+from wremnants import theory_corrections, theory_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+import hist
+import argparse
+import os
+import h5py
+import narf
+import pdb
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-i", "--input", nargs="?", type=str, default=["w_z_gen_dists_maxFiles_m1_powheg-weak.hdf5"], help="File containing EW hists")
+parser.add_argument("--debug", action='store_true', help="Print debug output")
+
+args = parser.parse_args()
+
+logger = logging.setup_logger("make_theory_corr_ew_powhegFO", 4 if args.debug else 3)
+
+procs = []
+procs.append("Zmumu_powheg-weak-low")
+procs.append("Zmumu_powheg-weak-peak")
+procs.append("Zmumu_powheg-weak-high")
+
+
+histnames = []
+histnames.append("lhe_weak_helicity")
+
+hists = input_tools.read_all_and_scale(fname = args.input, procs = procs, histnames = histnames)
+lhe_weak_helicity = hists[0]
+
+h = lhe_weak_helicity
+
+print(h)
+
+# nominal correction should be the first entry, so re-order the variations
+nominal_corr = "weak_default"
+weakvars = list(h.axes["weak"])
+weakvars.remove(nominal_corr)
+weakvars.insert(0, nominal_corr)
+
+s = hist.tag.Slicer()
+
+# integrate over pt and rapidity and re-order the variations
+h = h[{"ptVlhe" : hist.sum, "absYVlhe" : hist.sum, "weak" : weakvars}]
+
+# single bin axes for pt and y since the correction code assumes they're present
+axis_massVlhe = h.axes["massVlhe"]
+axis_absYVlhe = hist.axis.Variable([0., np.inf], underflow=False, overflow=False, name = "absYVlhe")
+axis_ptVlhe = hist.axis.Variable([0., np.inf], underflow=False, overflow=False, name = "ptVlhe")
+axis_chargeVlhe = h.axes["chargeVlhe"]
+axis_helicity = h.axes["helicity"]
+axis_uncorr_corr = hist.axis.StrCategory(["uncorr", "corr"], name="uncorr_corr")
+axis_weak = h.axes["weak"]
+
+# this is the order of the variables expected by the correction code
+hcorr = hist.Hist(axis_massVlhe, axis_absYVlhe, axis_ptVlhe, axis_chargeVlhe, axis_helicity, axis_uncorr_corr, axis_weak)
+# set uncorr to the denominator of the correction (LO)
+hcorr[{"uncorr_corr" : "uncorr", "ptVlhe" : 0, "absYVlhe" : 0}] = h[{"weak" : "weak_no_ew"}].values(flow=True)[..., None]
+hcorr[{"uncorr_corr" : "corr", "ptVlhe" : 0, "absYVlhe" : 0}] = h.values(flow=True)
+
+# sample is NLO QCD so NNLO angular coeffs are just noise, set them to zero
+for ihel in range(5, 8):
+    hcorr[{"helicity" : ihel*1.j}] = np.zeros_like(hcorr[{"helicity" : ihel*1.j}].values(flow=True))
+
+# EW corrections for NLO helicity contributions are not meaningful, so just preserve the corresponding
+# angular coefficients
+for ihel in range(0, 4):
+    uncorr_vals = hcorr[{"uncorr_corr" : "uncorr", "helicity" : -1.j}].values(flow=True)
+    corr_vals = hcorr[{"uncorr_corr" : "corr", "helicity" : -1.j}].values(flow=True)
+    hcorr[{"uncorr_corr" : "corr", "helicity" : ihel*1.j}] = np.where(uncorr_vals == 0., 0., corr_vals/uncorr_vals)
+
+# extreme bins are not populated, "extend" the corrections from the neighboring mass bins
+hcorr[{"massVlhe" : 0}] = hcorr[{"massVlhe" : 1}].values(flow=True)
+hcorr[{"massVlhe" : -1}] = hcorr[{"massVlhe" : -2}].values(flow=True)
+hcorr[{"massVlhe" : hist.overflow}] = hcorr[{"massVlhe" : -2}].values(flow=True)
+
+print(hcorr)
+
+# hack output name to comply with correction code
+correction_name = "powhegFOEWHelicity"
+hist_name = "powhegFOEW_minnlo_coeffs"
+
+res = {}
+res[hist_name] = hcorr
+
+meta_dict = {}
+for f in [args.input]:
+    label = os.path.basename(f)
+    try:
+        meta = input_tools.get_metadata(f)
+        meta_dict[label] = meta
+    except ValueError as e:
+        logger.warning(f"No meta data found for file {f}")
+        pass
+
+output_tools.write_theory_corr_hist(correction_name, "Z", res, args, meta_dict)

--- a/scripts/corrections/make_theory_corr_ew_powhegFO.py
+++ b/scripts/corrections/make_theory_corr_ew_powhegFO.py
@@ -67,17 +67,35 @@ for ihel in range(5, 8):
 
 # EW corrections for NLO helicity contributions are not meaningful, so just preserve the corresponding
 # angular coefficients
+uncorr_UL = hcorr[{"uncorr_corr" : "uncorr", "helicity" : -1.j}].values(flow=True)
+corr_UL = hcorr[{"uncorr_corr" : "corr", "helicity" : -1.j}].values(flow=True)
 for ihel in range(0, 4):
-    uncorr_vals = hcorr[{"uncorr_corr" : "uncorr", "helicity" : -1.j}].values(flow=True)
-    corr_vals = hcorr[{"uncorr_corr" : "corr", "helicity" : -1.j}].values(flow=True)
-    hcorr[{"uncorr_corr" : "corr", "helicity" : ihel*1.j}] = np.where(uncorr_vals == 0., 0., corr_vals/uncorr_vals)
+    corr = hcorr[{"uncorr_corr" : "corr", "helicity" : ihel*1.j}].values(flow=True)
+    uncorr = hcorr[{"uncorr_corr" : "uncorr", "helicity" : ihel*1.j}].values(flow=True)
+    hcorr[{"uncorr_corr" : "corr", "helicity" : ihel*1.j}] = np.where(uncorr_UL == 0., corr, corr_UL/uncorr_UL*uncorr)
 
 # extreme bins are not populated, "extend" the corrections from the neighboring mass bins
 hcorr[{"massVlhe" : 0}] = hcorr[{"massVlhe" : 1}].values(flow=True)
 hcorr[{"massVlhe" : -1}] = hcorr[{"massVlhe" : -2}].values(flow=True)
 hcorr[{"massVlhe" : hist.overflow}] = hcorr[{"massVlhe" : -2}].values(flow=True)
 
-print(hcorr)
+if args.debug:
+    print(hcorr)
+
+    hnumUL = hcorr[{"uncorr_corr" : "corr", "ptVlhe" : 0, "absYVlhe" : 0, "chargeVlhe" : 0.j, "helicity" : -1.j, "weak" : 0}]
+    hdenUL = hcorr[{"uncorr_corr" : "uncorr", "ptVlhe" : 0, "absYVlhe" : 0, "chargeVlhe" : 0.j, "helicity" : -1.j, "weak" : 0}]
+    hrUL = hh.divideHists(hnumUL, hdenUL)
+
+    for ihel in range(-1, 8):
+        hnum = hcorr[{"uncorr_corr" : "corr", "ptVlhe" : 0, "absYVlhe" : 0, "chargeVlhe" : 0.j, "helicity" : ihel*1.j, "weak" : 0}]
+        hden = hcorr[{"uncorr_corr" : "uncorr", "ptVlhe" : 0, "absYVlhe" : 0, "chargeVlhe" : 0.j, "helicity" : ihel*1.j, "weak" :0 }]
+
+        hr = hh.divideHists(hnum, hden)
+        hr2 = hh.divideHists(hr, hrUL)
+
+        print("ihel", ihel)
+        print(hr)
+        print(hr2)
 
 # hack output name to comply with correction code
 correction_name = "powhegFOEWHelicity"

--- a/scripts/corrections/make_theory_corr_ew_powhegFO.py
+++ b/scripts/corrections/make_theory_corr_ew_powhegFO.py
@@ -43,6 +43,24 @@ weakvars.insert(0, nominal_corr)
 
 s = hist.tag.Slicer()
 
+
+if args.debug:
+    hnumUL = h[{"absYVlhe" : hist.sum, "ptVlhe" : hist.sum, "chargeVlhe" : 0.j, "weak" : "weak_default", "helicity" : -1.j}]
+    hdenUL = h[{"absYVlhe" : hist.sum, "ptVlhe" : hist.sum, "chargeVlhe" : 0.j, "weak" : "weak_no_ew", "helicity" : -1.j}]
+    hrUL = hh.divideHists(hnumUL, hdenUL)
+
+    for ihel in range(-1, 8):
+        hnum = h[{"absYVlhe" : hist.sum, "ptVlhe" : hist.sum, "chargeVlhe" : 0.j, "weak" : "weak_default", "helicity" : ihel*1.j}]
+        hden = h[{"absYVlhe" : hist.sum, "ptVlhe" : hist.sum, "chargeVlhe" : 0.j, "weak" : "weak_no_ew", "helicity" : ihel*1.j}]
+
+        hr = hh.divideHists(hnum, hden)
+        hr2 = hh.divideHists(hr, hrUL)
+
+        print(ihel)
+        print(hr)
+        print(hr2)
+
+
 # integrate over pt and rapidity and re-order the variations
 h = h[{"ptVlhe" : hist.sum, "absYVlhe" : hist.sum, "weak" : weakvars}]
 

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -288,7 +288,7 @@ def build_graph(df, dataset):
 
     df = df.Define("csSineCosThetaPhill", "wrem::csSineCosThetaPhi(muonsPlus_mom4, muonsMinus_mom4)")
     df = df.Define("cosThetaStarll", "csSineCosThetaPhill.costheta")
-    df = df.Define("phiStarll", "std::atan2(csSineCosThetaPhill.sinphi, csSineCosThetaPhill.cosphi)")
+    df = df.Define("phiStarll", "csSineCosThetaPhill.phi()")
 
     # TODO might need to add an explicit cut on trigMuons_pt0 in case nominal pt range
     # extends below 26 GeV e.g. for calibration test purposes

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -28,7 +28,6 @@ parser.add_argument("--addRunAxis", action="store_true", help="Add axis with sli
 
 
 parser = common.set_parser_default(parser, "aggregateGroups", ["Diboson", "Top", "Wtaunu", "Wmunu"])
-parser = common.set_parser_default(parser, "ewTheoryCorr", ["virtual_ew", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR",])
 parser = common.set_parser_default(parser, "excludeProcs", ["QCD"])
 parser = common.set_parser_default(parser, "pt", common.get_default_ptbins(analysis_label))
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -27,7 +27,6 @@ logger = logging.setup_logger(__file__, initargs.verbose, initargs.noColorLogger
 isUnfolding = initargs.analysisMode == "unfolding"
 
 parser = common.set_parser_default(parser, "aggregateGroups", ["Diboson", "Top", "Wtaunu", "Wmunu"])
-parser = common.set_parser_default(parser, "ewTheoryCorr", ["virtual_ew_wlike", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR",])
 parser = common.set_parser_default(parser, "excludeProcs", ["QCD"])
 
 args = parser.parse_args()

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -143,9 +143,9 @@ def build_graph(df, dataset):
     if args.singleLeptonHists and (isW or isZ):
         results.append(df.HistoBoost("nominal_genlep", lep_axes, [*lep_cols, "nominal_weight"], storage=hist.storage.Weight()))
 
-    if not args.skipEWHists and (isW or isZ) and dataset.name == 'Zmumu_powheg-weak':
+    if not args.skipEWHists and (isW or isZ) and 'Zmumu_powheg-weak' in dataset.name:
         if isZ:
-            massBins = theory_tools.make_ew_binning(mass = 91.1535, width = 2.4932, initialStep=0.010, bin_edges_low=[0,50,60], bin_edges_high=[120])
+            massBins = theory_tools.make_ew_binning(mass = 91.1535, width = 2.4932, initialStep=0.10, bin_edges_low=[0,46,50,60,70,80], bin_edges_high=[100,110,120,140,160,200])
         else:
             massBins = theory_tools.make_ew_binning(mass = 80.3815, width = 2.0904, initialStep=0.010)
         

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -161,20 +161,28 @@ def build_graph(df, dataset):
         axis_lhechargeZ = hist.axis.Integer(0, 1, underflow=False, overflow=False, name = "chargeVlhe")
         axis_lhechargeW = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "chargeVlhe")
         axis_lhechargeV = axis_lhechargeZ if isZ else axis_lhechargeW
-        axis_lheCosTheta = hist.axis.Regular(50, -1, 1, name = "lheCosTheta")
+        axis_lheCosThetaStar = hist.axis.Regular(50, -1, 1, name = "cosThetaStarlhe")
+        axis_lhePhiStar = hist.axis.Regular(8, -np.pi, np.pi, circular=True, name="phiStarlhe")
         axis_weak = hist.axis.StrCategory(syst_tools.weakWeightNames(), name="weak")
         axis_helicity = wremnants.helicity_utils.axis_helicity
+
         results.append(df.HistoBoost("lhe_massVptV", [axis_lheMV, axis_lhePtV], ["massVlhe", "ptVlhe", "nominal_weight"], storage=hist.storage.Weight()))
         results.append(df.HistoBoost("lhe_absYVptV", [axis_lheAbsYV, axis_lhePtV], ["absYVlhe", "ptVlhe", "nominal_weight"], storage=hist.storage.Weight()))
         results.append(df.HistoBoost("lhe_absYVmassV", [axis_lheAbsYV, axis_lheMV], ["absYVlhe", "massVlhe", "nominal_weight"], storage=hist.storage.Weight()))
-        results.append(df.HistoBoost("lhe_massVcosTheta", [axis_lheMV, axis_lheCosTheta], ["massVlhe", "csCosThetalhe", "nominal_weight"], storage=hist.storage.Weight()))
-        syst_tools.add_weakweights_hist(results, df, [axis_lheMV, axis_lheCosTheta], ["massVlhe", "csCosThetalhe"], proc=dataset.name, base_name='lhe_massVcosTheta')
+        results.append(df.HistoBoost("lhe_massVcosTheta", [axis_lheMV, axis_lheCosThetaStar], ["massVlhe", "csCosThetalhe", "nominal_weight"], storage=hist.storage.Weight()))
+        syst_tools.add_weakweights_hist(results, df, [axis_lheMV, axis_lheCosThetaStar], ["massVlhe", "csCosThetalhe"], proc=dataset.name, base_name='lhe_massVcosTheta')
+
+        results.append(df.HistoBoost("lhe",  [axis_lheMV, axis_lheAbsYV, axis_lhePtV, axis_lhechargeV], ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe", "nominal_weight"], storage=hist.storage.Weight()))
+
+        results.append(df.HistoBoost("lhe_angular",  [axis_lheMV, axis_lheAbsYV, axis_lhePtV, axis_lhechargeV, axis_lheCosThetaStar, axis_lhePhiStar], ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe", "csCosThetalhe", "csPhilhe", "nominal_weight"], storage=hist.storage.Weight()))
 
         hist_lhe_helicity = df.HistoBoost("lhe_helicity", [axis_lheMV, axis_lheAbsYV, axis_lhePtV, axis_lhechargeV], ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe", "csAngularMomentslhe_wnom"], tensor_axes = [axis_helicity])
         results.append(hist_lhe_helicity)
 
         hist_lhe_weak_helicity = df.HistoBoost("lhe_weak_helicity", [axis_lheMV, axis_lheAbsYV, axis_lhePtV, axis_lhechargeV], ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe", "weakWeight_tensor_helicity"], tensor_axes = [axis_helicity, axis_weak])
         results.append(hist_lhe_weak_helicity)
+
+        results.append(df.HistoBoost("lhe_weak_angular",  [axis_lheMV, axis_lheAbsYV, axis_lhePtV, axis_lhechargeV, axis_lheCosThetaStar, axis_lhePhiStar], ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe", "csCosThetalhe", "csPhilhe", "weakWeight_tensor_wnom"], storage=hist.storage.Weight(), tensor_axes=[axis_weak]))
 
     if not args.skipEWHists and (isW or isZ) and "GenPart_status" in df.GetColumnNames():
         if isZ:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -299,7 +299,7 @@ def common_parser(analysis_label=""):
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--ewTheoryCorr", nargs="*", type=str, action=NoneFilterAction, choices=theory_corrections.valid_ew_theory_corrections(), 
-        default=["winhacnloew", "powhegFOEWHelicity", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
+        default=["winhacnloew", "powhegFOEW", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
         help="Add EW theory corrections without modifying the default theoryCorr list. Will be appended to args.theoryCorr")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--noRecoil", action='store_true', help="Don't apply recoild correction")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -299,7 +299,7 @@ def common_parser(analysis_label=""):
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--ewTheoryCorr", nargs="*", type=str, action=NoneFilterAction, choices=theory_corrections.valid_ew_theory_corrections(), 
-        default=["winhacnloew", "virtual_ew_wlike", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
+        default=["winhacnloew", "powhegFOEWHelicity", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
         help="Add EW theory corrections without modifying the default theoryCorr list. Will be appended to args.theoryCorr")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--noRecoil", action='store_true', help="Don't apply recoild correction")

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -36,8 +36,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
     info = dict(
         systAxes=["systIdx"],
         mirror=True,
-        #FIXME reconcile this with overall "theory" group
-        splitGroup={f"theory_ew" : f".*"},
+        splitGroup={"theory_ew" : f".*", "theory" : f".*"},
         passToFakes=passSystToFakes,
     )
     # different uncertainty for W and Z samples
@@ -57,7 +56,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     skipEntries=[(0, -1), (2, -1)],
                     group = f"theory_ew_virtW",
                 )                     
-        elif ewUnc == "powhegFOEWHelicity":
+        elif ewUnc == "powhegFOEW":
             if z_samples:
                 card_tool.addSystematic(f"{ewUnc}Corr",
                     preOp = lambda h : h[{"weak": ["weak_ps", "weak_aem"]}],
@@ -67,6 +66,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     systAxes=["weak"],
                     mirror=True,
                     group="theory_ew_virtZ_scheme",
+                    splitGroup={"theory_ew" : f".*", "theory" : f".*"},
                     passToFakes=passSystToFakes,
                     rename = "ewScheme",
                 )
@@ -78,6 +78,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     systAxes=["weak"],
                     mirror=True,
                     group="theory_ew_virtZ_corr",
+                    splitGroup={"theory_ew" : f".*", "theory" : f".*"},
                     passToFakes=passSystToFakes,
                     rename = "ew",
                 )

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -36,8 +36,8 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
     info = dict(
         systAxes=["systIdx"],
         mirror=True,
-        group="theory_ew",
-        splitGroup={"theory": ".*"},
+        #FIXME reconcile this with overall "theory" group
+        splitGroup={f"theory_ew" : f".*"},
         passToFakes=passSystToFakes,
     )
     # different uncertainty for W and Z samples
@@ -55,6 +55,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     labelsByAxis=[f"winhacnloewCorr"],
                     scale=1,
                     skipEntries=[(0, -1), (2, -1)],
+                    group = f"theory_ew_virtW",
                 )                     
         elif ewUnc == "powhegFOEWHelicity":
             if z_samples:
@@ -65,7 +66,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     scale=1.,
                     systAxes=["weak"],
                     mirror=True,
-                    group="theory_ew",
+                    group="theory_ew_virtZ_scheme",
                     passToFakes=passSystToFakes,
                     rename = "ewScheme",
                 )
@@ -76,7 +77,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     scale=1.,
                     systAxes=["weak"],
                     mirror=True,
-                    group="theory_ew",
+                    group="theory_ew_virtZ_corr",
                     passToFakes=passSystToFakes,
                     rename = "ew",
                 )
@@ -106,6 +107,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                 labelsByAxis=[f"{ewUnc}Corr"],
                 scale=scale,
                 skipEntries=[(1, -1), (2, -1)] if ewUnc.startswith("virtual_ew") else [(0, -1), (2, -1)],
+                group = f"theory_ew_{ewUnc}",
             )  
 
 def projectABCD(cardTool, h, return_variances=False, dtype="float64"):

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -47,7 +47,6 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
     mode = card_tool.datagroups.mode
     
     for ewUnc in ewUncs:
-        print("ewUnc", ewUnc)
         if ewUnc == "default":
             if w_samples:
                 # add winhac (approximate virtual EW) uncertainty on W samples

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -47,19 +47,8 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
     mode = card_tool.datagroups.mode
     
     for ewUnc in ewUncs:
+        print("ewUnc", ewUnc)
         if ewUnc == "default":
-            if z_samples:
-                if "wlike" in mode or mode[0] == "w":
-                    ewUnc = "virtual_ew_wlike"
-                else:
-                    ewUnc = "virtual_ew"
-                # add virtual EW uncertainty on Z samples
-                card_tool.addSystematic(f"{ewUnc}Corr", **info, 
-                    processes=z_samples,
-                    labelsByAxis=[f"{ewUnc}Corr"],
-                    scale=1,
-                    skipEntries=[(1, -1), (2, -1)],
-                )                
             if w_samples:
                 # add winhac (approximate virtual EW) uncertainty on W samples
                 card_tool.addSystematic(f"winhacnloewCorr", **info, 
@@ -68,6 +57,30 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     scale=1,
                     skipEntries=[(0, -1), (2, -1)],
                 )                     
+        elif ewUnc == "powhegFOEWHelicity":
+            if z_samples:
+                card_tool.addSystematic(f"{ewUnc}Corr",
+                    preOp = lambda h : h[{"weak": ["weak_ps", "weak_aem"]}],
+                    processes=z_samples,
+                    labelsByAxis=[f"{ewUnc}Corr"],
+                    scale=1.,
+                    systAxes=["weak"],
+                    mirror=True,
+                    group="theory_ew",
+                    passToFakes=passSystToFakes,
+                    rename = "ewScheme",
+                )
+                card_tool.addSystematic(f"{ewUnc}Corr",
+                    preOp = lambda h : h[{"weak": ["weak_no_ew"]}],
+                    processes=z_samples,
+                    labelsByAxis=[f"{ewUnc}Corr"],
+                    scale=1.,
+                    systAxes=["weak"],
+                    mirror=True,
+                    group="theory_ew",
+                    passToFakes=passSystToFakes,
+                    rename = "ew",
+                )
         else:
             if "FSR" in ewUnc:
                 if flavor == "e":

--- a/wremnants/datasets/datasetDict_gen.py
+++ b/wremnants/datasets/datasetDict_gen.py
@@ -213,11 +213,24 @@ genDataDict.update({
 })
 
 # NanoLHE
+# The Powheg EW LHE samples have negative weights but "genWeight" is always just 1, so we will use LHEWeight_originalXWGTUP instead. That also gives us the total cross section for each subsample, so we set that to 1 in this dict.
 genDataDict.update({
-    'Zmumu_powheg-weak' : { 
+    'Zmumu_powheg-weak-low' : {
                    'filepaths' :
-                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/test"],
-                   'xsec' : 1815.82,
+                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/46mll80"],
+                   'xsec' : 1,
+                   'group': "Zmumu",
+    },
+    'Zmumu_powheg-weak-peak' : {
+                   'filepaths' :
+                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/80mll100"],
+                   'xsec' : 1,
+                   'group': "Zmumu",
+    },
+    'Zmumu_powheg-weak-high' : {
+                   'filepaths' :
+                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/100mll150"],
+                   'xsec' : 1,
                    'group': "Zmumu",
     },
 })

--- a/wremnants/datasets/datasetDict_gen.py
+++ b/wremnants/datasets/datasetDict_gen.py
@@ -214,22 +214,23 @@ genDataDict.update({
 
 # NanoLHE
 # The Powheg EW LHE samples have negative weights but "genWeight" is always just 1, so we will use LHEWeight_originalXWGTUP instead. That also gives us the total cross section for each subsample, so we set that to 1 in this dict.
+# TODO copy these samples to central area when they are complete
 genDataDict.update({
     'Zmumu_powheg-weak-low' : {
                    'filepaths' :
-                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/46mll80"],
+                    ["root://eoscms.cern.ch//store/group/phys_smp/ec/wmass/fvazzole/powheg_nanoGEN/svn4049/46mll80"],
                    'xsec' : 1,
                    'group': "Zmumu",
     },
     'Zmumu_powheg-weak-peak' : {
                    'filepaths' :
-                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/80mll100"],
+                    ["root://eoscms.cern.ch//store/group/phys_smp/ec/wmass/fvazzole/powheg_nanoGEN/svn4049/80mll100"],
                    'xsec' : 1,
                    'group': "Zmumu",
     },
     'Zmumu_powheg-weak-high' : {
                    'filepaths' :
-                    ["{BASE_PATH}/NanoLHE/Zmumu_powheg-weak/100mll150"],
+                    ["root://eoscms.cern.ch//store/group/phys_smp/ec/wmass/fvazzole/powheg_nanoGEN/svn4049/100mll150"],
                    'xsec' : 1,
                    'group': "Zmumu",
     },

--- a/wremnants/include/csVariables.h
+++ b/wremnants/include/csVariables.h
@@ -33,12 +33,16 @@ Vector unitBoostedVector(ROOT::Math::Boost& boostOp, PxPyPzEVector& vec) {
     return Vector(boostvec.x(), boostvec.y(), boostvec.z()).Unit();
 }
 
-struct CSVars {
+class CSVars {
 
+public:
   double sintheta;
   double costheta;
   double sinphi;
   double cosphi;
+
+  double theta() const { return std::atan2(sintheta, costheta); }
+  double phi() const { return std::atan2(sinphi, cosphi); }
 
 };
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -465,8 +465,8 @@ def widthWeightNames(matches=None, proc=""):
 
 # weak weights from Powheg EW NanoLHE files
 def define_weak_weights(df, proc):
-    if proc != 'Zmumu_powheg-weak':
-        logger.debug("weakWeight_tensor only implemented for Zmumu_powheg-weak.")
+    if not 'Zmumu_powheg-weak' in proc:
+        logger.debug("weakWeight_tensor only implemented for Zmumu_powheg-weak samples.")
         return df
     if "weakWeight_tensor" in df.GetColumnNames():
         logger.debug("weakWeight_tensor already defined, do nothing here.")

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -463,6 +463,38 @@ def widthWeightNames(matches=None, proc=""):
 
     return [x if not matches or any(y in x for y in matches) else "" for x in names]
 
+def define_sin2theta_weights(df, proc):
+    if "sin2thetaWeight_tensor" in df.GetColumnNames():
+        logger.debug("sin2thetaWeight_tensor already defined, do nothing here.")
+        return df
+
+    if proc[0] != "Z":
+        raise RuntimeError("sin2theta weights are only defined for Z")
+
+    nweights = 11
+    df = df.Define("sin2thetaWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(MEParamWeightAltSet4)")
+    df = df.Define("sin2thetaWeight_tensor_wnom", "auto res = sin2thetaWeight_tensor; res = nominal_weight*res; return res;")
+    return df
+
+def add_sin2thetaweights_hist(results, df, axes, cols, base_name="nominal", proc="", storage_type=hist.storage.Double()):
+    name = Datagroups.histName(base_name, syst="sin2thetaWeight"+(proc[0] if len(proc) else proc))
+    sin2thetaWeight = df.HistoBoost(name, axes, [*cols, "sin2thetaWeight_tensor_wnom"],
+                    tensor_axes=[hist.axis.StrCategory(sin2thetaWeightNames(proc=proc), name="sin2theta")],
+                    storage=storage_type)
+    results.append(sin2thetaWeight)
+
+def sin2thetaWeightNames(matches=None, proc=""):
+    if proc[0] != "Z":
+        raise RuntimeError("sin2theta weights are only defined for Z")
+
+    sin2thetas = (0.23151, 0.23154, 0.23157, 0.2230, 0.2300, 0.2305, 0.2310, 0.2315, 0.2320, 0.2325, 0.2330)
+
+    # 1 is the central value
+    # 0 and 2 are Down, Up from uncertainty in EW fit
+    names = [f"sin2theta{proc[0]}{str(sin2theta).replace('.','p')}" for sin2theta in sin2thetas]
+
+    return [x if not matches or any(y in x for y in matches) else "" for x in names]
+
 # weak weights from Powheg EW NanoLHE files
 def define_weak_weights(df, proc):
     if not 'Zmumu_powheg-weak' in proc:
@@ -856,14 +888,16 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
         scale_axes = axes
         scale_cols = cols
 
+    isZ = dataset_name in common.zprocs_all
+
     df = theory_tools.define_scale_tensor(df)
     df = define_mass_weights(df, dataset_name)
     df = define_width_weights(df, dataset_name)
+    if isZ:
+        df = define_sin2theta_weights(df, dataset_name)
 
     add_pdf_hists(results, df, dataset_name, axes, cols, args.pdfs, base_name=base_name, addhelicity=addhelicity, storage_type=storage_type)
     add_qcdScale_hist(results, df, scale_axes, scale_cols, base_name=base_name, addhelicity=addhelicity, storage_type=storage_type)
-
-    isZ = dataset_name in common.zprocs_all
 
     theory_corrs = [*args.theoryCorr, *args.ewTheoryCorr]
     if theory_corrs and dataset_name in corr_helpers:
@@ -888,5 +922,7 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
         # TODO: Should have consistent order here with the scetlib correction function
         add_massweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name, addhelicity=addhelicity, storage_type=storage_type)
         add_widthweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name, storage_type=storage_type)
+        if isZ:
+            add_sin2thetaweights_hist(results, df, axes, cols, proc=dataset_name, base_name=base_name, storage_type=storage_type)
 
     return df

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -476,7 +476,7 @@ def define_weak_weights(df, proc):
     df = df.Define("weakWeight_tensor_wnom", "auto res = weakWeight_tensor; res = LHEWeight_originalXWGTUP*res; return res;")
 
     # note that makeHelicityMomentPdfTensor is actually generic for any variation along one axis
-    # and note specific to PDFs
+    # and not specific to PDFs
     var_helper = ROOT.wrem.makeHelicityMomentPdfTensor[nweights]()
     df = df.Define("LHEWeight_originalXWGTUP_D", "static_cast<double>(LHEWeight_originalXWGTUP)")
     df = df.Define("weakWeight_tensor_helicity", var_helper, ["csSineCosThetaPhilhe", "weakWeight_tensor", "LHEWeight_originalXWGTUP_D"])

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -474,6 +474,13 @@ def define_weak_weights(df, proc):
     nweights = 20
     df = df.Define("weakWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(LHEReweightingWeight)")
     df = df.Define("weakWeight_tensor_wnom", "auto res = weakWeight_tensor; res = LHEWeight_originalXWGTUP*res; return res;")
+
+    # note that makeHelicityMomentPdfTensor is actually generic for any variation along one axis
+    # and note specific to PDFs
+    var_helper = ROOT.wrem.makeHelicityMomentPdfTensor[nweights]()
+    df = df.Define("LHEWeight_originalXWGTUP_D", "static_cast<double>(LHEWeight_originalXWGTUP)")
+    df = df.Define("weakWeight_tensor_helicity", var_helper, ["csSineCosThetaPhilhe", "weakWeight_tensor", "LHEWeight_originalXWGTUP_D"])
+
     return df
 
 def add_weakweights_hist(results, df, axes, cols, base_name="nominal", proc="", storage_type=hist.storage.Double()):

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -503,7 +503,7 @@ def define_weak_weights(df, proc):
     if "weakWeight_tensor" in df.GetColumnNames():
         logger.debug("weakWeight_tensor already defined, do nothing here.")
         return df
-    nweights = 20
+    nweights = 24
     df = df.Define("weakWeight_tensor", f"wrem::vec_to_tensor_t<double, {nweights}>(LHEReweightingWeight)")
     df = df.Define("weakWeight_tensor_wnom", "auto res = weakWeight_tensor; res = LHEWeight_originalXWGTUP*res; return res;")
 
@@ -564,6 +564,14 @@ def weakWeightNames(matches=None, proc=""):
         'weak_s2eff_0p23205',
         # no_ew=0d0, weak-only=1d0, ew_ho=1d0, use-s2effin=0.23255d0
         'weak_s2eff_0p23255',
+        # no_ew=0d0, weak-only=1d0, ew_ho=1d0, use-s2effin=0.23355d0
+        'weak_s2eff_0p23355',
+        # no_ew=0d0, weak-only=1d0, ew_ho=1d0, use-s2effin=0.23455d0
+        'weak_s2eff_0p23455',
+        # no_ew=0d0, weak-only=1d0, ew_ho=1d0, use-s2effin=0.22955d0
+        'weak_s2eff_0p22955',
+        # no_ew=0d0, weak-only=1d0, ew_ho=1d0, use-s2effin=0.22655d0
+        'weak_s2eff_0p22655',
     ]
 
     return [x if not matches or any(y in x for y in matches) else "" for x in names]

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -571,6 +571,7 @@ def define_nominal_weight(df):
     return df.Define(f"nominal_weight", build_weight_expr(df))
 
 def define_ew_theory_corr(df, dataset_name, helpers, generators, modify_central_weight=False):
+    logger.debug("define_ew_theory_corr")
     df = df.Define(f"nominal_weight_ew_uncorr", build_weight_expr(df, exclude_weights=["ew_theory_corr_weight"]))
 
     dataset_helpers = helpers.get(dataset_name, [])
@@ -600,6 +601,7 @@ def define_ew_theory_corr(df, dataset_name, helpers, generators, modify_central_
     return df
 
 def define_theory_corr(df, dataset_name, helpers, generators, modify_central_weight):
+    logger.debug("define_theory_corr")
     df = df.Define(f"nominal_weight_uncorr", build_weight_expr(df, exclude_weights=["theory_corr_weight"]))
 
     dataset_helpers = helpers.get(dataset_name, [])
@@ -616,6 +618,7 @@ def define_theory_corr(df, dataset_name, helpers, generators, modify_central_wei
         helper = dataset_helpers[generator]
 
         if "Helicity" in generator:
+            # TODO check carefully if the weight below should instead be f"{generator}_corr_weight"  (though it's irrelevant as long as there's only one theory correction)
             df = df.Define(f"{generator}Weight_tensor", helper, ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhigen", "nominal_weight_uncorr"])
         else:
             df = define_theory_corr_weight_column(df, generator)

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -445,7 +445,7 @@ def make_ew_binning(mass = 91.1535, width = 2.4932, initialStep = 0.1, bin_edges
     if bin_edges_low:
         bins = bin_edges_low + [b for b in bins if b > bin_edges_low[-1]][1:]
     if bin_edges_high:
-        bins = [b for b in bins if b < bin_edges_high[-1]][:-1] + bin_edges_high
+        bins = [b for b in bins if b < bin_edges_high[0]][:-1] + bin_edges_high
 
     return bins
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -320,6 +320,8 @@ def define_prefsr_vars(df, mode=None):
     df = df.Define("absYVgen", "std::fabs(yVgen)")
     df = df.Define("chargeVgen", "GenPart_pdgId[prefsrLeps[0]] + GenPart_pdgId[prefsrLeps[1]]")
     df = df.Define("csSineCosThetaPhigen", "wrem::csSineCosThetaPhi(genlanti, genl)")
+    df = df.Define("csCosThetagen", "csSineCosThetaPhigen.costheta")
+    df = df.Define("csPhigen", "csSineCosThetaPhigen.phi()")
 
     # define w and w-like variables 
     df = df.Define("qgen", "isEvenEvent ? -1 : 1")
@@ -584,14 +586,14 @@ def define_ew_theory_corr(df, dataset_name, helpers, generators, modify_central_
         helper = dataset_helpers[generator]
         df = df.Define(f"ew_{generator}corr_weight", build_weight_expr(df))
         # hack for column names
-        if generator == "powhegFOEWHelicity":
-            ew_cols = ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhigen", f"ew_{generator}corr_weight"]
+        if generator == "powhegFOEW":
+            ew_cols = ["massVgen", "absYVgen", "csCosThetagen", "chargeVgen", f"ew_{generator}corr_weight"]
         else:
             ew_cols = [*helper.hist.axes.name[:-2], "chargeVgen", f"ew_{generator}corr_weight"]
 
         df = df.Define(f"{generator}Weight_tensor", helper, ew_cols) # multiplying with nominal QCD weight
 
-        if generator in ["powhegFOEWHelicity"] and modify_central_weight:
+        if generator in ["powhegFOEW"] and modify_central_weight:
             logger.debug(f"applying central value correction for {generator}")
             df = df.Define("ew_theory_corr_weight", f"nominal_weight_ew_uncorr == 0 ? 0 : {generator}Weight_tensor(0)/nominal_weight_ew_uncorr")
 


### PR DESCRIPTION
The virtual EW corrections and uncertainties. are implemented for Z from Powheg Fixed Order.

This is done differential in (prefsr) mass, absolute rapidity, and CS costheta*.

The uncertainties are currently implemented as the full (symmetrized) variation from the pole scheme as well as the alpha EM scheme (0.2 MeV for the wlike), and the full size of the correction (0.5 MeV for wlike).  Possibly something like 0.1 times the correction would be more reasonable, but this is already pretty small.

The sin2theta variation is added from MiNNLO rather than from the NLO EW sample, because otherwise the full EW correction/uncertainty would probably have to be rapidity-dependent.   The sin2theta impact on the mass uncertainty is totally negligible.

@mseidel42 @amsimone (sorry I don't know Federico's github username, someone feel free to tag him)