### PR TITLE
Restructure helicity utilities

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -686,9 +686,9 @@ def build_graph(df, dataset):
 
             # Don't think it makes sense to apply the mass weights to scale leptons from tau decays
             if not args.onlyTheorySyst and not "tau" in dataset.name:
-                syst_tools.add_muonscale_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols, storage_type=storage_type)
+                df = syst_tools.add_muonscale_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols, storage_type=storage_type)
                 if args.muonScaleVariation == 'smearingWeightsGaus':
-                    syst_tools.add_muonscale_smeared_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols_gen_smeared, storage_type=storage_type)
+                    df = syst_tools.add_muonscale_smeared_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols_gen_smeared, storage_type=storage_type)
 
             ####################################################
             # nuisances from the muon momemtum scale calibration 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -652,11 +652,10 @@ def build_graph(df, dataset):
             results.append(yieldsForWeffMC)
 
         if not args.noRecoil and args.recoilUnc:
-            df = recoilHelper.add_recoil_unc_W(df, results, dataset, cols, axes, "nominal", storage_type=storage_type)
+            df = recoilHelper.add_recoil_unc_W(df, results, dataset, cols, axes, base_name="nominal", storage_type=storage_type)
         if apply_theory_corr:
-            results.extend(theory_tools.make_theory_corr_hists(df, "nominal", axes, cols, corr_helpers[dataset.name], theory_corrs, 
+            syst_tools.add_theory_corr_hists(results, df, axes, cols, corr_helpers[dataset.name], theory_corrs, base_name="nominal", 
                 modify_central_weight=not args.theoryCorrAltOnly, isW = isW, storage_type=storage_type)
-            )
         if isWorZ:
             cols_gen, cols_gen_smeared = muon_calibration.make_alt_reco_and_gen_hists(df, results, axes, cols, reco_sel_GF)
             if args.validationHists: 
@@ -687,9 +686,9 @@ def build_graph(df, dataset):
 
             # Don't think it makes sense to apply the mass weights to scale leptons from tau decays
             if not args.onlyTheorySyst and not "tau" in dataset.name:
-                df = syst_tools.add_muonscale_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols, storage_type=storage_type)
+                syst_tools.add_muonscale_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols, storage_type=storage_type)
                 if args.muonScaleVariation == 'smearingWeightsGaus':
-                    df = syst_tools.add_muonscale_smeared_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols_gen_smeared, storage_type=storage_type)
+                    syst_tools.add_muonscale_smeared_hist(results, df, args.muonCorrEtaBins, args.muonCorrMag, isW, axes, cols_gen_smeared, storage_type=storage_type)
 
             ####################################################
             # nuisances from the muon momemtum scale calibration 

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -55,61 +55,15 @@ def makehelicityWeightHelper(is_w_like = False, filename=None):
 
     return makeCorrectionsTensor(corrh_noerrs, ROOT.wrem.WeightByHelicityHelper, tensor_rank=1)
 
-#Muon eff vars
-def make_muon_eff_stat_helpers_helicity(helper_stat, nhelicity=6):
-    axes = helper_stat.tensor_axes
-    nEta = axes[0].size
-    nPt = axes[1].size
-    nCharge = axes[2].size
-    helper_stat = ROOT.wrem.muon_eff_helper_stat_helicity[nEta, nPt, nCharge, nhelicity]()
+def make_helper_helicity(axes, nhelicity=6):
+    """
+    Converts axes into tensor axes expanded by the helicity tensor
+    """
+    ndim = len(axes)
+    shape = [a.size for a in axes]
+    try:
+        helper = ROOT.wrem.tensor_helper_helicity[ndim, nhelicity, *shape]()
+    except Exception as e:
+        logger.warning(f"An error occurred while trying to create a helicity tensor helper: {e}")
     tensor_axes = [axis_helicity_multidim, *axes]
-
-    return helper_stat, tensor_axes
-
-#1D tensor
-# axis_all = hist.axis.Integer(0, 5, underflow = False, overflow = False, name = "reco-tracking-idip-trigger-iso")
-def make_muon_eff_syst_helper_helicity(helper_syst, nhelicity=6):
-    nsize=helper_syst.tensor_axes[0].size
-    nvars=helper_syst.tensor_axes[1].size
-    helper_syst_helicity=ROOT.wrem.tensorRank2_helper_helicity[nsize, nvars, nhelicity]()
-    tensor_axes=[axis_helicity_multidim, *helper_syst.tensor_axes]
-    return helper_syst_helicity, tensor_axes
-
-#mass weights
-def make_massweight_helper_helicity(mass_axis, nhelicity=9):
-    tensor_axes=[axis_helicity_multidim, mass_axis]
-    helper = ROOT.wrem.tensor1D_helper_helicity[mass_axis.size, nhelicity]()
-    return helper, tensor_axes
-
-#muon prefire
-#this is helcity X <up/down> 
-def make_muon_prefiring_helper_syst_byHelicity(nhelicity=6):
-    helper_syst = ROOT.wrem.tensor1D_helper_helicity[2, nhelicity]()
-    axis_tensor = [axis_helicity_multidim, common.down_up_axis]
-    return helper_syst, axis_tensor
-
-#this is helicity X <Neta,2> type
-def make_muon_prefiring_helper_stat_byHelicity(helper_stat, nhelicity=6):
-    nEta = helper_stat.tensor_axes[0].size
-    helper_stat_helicity = ROOT.wrem.tensorupdownvar_helper_helicity[nEta, nhelicity]()
-    tensor_axes = [axis_helicity_multidim, *helper_stat.tensor_axes]
-    return helper_stat_helicity, tensor_axes
-
-
-#for muonscale_hist
-def make_dummymuonscale_helper_helicity(nweights, netabins, haxes,nhelicity=6):
-    helper = ROOT.wrem.tensorRank2_helper_helicity[nweights, netabins, nhelicity]()
-    tensor_axes = [axis_helicity_multidim, *haxes]
-    return helper, tensor_axes
-
-##for pdf
-def make_pdfweight_helper_helicity(npdf, pdf_axes, nhelicity=6):
-    helper=ROOT.wrem.tensor1D_helper_helicity[npdf, nhelicity]()
-    tensor_axes=[axis_helicity_multidim,pdf_axes]
-    return helper, tensor_axes
-
-#for qcd scale
-def make_qcdscale_helper_helicity(qcd_axes,nhelicity=6):
-    helper = ROOT.wrem.tensorRank2_helper_helicity[3, 3, nhelicity]()
-    tensor_axes = [axis_helicity_multidim, *qcd_axes]
     return helper, tensor_axes

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -6,79 +6,28 @@
 #include "theory_corrections.h"
 
 namespace wrem {
-
-  //class to expand the muon eff stat var tensor with helcitity weights
-template <std::size_t nEta, std::size_t nPt, std::size_t ch, std::size_t nhelicity>
-class muon_eff_helper_stat_helicity {  
- public:
-  using eff_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nEta, nPt, ch>>;
-  using hel_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity>>;
-  using value_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, nEta, nPt, ch>>;
-  
-  muon_eff_helper_stat_helicity() {}
-  
-  value_t operator() (const eff_t& et, const hel_t& ht) {
-    constexpr std::array<Eigen::Index, 4> broadcastEff = { 1, nEta, nPt, ch};
-    constexpr std::array<Eigen::Index, 4> broadcasthelicities = { nhelicity, 1, 1, 1};
-    auto shape3 = ht.reshape(broadcasthelicities).broadcast(broadcastEff);
-    auto shape4 = et.reshape(broadcastEff).broadcast(broadcasthelicities);
-    return shape3*shape4;
-  }
-};
  
-//class to expand a rank 1 tensor with helicity weights
-template <std::size_t nSize, std::size_t nhelicity>
-class tensor1D_helper_helicity {  
+//class to expand a rank N tensor with helicity weights
+template <std::size_t Rank, std::size_t nhelicity, std::size_t... Dims>
+class tensor_helper_helicity {
  public:
-  using tensor1D_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nSize>>;
-  using hel_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity>>;
-  using value_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, nSize>>;
-  
-  tensor1D_helper_helicity() {}
-  
-  value_t operator() (const tensor1D_t& et, const hel_t& ht) {
-    constexpr std::array<Eigen::Index, 2> broadcastEff = { 1, nSize };
-    constexpr std::array<Eigen::Index, 2> broadcasthelicities = { nhelicity, 1};
-    auto shape3 = ht.reshape(broadcasthelicities).broadcast(broadcastEff);
-    auto shape4 = et.reshape(broadcastEff).broadcast(broadcasthelicities);
-    return shape3*shape4;
+  using value_type = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, Dims...>>;
+  using pref_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<Dims...>>;
+  using hel_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity>>;
+
+  tensor_helper_helicity() {}
+
+  value_type operator()(const pref_tensor& et, const hel_tensor& ht) {
+    constexpr std::array<Eigen::Index, Rank + 1> broadcastpref = {1, Dims...};
+    std::array<Eigen::Index, Rank + 1> broadcasthelicities;
+    broadcasthelicities[0] = nhelicity;
+    std::fill(broadcasthelicities.begin() + 1, broadcasthelicities.end(), 1);
+
+    auto shape3 = ht.reshape(broadcasthelicities).broadcast(broadcastpref);
+    auto shape4 = et.reshape(broadcastpref).broadcast(broadcasthelicities);
+    return shape3 * shape4;
   }
 };
-
-//class to expand a rank 2 tensor of type <NSize,UP/DOWN> by helicity
- template <std::size_t nsize, std::size_t nhelicity>
-class tensorupdownvar_helper_helicity {
- public:
-  using value_type = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, nsize, 2>>;
-  using pref_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<nsize, 2>>;
-  using hel_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity>>;
-  tensorupdownvar_helper_helicity() {}
-  value_type operator() (const pref_tensor &pf, const hel_tensor &ht) const {
-    constexpr std::array<Eigen::Index, 3> broadcasthelicities = { nhelicity, 1, 1};
-    constexpr std::array<Eigen::Index, 3> broadcastpref = { 1, nsize,2};   
-    auto shape5 = pf.reshape(broadcastpref).broadcast(broadcasthelicities);
-    auto shape4 = ht.reshape(broadcasthelicities).broadcast(broadcastpref);
-    return shape4*shape5;
-  }
-}; 
-
-
-//Expand rank two tensor by helicity
- template <std::size_t dim1, std::size_t dim2, std::size_t nhelicity>
-class tensorRank2_helper_helicity {
- public:
-  using value_type = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity, dim1, dim2>>;
-  using pref_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<dim1, dim2>>;
-  using hel_tensor = Eigen::TensorFixedSize<double, Eigen::Sizes<nhelicity>>;
-  tensorRank2_helper_helicity() {}
-  value_type operator() (const pref_tensor &pf, const hel_tensor &ht) const {
-    constexpr std::array<Eigen::Index, 3> broadcasthelicities = { nhelicity, 1, 1};
-    constexpr std::array<Eigen::Index, 3> broadcastpref = { 1, dim1,dim2};   
-    auto shape5 = pf.reshape(broadcastpref).broadcast(broadcasthelicities);
-    auto shape4 = ht.reshape(broadcasthelicities).broadcast(broadcastpref);
-    return shape4*shape5;
-  }
-}; 
 
 Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>> scalarmultiplyHelWeightTensor(double wt, Eigen::TensorFixedSize<double, Eigen::Sizes<NHELICITY>>& helTensor) {
   return wt*helTensor;

--- a/wremnants/muon_calibration.py
+++ b/wremnants/muon_calibration.py
@@ -1315,12 +1315,13 @@ def make_pixel_multiplicity_helpers(filename = f"{common.data_dir}/calibration/p
     h1var = h1.variances(flow=True)
     num = h0val
     den = h0val + h1val
-    p0 = num/den
-    p0var = 1./den**4*(h1val**2*h0var + h0val**2*h1var)
+
+    p0 = np.divide(num, den, out=np.zeros_like(num), where=den!=0)
+    p0var = np.divide(1., den**4, out=np.zeros_like(den), where=den!=0) * (h1val**2*h0var + h0val**2*h1var)
 
     hp0 = hist.Hist(*h0.axes, storage = hist.storage.Weight())
-    hp0.values(flow=True)[...] = np.where(den==0., 0., p0)
-    hp0.variances(flow=True)[...] = np.where(den==0., 0., p0var)
+    hp0.values(flow=True)[...] = p0
+    hp0.variances(flow=True)[...] = p0var
 
     axis_nvalidpixel = hist.axis.Variable([-0.5, 0.5, np.inf], name = "nvalidpixel")
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -657,11 +657,12 @@ def add_luminosity_unc_hists(results, df, args, axes, cols, base_name="nominal",
 
 
 def add_theory_corr_hists(results, df, axes, cols, helpers, generators, modify_central_weight, isW, base_name="nominal", **kwargs):
-    results = []
-    
+   
     for i, generator in enumerate(generators):
         if generator not in helpers:
             continue
+
+        logger.debug(f"Now ar generator {i}: {generator}")
         
         if i == 0 and modify_central_weight:
             add_syst_hist(results, df, f"{base_name}_uncorr", axes, cols, "nominal_weight_uncorr", **kwargs)
@@ -867,6 +868,8 @@ def add_muonscale_hist(results, df, netabins, mag, isW, axes, cols, base_name="n
     name = Datagroups.histName(base_name, syst=f"muonScaleSyst")
     add_syst_hist(results, df, name, axes, cols, f"muonScaleDummy{netabins}Bins{muon_eta}", [common.down_up_axis, scale_etabins_axis], **kwargs)
 
+    return df
+
 
 def add_muonscale_smeared_hist(results, df, netabins, mag, isW, axes, cols, base_name="nominal", muon_eta="goodMuons_eta0", *kwargs):
     # add_muonscale_hist has to be called first such that "muonScaleDummy{netabins}Bins{muon_eta}" is defined
@@ -875,6 +878,8 @@ def add_muonscale_smeared_hist(results, df, netabins, mag, isW, axes, cols, base
     scale_etabins_axis = hist.axis.Regular(netabins, -2.4, 2.4, name="scaleEtaSlice", underflow=False, overflow=False)
     name = Datagroups.histName(base_name, syst="muonScaleSyst_gen_smear")
     add_syst_hist(results, df, name, axes, cols, f"muonScaleDummy{netabins}Bins{muon_eta}", [common.down_up_axis, scale_etabins_axis], **kwargs)
+
+    return df
 
 
 def scetlib_scale_unc_hist(h, obs, syst_ax="vars"):

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -26,9 +26,6 @@ axis_absYVgen = hist.axis.Variable(
     name = "absYVgenNP", underflow=False
 )
 
-axis_chargeWgen = hist.axis.Regular(2, -2, 2, name="chargeVgenNP", underflow=False, overflow=False)
-axis_chargeZgen = hist.axis.Integer(0, 1, name="chargeVgenNP", underflow=False, overflow=False)
-
 scale_tensor_axes = (axis_muRfact, axis_muFfact)
 
 pdfMap = {
@@ -678,84 +675,6 @@ def define_theory_corr_weight_column(df, generator):
 
     return df
 
-def make_theory_corr_hists(df, name, axes, cols, helpers, generators, modify_central_weight, isW, storage_type=hist.storage.Double()):
-    res = []
-    
-    for i, generator in enumerate(generators):
-        if generator not in helpers:
-            continue
-        
-        if i == 0 and modify_central_weight:
-            res.append(df.HistoBoost(f"{name}_uncorr", axes, [*cols, "nominal_weight_uncorr"], storage=storage_type))
-            if name == "nominal":
-                res.append(df.HistoBoost(f"weight_uncorr", [hist.axis.Regular(100, -2, 2)], ["nominal_weight_uncorr"], storage=storage_type))
-
-        var_axis = helpers[generator].tensor_axes[-1]
-
-        hist_name = f"{name}_{generator}Corr"
-        weight_tensor_name = f"{generator}Weight_tensor"
-        unc = df.HistoBoost(hist_name, axes, [*cols, weight_tensor_name], tensor_axes=[var_axis], storage=storage_type)
-        res.append(unc)
-
-        def is_flavor_dependent_np(var_label):
-            return var_label.startswith("Omega") \
-                    or var_label.startswith("Delta_Omega") \
-                    or var_label.startswith("Lambda2") \
-                    or var_label.startswith("Delta_Lambda2") \
-                    or var_label.startswith("Lambda4")
-
-        # special treatment for Lambda2/Omega since they need to be decorrelated in charge and possibly rapidity
-        if isinstance(var_axis, hist.axis.StrCategory) and any(is_flavor_dependent_np(var_label) for var_label in var_axis):
-            omegaidxs = [var_axis.index(var_label) for var_label in var_axis if is_flavor_dependent_np(var_label)]
-
-            # include nominal as well
-            omegaidxs = [0] + omegaidxs
-
-            if f"{generator}FlavDepNP" not in df.GetColumnNames():
-                np_idx_helper = ROOT.wrem.index_taker[df.GetColumnType(weight_tensor_name), len(omegaidxs)](omegaidxs)
-
-                df = df.Define(f"{generator}FlavDepNP", np_idx_helper, [weight_tensor_name])
-
-            axis_FlavDepNP = hist.axis.StrCategory([var_axis[idx] for idx in omegaidxs], name = var_axis.name)
-
-            hist_name_FlavDepNP = f"{name}_{generator}FlavDepNP"
-            axis_chargegen = axis_chargeWgen if isW else axis_chargeZgen
-            axes_FlavDepNP = axes + [axis_absYVgen, axis_chargegen]
-            cols_FlavDepNP = cols + ["absYVgen", "chargeVgen", f"{generator}FlavDepNP"]
-            unc_FlavDepNP = df.HistoBoost(hist_name_FlavDepNP, axes_FlavDepNP, cols_FlavDepNP, tensor_axes = [axis_FlavDepNP])
-            res.append(unc_FlavDepNP)
-
-        def is_pt_dependent_scale(var_label):
-            return var_label.startswith("renorm_fact_resum_transition_scale_envelope") \
-                    or var_label.startswith("renorm_fact_resum_scale_envelope")
-
-        # special treatment for envelope of scale variations since they need to be decorrelated in pt
-        if isinstance(var_axis, hist.axis.StrCategory) and any(is_pt_dependent_scale(var_label) for var_label in var_axis):
-
-            scaleidxs = [var_axis.index(var_label) for var_label in var_axis if is_pt_dependent_scale(var_label)]
-
-            # include nominal as well
-            scaleidxs = [0] + scaleidxs
-
-            if f"{generator}PtDepScales" not in df.GetColumnNames():
-                scale_idx_helper = ROOT.wrem.index_taker[df.GetColumnType(weight_tensor_name), len(scaleidxs)](scaleidxs)
-
-                df = df.Define(f"{generator}PtDepScales", scale_idx_helper, [weight_tensor_name])
-
-            axis_PtDepScales = hist.axis.StrCategory([var_axis[idx] for idx in scaleidxs], name = var_axis.name)
-
-            hist_name_PtDepScales = f"{name}_{generator}PtDepScales"
-            axis_ptVgen = hist.axis.Variable(common.ptV_binning, name = "ptVgen", underflow=False)
-
-            axes_PtDepScales = axes[:]
-            cols_PtDepScales = cols[:]
-            if "ptVgen" not in cols:
-                axes_PtDepScales += [axis_ptVgen]
-                cols_PtDepScales += ["ptVgen", f"{generator}PtDepScales"]
-            unc_PtDepScales = df.HistoBoost(hist_name_PtDepScales, axes_PtDepScales, cols_PtDepScales, tensor_axes = [axis_PtDepScales])
-            res.append(unc_PtDepScales)
-
-    return res
 
 def replace_by_neighbors(vals, replace):
     if np.count_nonzero(replace) == vals.size:


### PR DESCRIPTION
Currently, we have a separate helper for each systematic uncertainty to add the helicity axis. In this PR I replaced most of it by generic functions to more easily add systematic in the future and maintain the cases with and without helicity axis. 

I also made a small modification in the [muon_calibration.py](https://github.com/WMass/WRemnants/compare/main...davidwalter2:240627_restructure_helicity_utils?expand=1#diff-bd883547941e3fe5de15db4ea2f5a7a72f6a7f5f012d27dd2d426b7295c0f7a7) to avoid the division by 0 warning when running the histmaker.