### PR TITLE
Update electroweak corrections and uncertainties

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWCorr' --selectEntries weak_no_ew --varLabel no_EW_virtual --selectAxis weak --color blue
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWCorr' --selectEntries weak_default --varLabel 'EW(virtual)' --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,7 +597,7 @@ jobs:
           -o $WREMNANTS_OUTDIR -j $NTHREADS --maxFiles $MAX_FILES --axes etaAbsEta mll --forceDefaultName --postfix mll
 
       - name: dilepton plotting mll
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName nominal --nominalRef nominal --hists etaAbsEta-mll mll -o $WEB_DIR -f $PLOT_DIR -p z $HIST_FILE variation --varName 'powhegFOEWCorr' --selectEntries weak_no_ew --varLabel no_EW_virtual --selectAxis weak --color blue
 
       - name: dilepton combine mll setup
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py -i $HIST_FILE --fitvar etaAbsEta-mll --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --realData --hdf5

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -93,8 +93,8 @@ def make_parser(parser=None):
     parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--massVariation", type=float, default=100, help="Variation of boson mass")
-    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default", "powhegFOEW"], help="Include EW uncertainty (other than pure ISR or FSR)",
-        choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" not in x and "FSR" not in x])
+    parser.add_argument("--ewUnc", type=str, nargs="*", default=["renesanceEW", "powhegFOEW"], help="Include EW uncertainty (other than pure ISR or FSR)",
+        choices=[x for x in theory_corrections.valid_theory_corrections() if ("ew" in x or "EW" in x) and "ISR" not in x and "FSR" not in x])
     parser.add_argument("--isrUnc", type=str, nargs="*", default=["pythiaew_ISR",], help="Include ISR uncertainty", 
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" in x])
     parser.add_argument("--fsrUnc", type=str, nargs="*", default=["horaceqedew_FSR", "horacelophotosmecoffew_FSR"], help="Include FSR uncertainty", 

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -93,7 +93,7 @@ def make_parser(parser=None):
     parser.add_argument("--scalePdf", default=1, type=float, help="Scale the PDF hessian uncertainties by this factor")
     parser.add_argument("--pdfUncFromCorr", action='store_true', help="Take PDF uncertainty from correction hist (Requires having run that correction)")
     parser.add_argument("--massVariation", type=float, default=100, help="Variation of boson mass")
-    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default"], help="Include EW uncertainty (other than pure ISR or FSR)",
+    parser.add_argument("--ewUnc", type=str, nargs="*", default=["default", "powhegFOEW"], help="Include EW uncertainty (other than pure ISR or FSR)",
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" not in x and "FSR" not in x])
     parser.add_argument("--isrUnc", type=str, nargs="*", default=["pythiaew_ISR",], help="Include ISR uncertainty", 
         choices=[x for x in theory_corrections.valid_theory_corrections() if "ew" in x and "ISR" in x])

--- a/scripts/corrections/make_theory_corr_ew_powhegFO.py
+++ b/scripts/corrections/make_theory_corr_ew_powhegFO.py
@@ -60,22 +60,20 @@ if args.debug:
         plt.savefig(f"plotsew/ratio_{var}.png")
         plt.close()
 
-
-# nominal correction should be the first entry, so re-order the variations in case we want to correct the central value
-nominal_corr = "weak_default"
-weakvars = list(h.axes["weak"])
-weakvars.remove(nominal_corr)
-weakvars.insert(0, nominal_corr)
-
-#  re-order the variations and integrate over pt and phistar
-h = h[{"ptVlhe" : hist.sum, "phiStarlhe" : hist.sum, "weak" : weakvars}]
+# integrate over pt and phistar
+h = h[{"ptVlhe" : hist.sum, "phiStarlhe" : hist.sum}]
 
 hcorr = hist.Hist(*h.axes)
 # safe default
 hcorr.values(flow=True)[...] = 1.
-# set correction to the ratio to LO
-den = h[{"weak" : "weak_no_ew"}].values()[..., None]
+# set variations as the ratio to NLO EW
+den = h[{"weak" : "weak_default"}].values()[..., None]
 hcorr[...] = np.where(den==0., np.ones_like(h.values()), h.values()/den)
+
+# set variation for NLO EW as the ratio to LO EW
+denlo = h[{"weak" : "weak_no_ew"}].values()
+numnlo = h[{"weak" : "weak_default"}].values()
+hcorr[{"weak" : "weak_default"}] = np.where(denlo==0., np.ones_like(numnlo), numnlo/denlo)
 
 # extreme bins are not populated, "extend" the corrections from the neighboring mass bins
 hcorr[{"massVlhe" : 0}] = hcorr[{"massVlhe" : 1}].values()

--- a/scripts/corrections/make_theory_corr_ew_renesance.py
+++ b/scripts/corrections/make_theory_corr_ew_renesance.py
@@ -1,0 +1,135 @@
+import numpy as np
+from wremnants import theory_corrections, theory_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+import hist
+import argparse
+import os
+import h5py
+import narf
+import pdb
+import ROOT
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("--debug", action='store_true', help="Print debug output")
+parser.add_argument("--random", action='store_true', help="Produce correction with statistical fluctuations")
+parser.add_argument("--project", default=["massVgen", "absYVgen", "csCosThetagen"], nargs="*", type=str, help="axes to project to")
+parser.add_argument("-p", "--postfix", type=str, help="Postfix for plots and correction files")
+
+args = parser.parse_args()
+
+data_dir = common.data_dir
+
+def load_renesance(dirname):
+
+    def load_hist(fname):
+        f = ROOT.TFile.Open(fname)
+        f.ls()
+
+        h = f.Get("h_dilepton_m_y_costheta")
+        hxsec = f.Get("h_xsec")
+
+        h = narf.root_to_hist(h, axis_names = ["massVgen", "yVgen", "csCosThetagen"])
+        hxsec = narf.root_to_hist(hxsec)
+
+        f.Close()
+
+        # this is already 1.0 so no need to actually apply it, but just checking
+        wnorm = hxsec.values()[0]/h.sum(flow=True).value
+        print("wnorm", wnorm)
+
+        axis_yVgen = h.axes["yVgen"]
+
+        if 0. not in axis_yVgen.edges:
+            raise ValueError("Can't consistently convert to absolute rapidity unless there is a bin edge at 0.")
+
+        if not isinstance(axis_yVgen, hist.axis.Regular):
+            raise ValueError("Expected a regular axis for the rapidity")
+
+        axis_absYVgen = hist.axis.Regular(axis_yVgen.size//2, 0., axis_yVgen.edges[-1], underflow=False, overflow=True, name="absYVgen")
+
+        axis_massVgen = h.axes["massVgen"]
+        axis_csCosThetagen = h.axes["csCosThetagen"]
+
+        hout = hist.Hist(axis_massVgen, axis_absYVgen, axis_csCosThetagen, storage=h.storage_type())
+
+
+        for val in axis_yVgen.centers:
+            hout[{"absYVgen" : abs(val)*1.j}] = hout[{"absYVgen" : abs(val)*1.j}].view(flow=True) + h[{"yVgen" : val*1.j}].view(flow=True)
+
+        hout[{"absYVgen" : hist.overflow}] = h[{"yVgen" : hist.underflow}].view(flow=True) + h[{"yVgen" : hist.overflow}].view(flow=True)
+
+
+        mass_binning = [edge for edge in axis_massVgen.edges if (edge % 10. == 0. or (edge>70. and edge<90.))]
+
+        hout = hh.rebinHist(hout, axis_name = "massVgen", edges = mass_binning)
+        hout = hout[{"absYVgen" : hist.rebin(2)}]
+
+        print(hout.project("massVgen"))
+        print(hout.project("absYVgen"))
+        print(hout.project("csCosThetagen"))
+
+        hout = hout.project(*args.project)
+
+        print(h)
+        print(hout)
+
+        return hout
+
+    fnameLO = f"{dirname}/plots_LO.root"
+    fnameNLO = f"{dirname}/plots_NLO.root"
+
+    hLO = load_hist(fnameLO)
+    hNLO = load_hist(fnameNLO)
+
+    if (args.random):
+        rng = np.random.default_rng(12345)
+
+        hNLO.values(flow=True)[...] = np.maximum(0., hLO.values(flow=True) + rng.standard_normal(hLO.values(flow=True).shape)*np.sqrt(hLO.variances(flow=True)))
+        hNLO.variances(flow=True)[...] = hLO.variances(flow=True)
+
+
+    print("hLO", hLO)
+    print("hNLO", hNLO)
+
+    hcorr = hh.divideHists(hNLO, hLO)
+
+
+    print("hcorr", hcorr)
+    print(np.mean(hcorr.values()))
+    return hcorr
+
+rdirwm = f"{data_dir}//EWCorrections/reneSANCe/pptowm_13tev_iqcd0_iqed0_iew1_iscale3_sum"
+rdirwp = f"{data_dir}//EWCorrections/reneSANCe/pptowp_13tev_iqcd0_iqed0_iew1_iscale3_sum"
+
+
+h_wm = load_renesance(rdirwm)
+h_wp = load_renesance(rdirwp)
+
+axis_chargeVgen = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name="chargeVgen")
+axis_var = hist.axis.StrCategory(["nlo_ew_virtual"], name="var")
+
+hcorr = hist.Hist(*h_wm.axes, axis_chargeVgen, axis_var)
+
+hcorr[{"chargeVgen" : -1.j, "var" : "nlo_ew_virtual"}] = h_wm.values(flow=True)
+hcorr[{"chargeVgen" : 1.j, "var" : "nlo_ew_virtual"}] = h_wp.values(flow=True)
+
+
+hcorr.values(flow=True)[...] = np.maximum(hcorr.values(flow=True), 0.)
+
+print(hcorr)
+print(hcorr[{"chargeVgen" : -1.j, "var" : 0}])
+print(hcorr[{"chargeVgen" : 1.j, "var" : 0}])
+
+# hack output name to comply with correction code
+correction_name = "renesanceEW"
+if args.postfix:
+    correction_name += f"_{args.postfix}"
+hist_name = f"{correction_name}_minnlo_ratio"
+
+res = {}
+res[hist_name] = hcorr
+
+output_tools.write_theory_corr_hist(correction_name, "W", res, args)

--- a/scripts/corrections/make_theory_corr_ew_renesance_smooth.py
+++ b/scripts/corrections/make_theory_corr_ew_renesance_smooth.py
@@ -1,0 +1,156 @@
+import numpy as np
+from wremnants import theory_corrections, theory_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+import hist
+import argparse
+import os
+import h5py
+import narf
+import pdb
+import ROOT
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument("--debug", action='store_true', help="Print debug output")
+parser.add_argument("--project", default=["massVgen", "absYVgen"], nargs="*", type=str, help="axes to project to")
+parser.add_argument("-p", "--postfix", type=str, help="Postfix for plots and correction files")
+
+args = parser.parse_args()
+
+data_dir = common.data_dir
+
+
+def dorebin(h):
+    axis_yVgen = h.axes["yVgen"]
+
+    if 0. not in axis_yVgen.edges:
+        raise ValueError("Can't consistently convert to absolute rapidity unless there is a bin edge at 0.")
+
+    if not isinstance(axis_yVgen, hist.axis.Regular):
+        raise ValueError("Expected a regular axis for the rapidity")
+
+    axis_absYVgen = hist.axis.Regular(axis_yVgen.size//2, 0., axis_yVgen.edges[-1], underflow=False, overflow=True, name="absYVgen")
+
+    hout = hist.Hist(*[axis if axis.name != "yVgen" else axis_absYVgen for axis in h.axes], storage=h.storage_type())
+
+    for val in axis_yVgen.centers:
+        hout[{"absYVgen" : abs(val)*1.j}] = hout[{"absYVgen" : abs(val)*1.j}].view(flow=True) + h[{"yVgen" : val*1.j}].view(flow=True)
+
+    hout[{"absYVgen" : hist.overflow}] = h[{"yVgen" : hist.underflow}].view(flow=True) + h[{"yVgen" : hist.overflow}].view(flow=True)
+
+    axis_massVgen = h.axes["massVgen"]
+
+    mass_binning = [edge for edge in axis_massVgen.edges if (edge % 10. == 0. or (edge>70. and edge<90.))]
+
+    hout = hh.rebinHist(hout, axis_name = "massVgen", edges = mass_binning)
+    hout = hout[{"absYVgen" : hist.rebin(2)}]
+
+    hout = hout.project(*args.project)
+
+    return hout
+
+
+
+def load_renesance(dirname):
+
+    def load_hist(fname):
+        f = ROOT.TFile.Open(fname)
+        f.ls()
+
+        h = f.Get("h_dilepton_m_y")
+        h0 = f.Get("h_dilepton_m_y_mom0")
+        h4 = f.Get("h_dilepton_m_y_mom4")
+        hxsec = f.Get("h_xsec")
+
+        h = narf.root_to_hist(h, axis_names = ["massVgen", "yVgen"])
+        h0 = narf.root_to_hist(h0, axis_names = ["massVgen", "yVgen"])
+        h4 = narf.root_to_hist(h4, axis_names = ["massVgen", "yVgen"])
+        hxsec = narf.root_to_hist(hxsec)
+
+        f.Close()
+
+        # this is already 1.0 so no need to actually apply it, but just checking
+        wnorm = hxsec.values()[0]/h.sum(flow=True).value
+        print("wnorm", wnorm)
+
+        h = dorebin(h)
+        h0 = dorebin(h0)
+        h4 = dorebin(h4)
+
+        axis_csCosThetagen = hist.axis.Regular(200, -1., 1., name="csCosThetagen")
+
+        hout = hist.Hist(*h.axes, axis_csCosThetagen)
+
+        costhetavals = axis_csCosThetagen.centers
+        costhetavals = np.concatenate([[-1.], costhetavals, [1.]])
+        costhetavals = costhetavals[None, None, ...]
+
+        print("costhetavals", costhetavals)
+        print(costhetavals.shape)
+
+        hout[...] = h.values(flow=True)[..., None]*(1. + costhetavals**2) + h0.values(flow=True)[..., None]*0.5*(1. - 3.*costhetavals**2) + h4.values(flow=True)[..., None]*costhetavals
+
+        return hout
+
+    fnameLO = f"{dirname}/plots_LO.root"
+    fnameNLO = f"{dirname}/plots_NLO.root"
+
+    hLO = load_hist(fnameLO)
+    hNLO = load_hist(fnameNLO)
+
+    print("hLO", hLO)
+    print("hNLO", hNLO)
+
+    hcorr = hh.divideHists(hNLO, hLO)
+
+    # axis_var = hist.axis.StrCategory(["nlo_ew_virtual", "no_ew_virtual"], name="var")
+    # hcorr = hist.Hist(*hNLO.axes, axis_var)
+    #
+    # hcorr[{"var" : "nlo_ew_virtual"}] = hh.divideHists(hNLO, hLO).values(flow=True)
+    # hcorr[{"var" : "no_ew_virtual"}] = np.ones_like(hLO.values(flow=True))
+
+    print("hcorr", hcorr)
+    print(np.mean(hcorr.values()))
+
+    # print(h)
+    return hcorr
+
+rdirwm = f"{data_dir}//EWCorrections/reneSANCe/pptowm_13tev_iqcd0_iqed0_iew1_iscale3_sum"
+rdirwp = f"{data_dir}//EWCorrections/reneSANCe/pptowp_13tev_iqcd0_iqed0_iew1_iscale3_sum"
+
+
+h_wm = load_renesance(rdirwm)
+h_wp = load_renesance(rdirwp)
+
+axis_chargeVgen = hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name="chargeVgen")
+axis_var = hist.axis.StrCategory(["nlo_ew_virtual"], name="var")
+# axis_var = h_wp.axes["var"]
+
+# hcorr = hist.Hist(*[axis for axis in h_wm.axes if axis.name != "var"], axis_chargeVgen, axis_var)
+
+hcorr = hist.Hist(*h_wm.axes, axis_chargeVgen, axis_var)
+
+hcorr[{"chargeVgen" : -1.j, "var" : "nlo_ew_virtual"}] = h_wm.values(flow=True)
+hcorr[{"chargeVgen" : 1.j, "var" : "nlo_ew_virtual"}] = h_wp.values(flow=True)
+
+# hcorr[{"chargeVgen" : -1.j}] = h_wm.values(flow=True)
+# hcorr[{"chargeVgen" : 1.j}] = h_wp.values(flow=True)
+
+hcorr.values(flow=True)[...] = np.maximum(hcorr.values(flow=True), 0.)
+
+print(hcorr)
+print(hcorr[{"chargeVgen" : -1.j, "var" : 0}])
+print(hcorr[{"chargeVgen" : 1.j, "var" : 0}])
+
+# hack output name to comply with correction code
+correction_name = "renesanceEW_smooth"
+if args.postfix:
+    correction_name += f"_{args.postfix}"
+hist_name = f"{correction_name}_minnlo_ratio"
+
+res = {}
+res[hist_name] = hcorr
+
+output_tools.write_theory_corr_hist(correction_name, "W", res, args)

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -299,7 +299,7 @@ def common_parser(analysis_label=""):
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--ewTheoryCorr", nargs="*", type=str, action=NoneFilterAction, choices=theory_corrections.valid_ew_theory_corrections(), 
-        default=["winhacnloew", "powhegFOEW", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
+        default=["renesanceEW", "powhegFOEW", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
         help="Add EW theory corrections without modifying the default theoryCorr list. Will be appended to args.theoryCorr")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--noRecoil", action='store_true', help="Don't apply recoild correction")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -299,7 +299,7 @@ def common_parser(analysis_label=""):
         help="Apply corrections from indicated generator. First will be nominal correction.")
     parser.add_argument("--theoryCorrAltOnly", action='store_true', help="Save hist for correction hists but don't modify central weight")
     parser.add_argument("--ewTheoryCorr", nargs="*", type=str, action=NoneFilterAction, choices=theory_corrections.valid_ew_theory_corrections(), 
-        default=["winhacnloew", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
+        default=["winhacnloew", "powhegFOEW", "pythiaew_ISR", "horaceqedew_FSR", "horacelophotosmecoffew_FSR", ],
         help="Add EW theory corrections without modifying the default theoryCorr list. Will be appended to args.theoryCorr")
     parser.add_argument("--skipHelicity", action='store_true', help="Skip the qcdScaleByHelicity histogram (it can be huge)")
     parser.add_argument("--noRecoil", action='store_true', help="Don't apply recoild correction")

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -46,16 +46,21 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
     mode = card_tool.datagroups.mode
     
     for ewUnc in ewUncs:
-        if ewUnc == "default":
+        if "renesanceEW" in ewUnc:
+            pass
             if w_samples:
-                # add winhac (approximate virtual EW) uncertainty on W samples
-                card_tool.addSystematic(f"winhacnloewCorr", **info, 
+                # add renesance (virtual EW) uncertainty on W samples
+                card_tool.addSystematic(f"{ewUnc}Corr",
                     processes=w_samples,
-                    labelsByAxis=[f"winhacnloewCorr"],
-                    scale=1,
-                    skipEntries=[(0, -1), (2, -1)],
-                    group = f"theory_ew_virtW",
-                )                     
+                    preOp = lambda h : h[{"var": ["nlo_ew_virtual"]}],
+                    labelsByAxis=[f"renesanceEWCorr"],
+                    scale=1.,
+                    systAxes=["var"],
+                    group = "theory_ew_virtW_corr",
+                    splitGroup={"theory_ew" : f".*", "theory" : f".*"},
+                    passToFakes=passSystToFakes,
+                    mirror = True,
+                )
         elif ewUnc == "powhegFOEW":
             if z_samples:
                 card_tool.addSystematic(f"{ewUnc}Corr",
@@ -71,7 +76,7 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
                     rename = "ewScheme",
                 )
                 card_tool.addSystematic(f"{ewUnc}Corr",
-                    preOp = lambda h : h[{"weak": ["weak_no_ew"]}],
+                    preOp = lambda h : h[{"weak": ["weak_default"]}],
                     processes=z_samples,
                     labelsByAxis=[f"{ewUnc}Corr"],
                     scale=1.,

--- a/wremnants/datasets/datasetDict_gen.py
+++ b/wremnants/datasets/datasetDict_gen.py
@@ -92,12 +92,12 @@ genDataDict = {
                    'xsec' : xsec_powheg_WplusToMuNu_LO,
                     'group': "Wmunu",
     },
-    'Wplusmunu_horace-lo-photos-mecoff' : { 
+    'Wplusmunu_horace-lo-photos-mecoff' : {
                  'filepaths' :
-                ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_PhotosMecOff_13TeV-horace-pythia8-photospp"],
+                ["{BASE_PATH}/WplusJetsToMuNu_LO_TuneCP5_PhotosAllMecOff_13TeV-horace-pythia8-photospp"],
                  'xsec' : xsec_powheg_WplusToMuNu_LO,
                  'group': "Wmunu",
-    },    
+    },
     'Wplusmunu_horace-lo-photos-isroff' : { 
                 'filepaths' :
                 ["{BASE_PATH}/WplusJetsToMuNu_LO_NoQEDISR_TuneCP5_13TeV-horace-pythia8-photospp"],
@@ -146,12 +146,12 @@ genDataDict = {
                    'xsec' : xsec_powheg_WminusToMuNu_LO,
                     'group': "Wmunu",
     },
-    'Wminusmunu_horace-lo-photos-mecoff' : { 
+    'Wminusmunu_horace-lo-photos-mecoff' : {
                  'filepaths' :
-                ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_PhotosMecOff_13TeV-horace-pythia8-photospp"],
+                ["{BASE_PATH}/WminusJetsToMuNu_LO_TuneCP5_PhotosAllMecOff_13TeV-horace-pythia8-photospp"],
                  'xsec' : xsec_powheg_WminusToMuNu_LO,
                  'group': "Wmunu",
-    },  
+    },
     'Wminusmunu_horace-lo-photos-isroff' : { 
                 'filepaths' :
                 ["{BASE_PATH}/WminusJetsToMuNu_LO_NoQEDISR_TuneCP5_13TeV-horace-pythia8-photospp"],

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -22,7 +22,7 @@ def valid_theory_corrections():
     return [m[1] for m in matches if m]+["none"]
 
 def valid_ew_theory_corrections():
-    corr_files = glob.glob(common.data_dir+"TheoryCorrections/*ew*Corr*.pkl.lz4")
+    corr_files = glob.glob(common.data_dir+"TheoryCorrections/*[eE][wW]*Corr*.pkl.lz4")
     matches = [re.match("(^.*)Corr[W|Z]\.pkl\.lz4", os.path.basename(c)) for c in corr_files]
     return [m[1] for m in matches if m]+["none"]
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -536,7 +536,7 @@ def define_theory_weights_and_corrs(df, dataset_name, helpers, args):
     df = define_central_pdf_weight(df, dataset_name, args.pdfs[0] if len(args.pdfs) >= 1 else None)
     df = define_theory_corr(df, dataset_name, helpers, generators=args.theoryCorr, 
         modify_central_weight=not args.theoryCorrAltOnly)
-    df = define_ew_theory_corr(df, dataset_name, helpers, generators=args.ewTheoryCorr, modify_central_weight=not args.theoryCorrAltOnly)
+    df = define_ew_theory_corr(df, dataset_name, helpers, generators=args.ewTheoryCorr, modify_central_weight=False)
 
     if args.highptscales:
         df = df.Define("extra_weight", "MEParamWeightAltSet3[0]")
@@ -574,6 +574,10 @@ def define_nominal_weight(df):
 
 def define_ew_theory_corr(df, dataset_name, helpers, generators, modify_central_weight=False):
     logger.debug("define_ew_theory_corr")
+
+    if modify_central_weight:
+        raise ValueError("Modifying central weight not currently supported for EW corrections.")
+
     df = df.Define(f"nominal_weight_ew_uncorr", build_weight_expr(df, exclude_weights=["ew_theory_corr_weight"]))
 
     dataset_helpers = helpers.get(dataset_name, [])
@@ -593,7 +597,7 @@ def define_ew_theory_corr(df, dataset_name, helpers, generators, modify_central_
 
         df = df.Define(f"{generator}Weight_tensor", helper, ew_cols) # multiplying with nominal QCD weight
 
-        if generator in ["powhegFOEW"] and modify_central_weight:
+        if generator in ["renesanceEW", "powhegFOEW"] and modify_central_weight:
             logger.debug(f"applying central value correction for {generator}")
             df = df.Define("ew_theory_corr_weight", f"nominal_weight_ew_uncorr == 0 ? 0 : {generator}Weight_tensor(0)/nominal_weight_ew_uncorr")
 


### PR DESCRIPTION
The photos ME correction off uncertainties have been updated using the new MC samples that really switch off the ME corrections for the W.

The electroweak variations have been reverted to not apply to the central value since this caused some technical problems/inconsistencies (but there are also concerns about introducing inconsistencies via the breaking of the angular decomposition)

The powheg FO EW virtual uncertainties are restored for the Z, and renesance EW virtual uncertainty is added for the W , applied three-dimensionally in prefsr mass, absY and costhetastar.