### PR TITLE
Applies new pdf as multiplicative correction (not absolute) for alphaS

### DIFF
--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -189,7 +189,6 @@ def expand_pdf_entries(pdf, alphas=False, renorm=False):
         vals = [f"std::clamp<float>({x}/{vals[0]}*central_pdf_weight, -theory_weight_truncate, theory_weight_truncate)" for x in vals]
     else:
         vals = [f"std::clamp<float>({x}, -theory_weight_truncate, theory_weight_truncate)" for x in vals]
-
     return vals
 
 def define_scale_tensor(df):
@@ -206,7 +205,7 @@ theory_corr_weight_map = {
         "scetlib_dyturboMSHT20_pdfas" : expand_pdf_entries("msht20", alphas=True),
         "scetlib_dyturboMSHT20Vars" : expand_pdf_entries("msht20"),
         "scetlib_dyturboCT18ZVars" : expand_pdf_entries("ct18z"),
-        "scetlib_dyturboCT18Z_pdfas" : expand_pdf_entries("ct18z", alphas=True),
+        "scetlib_dyturboCT18Z_pdfas" : expand_pdf_entries("ct18z", alphas=True, renorm=True),
         "scetlib_dyturboMSHT20an3lo_pdfas" : expand_pdf_entries("msht20an3lo", alphas=True),
         "scetlib_dyturboMSHT20an3loVars" : expand_pdf_entries("msht20an3lo"),
         # Tested this, better not to treat this way unless using MSHT20nnlo as central set
@@ -675,7 +674,6 @@ def define_theory_corr_weight_column(df, generator):
             "; return res;")
     else:
         df = df.Alias(f"{generator}_corr_weight", "nominal_weight_uncorr")
-
     return df
 
 def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_central_weight, isW, storage_type=hist.storage.Double()):


### PR DESCRIPTION
Updated the variation in alphaS to have renorm = True. Previously, this correction on non-CT18Z default pdf sets was not multiplicative (see here, with running on nnpdf31 set/lowPU conditions):
<img src="https://github.com/WMass/WRemnants/assets/62822528/1dd896e7-8a9d-4457-a603-057357649639" width="300"/>


After the edit is applied, alphaS is centered:
<img src="https://github.com/WMass/WRemnants/assets/62822528/a41700ac-ee0c-4300-8d98-ad61b5600e8b" width="300"/>