### PR TITLE
Updates to helicity uncertainties

### DIFF
--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -300,6 +300,9 @@ logger.info("computing angular coefficients")
 z_moments = None
 w_moments = None
 
+z_moments_lhe = None
+w_moments_lhe = None
+
 if not args.skipAngularCoeffs:
     for dataset in datasets:
         name = dataset.name
@@ -307,30 +310,33 @@ if not args.skipAngularCoeffs:
             logger.warning(f"Failed to find helicity_moments_scale hist for proc {name}. Skipping!")
             continue
         moments = resultdict[name]["output"]["nominal_gen_helicity_moments_scale"].get()
-        if name in common.zprocs:
+        moments_lhe = resultdict[name]["output"]["nominal_gen_helicity_moments_scale_lhe"].get()
+        if name in ["ZmumuPostVFP"]:
             if z_moments is None:
                 z_moments = moments
+                z_moments_lhe = moments_lhe
             else:
                 new_moments = moments
+                new_moments_lhe = moments_lhe
                 z_moments = hh.addHists(z_moments, new_moments, createNew=False)
-        elif name in common.wprocs:
+                z_moments_lhe = hh.addHists(z_moments_lhe, new_moments_lhe, createNew=False)
+        elif name in ["WplusmunuPostVFP", "WminusmunuPostVFP"]:
             if w_moments is None:
                 w_moments = moments
+                w_moments_lhe = moments_lhe
             else:
                 new_moments = moments
+                new_moments_lhe = moments_lhe
                 w_moments = hh.addHists(w_moments, new_moments, createNew=False)
+                w_moments_lhe = hh.addHists(w_moments_lhe, new_moments_lhe, createNew=False)
 
     moments_out={}
-    # Common.ptV_binning is the approximate 5% quantiles, rounded to integers. Rebin for approx 10% quantiles
     if z_moments:
-        if not args.useTheoryAgnosticBinning:
-            z_moments = hh.rebinHist(z_moments, axis_ptVgen.name, common.ptV_binning[::2])
-            z_moments = hh.rebinHist(z_moments, axis_massZgen.name, axis_massZgen.edges[::2])
         moments_out["Z"] = z_moments
+        moments_out["Z_lhe"] = z_moments_lhe
     if w_moments:
-        if not args.useTheoryAgnosticBinning:
-            w_moments = hh.rebinHist(w_moments, axis_ptVgen.name, common.ptV_binning[::2])
         moments_out["W"] = w_moments
+        moments_out["W_lhe"] = w_moments_lhe
     if moments_out:
         outfname = "w_z_moments"
         if args.signedY:

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -152,7 +152,6 @@ def build_graph(df, dataset):
             massBins = theory_tools.make_ew_binning(mass = 80.3815, width = 2.0904, initialStep=0.010)
         
         # LHE level
-        df = theory_tools.define_lhe_vars(df)
         df = syst_tools.define_weak_weights(df, dataset.name)
         axis_lheMV = hist.axis.Variable(massBins, name = "massVlhe", underflow=False)
         axis_lhePtV = hist.axis.Variable(common.ptV_binning, underflow=False, name = "ptVlhe") 

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -145,6 +145,9 @@ class TheoryHelper(object):
                     self.add_minnlo_scale_uncertainty(sample_group, extra_name = "fine", rebin_pt=common.ptV_binning[::2], helicities_to_exclude=helicities_to_exclude)
                     self.add_minnlo_scale_uncertainty(sample_group, extra_name = "inclusive", rebin_pt=[common.ptV_binning[0], common.ptV_binning[-1]], helicities_to_exclude=helicities_to_exclude)
 
+            # additional uncertainty for effect of shower and intrinsic kt on angular coeffs
+            self.add_helicity_shower_kt_uncertainty()
+
     def add_minnlo_scale_uncertainty(self, sample_group, extra_name="", use_hel_hist=True, rebin_pt=None, helicities_to_exclude=None, pt_min = None):
         if not sample_group or sample_group not in self.card_tool.procGroups:
             logger.warning(f"Skipping QCD scale syst '{self.minnlo_unc}' for group '{sample_group}.' No process to apply it to")
@@ -174,6 +177,9 @@ class TheoryHelper(object):
 
         # skip nominal
         skip_entries.append({"vars" : "nominal"})
+
+        # skip pythia shower and kt variations since they are handled elsewhere
+        skip_entries.append({"vars" : "pythia_shower_kt"})
 
         if helicities_to_exclude:
             for helicity in helicities_to_exclude:
@@ -231,7 +237,7 @@ class TheoryHelper(object):
                 symmetrize = "quadratic",
                 processes=[sample_group],
                 group=group_name,
-                splitGroup={"QCDscale": ".*", "pTModeling" : ".*", "theory": ".*"},
+                splitGroup={"QCDscale": ".*", "angularCoeffs" : ".*", "theory": ".*"},
                 systAxes=syst_axes,
                 labelsByAxis=syst_ax_labels,
                 skipEntries=skip_entries,
@@ -240,6 +246,24 @@ class TheoryHelper(object):
                 passToFakes=self.propagate_to_fakes,
                 rename=base_name, # Needed to allow it to be called multiple times
             )
+
+    def add_helicity_shower_kt_uncertainty(self):
+        # select the proper variation and project over gen pt unless it is one of the fit variables
+        if "ptVgen" in self.card_tool.fit_axes:
+            op = lambda h: h[{self.syst_ax : ["pythia_shower_kt"]}]
+        else:
+            op = lambda h: h[{"ptVgen" : hist.sum, self.syst_ax : ["pythia_shower_kt"]}]
+
+        self.card_tool.addSystematic(name="qcdScaleByHelicity",
+            processes=['wtau_samples', 'single_v_nonsig_samples'] if self.skipFromSignal else ['single_v_samples'],
+            passToFakes=self.propagate_to_fakes,
+            systAxes=[self.syst_ax],
+            preOp=op,
+            group="helicity_shower_kt",
+            splitGroup={"angularCoeffs": ".*", "theory": ".*"},
+            rename="helicity_shower_kt",
+            mirror=True,
+        )
 
     def add_scetlib_dyturbo_scale_uncertainty(self, extra_name="", transition = True, rebin_pt=None):
         obs = self.card_tool.fit_axes[:]

--- a/wremnants/include/csVariables.h
+++ b/wremnants/include/csVariables.h
@@ -78,5 +78,30 @@ CSVars csSineCosThetaPhi(const PtEtaPhiMVector &antilepton, const PtEtaPhiMVecto
     return angles;
 }
 
+CSVars csSineCosThetaPhiTransported(const PtEtaPhiMVector &antilepton, const PtEtaPhiMVector &lepton, const PtEtaPhiMVector &targetV) {
+    const PxPyPzEVector lepton_v(lepton);
+    const PxPyPzEVector anti_lepton_v(antilepton);
+    const PxPyPzEVector dilepton = lepton_v + anti_lepton_v;
+
+    // boost to rest frame of dilepton system
+    auto const dilepCM = dilepton.BoostToCM();
+    const ROOT::Math::Boost dilepCMBoost(dilepCM);
+
+    auto const lepton_boost = dilepCMBoost(lepton_v);
+    auto const antilepton_boost = dilepCMBoost(anti_lepton_v);
+
+    // boost from rest frame of target back to lab frame
+    auto const targetCM = targetV.BoostToCM();
+    const ROOT::Math::Boost labBoost(-targetCM);
+
+    auto const lepton_target = labBoost(lepton_boost);
+    auto const antilepton_target = labBoost(antilepton_boost);
+
+    // finally compute cs variables
+    return csSineCosThetaPhi(PtEtaPhiMVector(antilepton_target), PtEtaPhiMVector(lepton_target));
+
+
+}
+
 }
 #endif

--- a/wremnants/include/csVariables.h
+++ b/wremnants/include/csVariables.h
@@ -52,8 +52,10 @@ CSVars csSineCosThetaPhi(const PtEtaPhiMVector &antilepton, const PtEtaPhiMVecto
     PxPyPzEVector dilepton = lepton_v + PxPyPzEVector(antilepton);
     const int zsign = std::copysign(1.0, dilepton.z());
     const double energy = 6500.;
-    PxPyPzEVector proton1(0., 0., zsign * energy, energy);
-    PxPyPzEVector proton2(0., 0., -1. * zsign * energy, energy);
+    const double mp = 0.93827208816;
+    const double pbeam = std::sqrt(energy*energy - mp*mp);
+    PxPyPzEVector proton1(0., 0., zsign * pbeam, energy);
+    PxPyPzEVector proton2(0., 0., -1. * zsign * pbeam, energy);
 
     auto dilepCM = dilepton.BoostToCM();
     ROOT::Math::Boost dilepCMBoost(dilepCM);

--- a/wremnants/include/theoryTools.h
+++ b/wremnants/include/theoryTools.h
@@ -335,6 +335,32 @@ ROOT::Math::PxPyPzEVector ewGenVPhos(const ROOT::VecOps::RVec<PxPyPzEVector>& le
 }
 
 
+int selectGenPart(const ROOT::VecOps::RVec<int>& status, const ROOT::VecOps::RVec<int>& pdgId, const int absPdgIdMin, const int absPdgIdMax, const int statusMin, const int statusMax, bool require = true) {
+
+
+  const std::size_t ngenparts = status.size();
+
+  int selidx = -1;
+  int selstatus = -1;
+  for (std::size_t i = 0; i < ngenparts; ++i) {
+    const int &istatus = status[i];
+    const int &iabsPdgId = std::abs(pdgId[i]);
+
+    if (iabsPdgId >= absPdgIdMin && iabsPdgId <= absPdgIdMax && istatus >= statusMin && istatus <= statusMax && istatus > selstatus) {
+      selidx = i;
+      selstatus = istatus;
+    }
+  }
+
+  if (require and selidx == -1) {
+    throw std::runtime_error("Expected to find a gen particle matching the criteria, but did not.");
+  }
+
+  return selidx;
+
+}
+
+
 } 
 
 #endif

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -918,25 +918,28 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
         helicity_moments_scale = df.HistoBoost("nominal_gen_helicity_moments_scale", axes, [*cols, "helicity_moments_scale_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
         results.append(helicity_moments_scale)
 
-        df = df.Define("helicity_moments_scale_lhe_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhilhe, scaleWeights_tensor, nominal_weight)")
-        lhe_cols = ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe"]
-        helicity_moments_scale_lhe = df.HistoBoost("nominal_gen_helicity_moments_scale_lhe", axes, [*lhe_cols, "helicity_moments_scale_lhe_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
-        results.append(helicity_moments_scale_lhe)
+        # below logic only valid for specific columns
+        if cols == ["massVgen", "absYVgen", "ptVgen", "chargeVgen"]:
 
-        df = df.Define("helicity_moments_scale_hardProcess_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhihardProcess, scaleWeights_tensor, nominal_weight)")
-        hardProcess_cols = ["massVhardProcess", "absYVhardProcess", "ptVhardProcess", "chargeVhardProcess"]
-        helicity_moments_scale_hardProcess = df.HistoBoost("nominal_gen_helicity_moments_scale_hardProcess", axes, [*hardProcess_cols, "helicity_moments_scale_hardProcess_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
-        results.append(helicity_moments_scale_hardProcess)
+            df = df.Define("helicity_moments_scale_lhe_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhilhe, scaleWeights_tensor, nominal_weight)")
+            lhe_cols = ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe"]
+            helicity_moments_scale_lhe = df.HistoBoost("nominal_gen_helicity_moments_scale_lhe", axes, [*lhe_cols, "helicity_moments_scale_lhe_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+            results.append(helicity_moments_scale_lhe)
 
-        df = df.Define("helicity_moments_scale_postShower_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostShower, scaleWeights_tensor, nominal_weight)")
-        postShower_cols = ["massVpostShower", "absYVpostShower", "ptVpostShower", "chargeVpostShower"]
-        helicity_moments_scale_postShower = df.HistoBoost("nominal_gen_helicity_moments_scale_postShower", axes, [*postShower_cols, "helicity_moments_scale_postShower_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
-        results.append(helicity_moments_scale_postShower)
+            df = df.Define("helicity_moments_scale_hardProcess_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhihardProcess, scaleWeights_tensor, nominal_weight)")
+            hardProcess_cols = ["massVhardProcess", "absYVhardProcess", "ptVhardProcess", "chargeVhardProcess"]
+            helicity_moments_scale_hardProcess = df.HistoBoost("nominal_gen_helicity_moments_scale_hardProcess", axes, [*hardProcess_cols, "helicity_moments_scale_hardProcess_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+            results.append(helicity_moments_scale_hardProcess)
 
-        df = df.Define("helicity_moments_scale_postBeamRemnants_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostBeamRemnants, scaleWeights_tensor, nominal_weight)")
-        postBeamRemnants_cols = ["massVpostBeamRemnants", "absYVpostBeamRemnants", "ptVpostBeamRemnants", "chargeVpostBeamRemnants"]
-        helicity_moments_scale_postBeamRemnants = df.HistoBoost("nominal_gen_helicity_moments_scale_postBeamRemnants", axes, [*postBeamRemnants_cols, "helicity_moments_scale_postBeamRemnants_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
-        results.append(helicity_moments_scale_postBeamRemnants)
+            df = df.Define("helicity_moments_scale_postShower_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostShower, scaleWeights_tensor, nominal_weight)")
+            postShower_cols = ["massVpostShower", "absYVpostShower", "ptVpostShower", "chargeVpostShower"]
+            helicity_moments_scale_postShower = df.HistoBoost("nominal_gen_helicity_moments_scale_postShower", axes, [*postShower_cols, "helicity_moments_scale_postShower_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+            results.append(helicity_moments_scale_postShower)
+
+            df = df.Define("helicity_moments_scale_postBeamRemnants_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostBeamRemnants, scaleWeights_tensor, nominal_weight)")
+            postBeamRemnants_cols = ["massVpostBeamRemnants", "absYVpostBeamRemnants", "ptVpostBeamRemnants", "chargeVpostBeamRemnants"]
+            helicity_moments_scale_postBeamRemnants = df.HistoBoost("nominal_gen_helicity_moments_scale_postBeamRemnants", axes, [*postBeamRemnants_cols, "helicity_moments_scale_postBeamRemnants_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+            results.append(helicity_moments_scale_postBeamRemnants)
 
     if for_wmass or isZ:
         logger.debug(f"Make QCD scale histograms for {dataset_name}")

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -918,6 +918,26 @@ def add_theory_hists(results, df, args, dataset_name, corr_helpers, qcdScaleByHe
         helicity_moments_scale = df.HistoBoost("nominal_gen_helicity_moments_scale", axes, [*cols, "helicity_moments_scale_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
         results.append(helicity_moments_scale)
 
+        df = df.Define("helicity_moments_scale_lhe_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhilhe, scaleWeights_tensor, nominal_weight)")
+        lhe_cols = ["massVlhe", "absYVlhe", "ptVlhe", "chargeVlhe"]
+        helicity_moments_scale_lhe = df.HistoBoost("nominal_gen_helicity_moments_scale_lhe", axes, [*lhe_cols, "helicity_moments_scale_lhe_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+        results.append(helicity_moments_scale_lhe)
+
+        df = df.Define("helicity_moments_scale_hardProcess_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhihardProcess, scaleWeights_tensor, nominal_weight)")
+        hardProcess_cols = ["massVhardProcess", "absYVhardProcess", "ptVhardProcess", "chargeVhardProcess"]
+        helicity_moments_scale_hardProcess = df.HistoBoost("nominal_gen_helicity_moments_scale_hardProcess", axes, [*hardProcess_cols, "helicity_moments_scale_hardProcess_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+        results.append(helicity_moments_scale_hardProcess)
+
+        df = df.Define("helicity_moments_scale_postShower_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostShower, scaleWeights_tensor, nominal_weight)")
+        postShower_cols = ["massVpostShower", "absYVpostShower", "ptVpostShower", "chargeVpostShower"]
+        helicity_moments_scale_postShower = df.HistoBoost("nominal_gen_helicity_moments_scale_postShower", axes, [*postShower_cols, "helicity_moments_scale_postShower_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+        results.append(helicity_moments_scale_postShower)
+
+        df = df.Define("helicity_moments_scale_postBeamRemnants_tensor", "wrem::makeHelicityMomentScaleTensor(csSineCosThetaPhipostBeamRemnants, scaleWeights_tensor, nominal_weight)")
+        postBeamRemnants_cols = ["massVpostBeamRemnants", "absYVpostBeamRemnants", "ptVpostBeamRemnants", "chargeVpostBeamRemnants"]
+        helicity_moments_scale_postBeamRemnants = df.HistoBoost("nominal_gen_helicity_moments_scale_postBeamRemnants", axes, [*postBeamRemnants_cols, "helicity_moments_scale_postBeamRemnants_tensor"], tensor_axes = [axis_helicity, *theory_tools.scale_tensor_axes], storage=hist.storage.Double())
+        results.append(helicity_moments_scale_postBeamRemnants)
+
     if for_wmass or isZ:
         logger.debug(f"Make QCD scale histograms for {dataset_name}")
         # there is no W backgrounds for the Wlike, make QCD scale histograms only for Z

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -276,7 +276,7 @@ def make_qcd_uncertainty_helper_by_helicity(is_w_like = False, filename=None):
     moments_lhe = hh.rebinHist(moments_lhe, "ptVgen", common.ptV_binning)
 
     if is_w_like:
-        axis_massVgen = moments.axis["massVgen"]
+        axis_massVgen = moments.axes["massVgen"]
         moments = hh.rebinHist(moments, "massVgen", axis_massVgen.edges[::2])
         moments_lhe = hh.rebinHist(moments_lhe, "massVgen", axis_massVgen.edges[::2])
 

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -303,7 +303,11 @@ def define_lhe_vars(df, mode=None):
     df = df.Define("csCosThetalhe", "csSineCosThetaPhilhe.costheta")
     df = df.Define("csPhilhe", "csSineCosThetaPhilhe.phi()")
     df = df.Define("csAngularMomentslhe", "wrem::csAngularMoments(csSineCosThetaPhilhe)")
-    df = df.Define("csAngularMomentslhe_wnom", "auto res = csAngularMomentslhe; res = LHEWeight_originalXWGTUP*res; return res;")
+
+    if "LHEWeight_originalXWGTUP" in df.GetColumnNames():
+        df = df.Define("csAngularMomentslhe_wnom", "auto res = csAngularMomentslhe; res = LHEWeight_originalXWGTUP*res; return res;")
+    else:
+        df = df.Alias("csAngularMomentslhe_wnom", "csAngularMomentslhe")
 
     return df
 


### PR DESCRIPTION
This fixes a serious bug in the construction of the helicity moments histograms where all of the alternate electroweak samples were accidentally being summed together with the signal samples.

The tau samples have now also been removed from the moment calculation since although they were previously included intentionally, small differences in angular coefficients have been observed, likely due to momentum reshuffling when pythia adds the tau mass.

In addition to the above critical update of the inputs used to construct the QCD scale variations split by helicity, the binning for the weight computation is also slightly refined.  (The ptV binning for the actual uncertainties is unchanged.)

An additional uncertainty has been added for the difference in angular coefficients at preFSR vs LHE level, since in particular the pythia beam remnants/intrinsic kT treatment was found to introduce significant differences.

