### PR TITLE
Remove double counting between inclusive and binned QCD scale variations and add inclusive variation for polynomial case

### DIFF
--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -422,7 +422,7 @@ class TheoryHelper(object):
             preOp=lambda h: h[{self.syst_ax : var_vals}],
             outNames=var_names,
             group="resumNonpert",
-            splitGroup={"resum": ".*", "theory": ".*"},
+            splitGroup={"resum": ".*", "pTModeling" : ".*", "theory": ".*"},
             rename="scetlibNP",
         )
 
@@ -440,7 +440,7 @@ class TheoryHelper(object):
         card_tool.addSystematic(name=theory_hist,
             processes=self.samples,
             group="resumScale",
-            splitGroup={"resum": ".*", "theory": ".*"},
+            splitGroup={"resum": ".*", "pTModeling" : ".*", "theory": ".*"},
             passToFakes=to_fakes,
             skipEntries=[{syst_ax : x} for x in both_exclude+tnp_nuisances],
             systAxes=["downUpVar"], # Is added by the preOpMap
@@ -453,6 +453,7 @@ class TheoryHelper(object):
         card_tool.addSystematic(name=theory_hist,
             processes=self.samples,
             group="resumScale",
+            splitGroup={"resum": ".*", "pTModeling" : ".*", "theory": ".*"},
             splitGroup={"resum": ".*", "theory": ".*"},
             passToFakes=to_fakes,
             systAxes=["vars"],
@@ -504,7 +505,7 @@ class TheoryHelper(object):
                 self.card_tool.addSystematic(name=self.np_hist_name,
                     processes=[sample_group],
                     group="resumNonpert",
-                    splitGroup={"resum": ".*", "theory": ".*"},
+                    splitGroup={"resum": ".*", "pTModeling" : ".*", "theory": ".*"},
                     systAxes=syst_axes,
                     passToFakes=self.propagate_to_fakes,
                     preOp=operation,


### PR DESCRIPTION
Previously the inclusive scale variation was just added on top of the binned ones.  Since there are only 10 bins, this in principle results in an overestimate of the fully correlated component by ~5%, which is removed by scaling down the inclusive variation by the corresponding amount.

The appropriate inclusive variation is also added on top of the polynomial scale variations when these are used (though this may be replaced with an inclusive variation from the polynomials themselves at some point)

There were also some cases where theory uncertainties were not being added to the appropriate groups, which is improved now (but a broader harmonization of the groups with some kind of coherent naming scheme would be very good indeed)