### PR TITLE
Reduce default bins in mt and iso for abcd method

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -118,7 +118,8 @@ axis_fakes_eta = hist.axis.Regular(int((template_maxeta-template_mineta)*10/2), 
 axis_fakes_pt = hist.axis.Variable(common.get_binning_fakes_pt(template_minpt, template_maxpt), name = "pt", overflow=False, underflow=False)
 
 axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min), name = "mt", underflow=False, overflow=True)
-axes_abcd = [axis_mtCat, common.axis_relIsoCat]
+axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(), name = "relIso",underflow=False, overflow=True)
+axes_abcd = [axis_mtCat, axis_isoCat]
 axes_fakerate = [axis_fakes_eta, axis_fakes_pt, axis_charge, *axes_abcd]
 columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "transverseMass", "goodMuons_relIso0"]
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -114,6 +114,7 @@ axis_passMT = hist.axis.Boolean(name = passMTName)
 axis_isoCat = hist.axis.Variable([0,4,8], name = "iso",underflow=False, overflow=True)
 axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=False, overflow=True)
 
+
 def get_binning_fakes_pt(min_pt, max_pt):
     edges = np.arange(min_pt,32,1)
     edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
@@ -127,13 +128,26 @@ def get_binning_fakes_pt(min_pt, max_pt):
     #edges = np.append(edges, [max_pt])
     return edges
 
-def get_binning_fakes_mt(mt_cut=40):
+
+def get_binning_fakes_mt(mt_cut=40, high_mt_bins=False):
     edges = np.array([0, int(mt_cut/2.), mt_cut])
-    edges = np.append(edges, [e for e in [30,32,34,36,38,40,44,49,55,62] if e>mt_cut])
+    if high_mt_bins:
+        # needed for extended 2D method
+        edges = np.append(edges, [e for e in [30,32,34,36,38,40,44,49,55,62] if e>mt_cut])
     return edges
+
+
+def get_binning_fakes_relIso(high_iso_bins=False):
+    edges = [0,0.15]
+    if high_iso_bins:
+        # needed for extended 2D method
+        edges.append(0.3)
+    return edges
+
 
 def get_dilepton_ptV_binning(fine=False):
     return [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 20, 23, 27, 32, 40, 54, 100] if not fine else range(60)
+
 
 def get_gen_axes(flow=False, dilepton_ptV_binning=None, inclusive=False):
     if dilepton_ptV_binning is None:
@@ -148,6 +162,7 @@ def get_gen_axes(flow=False, dilepton_ptV_binning=None, inclusive=False):
         gen_axes["absYVGen"] = hist.axis.Variable(binning, name="absYVGen", underflow=False, overflow=flow)
     return gen_axes
 
+
 def get_default_ptbins(analysis_label, unfolding=False, gen=False):
     vals = [30,26.,56.] if analysis_label[0] == "w" else [34,26.,60.]
     if unfolding and gen:
@@ -161,14 +176,18 @@ def get_default_ptbins(analysis_label, unfolding=False, gen=False):
         vals[1] += 2
     return vals
 
+
 def get_default_etabins(analysis_label=None):
     return (48,-2.4,2.4)
+
 
 def get_default_mtcut(analysis_label=None):
     return 40. if analysis_label[0] == "w" else 45.
 
+
 def get_default_mz_window():
     return 60, 120
+
 
 # following list is used in other scripts to track what steps are charge dependent
 # but assumes the corresponding efficiencies were made that way
@@ -176,12 +195,15 @@ muonEfficiency_chargeDependentSteps = ["reco", "tracking", "idip", "trigger", "a
 muonEfficiency_altBkgSyst_effSteps = ["tracking"]
 muonEfficiency_standaloneNumberOfValidHits = 1 # to use as "var >= this" (if this=0 the define for the cut is not used at all)
 
+
 def getIsoMtRegionID(passIso=True, passMT=True):
     return passIso * 1 + passMT * 2
+
 
 def getIsoMtRegionFromID(regionID):
     return {passIsoName : regionID & 1,
             passMTName  : regionID & 2}
+
 
 def set_parser_default(parser, argument, newDefault):
     # change the default argument of the parser, must be called before parse_arguments
@@ -193,6 +215,7 @@ def set_parser_default(parser, argument, newDefault):
     else:
         logger.warning(f" Parser argument {argument} not found!")
     return parser
+
 
 def set_subparsers(subparser, name, analysis_label):
 
@@ -242,6 +265,7 @@ def set_subparsers(subparser, name, analysis_label):
 
     return subparser
 
+
 def common_histmaker_subparsers(parser, analysis_label):
 
     parser.add_argument("--analysisMode", type=str, default=None,
@@ -256,12 +280,14 @@ def common_histmaker_subparsers(parser, analysis_label):
 
     return parser
 
+
 def base_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", type=int, default=3, choices=[0,1,2,3,4],
                         help="Set verbosity level with logging, the larger the more verbose")
     parser.add_argument("--noColorLogger", action="store_true", help="Do not use logging with colors")
     return parser
+
 
 def common_parser(analysis_label=""):
     for_reco_highPU = "gen" not in analysis_label and "lowpu" not in analysis_label
@@ -417,7 +443,8 @@ def common_parser(analysis_label=""):
     parser.add_argument("--printParser", action=PrintParserAction, help="Print the whole parser with its arguments (use it as the last argument or default values might not be displayed correctly)")
     
     return parser,initargs
-    
+
+
 def plot_parser():
     parser = base_parser()
     parser.add_argument("-o", "--outpath", type=str, default=os.path.expanduser("~/www/WMassAnalysis"), help="Base path for output")
@@ -430,18 +457,23 @@ def plot_parser():
 
     return parser
 
+
 def natural_sort_key(s):
     # Sort string in a number aware way by plitting the string into alphabetic and numeric parts
     parts = re.split(r'(\d+)', s)
     return [int(part) if part.isdigit() else part.lower() for part in parts]
 
+
 def natural_sort(strings):
     return sorted(strings, key=natural_sort_key)
-    
+
+
 def natural_sort_dict(dictionary):
     sorted_keys = natural_sort(dictionary.keys())
     sorted_dict = {key: dictionary[key] for key in sorted_keys}
     return sorted_dict
+
+
 '''
 INPUT -------------------------------------------------------------------------
 |* (str) string: the string to be converted to list
@@ -464,6 +496,7 @@ def string_to_list(string):
             "string_to_list(): cannot convert an input that is"
             "neither a single string nor a list of strings to a list"
         )
+
 
 '''
 INPUT -------------------------------------------------------------------------


### PR DESCRIPTION
Currently, there are several bins in high mT and high Iso that would be needed for the extended 2D ABCD method, but since we are using the extended 1D as default and don't plan to switch to 2D in the near future we can reduce these bins and reduce the histogram size, and with this also resource consumption.