### PR TITLE
Added option to replace MiNNLO muR/muF binned variations with continuous polynomial variations

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -391,6 +391,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
     WMatch = ["W"] # TODO: the name of out-of-acceptance might be changed at some point, maybe to WmunuOutAcc, so W will match it as well (and can exclude it using "OutAcc" if needed)
     ZMatch = ["Z"]
     signalMatch = WMatch if wmass else ZMatch
+    nonSignalMatch = ZMatch if wmass else WMatch
 
     cardTool.addProcessGroup("single_v_samples", lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=dibosonMatch))
     if wmass:
@@ -402,10 +403,13 @@ def setup(args, inputFile, fitvar, xnorm=False):
     cardTool.addProcessGroup("single_vmu_samples",    lambda x: assertSample(x, startsWith=[*WMatch, *ZMatch], excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples",        lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch, "tau"]))
     cardTool.addProcessGroup("signal_samples_inctau", lambda x: assertSample(x, startsWith=signalMatch,        excludeMatch=[*dibosonMatch]))
+    cardTool.addProcessGroup("nonsignal_samples_inctau", lambda x: assertSample(x, startsWith=nonSignalMatch,        excludeMatch=[*dibosonMatch]))
     cardTool.addProcessGroup("MCnoQCD", lambda x: x not in ["QCD", "Data"] + (["Fake"] if simultaneousABCD else []) )
     # FIXME/FOLLOWUP: the following groups may actually not exclude the OOA when it is not defined as an independent process with specific name
     cardTool.addProcessGroup("signal_samples_noOutAcc",        lambda x: assertSample(x, startsWith=signalMatch, excludeMatch=[*dibosonMatch, "tau", "OOA"]))
+    cardTool.addProcessGroup("nonsignal_samples_noOutAcc",     lambda x: assertSample(x, startsWith=nonSignalMatch, excludeMatch=[*dibosonMatch, "tau", "OOA"]))
     cardTool.addProcessGroup("signal_samples_inctau_noOutAcc", lambda x: assertSample(x, startsWith=signalMatch, excludeMatch=[*dibosonMatch, "OOA"]))
+    cardTool.addProcessGroup("nonsignal_samples_inctau_noOutAcc", lambda x: assertSample(x, startsWith=nonSignalMatch, excludeMatch=[*dibosonMatch, "OOA"]))
 
     if not (isTheoryAgnostic or isUnfolding) :
         logger.info(f"All MC processes {cardTool.procGroups['MCnoQCD']}")
@@ -642,7 +646,7 @@ def setup(args, inputFile, fitvar, xnorm=False):
         muRmuFPolVar_helper = combine_theoryAgnostic_helper.TheoryAgnosticHelper(cardTool, externalArgs=args)
         muRmuFPolVar_helper.configure_polVar(label,
                                              passSystToFakes,
-                                             hasSeparateOutOfAcceptanceSignal,
+                                             False,
                                              )
         muRmuFPolVar_helper.add_theoryAgnostic_uncertainty()
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -37,8 +37,6 @@ parser.add_argument("--noTrigger", action="store_true", help="Just for test: rem
 parser.add_argument("--selectNonPromptFromSV", action="store_true", help="Test: define a non-prompt muon enriched control region")
 parser.add_argument("--selectNonPromptFromLighMesonDecay", action="store_true", help="Test: define a non-prompt muon enriched control region with muons from light meson decays")
 parser.add_argument("--useGlobalOrTrackerVeto", action="store_true", help="Use global-or-tracker veto definition and scale factors instead of global only")
-parser.add_argument("--muRmuFPolVarFilePath", type=str, default=f"{data_dir}/MiNNLOmuRmuFPolVar/", help="Path where input files are stored")
-parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_ConstrPol5Ext_Trad", choices=["x0p50_y4p00_ConstrPol5Ext_Trad"],help="Tag for input files")
 
 #
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -619,20 +619,23 @@ def build_graph(df, dataset):
         # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
         return results, weightsum
 
-    if args.muRmuFPolVar and isWorZ and not isTheoryAgnosticPolVar:
+    if args.muRmuFPolVar and isWorZ and not hasattr(dataset, "out_of_acceptance"):
         theoryAgnostic_helpers_cols = ["qtOverQ", "absYVgen", "chargeVgen", "csSineCosThetaPhigen", "nominal_weight"]
         # assume to have same coeffs for plus and minus (no reason for it not to be the case)
         if dataset.name == "WplusmunuPostVFP" or dataset.name == "WplustaunuPostVFP":
             helpers_class = muRmuFPolVar_helpers_plus
+            process_name = "W"
         elif dataset.name == "WminusmunuPostVFP" or dataset.name == "WminustaunuPostVFP":
             helpers_class = muRmuFPolVar_helpers_minus
+            process_name = "W"
         elif dataset.name == "ZmumuPostVFP" or dataset.name == "ZtautauPostVFP":
             helpers_class = muRmuFPolVar_helpers_Z
+            process_name = "Z"
         for coeffKey in helpers_class.keys():
             logger.debug(f"Creating muR/muF histograms with polynomial variations for {coeffKey}")
             helperQ = helpers_class[coeffKey]
             df = df.Define(f"muRmuFPolVar_{coeffKey}_tensor", helperQ, theoryAgnostic_helpers_cols)
-            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar_{coeffKey}")
+            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar{process_name}_{coeffKey}")
             results.append(df.HistoBoost(noiAsPoiWithPolHistName, nominal_axes, [*nominal_cols, f"muRmuFPolVar_{coeffKey}_tensor"], tensor_axes=helperQ.tensor_axes, storage=hist.storage.Double()))
 
     if not args.onlyMainHistograms:

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -319,11 +319,13 @@ def build_graph(df, dataset):
             
             unfolding_tools.add_xnorm_histograms(results, df, args, dataset.name, corr_helpers, qcdScaleByHelicity_helper, unfolding_axes, unfolding_cols)
 
-    if isTheoryAgnostic and isWmunu: # should be isW to do also Wtaunu
+    if isWorZ:
         df = theory_tools.define_prefsr_vars(df)
+        df = df.Define("qtOverQ", "ptVgen/massVgen") # FIXME: should there be a protection against mass=0 and what value to use?
+    
+    if isTheoryAgnostic and isWmunu: # should be isW to do also Wtaunu
         usePtOverM = False
         if isTheoryAgnosticPolVar:
-            df = df.Define("qtOverQ", "ptVgen/massVgen") # FIXME: should there be a protection against mass=0 and what value to use?
             OOAthresholds = args.theoryAgnosticFileTag.split("_")
             ptVthresholdOOA   = float(OOAthresholds[0].replace("x","").replace("p","."))
             absyVthresholdOOA = float(OOAthresholds[1].replace("y","").replace("p","."))
@@ -341,10 +343,6 @@ def build_graph(df, dataset):
                     axes = [*nominal_axes, *theoryAgnostic_axes]
                     cols = [*nominal_cols, *theoryAgnostic_cols]
                     theoryAgnostic_tools.add_xnorm_histograms(results, df, args, dataset.name, corr_helpers, qcdScaleByHelicity_helper, theoryAgnostic_axes, theoryAgnostic_cols)
-
-    if isWorZ and not (isTheoryAgnostic and isWmunu): #it should probably be isW also above
-        df = theory_tools.define_prefsr_vars(df)
-        df = df.Define("qtOverQ", "ptVgen/massVgen") # FIXME: should there be a protection against mass=0 and what value to use?
 
     if not args.makeMCefficiency and not args.noTrigger:
         # remove trigger, it will be part of the efficiency selection for passing trigger

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -1,5 +1,6 @@
 from utilities import boostHistHelpers as hh, common, logging, differential
 from utilities.io_tools import output_tools
+from utilities.common import data_dir
 from wremnants.datasets.datagroups import Datagroups
 import os
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -30,8 +30,6 @@ isUnfolding = initargs.analysisMode == "unfolding"
 
 parser = common.set_parser_default(parser, "aggregateGroups", ["Diboson", "Top", "Wtaunu", "Wmunu"])
 parser = common.set_parser_default(parser, "excludeProcs", ["QCD"])
-parser.add_argument("--muRmuFPolVarFilePath", type=str, default=f"{data_dir}/MiNNLOmuRmuFPolVar/", help="Path where input files are stored")
-parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_ConstrPol5Ext_Trad", choices=["x0p50_y4p00_ConstrPol5Ext_Trad"],help="Tag for input files")
 
 args = parser.parse_args()
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -325,6 +325,8 @@ def common_parser(analysis_label=""):
     parser.add_argument("--dummyNonClosureMMag", default=0., type=float, help="magnitude of the dummy value for the alignment part of the Z non-closure")
     parser.add_argument("--noScaleToData", action="store_true", help="Do not scale the MC histograms with xsec*lumi/sum(gen weights) in the postprocessing step")
     parser.add_argument("--aggregateGroups", type=str, nargs="*", default=["Diboson", "Top"], help="Sum up histograms from members of given groups in the postprocessing step")
+    parser.add_argument("--muRmuFPolVarFilePath", type=str, default=f"{data_dir}/MiNNLOmuRmuFPolVar/", help="Path where input files are stored")
+    parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_ConstrPol5Ext_Trad", choices=["x0p50_y4p00_ConstrPol5Ext_Trad"],help="Tag for input files")
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)

--- a/wremnants/combine_theoryAgnostic_helper.py
+++ b/wremnants/combine_theoryAgnostic_helper.py
@@ -56,6 +56,37 @@ class TheoryAgnosticHelper(object):
                                        #splitGroup={f"{groupName}_{coeffKey}" : f"{groupName}_{coeffKey}"}
                                        )
 
+    def add_muRmuF_polVar_uncertainty(self):
+        coeffs = [f"A{i}" for i in range(8)]
+        signalGroupName = "muRmuFPolVarW" if self.label == "W" else "muRmuFPolVarZ"
+        nonSignalGroupName = "muRmuFPolVarZ" if self.label == "W" else "muRmuFPolVarW"
+        for coeffKey in coeffs:
+            self.card_tool.addSystematic(f"{signalGroupName}_{coeffKey}",
+                                   group=signalGroupName,
+                                   mirror=False,
+                                   passToFakes=self.passSystToFakes,
+                                   processes=["signal_samples_inctau_noOutAcc" if self.separateOutOfAccSignal else "signal_samples_inctau"],
+                                   baseName=f"{signalGroupName}_{coeffKey}_",
+                                   noConstraint=False,
+                                   systAxes=["nPolVarSyst", "downUpVar"], 
+                                   labelsByAxis=["v", "downUpVar"],
+                                   #splitGroup={f"{groupName}_{coeffKey}" : f"{groupName}_{coeffKey}"}
+                                   )
+        
+        for coeffKey in coeffs:
+            self.card_tool.addSystematic(f"{nonSignalGroupName}_{coeffKey}",
+                                   group=nonSignalGroupName,
+                                   mirror=False,
+                                   passToFakes=self.passSystToFakes,
+                                   processes=["nonsignal_samples_inctau_noOutAcc" if self.separateOutOfAccSignal else "nonsignal_samples_inctau"],
+                                   baseName=f"{nonSignalGroupName}_{coeffKey}_",
+                                   noConstraint=False,
+                                   systAxes=["nPolVarSyst", "downUpVar"], 
+                                   labelsByAxis=["v", "downUpVar"],
+                                   #splitGroup={f"{groupName}_{coeffKey}" : f"{groupName}_{coeffKey}"}
+                                   )
+        
+
     def add_theoryAgnostic_normVar_uncertainty(self, flow=True):
 
         common_noi_args = dict(
@@ -166,5 +197,7 @@ class TheoryAgnosticHelper(object):
     def add_theoryAgnostic_uncertainty(self):
         if self.args.analysisMode == "theoryAgnosticPolVar":
             self.add_theoryAgnostic_polVar_uncertainty()
+        elif self.args.muRmuFPolVar == True:
+            self.add_muRmuF_polVar_uncertainty()
         else:
             self.add_theoryAgnostic_normVar_uncertainty()

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -9,7 +9,7 @@ logger = logging.child_logger(__name__)
 
 class TheoryHelper(object):
     valid_np_models = ["Lambda", "Omega", "Delta_Lambda", "Delta_Omega", "binned_Omega", "none"]
-    def __init__(self, card_tool, hasNonsigSamples=False):
+    def __init__(self, card_tool, args, hasNonsigSamples=False):
         toCheck = ['signal_samples', 'signal_samples_inctau', 'single_v_samples']
         if hasNonsigSamples:
             toCheck.extend(['single_v_nonsig_samples', 'wtau_samples'])
@@ -29,6 +29,7 @@ class TheoryHelper(object):
         self.mirror_tnp = True
         self.minnlo_unc = 'byHelicityPt'
         self.skipFromSignal = False
+        self.args = args
 
     def sample_label(self, sample_group):
         if sample_group not in self.card_tool.procGroups:
@@ -137,6 +138,8 @@ class TheoryHelper(object):
             # sigma_-1 uncertainty is covered by scetlib-dyturbo uncertainties if they are used
             helicities_to_exclude = None if self.resumUnc == "minnlo" else [-1]
             for sample_group in self.samples:
+                if self.args.muRmuFPolVar:
+                    continue
                 if self.card_tool.procGroups.get(sample_group, None):
                     # two sets of nuisances, one binned in ~10% quantiles, and one inclusive in pt
                     # to avoid underestimating the correlated part of the uncertainty

--- a/wremnants/helicity_utils_polvar.py
+++ b/wremnants/helicity_utils_polvar.py
@@ -22,12 +22,10 @@ logger = logging.child_logger(__name__)
 data_dir = common.data_dir
 
 def makehelicityWeightHelper_polvar(genVcharge=-1, fileTag="x0p40_y3p50_V6", filePath=".", noUL = False):
-    '''
-    if genVcharge not in [-1, 1]:
-        errmsg = f"genVcharge must be -1 or 1, {genVcharge} was given"
+    if genVcharge not in [-1, 1, 0]:
+        errmsg = f"genVcharge must be -1, 1 or 0, {genVcharge} was given"
         logger.error(errmsg)
         raise ValueError(errmsg)
-    '''
 
     charges = { -1. : "minus", 1. : "plus", 0.: "Z"}
     # these inputs should be copied somewhere

--- a/wremnants/helicity_utils_polvar.py
+++ b/wremnants/helicity_utils_polvar.py
@@ -21,28 +21,37 @@ logger = logging.child_logger(__name__)
 
 data_dir = common.data_dir
 
-def makehelicityWeightHelper_polvar(genVcharge=-1, fileTag="x0p40_y3p50_V6", filePath="."):
-
+def makehelicityWeightHelper_polvar(genVcharge=-1, fileTag="x0p40_y3p50_V6", filePath=".", noUL = False):
+    '''
     if genVcharge not in [-1, 1]:
         errmsg = f"genVcharge must be -1 or 1, {genVcharge} was given"
         logger.error(errmsg)
         raise ValueError(errmsg)
+    '''
 
-    charges = { -1. : "minus", 1. : "plus"}
+    charges = { -1. : "minus", 1. : "plus", 0.: "Z"}
     # these inputs should be copied somewhere
     filenamePlus = f"{filePath}/fout_syst_wp_{fileTag}.root"
     filenameMinus = f"{filePath}/fout_syst_wm_{fileTag}.root"
+    filenameZ = f"{filePath}/fout_syst_z_{fileTag}.root"
     filenames = {-1 : filenamePlus,
-                  1 : filenameMinus}
+                  1 : filenameMinus,
+                  0 : filenameZ}
 
     chargeTag = f"genChargeV{charges[genVcharge]}"
 
     logger.debug(f"Preparing helicity weights for theory agnostic analysis: gen V charge {charges[genVcharge]}")
-    folders = ["UL"] + [f"A{i}" for i in range(5)] # up to A4
+
+    uptorange = 8 #up to A4
 
     down_up_axis = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "downUpVar")
-    
-    axis_helicity_part = hist.axis.Integer(-1, len(folders)-1, name="helicityPart", overflow=False, underflow=False)
+
+    if noUL:
+        folders = [f"A{i}" for i in range(uptorange)]
+        axis_helicity_part = hist.axis.Integer(-1, len(folders), name="helicityPart", overflow=False, underflow=False)
+    else:
+        folders = ["UL"] + [f"A{i}" for i in range(uptorange)]
+        axis_helicity_part = hist.axis.Integer(-1, len(folders)-1, name="helicityPart", overflow=False, underflow=False)
 
     hnom_hist_full = None
     hsys_hist_full = {fld: None for fld in folders}
@@ -62,12 +71,16 @@ def makehelicityWeightHelper_polvar(genVcharge=-1, fileTag="x0p40_y3p50_V6", fil
             hnom_hist_full = hist.Hist(axis_qtOverQ, axis_absY, axis_helicity_part,
                                        name = f"hnom_hist_full_{chargeTag}",
                                        storage = hist.storage.Double())
-        hnom_hist_full.values(flow=False)[:, :, ifld] = hnom_hist.values(flow=False)[:,:]
+        if noUL:
+            nomIndex = ifld + 1
+        else:
+            nomIndex = ifld
+        hnom_hist_full.values(flow=False)[:, :, nomIndex] = hnom_hist.values(flow=False)[:,:]
         # now the syst
         nSysts = 0
         for k in f.GetListOfKeys():
             name = k.GetName()
-            if name.startswith("h_pdf") and "syst" in name and name.endswith("Up"):
+            if name.startswith("h_pdf") and "syst" in name and not "muF" in name and not "muR" in name and name.endswith("Up"):
                 nSysts += 1
         # create and fill boost histogram
         if hsys_hist_full[fld] is None:
@@ -113,8 +126,13 @@ def makehelicityWeightHelper_polvar(genVcharge=-1, fileTag="x0p40_y3p50_V6", fil
     
         hnom_hist_full_pyroot = narf.hist_to_pyroot_boost(hnom_hist_full_cp)
         hsys_hist_full_pyroot = narf.hist_to_pyroot_boost(hsys_hist_full[fld])
+        if noUL:
+            varIndex = ifld + 1
+        else:
+            varIndex = ifld
+
         helper = ROOT.wrem.WeightByHelicityHelper_polvar[genVcharge,
-                                                         ifld,
+                                                         varIndex,
                                                          nSysts,
                                                          type(hsys_hist_full_pyroot),
                                                          type(hnom_hist_full_pyroot)](ROOT.std.move(hsys_hist_full_pyroot),


### PR DESCRIPTION
This PR adds the option to replace MiNNLO muR/muF binned variations with continuous polynomial variations as in the theory agnostic implementation by the ERC ASYMOW group. To do this you run setupCombine.py with the "--muRmuFPolVar" option. This is implemented both the W mass analysis and the W-like analysis, and it doesn't require to define an out-of-acceptance dataset.