### PR TITLE
Implement bootstrapping of MC and data for toys

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -391,7 +391,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if not isTheoryAgnostic:
         logger.info(f"cardTool.allMCProcesses(): {cardTool.allMCProcesses()}")
 
-    passSystToFakes = wmass and not (simultaneousABCD or xnorm or args.skipSignalSystOnFakes) and cardTool.getFakeName() != "QCD" and (excludeGroup != None and cardTool.getFakeName() not in excludeGroup) and (filterGroup == None or args.qcdProcessName in filterGroup)
+    passSystToFakes = wmass and not (simultaneousABCD or xnorm or args.skipSignalSystOnFakes) and cardTool.getFakeName() != "QCD" and (excludeGroup != None and cardTool.getFakeName() not in excludeGroup) and (filterGroup == None or cardTool.getFakeName() in filterGroup)
 
     # TODO: move to a common place if it is  useful
     def assertSample(name, startsWith=["W", "Z"], excludeMatch=[]):

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -247,8 +247,9 @@ if not args.noRecoil:
 seed_data = 2*args.randomSeedForToys
 seed_mc = 2*args.randomSeedForToys + 1
 
-toy_helper_data = ROOT.wrem.ToyHelper(args.nToysMC, seed_data, 1, ROOT.ROOT.GetThreadPoolSize())
-toy_helper_mc = ROOT.wrem.ToyHelper(args.nToysMC, seed_mc, args.varianceScalingForToys, ROOT.ROOT.GetThreadPoolSize())
+if args.nToysMC > 0:
+    toy_helper_data = ROOT.wrem.ToyHelper(args.nToysMC, seed_data, 1, ROOT.ROOT.GetThreadPoolSize())
+    toy_helper_mc = ROOT.wrem.ToyHelper(args.nToysMC, seed_mc, args.varianceScalingForToys, ROOT.ROOT.GetThreadPoolSize())
 
 ######################################################
 ######################################################

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -127,6 +127,11 @@ columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "tra
 nominal_axes = [axis_eta, axis_pt, axis_charge, *axes_abcd]
 nominal_cols = columns_fakerate
 
+if args.nToysMC > 0:
+    axis_toys = hist.axis.Integer(0, args.nToysMC, underflow=False, overflow=False, name = "toys")
+    nominal_axes = [*nominal_axes, axis_toys]
+    nominal_cols = [*nominal_cols, "toyIdxs"]
+
 # auxiliary axes
 axis_iso = hist.axis.Regular(100, 0, 25, name = "iso",underflow=False, overflow=True)
 axis_relIso = hist.axis.Regular(100, 0, 1, name = "relIso",underflow=False, overflow=True)
@@ -239,6 +244,11 @@ if not args.noRecoil:
     from wremnants import recoil_tools
     recoilHelper = recoil_tools.Recoil("highPU", args, flavor="mu")
 
+seed_data = 2*args.randomSeedForToys
+seed_mc = 2*args.randomSeedForToys + 1
+
+toy_helper_data = ROOT.wrem.ToyHelper(args.nToysMC, seed_data, 1, ROOT.ROOT.GetThreadPoolSize())
+toy_helper_mc = ROOT.wrem.ToyHelper(args.nToysMC, seed_mc, args.varianceScalingForToys, ROOT.ROOT.GetThreadPoolSize())
 
 ######################################################
 ######################################################
@@ -295,6 +305,13 @@ def build_graph(df, dataset):
         df = df.DefinePerSample("weight", "1.0")
     else:
         df = df.Define("weight", "std::copysign(1.0, genWeight)")
+
+
+    if args.nToysMC > 0:
+        if dataset.is_data:
+            df = df.Define("toyIdxs", toy_helper_data, ["rdfslot_"])
+        else:
+            df = df.Define("toyIdxs", toy_helper_mc, ["rdfslot_"])
 
     df = df.Define("isEvenEvent", "event % 2 == 0")
 
@@ -783,19 +800,29 @@ def build_graph(df, dataset):
 
     return results, weightsum
 
-resultdict = narf.build_and_run(datasets, build_graph)
-if not args.onlyMainHistograms and args.muonScaleVariation == 'smearingWeightsGaus' and not isFloatingPOIsTheoryAgnostic:
-    logger.debug("Apply smearingWeights")
-    muon_calibration.transport_smearing_weights_to_reco(
-        resultdict,
-        smearing_weights_procs,
-        nonClosureScheme = args.nonClosureScheme
-    )
-if args.validationHists:
-    muon_validation.muon_scale_variation_from_manual_shift(resultdict)
+if args.sequentialEventLoops:
+    dataset_sets = [[dataset] for dataset in datasets]
+else:
+    dataset_sets = [datasets]
 
-if not args.noScaleToData:
-    scale_to_data(resultdict)
-    aggregate_groups(datasets, resultdict, groups_to_aggregate)
+for loop_datasets in dataset_sets:
+    resultdict = narf.build_and_run(loop_datasets, build_graph)
+    if not args.onlyMainHistograms and args.muonScaleVariation == 'smearingWeightsGaus' and not isFloatingPOIsTheoryAgnostic:
+        logger.debug("Apply smearingWeights")
+        muon_calibration.transport_smearing_weights_to_reco(
+            resultdict,
+            smearing_weights_procs,
+            nonClosureScheme = args.nonClosureScheme
+        )
+    if args.validationHists:
+        muon_validation.muon_scale_variation_from_manual_shift(resultdict)
 
-output_tools.write_analysis_output(resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args)
+    if not args.noScaleToData and not args.sequentialEventLoops:
+        scale_to_data(resultdict)
+        aggregate_groups(loop_datasets, resultdict, groups_to_aggregate)
+
+    fout = f"{os.path.basename(__file__).replace('py', 'hdf5')}"
+    fout = output_tools.write_analysis_output(resultdict, fout, args)
+    if not args.appendOutputFile:
+        args.appendOutputFile = fout
+    resultdict = None

--- a/scripts/utilities/split_hists.py
+++ b/scripts/utilities/split_hists.py
@@ -1,0 +1,119 @@
+import argparse
+import h5py
+import copy
+
+from utilities import logging
+from utilities.io_tools import input_tools
+import narf
+import narf.ioutils
+import boost_histogram as bh
+
+import concurrent.futures
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--input", type=str, help="Input hdf5 file")
+parser.add_argument("-a", "--axis", required=True, type=str, help="axis name to split on")
+parser.add_argument("-s", "--start", type=int, default=0, help="start index for splitting")
+parser.add_argument("-e", "--end", required=True, type=int, help="end index for splitting")
+parser.add_argument("-p", "--postfix", type=str, help="Postfix for output file name", default="")
+parser.add_argument("--nominalData", action="store_true", help="use nominal data for all outputs")
+args = parser.parse_args()
+logger = logging.setup_logger(__file__)
+
+def copy_and_slice(h5proxy, axis, idx):
+    print("copy_and_slice")
+    obj = h5proxy.get()
+    print(type(obj))
+    if isinstance(obj, bh.Histogram):
+        print("is histogram")
+        print(obj.axes.name)
+        if axis in obj.axes.name:
+            print("slicing")
+            obj = obj[{axis : idx}]
+
+    return narf.ioutils.H5PickleProxy(obj)
+
+class DeepCopyOverride:
+    def __init__(self, target_class, targetfn):
+        self.target_class = target_class
+        self.targetfn = targetfn
+        self.oldfn = None
+
+    def __enter__(self):
+        if hasattr(self.target_class, "__deepcopy__"):
+            self.oldfn = self.target_class.__deepcopy__
+        self.target_class.__deepcopy__ = self.targetfn
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        if self.oldfn:
+            self.target_class.__deepcopy__ = oldfn
+        else:
+            del self.target_class.__deepcopy__
+
+newfiles = True
+
+# def copy_and_write(key, value, isplit)
+
+with h5py.File(args.input, "r") as h5file:
+    keys = list(h5file.keys())
+
+print(keys)
+
+
+for key in keys:
+
+    with h5py.File(args.input, "r") as h5file:
+        res = narf.ioutils.pickle_load_h5py(h5file[key])
+        # print("res.keys", res.keys())
+        # print(res["dataset"].keys())
+        # quit()
+
+        # preload all the proxied objects so we can close the file
+        # TODO should this be an option in pickle_load_h5py directly?
+        with DeepCopyOverride(narf.ioutils.H5PickleProxy, lambda h5proxy, memo : narf.ioutils.H5PickleProxy(h5proxy.get())):
+            copy.deepcopy(res)
+
+
+    def copy_and_write(isplit):
+
+    # for isplit in range(args.start, args.end):
+        print("isplit", isplit)
+        # narf.ioutils.H5PickleProxy.__deepcopy__ = lambda h5proxy, memo : copy_and_slice(h5proxy, args.axis, isplit)
+        # outres = copy.deepcopy(res)
+        # del narf.ioutils.H5PickleProxy.__deepcopy__
+
+        if args.nominalData and "dataset" in res and res["dataset"]["is_data"]:
+            isplitsource = 0
+        else:
+            isplitsource = isplit
+
+        with DeepCopyOverride(narf.ioutils.H5PickleProxy, lambda h5proxy, memo : copy_and_slice(h5proxy, args.axis, isplitsource)):
+            outres = copy.deepcopy(res)
+
+        outfile = args.input.replace(".hdf5", f"{args.postfix}_{args.axis}_{isplit}.hdf5")
+        mode = "w" if newfiles else "r+"
+
+        print("outfile", outfile, mode)
+
+        with h5py.File(outfile, mode) as h5out:
+            narf.ioutils.pickle_dump_h5py(key, outres, h5out)
+
+        outres = None
+
+        return True
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers = 64) as executor:
+        for res in executor.map(copy_and_write, range(args.start, args.end)):
+            pass
+
+    res = None
+    newfiles = False
+
+
+
+
+
+
+
+

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -346,6 +346,7 @@ def common_parser(analysis_label=""):
     parser.add_argument("--met", type=str, choices=["DeepMETReso", "RawPFMET", "DeepMETPVRobust", "DeepMETPVRobustNoPUPPI"], help="Choice of MET", default="DeepMETPVRobust")
     parser.add_argument("-o", "--outfolder", type=str, default="", help="Output folder")
     parser.add_argument("--appendOutputFile", type=str, default="", help="Append analysis output to specified output file")
+    parser.add_argument("--sequentialEventLoops", action='store_true', help="Run event loops sequentially for each process to reduce memory usage")
     parser.add_argument("-e", "--era", type=str, choices=["2016PreVFP","2016PostVFP", "2017", "2018"], help="Data set to process", default="2016PostVFP")
     parser.add_argument("--scale_A", default=1.0, type=float, help="scaling of the uncertainty on the b-field scale parameter A")
     parser.add_argument("--scale_e", default=1.0, type=float, help="scaling of the uncertainty on the material scale parameter e")
@@ -360,6 +361,9 @@ def common_parser(analysis_label=""):
     parser.add_argument("--aggregateGroups", type=str, nargs="*", default=["Diboson", "Top"], help="Sum up histograms from members of given groups in the postprocessing step")
     parser.add_argument("--muRmuFPolVarFilePath", type=str, default=f"{data_dir}/MiNNLOmuRmuFPolVar/", help="Path where input files are stored")
     parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_ConstrPol5ExtYdep_Trad", choices=["x0p50_y4p00_ConstrPol5ExtYdep_Trad","x0p50_y4p00_ConstrPol5Ext_Trad"],help="Tag for input files")
+    parser.add_argument("--nToysMC", type=int, help="random toys for data and MC", default=-1)
+    parser.add_argument("--varianceScalingForToys", type=int, default=1, help="Scaling of variance for toys (effective mc statistics corresponds to 1./scaling)")
+    parser.add_argument("--randomSeedForToys", type=int, default=0, help="random seed for toys")
 
     if for_reco_highPU:
         # additional arguments specific for histmaker of reconstructed objects at high pileup (mw, mz_wlike, and mz_dilepton)

--- a/utilities/io_tools/output_tools.py
+++ b/utilities/io_tools/output_tools.py
@@ -100,6 +100,8 @@ def write_analysis_output(results, outfile, args):
     logger.info(f"Writing output: {time.time()-time0}")
     logger.info(f"Output saved in {outfile}")
 
+    return outfile
+
 def is_eosuser_path(path):
     if not path:
         return False

--- a/wremnants/include/utils.h
+++ b/wremnants/include/utils.h
@@ -679,6 +679,55 @@ private:
 
 enum class TriggerCat { nonTriggering = 0, triggering = 1 };
 
+std::vector<int> seq_idxs(const int size, const int start = 0) {
+  std::vector<int> res(size);
+  std::iota(res.begin(), res.end(), start);
+  return res;
+}
+
+class ToyHelper {
+
+public:
+    ToyHelper(const std::size_t ntoys, const std::size_t seed = 0, const unsigned int var_scaling = 1, const unsigned int nslots = 1) : ntoys_(ntoys), var_scaling_(var_scaling) {
+        const unsigned int nslotsactual = std::max(nslots, 1U);
+        rng_.reserve(nslotsactual);
+        auto const hash = std::hash<std::string>()("ToyHelper");
+        for (std::size_t islot = 0; islot < nslotsactual; ++islot) {
+            std::seed_seq seq{hash, seed, islot};
+            rng_.emplace_back(seq);
+        }
+    }
+
+    std::vector<int> operator() (const unsigned int slot) {
+
+        std::poisson_distribution pois(1./double(var_scaling_));
+
+        std::vector<int> res;
+        res.reserve(2*ntoys_);
+
+        // index 0 is the nominal, so just one entry, not randomized)
+        res.emplace_back(0);
+
+        auto &rngslot = rng_[slot];
+
+        for (std::size_t itoy = 1; itoy < ntoys_; ++itoy) {
+          const std::size_t nsamples = var_scaling_*pois(rngslot);
+          for (std::size_t isample = 0; isample < nsamples; ++isample) {
+            res.emplace_back(itoy);
+          }
+        }
+
+        return res;
+    }
+
+
+private:
+    std::size_t ntoys_;
+    double var_scaling_;
+    std::vector<mt19937> rng_;
+
+};
+
 }
 
 


### PR DESCRIPTION
Add new functionality for bootstrapping of MC and data to produce toys in the histmaker.

A new option is also added to automate the running of the event loops in series to save memory (useful when running many toys in parallel)

Some performance optimizations have been made to the boot histogram conversion in narf, which is relevant since the histograms can become very large with many toys.

Some combinetf2 updates as well to support the statistical studies (initial implementation of binByBin uncertainties and toys)

There is also a bug fix in setupCombine which was not correctly propagating systematic uncertainties to the fakes in case groups were being filtered.

This should have no effect on standard workflows.