### PR TITLE
Adapt/clarify helicity utilities 

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -15,7 +15,6 @@ isUnfolding = args.analysisMode == "unfolding"
 
 
 import narf
-import wremnants
 from wremnants import theory_tools, syst_tools, theory_corrections, muon_selections, unfolding_tools
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
@@ -58,7 +57,7 @@ axis_iso = hist.axis.Regular(50, 0, 1, underflow=False, overflow=True, name = "i
 
 axis_lin = hist.axis.Regular(5, 0, 5, name = "lin")
 
-qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
+qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 axis_ptVgen = qcdScaleByHelicity_helper.hist.axes["ptVgen"]
 axis_chargeVgen = qcdScaleByHelicity_helper.hist.axes["chargeVgen"]
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -11,7 +11,8 @@ parser,initargs = common.common_parser(analysis_label)
 import ROOT
 import narf
 import wremnants
-from wremnants import theory_tools,syst_tools,theory_corrections, muon_calibration, muon_selections, muon_validation, unfolding_tools, theoryAgnostic_tools, helicity_utils
+from wremnants import (helicity_utils, theory_tools, syst_tools,theory_corrections, muon_calibration, muon_prefiring, muon_selections, 
+    muon_efficiencies_binned, muon_efficiencies_smooth, muon_efficiencies_veto, muon_validation, unfolding_tools, theoryAgnostic_tools, pileup, vertex)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 from wremnants.helicity_utils_polvar import makehelicityWeightHelper_polvar 
@@ -166,20 +167,20 @@ axis_met = hist.axis.Regular(100, 0., 200., name = "met", underflow=False, overf
 axis_recoWpt = hist.axis.Regular(40, 0., 80., name = "recoWpt", underflow=False, overflow=True)
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = muon_prefiring.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
+qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 
 if args.noScaleFactors:
     logger.info("Running with no scale factors")
 elif args.binnedScaleFactors:
     logger.info("Using binned scale factors and uncertainties")
     # add usePseudoSmoothing=True for tests with Asimov
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_binned(filename = data_dir + "/muonSF/allSmooth_GtoH3D.root", era = era, max_pt = axis_pt.edges[-1], usePseudoSmoothing=True)
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_binned.make_muon_efficiency_helpers_binned(filename = data_dir + "/muonSF/allSmooth_GtoH3D.root", era = era, max_pt = axis_pt.edges[-1], usePseudoSmoothing=True)
 else:
     logger.info("Using smoothed scale factors and uncertainties")
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_smooth(filename = args.sfFile, era = era, what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1], isoEfficiencySmoothing = args.isoEfficiencySmoothing, smooth3D=args.smooth3dsf, isoDefinition=args.isolationDefinition)
-    muon_efficiency_veto_helper, muon_efficiency_veto_helper_syst, muon_efficiency_veto_helper_stat = wremnants.make_muon_efficiency_helpers_veto(useGlobalOrTrackerVeto = useGlobalOrTrackerVeto, era = era)
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth(filename = args.sfFile, era = era, what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1], isoEfficiencySmoothing = args.isoEfficiencySmoothing, smooth3D=args.smooth3dsf, isoDefinition=args.isolationDefinition)
+    muon_efficiency_veto_helper, muon_efficiency_veto_helper_syst, muon_efficiency_veto_helper_stat = muon_efficiencies_veto.make_muon_efficiency_helpers_veto(useGlobalOrTrackerVeto = useGlobalOrTrackerVeto, era = era)
 
 logger.info(f"SF file: {args.sfFile}")
 
@@ -187,12 +188,12 @@ muon_efficiency_helper_syst_altBkg = {}
 for es in common.muonEfficiency_altBkgSyst_effSteps:
     altSFfile = args.sfFile.replace(".root", "_altBkg.root")
     logger.info(f"Additional SF file for alternate syst with {es}: {altSFfile}")
-    muon_efficiency_helper_syst_altBkg[es] = wremnants.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
+    muon_efficiency_helper_syst_altBkg[es] = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
                                                                                                    what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1],
                                                                                                    effStep=es)
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+pileup_helper = pileup.make_pileup_helper(era = era)
+vertex_helper = vertex.make_vertex_helper(era = era)
 
 calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
@@ -205,9 +206,9 @@ z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibratio
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args,era=era)
 
-closure_unc_helper = wremnants.muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
-closure_unc_helper_A = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
-closure_unc_helper_M = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
+closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
+closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
+closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
 
 smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
 
@@ -225,13 +226,13 @@ else:
     
 # For polynominal variations
 if isTheoryAgnosticPolVar:
-    theoryAgnostic_helpers_minus = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.theoryAgnosticFileTag, filePath=args.theoryAgnosticFilePath)
-    theoryAgnostic_helpers_plus  = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.theoryAgnosticFileTag, filePath=args.theoryAgnosticFilePath)
+    theoryAgnostic_helpers_minus = makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.theoryAgnosticFileTag, filePath=args.theoryAgnosticFilePath)
+    theoryAgnostic_helpers_plus  = makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.theoryAgnosticFileTag, filePath=args.theoryAgnosticFilePath)
 
 # Helper for muR and muF as polynomial variations
-muRmuFPolVar_helpers_minus = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
-muRmuFPolVar_helpers_plus  = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
-muRmuFPolVar_helpers_Z     = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=0,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_minus = makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_plus  = makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_Z     = makehelicityWeightHelper_polvar(genVcharge=0,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
 
 # recoil initialization
 if not args.noRecoil:

--- a/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
@@ -11,7 +11,8 @@ parser,initargs = common.common_parser(analysis_label)
 import ROOT
 import narf
 import wremnants
-from wremnants import theory_tools,syst_tools,theory_corrections, muon_calibration, muon_selections, muon_validation
+from wremnants import (theory_tools,syst_tools,theory_corrections, muon_calibration, muon_prefiring, muon_selections, 
+    muon_efficiencies_binned, muon_efficiencies_smooth, muon_validation, unfolding_tools, theoryAgnostic_tools, helicity_utils, pileup, vertex)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 import hist
@@ -62,12 +63,12 @@ nominal_cols = ["postFSRmuon_eta0", "postFSRmuon_pt0", "postFSRmuon_charge0", "p
 # sum those groups up in post processing
 groups_to_aggregate = args.aggregateGroups
 
-#qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity()
+#qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 
 logger.info("Running with no scale factors")
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+pileup_helper = pileup.make_pileup_helper(era = era)
+vertex_helper = vertex.make_vertex_helper(era = era)
 
 calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -9,7 +9,8 @@ parser,initargs = common.common_parser(analysis_label)
 import ROOT
 import narf
 import wremnants
-from wremnants import theory_tools,syst_tools,theory_corrections, muon_validation, muon_calibration, muon_selections, unfolding_tools
+from wremnants import (theory_tools,syst_tools,theory_corrections, muon_validation, muon_calibration, muon_prefiring, muon_selections, unfolding_tools, 
+    muon_efficiencies_binned, muon_efficiencies_smooth, pileup, vertex)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 import hist
@@ -111,9 +112,9 @@ if isUnfolding:
         datasets = unfolding_tools.add_out_of_acceptance(datasets, group = "Zmumu")
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = muon_prefiring.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
+qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:
@@ -121,13 +122,13 @@ if args.binnedScaleFactors:
     # might never use it really anymore, but let's warn the user that this is obsolete
     logger.warning("Only SF with no uT dependence are implemented, and the treatment for trigger is like Wlike")
     # add usePseudoSmoothing=True for tests with Asimov
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_binned(filename = args.sfFile,
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_binned.make_muon_efficiency_helpers_binned(filename = args.sfFile,
                                                                                                                                      era = era,
                                                                                                                                      max_pt = args.pt[2],
                                                                                                                                      is_w_like = True) 
 else:
     logger.info("Using smoothed scale factors and uncertainties")
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_smooth(filename = args.sfFile,
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth(filename = args.sfFile,
                                                                                                                                      era = era,
                                                                                                                                      max_pt = args.pt[2],
                                                                                                                                      what_analysis = thisAnalysis, isoEfficiencySmoothing=args.isoEfficiencySmoothing, smooth3D=args.smooth3dsf, isoDefinition=args.isolationDefinition)
@@ -137,12 +138,12 @@ muon_efficiency_helper_syst_altBkg = {}
 for es in common.muonEfficiency_altBkgSyst_effSteps:
     altSFfile = args.sfFile.replace(".root", "_altBkg.root")
     logger.info(f"Additional SF file for alternate syst with {es}: {altSFfile}")
-    muon_efficiency_helper_syst_altBkg[es] = wremnants.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
+    muon_efficiency_helper_syst_altBkg[es] = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
                                                                                                    what_analysis = thisAnalysis, max_pt = args.pt[2],
                                                                                                    effStep=es)
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+pileup_helper = pileup.make_pileup_helper(era = era)
+vertex_helper = vertex.make_vertex_helper(era = era)
 
 calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
@@ -152,13 +153,13 @@ z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibratio
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args,era=era)
 
-closure_unc_helper = wremnants.muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
-closure_unc_helper_A = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
-closure_unc_helper_M = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
+closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
+closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
+closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
 
 smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
 
-smearinggradhelper = wremnants.muon_calibration.make_smearing_grad_helper()
+smearinggradhelper = muon_calibration.make_smearing_grad_helper()
 
 bias_helper = muon_calibration.make_muon_bias_helpers(args) 
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -9,8 +9,8 @@ parser,initargs = common.common_parser(analysis_label)
 
 import ROOT
 import narf
-import wremnants
-from wremnants import theory_tools,syst_tools,theory_corrections, muon_validation, muon_calibration, muon_selections, unfolding_tools, theoryAgnostic_tools, helicity_utils
+from wremnants import (theory_tools,syst_tools,theory_corrections, muon_validation, muon_calibration, muon_selections, muon_prefiring, 
+    muon_efficiencies_binned, muon_efficiencies_smooth, unfolding_tools, theoryAgnostic_tools, helicity_utils)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 from wremnants.helicity_utils_polvar import makehelicityWeightHelper_polvar 
@@ -82,30 +82,30 @@ axis_mt = hist.axis.Regular(200, 0., 200., name = "mt",underflow=False, overflow
 axis_eta_mT = hist.axis.Variable([-2.4, 2.4], name = "eta")
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = wremnants.make_muon_prefiring_helpers(era = era)
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = muon_prefiring.make_muon_prefiring_helpers(era = era)
 
-qcdScaleByHelicity_helper = wremnants.theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
+qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(is_w_like = True)
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:
     logger.info("Using binned scale factors and uncertainties")
     # add usePseudoSmoothing=True for tests with Asimov
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_binned(filename = args.sfFile, era = era, max_pt = axis_pt.edges[-1], is_w_like = True) 
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_binned.make_muon_efficiency_helpers_binned(filename = args.sfFile, era = era, max_pt = axis_pt.edges[-1], is_w_like = True) 
 else:
     logger.info("Using smoothed scale factors and uncertainties")
-    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = wremnants.make_muon_efficiency_helpers_smooth(filename = args.sfFile, era = era, what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1], isoEfficiencySmoothing = args.isoEfficiencySmoothing, smooth3D=args.smooth3dsf, isoDefinition=args.isolationDefinition)
+    muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth(filename = args.sfFile, era = era, what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1], isoEfficiencySmoothing = args.isoEfficiencySmoothing, smooth3D=args.smooth3dsf, isoDefinition=args.isolationDefinition)
 logger.info(f"SF file: {args.sfFile}")
 
 muon_efficiency_helper_syst_altBkg = {}
 for es in common.muonEfficiency_altBkgSyst_effSteps:
     altSFfile = args.sfFile.replace(".root", "_altBkg.root")
     logger.info(f"Additional SF file for alternate syst with {es}: {altSFfile}")
-    muon_efficiency_helper_syst_altBkg[es] = wremnants.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
+    muon_efficiency_helper_syst_altBkg[es] = muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth_altSyst(filename = altSFfile, era = era,
                                                                                                    what_analysis = thisAnalysis, max_pt = axis_pt.edges[-1],
                                                                                                    effStep=es)
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+pileup_helper = pileup.make_pileup_helper(era = era)
+vertex_helper = vertex.make_vertex_helper(era = era)
 
 calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
@@ -115,9 +115,9 @@ z_non_closure_parametrized_helper, z_non_closure_binned_helper = muon_calibratio
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = muon_calibration.make_muon_calibration_helpers(args,era=era)
 
-closure_unc_helper = wremnants.muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
-closure_unc_helper_A = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
-closure_unc_helper_M = wremnants.muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
+closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(common.closure_filepaths["parametrized"])
+closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(0, common.correlated_variation_base_size["A"])
+closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(2, common.correlated_variation_base_size["M"])
 
 smearing_helper, smearing_uncertainty_helper = (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
 
@@ -130,9 +130,9 @@ corr_helpers = theory_corrections.load_corr_helpers([d.name for d in datasets if
 
 # helpers for muRmuF MiNNLO polynomial variations
 
-muRmuFPolVar_helpers_minus = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
-muRmuFPolVar_helpers_plus  = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
-muRmuFPolVar_helpers_Z     = wremnants.helicity_utils_polvar.makehelicityWeightHelper_polvar(genVcharge=0,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_minus = makehelicityWeightHelper_polvar(genVcharge=-1, fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_plus  = makehelicityWeightHelper_polvar(genVcharge=1,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
+muRmuFPolVar_helpers_Z     = makehelicityWeightHelper_polvar(genVcharge=0,  fileTag=args.muRmuFPolVarFileTag, filePath=args.muRmuFPolVarFilePath, noUL=True)
 
 # recoil initialization
 if not args.noRecoil:

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -10,7 +10,7 @@ parser,initargs = common.common_parser(analysis_label)
 import ROOT
 import narf
 from wremnants import (theory_tools,syst_tools,theory_corrections, muon_validation, muon_calibration, muon_selections, muon_prefiring, 
-    muon_efficiencies_binned, muon_efficiencies_smooth, unfolding_tools, theoryAgnostic_tools, helicity_utils)
+    muon_efficiencies_binned, muon_efficiencies_smooth, unfolding_tools, theoryAgnostic_tools, helicity_utils, pileup, vertex)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 from wremnants.helicity_utils_polvar import makehelicityWeightHelper_polvar 

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -5,8 +5,8 @@ from utilities.io_tools import output_tools
 parser,initargs = common.common_parser("w_mass")
 
 import narf
-import wremnants
-from wremnants import theory_tools,syst_tools,theory_corrections, muon_calibration, muon_selections, muon_validation, unfolding_tools
+from wremnants import (theory_tools,syst_tools,theory_corrections, muon_calibration, muon_selections, muon_validation, 
+    pileup, vertex, unfolding_tools)
 from wremnants.histmaker_tools import scale_to_data, aggregate_groups
 from wremnants.datasets.dataset_tools import getDatasets
 import hist
@@ -45,8 +45,8 @@ axis_nvalidpixel = hist.axis.Integer(0, 10, name="nvalidpixel")
 
 response_axes = [axis_genPt, axis_genEta, axis_genCharge, axis_qopr]
 
-pileup_helper = wremnants.make_pileup_helper(era = era)
-vertex_helper = wremnants.make_vertex_helper(era = era)
+pileup_helper = pileup.make_pileup_helper(era = era)
+vertex_helper = vertex.make_vertex_helper(era = era)
 
 calib_filepaths = common.calib_filepaths
 mc_jpsi_crctn_helper, data_jpsi_crctn_helper, jpsi_crctn_MC_unc_helper, jpsi_crctn_data_unc_helper = muon_calibration.make_jpsi_crctn_helpers(args, calib_filepaths, make_uncertainty_helper=True)
@@ -63,7 +63,7 @@ nreps = 100
 smearing_helper_simple_multi = ROOT.wrem.SmearingHelperSimpleMulti[nreps](sigmarel)
 
 if args.testHelpers:
-    response_helper = ROOT.wrem.SplinesDifferentialWeightsHelper(f"{wremnants.data_dir}/calibration/muon_response.tflite")
+    response_helper = ROOT.wrem.SplinesDifferentialWeightsHelper(f"{common.data_dir}/calibration/muon_response.tflite")
 
     smearing_helper_simple = ROOT.wrem.SmearingHelperSimple(sigmarel, ROOT.ROOT.GetThreadPoolSize())
     smearing_helper_simple_weights = ROOT.wrem.SmearingHelperSimpleWeight(sigmarel)

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -1,6 +1,6 @@
 from wremnants.datasets.datagroups import Datagroups
 from wremnants import plot_tools,theory_tools,syst_tools
-from utilities import boostHistHelpers as hh,common
+from utilities import boostHistHelpers as hh, common, logging
 from utilities.styles import styles
 from utilities.io_tools import output_tools
 import matplotlib.pyplot as plt
@@ -8,7 +8,6 @@ from matplotlib import colormaps
 import argparse
 import os
 import shutil
-from wremnants import logging, common
 import pathlib
 import hist
 import re

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -125,7 +125,7 @@ for dataset in args.datasets:
         #     alphaHists = input_tools.read_all_and_scale(args.infile, args.datasets, alphaNames)
         #     alphaHists_hel = []
         #     for alphaHist in alphaHists:
-        #         alphaHists_hel.append(theory_tools.moments_to_angular_coeffs(alphaHist.project('helicity','absYVgen','ptVgen',axis_label)))
+        #         alphaHists_hel.append(theory_tools.helicity_xsec_to_angular_coeffs(alphaHist.project('helicity','absYVgen','ptVgen',axis_label)))
         #     uncHists[ipdf].extend([alphaHists_hel[ipdf][...,0],alphaHists_hel[ipdf][...,1]])
         #     names[ipdf].extend([pdfNames[ipdf]+"alpha $\pm1\sigma$",""])
         #     colors[ipdf].extend([[cmap(i)]*2 for i in range(len(args.pdfs),2*len(args.pdfs))][0])

--- a/scripts/plotting/plot_angular_coefficients.py
+++ b/scripts/plotting/plot_angular_coefficients.py
@@ -14,119 +14,141 @@ if __name__ == '__main__':
     parser = common.plot_parser()
     parser.add_argument("helicities", nargs="+", type=str, help="File `w_z_helicity_xsecs.hdf` with helicity cross sections produced in w_z_gen_dists.py histmaker")
     parser.add_argument("--labels", nargs="+", type=str, help="Labels for the different input files")
+    parser.add_argument("--keys", nargs="+", type=str, default=["", "_lhe"], help="List of histogram keys to be loaded; For a given KEY he object '{PROCESS}{KEY}' will be searched")
     parser.add_argument("--process", default="Z", choices=["Z", "W"], help="Process to be plotted")
     parser.add_argument("--plotXsecs", action="store_true", help="Plot helicity cross sections instead of angular coefficients")
+    parser.add_argument("--plotSum", action="store_true", help="Plot sum of histograms from different input files")
 
     args = parser.parse_args()
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
     outdir = output_tools.make_plot_dir(args.outpath, args.outfolder, eoscp=args.eoscp)
 
-    plot_coefficients = not args.plotXsecs
+    linestyles = ["solid", "dashed"]
+    suffixes = {"":"MiNNLO(pythia)", "lhe": "MiNNLO(LHE)"}
 
-    helicities = []
-    helicity_sum = None
-    weight_sum_all=0
-    xsec=0
+    helicities = {}
+    helicity_sum = {}
     for helicity_file in args.helicities:
         with h5py.File(helicity_file, "r") as ff:
             out = input_tools.load_results_h5py(ff)
-        hhelicity = out[args.process]
-        hhelicity = hhelicity[{"muRfact":1j, "muFfact":1j, "chargeVgen":0, "massVgen":0}]
-        hhelicity = hh.disableFlow(hhelicity, "absYVGen")
+        for key in out.keys():
+            if not key.startswith(args.process) or key in ["meta_info"]:
+                continue
+            if key.replace(args.process,"") not in args.keys:
+                continue
+            if key not in helicities:
+                helicities[key] = []
+                if args.plotSum:
+                    helicity_sum[key] = None
+            hhelicity = out[key]
+            hhelicity = hhelicity[{"muRfact":1j, "muFfact":1j, "chargeVgen":0, "massVgen":0}]
+            hhelicity = hh.disableFlow(hhelicity, "absYVGen")
 
-        weight_sum=0
-        with h5py.File(helicity_file.replace("helicity_xsecs","gen_dists"), "r") as ff:
-            out = input_tools.load_results_h5py(ff)
-            for key in out.keys():
-                if key.startswith(args.process) and key not in ["meta_info"]:
-                    xsec = out[key]["dataset"]["xsec"]
-                    weight_sum = out[key]["weight_sum"]
-                    weight_sum_all += weight_sum
+            if len(args.helicities)>1 and args.plotSum:
+                if helicity_sum[key] is None:
+                    helicity_sum[key] = hhelicity.copy()
+                else:
+                    helicity_sum[key] = hh.addHists(helicity_sum[key], hhelicity)
 
-        if len(args.helicities)>1:
-            if helicity_sum is None:
-                helicity_sum = hhelicity.copy()
-            else:
-                helicity_sum = hh.addHists(helicity_sum, hhelicity)
+            helicities[key].append(hhelicity)
 
-        hhelicity = hh.scaleHist(hhelicity, xsec/weight_sum)
-        helicities.append(hhelicity)
+    if args.plotXsecs:
+        weight_sum_all=0
+        for i, helicity_file in enumerate(args.helicities):
+            weight_sum=0
+            xsec=0
+            with h5py.File(helicity_file.replace("helicity_xsecs","gen_dists"), "r") as ff:
+                out = input_tools.load_results_h5py(ff)
+            procs = [k for k in out.keys() if k.startswith(args.process)]
+            if len(procs)>1:
+                logger.warning(f"Number of matched processes should be 1 but found {len(procs)}")
+            xsec = out[procs[0]]["dataset"]["xsec"]
+            weight_sum = out[procs[0]]["weight_sum"]
+            weight_sum_all += weight_sum
 
-    if helicity_sum is not None:
-        # under the assumption that xsec is the same for all processes
-        helicity_sum = hh.scaleHist(helicity_sum, xsec/weight_sum_all)
+            for hkey in helicities.keys():
+                helicities[hkey][i] = hh.scaleHist(helicities[hkey][i], xsec/weight_sum)
 
-    if len(helicities) == 2:
-        chi2_stat = np.sum( (helicities[0].values(flow=True)-helicities[1].values(flow=True))**2/(helicities[0].variances(flow=True)+helicities[1].variances(flow=True)) )
-        dof = len(helicities[0].values(flow=True).flatten()) - 1
-        p_val = chi2.sf(chi2_stat, dof)
+        for hkey in helicity_sum.keys():
+            if helicity_sum.get(hkey, None) is not None:
+                # under the assumption that xsec is the same for all processes
+                helicity_sum[hkey] = hh.scaleHist(helicity_sum[hkey], xsec/weight_sum_all)
 
-        logger.info(f"Chi2/ndf = {chi2_stat} with p-value = {p_val}")
+        for k, h in helicities.items():
+            if len(h) == 2:
+                chi2_stat = np.sum( (h[0].values(flow=True)-h[1].values(flow=True))**2/(h[0].variances(flow=True)+h[1].variances(flow=True)) )
+                dof = len(h[0].values(flow=True).flatten()) - 1
+                p_val = chi2.sf(chi2_stat, dof)
+
+                logger.info(f"For {k}; Chi2/ndf = {chi2_stat} with p-value = {p_val}")
 
     colors = mpl.colormaps["tab10"]
 
     for var in ("absYVGen", "ptVGen"):
 
-        hhelicities_1D = [h.project(var, "helicity") for h in helicities]
-        if helicity_sum is not None:
-            h1d_sum = helicity_sum.project(var, "helicity")
+        hists1d = {k: [h.project(var, "helicity") for h in v] for k,v in helicities.items()}
+        if len(helicity_sum):
+            h1d_sum = {k: v.project(var, "helicity") for k,v in helicity_sum.items()}
 
-        if plot_coefficients:
-            hists1d = [theory_tools.helicity_xsec_to_angular_coeffs(h) for h in hhelicities_1D]
-            if helicity_sum is not None:
-                h1d_sum = theory_tools.helicity_xsec_to_angular_coeffs(h1d_sum)
-        else:
-            hists1d = hhelicities_1D
-            if helicity_sum is not None:
-                h1d_sum = helicity_sum.project(var, "helicity")
+        if not args.plotXsecs:
+            hists1d = {k: [theory_tools.helicity_xsec_to_angular_coeffs(h) for h in v] for k,v in hists1d.items()}
+            if len(helicity_sum):
+                h1d_sum = {k: theory_tools.helicity_xsec_to_angular_coeffs(v) for k,v in h1d_sum.items()}
 
-        for i in hists1d[0].axes["helicity"]:
-            if i == -1 and plot_coefficients:
+        for i in next(iter(hists1d.values()))[0].axes["helicity"]:
+            if i == -1 and not args.plotXsecs:
                 continue
 
-            h1ds = [h[{"helicity":complex(0,i)}] for h in hists1d]
+            h1ds = {k: [h[{"helicity":complex(0,i)}] for h in v] for k,v in hists1d.items()}
 
-            ylabel = f"$\mathrm{{A}}_{i}$" if plot_coefficients else r"$\sigma_{"+(r"\mathrm{UL}" if i==-1 else str(i))+r"}\,[\mathrm{pb}]$"
-            fig, ax1 = plot_tools.figure(h1ds[0], xlabel=styles.xlabels.get(var, var), 
+            ylabel = f"$\mathrm{{A}}_{i}$" if not args.plotXsecs else r"$\sigma_{"+(r"\mathrm{UL}" if i==-1 else str(i))+r"}\,[\mathrm{pb}]$"
+            fig, ax1 = plot_tools.figure(next(iter(h1ds.values()))[0], xlabel=styles.xlabels.get(var, var), 
                 ylabel=ylabel,
-                grid=False, automatic_scale=False, width_scale=1.2, logy=False)    
+                grid=False, automatic_scale=False, width_scale=1.2, logy=False)
             
             y_min=np.inf
             y_max=-np.inf
-            for j, h in enumerate(h1ds):
-                hep.histplot(
-                    h,
-                    histtype="step",
-                    color=colors(j),
-                    label=args.labels[j],
-                    yerr=False,
-                    ax=ax1,
-                    zorder=3,
-                    density=False,
-                    binwnorm=None if plot_coefficients else 1,
-                )
-                y_min = min(y_min, min(h.values()))
-                y_max = max(y_max, max(h.values()))
 
-            if helicity_sum is not None:
-                h = h1d_sum[{"helicity":complex(0,i)}]
-                hep.histplot(
-                    h,
-                    histtype="step",
-                    color="black",
-                    label="Sum",
-                    linestyle="-",
-                    yerr=False,
-                    ax=ax1,
-                    zorder=3,
-                    density=False,
-                    binwnorm=None if plot_coefficients else 1,
-                )    
-                y_min = min(y_min, min(h.values()))
-                y_max = max(y_max, max(h.values()))
-
-            if not plot_coefficients:
+            if args.plotSum:
+                for m, (k, hs_sum) in enumerate(h1d_sum.items()):
+                    suffix = suffixes[k.replace(args.process,"").replace("_","")]
+                    if len(helicity_sum):
+                        h = hs_sum[{"helicity":complex(0,i)}]
+                        hep.histplot(
+                            h,
+                            histtype="step",
+                            color="black",
+                            label=suffix,
+                            linestyle=linestyles[m],
+                            yerr=False,
+                            ax=ax1,
+                            zorder=3,
+                            density=False,
+                            binwnorm=1 if args.plotXsecs else None,
+                        )    
+                        y_min = min(y_min, min(h.values()))
+                        y_max = max(y_max, max(h.values()))
+            else:
+                for m, (k, hs) in enumerate(h1ds.items()):
+                    suffix = suffixes[k.replace(args.process,"").replace("_","")]
+                    for j, h in enumerate(hs):
+                        hep.histplot(
+                            h,
+                            histtype="step",
+                            color=colors(j),
+                            label=f"{args.labels[j]} {suffix}",
+                            linestyle=linestyles[m],
+                            yerr=False,
+                            ax=ax1,
+                            zorder=3,
+                            density=False,
+                            binwnorm=1 if args.plotXsecs else None,
+                        )
+                        y_min = min(y_min, min(h.values()))
+                        y_max = max(y_max, max(h.values()))
+                
+            if args.plotXsecs:
                 y_min, y_max = ax1.get_ylim()
             yrange = y_max-y_min
 
@@ -142,10 +164,10 @@ if __name__ == '__main__':
             hep.cms.label(ax=ax1, lumi=None, fontsize=20*args.scaleleg*scale, 
                 label=args.cmsDecor, data=False)
 
-            if plot_coefficients:
-                outfile = f"angular_coefficient_{i}"
-            else:
+            if args.plotXsecs:
                 outfile = f"helicity_xsec_" + ("UL" if i==-1 else str(i))
+            else:
+                outfile = f"angular_coefficient_{i}"
 
             outfile += f"_{var}"
             if args.postfix:

--- a/scripts/plotting/response_matrix.py
+++ b/scripts/plotting/response_matrix.py
@@ -5,10 +5,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import hist
 
-from wremnants import logging, common
 from wremnants import plot_tools
 from wremnants.datasets.datagroups import Datagroups
-from utilities import boostHistHelpers as hh
+from utilities import boostHistHelpers as hh, common, logging
 from utilities.io_tools import output_tools
 
 import pdb

--- a/wremnants/__init__.py
+++ b/wremnants/__init__.py
@@ -12,20 +12,3 @@ narf.clingutils.Declare('#include "csVariables.h"')
 narf.clingutils.Declare('#include "EtaPtCorrelatedEfficiency.h"')
 narf.clingutils.Declare('#include "theoryTools.h"')
 narf.clingutils.Declare('#include "syst_helicity_utils_polvar.h"')
-
-from .muon_prefiring import make_muon_prefiring_helpers
-from .muon_efficiencies_smooth import make_muon_efficiency_helpers_smooth, make_muon_efficiency_helpers_smooth_altSyst
-from .muon_efficiencies_veto import make_muon_efficiency_helpers_veto
-from .muon_efficiencies_binned import make_muon_efficiency_helpers_binned
-from .muon_efficiencies_binned_vqt import make_muon_efficiency_helpers_binned_vqt
-from .muon_efficiencies_binned_vqt_integrated import make_muon_efficiency_helpers_binned_vqt_integrated
-from .muon_efficiencies_binned_vqt_real import make_muon_efficiency_helpers_binned_vqt_real
-from .qcdScaleByHelicity_helper import makeQCDScaleByHelicityHelper
-from .pileup import make_pileup_helper
-from .vertex import make_vertex_helper
-from .syst_tools import scale_helicity_hist_to_variations
-from .theory_tools import scale_tensor_axes, define_prefsr_vars, moments_to_angular_coeffs
-from .muon_calibration import *
-from .helicity_utils import *
-
-data_dir = f"{pathlib.Path(__file__).parent}/../wremnants-data/data/"

--- a/wremnants/helicity_utils.py
+++ b/wremnants/helicity_utils.py
@@ -7,8 +7,8 @@ import pathlib
 import hist
 import pickle
 import lz4.frame
-from .correctionsTensor_helper import makeCorrectionsTensor
-from .theory_tools import moments_to_angular_coeffs
+from wremnants.correctionsTensor_helper import makeCorrectionsTensor
+from wremnants.theory_tools import helicity_xsec_to_angular_coeffs
 from utilities import common, logging
 from utilities import boostHistHelpers as hh
 from utilities.io_tools import input_tools
@@ -30,13 +30,13 @@ axis_helicity_multidim = hist.axis.Integer(-1, 8, name="helicitySig", overflow=F
 #creates the helicity weight tensor
 def makehelicityWeightHelper(is_w_like = False, filename=None):
     if filename is None:
-        filename = f"{common.data_dir}/angularCoefficients/w_z_moments_theoryAgnosticBinning.hdf5"
+        filename = f"{common.data_dir}/angularCoefficients//w_z_moments_theoryAgnosticBinning.hdf5"
     with h5py.File(filename, "r") as ff:
         out = input_tools.load_results_h5py(ff)
 
-    moments = out["Z"] if is_w_like else out["W"]
+    hist_helicity_xsec_scales = out["Z"] if is_w_like else out["W"]
 
-    corrh = moments_to_angular_coeffs(moments)
+    corrh = helicity_xsec_to_angular_coeffs(hist_helicity_xsec_scales)
 
     if 'muRfact' in corrh.axes.name:
         corrh = corrh[{'muRfact' : 1.j,}]

--- a/wremnants/include/syst_helicity_utils.h
+++ b/wremnants/include/syst_helicity_utils.h
@@ -47,13 +47,13 @@ class WeightByHelicityHelper : public TensorCorrectionsHelper<T> {
 
    helweight_tensor_t operator() (double mV, double yV, double ptV, int qV, const CSVars &csvars, double nominal_weight) {
      //static_assert(nhelicity == NHELICITY);
-     const auto moments = csAngularFactors(csvars);
+     const auto angular = csAngularFactors(csvars);
      const auto coeffs = base_t::get_tensor(mV, yV, ptV, qV);
      helweight_tensor_t helWeights;
      double sum = 0.;
      for(unsigned int i = 0; i < NHELICITY; i++) {
-       if (i<NHELICITY_WEIGHTS) helWeights(i) = coeffs(i) * moments(i);
-       sum += coeffs(i) * moments(i);//full sum of all components
+       if (i<NHELICITY_WEIGHTS) helWeights(i) = coeffs(i) * angular(i);
+       sum += coeffs(i) * angular(i);//full sum of all components
      }
      double factor = 1./sum;
      helweight_tensor_t helWeights_tensor = factor*helWeights;

--- a/wremnants/plot_tools.py
+++ b/wremnants/plot_tools.py
@@ -2,8 +2,7 @@ import pathlib
 import mplhep as hep
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from matplotlib import ticker
-from matplotlib import patches
+from matplotlib import patches, ticker
 from matplotlib.ticker import StrMethodFormatter # for setting number of decimal places on tick labels
 from utilities import boostHistHelpers as hh,common,logging
 from utilities.io_tools import output_tools

--- a/wremnants/qcdScaleByHelicity_helper.py
+++ b/wremnants/qcdScaleByHelicity_helper.py
@@ -2,7 +2,7 @@ import ROOT
 import hist
 import pickle
 import lz4.frame
-from .correctionsTensor_helper import makeCorrectionsTensor
+from wremnants.correctionsTensor_helper import makeCorrectionsTensor
 from utilities import common, logging
 import numpy as np
 

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 
 ROOT.gInterpreter.Declare('#include "recoil_tools.h"')
 ROOT.gInterpreter.Declare('#include "recoil_helper.h"')
-logger = logging.getLogger("wremnants").getChild(__name__.split(".")[-1])
+logger = logging.child_logger(__name__)
 
 
 def RecoilCalibrationHelper(fIn, args):

--- a/wremnants/recoil_tools.py
+++ b/wremnants/recoil_tools.py
@@ -2,13 +2,12 @@ import ROOT
 import hist
 import numpy as np
 import copy
-import logging
 import sys
 import decimal
 import json
 import os
 import array
-from utilities import common as common
+from utilities import common, logging
 from utilities.io_tools import input_tools
 
 import tensorflow as tf

--- a/wremnants/theoryAgnostic_tools.py
+++ b/wremnants/theoryAgnostic_tools.py
@@ -1,5 +1,5 @@
 from utilities import differential, logging
-from wremnants import syst_tools, theory_tools, helicity_utils, helicity_utils_polvar
+from wremnants import syst_tools, theory_tools, helicity_utils
 from copy import deepcopy
 import hist
 

--- a/wremnants/theoryAgnostic_tools.py
+++ b/wremnants/theoryAgnostic_tools.py
@@ -1,6 +1,5 @@
-from utilities import differential
-import wremnants
-from wremnants import syst_tools, theory_tools, logging, helicity_utils, helicity_utils_polvar
+from utilities import differential, logging
+from wremnants import syst_tools, theory_tools, helicity_utils, helicity_utils_polvar
 from copy import deepcopy
 import hist
 
@@ -27,7 +26,7 @@ def select_fiducial_space(df, ptVgenMax, absYVgenMax, accept=True, select=True, 
 
 def define_helicity_weights(df, filename=None):
     # define the helicity tensor, here nominal_weight will only have theory weights, no experimental pieces, it is defined in theory_tools.define_theory_weights_and_corrs
-    weightsByHelicity_helper = wremnants.makehelicityWeightHelper(filename)
+    weightsByHelicity_helper = helicity_utils.makehelicityWeightHelper(filename)
     df = df.Define("helWeight_tensor", weightsByHelicity_helper, ["massVgen", "absYVgen", "ptVgen", "chargeVgen", "csSineCosThetaPhigen", "nominal_weight"])
     df = df.Define("nominal_weight_helicity", "wrem::scalarmultiplyHelWeightTensor(nominal_weight, helWeight_tensor)")
     return df

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -681,13 +681,13 @@ def replace_by_neighbors(vals, replace):
     indices = ndimage.distance_transform_edt(replace, return_distances=False, return_indices=True)
     return vals[tuple(indices)]
 
-def moments_to_angular_coeffs(hist_moments_scales, cutoff=1e-5):
-    if hist_moments_scales.empty():
+def helicity_xsec_to_angular_coeffs(hist_helicity_xsec_scales, cutoff=1e-5):
+    if hist_helicity_xsec_scales.empty():
        raise ValueError("Cannot make coefficients from empty hist")
     # broadcasting happens right to left, so move to rightmost then move back
-    hel_ax = hist_moments_scales.axes["helicity"]
-    hel_idx = hist_moments_scales.axes.name.index("helicity")
-    vals = np.moveaxis(hist_moments_scales.view(flow=True), hel_idx, -1)
+    hel_ax = hist_helicity_xsec_scales.axes["helicity"]
+    hel_idx = hist_helicity_xsec_scales.axes.name.index("helicity")
+    vals = np.moveaxis(hist_helicity_xsec_scales.view(flow=True), hel_idx, -1)
     values = vals.value if hasattr(vals,"value") else vals
     
     # select constant term, leaving dummy axis for broadcasting
@@ -699,8 +699,11 @@ def moments_to_angular_coeffs(hist_moments_scales, cutoff=1e-5):
 
     coeffs = np.moveaxis(coeffs, -1, hel_idx)
 
-    hist_coeffs_scales = hist.Hist(*hist_moments_scales.axes, storage = hist_moments_scales._storage_type(),
-        name = "hist_coeffs_scales", data = coeffs
+    hist_coeffs_scales = hist.Hist(
+        *hist_helicity_xsec_scales.axes, 
+        storage = hist_helicity_xsec_scales._storage_type(),
+        name = "hist_coeffs_scales", 
+        data = coeffs,
     )
 
     return hist_coeffs_scales

--- a/wremnants/unfolding_tools.py
+++ b/wremnants/unfolding_tools.py
@@ -1,6 +1,5 @@
 from utilities import differential, common, logging
 from wremnants import syst_tools, theory_tools, theory_corrections, theoryAgnostic_tools
-from wremnants import syst_tools, theory_tools, logging
 from copy import deepcopy
 import hist
 import numpy as np

--- a/wremnants/vertex.py
+++ b/wremnants/vertex.py
@@ -4,7 +4,6 @@ import hist
 import narf
 import numpy as np
 import boost_histogram as bh
-from utilities import common
 from utilities import common, logging
 
 narf.clingutils.Declare('#include "vertex.h"')


### PR DESCRIPTION
- Rename a few places where helicity cross sections were incorrectly denoted as angular coefficients or moments, and vice versa. 
- Remove relative imports to improve code readability
- The files in wremnants-data/data/angularCoefficients are still incorrectly denoted as "moments" but contain helicity cross sections, this will be changed in a future update.