### PR TITLE
Implement smoothing of full fake estimate and enable by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,19 +235,19 @@ jobs:
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --hists pt eta pt-eta -o $WEB_DIR -f $PLOT_DIR -p W $HIST_FILE variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: wmass plot lepton phi
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 10 --logy --baseName leptonPhi --hists phi --fineGroups -o $WEB_DIR -f $PLOT_DIR -p W $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 10 --logy --baseName leptonPhi --fakeSmoothingMode fakerate --hists phi --fineGroups -o $WEB_DIR -f $PLOT_DIR -p W $HIST_FILE
 
       - name: wmass plot mt
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName transverseMass --hists mt -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName transverseMass --fakeSmoothingMode fakerate --hists mt -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot MET
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 2 --yscale 1.5 --baseName MET --hists met --fakeSmoothingMode fakerate -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot MET phi
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName METPhi --hists phi -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --yscale 1.3 --baseName METPhi --hists phi --fakeSmoothingMode fakerate -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot Wpt
-        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 1 --yscale 1.5 --baseName ptW  --normToData --fineGroups --hists recoWpt -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
+        run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --rebin 1 --yscale 1.5 --baseName ptW  --fakeSmoothingMode fakerate --normToData --fineGroups --hists recoWpt -o $WEB_DIR -f $PLOT_DIR $HIST_FILE
 
       - name: wmass plot massShift
         run: scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py -p massVariation --yscale 1.4 --hist pt --baseName nominal -r 0.98 1.02 -o $WEB_DIR -f $PLOT_DIR $HIST_FILE variation --varName massWeightW --selectEntries massShiftW100MeVUp massShiftW100MeVDown --varLabel massShift100MeVUp massShift100MeVDown --selectAxis massShift --color grey grey

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,22 +285,22 @@ jobs:
 
       - name: lowpu w mu plot ptW
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --hists ptW -o $WEB_DIR -f $PLOT_DIR/lowPU -p mu $HIST_FILE_MU variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: lowpu w mu plot lepton pt
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --baseName lep_pt_eta_phi --hists pt -p mu -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
 
       - name: lowpu w mu plot lepton
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --yscale 1.5 --baseName lep_pt_eta_phi --hists eta phi -p mu -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
 
       - name: lowpu w mu plot mt
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --rebin 2 --baseName transverseMass --hists mt -p mu -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_MU
 
       - name: lowpu w mu plot response matrix
@@ -315,22 +315,22 @@ jobs:
 
       - name: lowpu w e plot ptW
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --hists ptW -o $WEB_DIR -f $PLOT_DIR/lowPU -p e $HIST_FILE_E variation --varName nominal_uncorr --varLabel MiNNLO --colors red
 
       - name: lowpu w e plot lepton pt
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --baseName lep_pt_eta_phi --hists pt -p e -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
 
       - name: lowpu w e plot lepton
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --yscale 1.5 --baseName lep_pt_eta_phi --hists eta phi -p e -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
 
       - name: lowpu w e plot mt
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/plotting/makeDataMCStackPlot.py --fakeEstimation simple --fakeSmoothingMode binned
           --rebin 2 --baseName transverseMass --hists mt -p e -o $WEB_DIR -f $PLOT_DIR/lowPU $HIST_FILE_E
 
       - name: lowpu w e plot response matrix
@@ -340,7 +340,7 @@ jobs:
 
       - name: w mu/e combine mt setup
         run: >-
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py --fakeEstimation simple --binnedFakeEstimation
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py --fakeEstimation simple --fakeSmoothingMode binned
           -i $HIST_FILE_MU $HIST_FILE_E --baseName transverseMass transverseMass --fitvar mt-charge mt-charge --hdf5 -o $COMBINED_DIR
 
       - name: lowpu combine mt fit 
@@ -441,7 +441,7 @@ jobs:
 
       - name: lowpu combine unfolding setup
         run: >- 
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py --fakeEstimation simple --binnedFakeEstimation 
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/combine/setupCombine.py --fakeEstimation simple --fakeSmoothingMode binned
           --analysisMode unfolding -i $HIST_FILE_MU $HIST_FILE_E $HIST_FILE_MUMU $HIST_FILE_EE --fitvar ptW-charge ptW-charge ptll ptll -o $COMBINED_DIR --postfix ptll --hdf5 --sparse --ewUnc
 
       - name: lowpu combine unfolding fit 

--- a/scripts/analysisTools/runFit_theoryAgnosticPoisAsNoi_polVar.py
+++ b/scripts/analysisTools/runFit_theoryAgnosticPoisAsNoi_polVar.py
@@ -33,7 +33,7 @@ lumiScaleVarianceLinearly = ["Data"] # [], ["Data", "MC"], use in conjunction wi
 
 splitOOAtag = ""
 setupLumiOption = ""
-setupFakeOption = " --fakeEstimation simple --binnedFakeEstimation"
+setupFakeOption = " --fakeEstimation simple --fakeSmoothingMode binned"
 if splitOOA:
     splitOOAtag = "_splitOOA"
     testFolder = f"{testFolder}{splitOOAtag}"

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -81,7 +81,7 @@ def make_parser(parser=None):
     parser.add_argument("--noMCStat", action='store_true', help="Do not include MC stat uncertainty in covariance for theory fit (only when using --fitresult)")
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
     parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
-    parser.add_argument("--binnedFakeEstimation", action='store_true', help="Compute fakerate factor (and shaperate factor) without smooting in pT (and mT)")
+    parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
     parser.add_argument("--simultaneousABCD", action="store_true", help="Produce datacard for simultaneous fit of ABCD regions")
@@ -201,8 +201,8 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if args.fitXsec:
         datagroups.unconstrainedProcesses.append(base_group)
 
-    if lowPU and ((args.fakeEstimation != 'simple') or (args.binnedFakeEstimation == False)):
-        logger.error(f"When running lowPU mode, fakeEstimation should be set to 'simple' and binnedFakeEstimation set.")
+    if lowPU and ((args.fakeEstimation != 'simple') or (args.fakeSmoothingMode != "binned")):
+        logger.error(f"When running lowPU mode, fakeEstimation should be set to 'simple' and fakeSmoothingMode set to 'binned'.")
 
     if "run" in fitvar:
         # in case fit is split by runs/ cumulated lumi
@@ -285,7 +285,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if wmass and not xnorm:
         datagroups.fakerate_axes=args.fakerateAxes
         datagroups.set_histselectors(datagroups.getNames(), inputBaseName, mode=args.fakeEstimation,
-                                     smoothen=not args.binnedFakeEstimation, smoothingOrderFakerate=args.smoothingOrderFakerate,
+                                     smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate,
                                      integrate_x="mt" not in fitvar,
                                      simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
 
@@ -361,7 +361,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             if wmass and not xnorm:
                 pseudodataGroups.fakerate_axes=args.fakerateAxes
                 pseudodataGroups.set_histselectors(pseudodataGroups.getNames(), inputBaseName, mode=args.fakeEstimation,
-                smoothen=not args.binnedFakeEstimation, smoothingOrderFakerate=args.smoothingOrderFakerate,
+                smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate,
                 integrate_x="mt" not in fitvar,
                 simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
 
@@ -375,7 +375,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             pseudodataGroups.fakerate_axes=args.fakerateAxes
             pseudodataGroups.copyGroup("QCD", "QCDTruth")
             pseudodataGroups.set_histselectors(pseudodataGroups.getNames(), inputBaseName, 
-                mode=args.fakeEstimation, fake_processes=["QCD",], smoothen=not args.binnedFakeEstimation, 
+                mode=args.fakeEstimation, fake_processes=["QCD",], smoothing_mode=args.fakeSmoothingMode,
                 simultaneousABCD=simultaneousABCD, 
                 )
         else:
@@ -718,8 +718,8 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
         cardTool.addLnNSystematic("CMS_background", processes=["Other"], size=1.15, group="CMS_background", splitGroup = {"experiment": ".*"},)
         cardTool.addLnNSystematic("lumi", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity", splitGroup = {"experiment": ".*"},)
 
-    if cardTool.getFakeName() != "QCD" and cardTool.getFakeName() in datagroups.groups.keys() and not xnorm and (not args.binnedFakeEstimation or (args.fakeEstimation in ["extrapolate"] and "mt" in fitvar)):
-        syst_axes = ["eta", "charge"] if (not args.binnedFakeEstimation or args.fakeEstimation not in ["extrapolate"]) else ["eta", "pt", "charge"]
+    if cardTool.getFakeName() != "QCD" and cardTool.getFakeName() in datagroups.groups.keys() and not xnorm and (args.fakeSmoothingMode != "binned" or (args.fakeEstimation in ["extrapolate"] and "mt" in fitvar)):
+        syst_axes = ["eta", "charge"] if (args.fakeSmoothingMode != "binned" or args.fakeEstimation not in ["extrapolate"]) else ["eta", "pt", "charge"]
         info=dict(
             name=inputBaseName, 
             group="Fake",
@@ -735,7 +735,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             rename=subgroup,
             splitGroup = {subgroup: f".*", "experiment": ".*"},
             systNamePrepend=subgroup,
-            actionArgs=dict(variations_frf=True),
+            actionArgs=dict(variations_smoothing=True),
         )
         if args.fakeEstimation in ["extended2D",]:
             subgroup = f"{cardTool.getFakeName()}Shape"

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -43,7 +43,7 @@ parser.add_argument("--selection", type=str, help="Specify custom selections as 
 parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
 parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
-parser.add_argument("--binnedFakeEstimation", action='store_true', help="Compute fakerate factor (and shaperate factor) without smooting in pT (and mT)")
+parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
 parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
 parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
@@ -132,7 +132,7 @@ else:
 
 groups.fakerate_axes=args.fakerateAxes
 if applySelection:
-    groups.set_histselectors(datasets, args.baseName, smoothen=not args.binnedFakeEstimation, smoothingOrderFakerate=args.smoothingOrderFakerate, integrate_x=all("mt" not in x.split("-") for x in args.hists), mode=args.fakeEstimation, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
+    groups.set_histselectors(datasets, args.baseName, smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate, integrate_x=all("mt" not in x.split("-") for x in args.hists), mode=args.fakeEstimation, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
 
 if not args.nominalRef:
     nominalName = args.baseName.rsplit("_", 1)[0]

--- a/scripts/recoil/functions.py
+++ b/scripts/recoil/functions.py
@@ -98,7 +98,7 @@ def drange(x, y, jump):
 def readBoostHist(groups, hName, procs, charge="combined", boost=False, integrateAxes=[], abcd=True, rebin=None, applySelection=True):
 
     if abcd:
-        groups.set_histselectors(procs, hName, mode="simple", smoothen=False, simultaneousABCD=False, integrate_x=False if "mt" in hName else True)
+        groups.set_histselectors(procs, hName, mode="simple", smoothing_mode="binned", simultaneousABCD=False, integrate_x=False if "mt" in hName else True)
     groups.loadHistsForDatagroups(hName, syst="", procsToRead=procs, applySelection=applySelection)
     bhist = sum([groups.groups[p].hists[hName] for p in procs])
 

--- a/utilities/boostHistHelpers.py
+++ b/utilities/boostHistHelpers.py
@@ -575,7 +575,7 @@ def transfer_variances(h1, h2, flow=True):
     # extra dimensions for systematic axes
     extra_dimensions = (Ellipsis,) + (np.newaxis,) * (val1.ndim - val2.ndim)
     var1 = np.ones_like(val1)*var2[extra_dimensions] # use var2 directly in cases of not finite values
-    mask = np.isfinite(var2) & (var2!=0)
+    mask = np.isfinite(var2) & (var2!=0.) & (val2!=0.)
     # scale uncertainty with difference in yield with respect to second histogram such that relative uncertainty stays the same,
     factors = (val1[mask] / val2[mask][extra_dimensions])
     var1[mask] = var2[mask][extra_dimensions] * factors**2

--- a/wremnants/combine_helpers.py
+++ b/wremnants/combine_helpers.py
@@ -216,11 +216,17 @@ def add_electroweak_uncertainty(card_tool, ewUncs, flavor="mu", samples="single_
             else:
                 samples = all_samples
 
+            s = hist.tag.Slicer()
+            if ewUnc.startswith("virtual_ew"):
+                preOp = lambda h : h[{"systIdx" : s[0:1]}]
+            else:
+                preOp = lambda h : h[{"systIdx" : s[1:2]}]
+
             card_tool.addSystematic(f"{ewUnc}Corr", **info,
                 processes=samples,
                 labelsByAxis=[f"{ewUnc}Corr"],
                 scale=scale,
-                skipEntries=[(1, -1), (2, -1)] if ewUnc.startswith("virtual_ew") else [(0, -1), (2, -1)],
+                preOp = preOp,
                 group = f"theory_ew_{ewUnc}",
             )  
 

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -196,12 +196,12 @@ class Datagroups(object):
             logger.warning(f"Excluded all groups using '{excludes}'. Continue without any group.")
 
     def set_histselectors(self, 
-                          group_names, histToRead="nominal", fake_processes=None, mode="extended1D", smoothen=True, smoothingOrderFakerate=2, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
+                          group_names, histToRead="nominal", fake_processes=None, mode="extended1D", smoothing_mode="full", smoothingOrderFakerate=2, simultaneousABCD=False, forceGlobalScaleFakes=None, **kwargs
     ):
         logger.info(f"Set histselector")
         if self.mode[0] != "w":
             return # histselectors only implemented for single lepton (with fakes)
-        auxiliary_info={"rebin_smoothing_axis": "automatic" if smoothen else None}
+        auxiliary_info={}
         signalselector = sel.SignalSelectorABCD
         scale = 1
         if mode == "extended1D":
@@ -209,6 +209,7 @@ class Datagroups(object):
             scale = 1/1.15
         elif mode == "extended2D":
             fakeselector = sel.FakeSelector2DExtendedABCD
+            smoothen = smoothing_mode == "fakerate"
             auxiliary_info.update(dict(smooth_shapecorrection=smoothen, interpolate_x=smoothen, rebin_x="automatic" if smoothen else None))
         elif mode == "extrapolate":
             fakeselector = sel.FakeSelectorExtrapolateABCD
@@ -230,7 +231,7 @@ class Datagroups(object):
             base_member = members[0].name
             h = self.results[base_member]["output"][histToRead].get()
             if g in fake_processes:
-                self.groups[g].histselector = fakeselector(h[{"charge": hist.sum}], global_scalefactor=scale, fakerate_axes=self.fakerate_axes, smooth_fakerate=smoothen, smoothing_order_fakerate=smoothingOrderFakerate, **auxiliary_info, **kwargs)
+                self.groups[g].histselector = fakeselector(h[{"charge": hist.sum}], global_scalefactor=scale, fakerate_axes=self.fakerate_axes, smoothing_mode=smoothing_mode, smoothing_order_fakerate=smoothingOrderFakerate, **auxiliary_info, **kwargs)
             else:
                 self.groups[g].histselector = signalselector(h[{"charge": hist.sum}], fakerate_axes=self.fakerate_axes, **kwargs)
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -252,7 +252,7 @@ class HistselectorABCD(object):
     def __init__(self, h, name_x=None, name_y=None,
         fakerate_axes=["eta","pt","charge"], 
         smoothing_axis_name="pt", 
-        rebin_smoothing_axis=None, # can be a list of bin edges, "automatic", or None
+        rebin_smoothing_axis="automatic", # can be a list of bin edges, "automatic", or None
         upper_bound_y=None, # using an upper bound on the abcd y-axis (e.g. isolation)
         integrate_x=True, # integrate the abcd x-axis in final histogram (allows simplified procedure e.g. for extrapolation method)   
     ):           
@@ -357,9 +357,9 @@ class SignalSelectorABCD(HistselectorABCD):
 class FakeSelectorSimpleABCD(HistselectorABCD):
     # simple ABCD method
     def __init__(self, h, *args, 
-        smooth_fakerate=True, 
+        smoothing_mode="full",
         smoothing_order_fakerate=2,
-        polynomial="bernstein", # "power",
+        polynomial="power", # "power",
         throw_toys=None,#"normal", # None, 'normal' or 'poisson'
         global_scalefactor=1, # apply global correction factor on prediction
         **kwargs
@@ -379,9 +379,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         self.throw_toys = throw_toys
 
         # fakerate factor
-        self.smooth_fakerate = smooth_fakerate
+        self.smoothing_mode = smoothing_mode
         self.smoothing_order_fakerate = smoothing_order_fakerate
-        if self.smooth_fakerate:
+        if self.smoothing_mode != "binned":
             logger.info(f"Fakerate smoothing order is {self.smoothing_order_fakerate}")
 
         # solve with non negative least squares
@@ -391,9 +391,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             self.solve = solve_leastsquare
 
         # set smooth functions
-        self.f_frf = None
-        if self.smooth_fakerate:
-            self.f_frf = get_regression_function(self.smoothing_order_fakerate, pol=self.polynomial)
+        self.f_smoothing = None
+        if self.smoothing_mode != "binned":
+            self.f_smoothing = get_regression_function(self.smoothing_order_fakerate, pol=self.polynomial)
 
     def transfer_variances(self, h, set_nominal=False):
         if set_nominal:
@@ -406,26 +406,30 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             raise RuntimeError(f"Failed to transfer variances")
         return h
 
-    def get_hist(self, h, is_nominal=False, variations_frf=False, flow=True):
+    def get_hist(self, h, is_nominal=False, variations_smoothing=False, flow=True):
         idx_x = h.axes.name.index(self.name_x)
-        if self.smooth_fakerate:
+        if self.smoothing_mode == "fakerate":
             h = self.transfer_variances(h, set_nominal=is_nominal)
-            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_frf)
+            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_smoothing)
             c, cvar = self.get_yields_applicationregion(h)
             d = c * y_frf
 
-            if variations_frf:
+            if variations_smoothing:
                 dvar = c[..., np.newaxis,np.newaxis] * y_frf_var[...,:,:]
             else:
                 # only take bin by bin uncertainty from c region
                 dvar = y_frf**2 * cvar
-        else:
+        elif self.smoothing_mode == "full":
+            raise NotImplementedError("full smoothing not implemented for simple ABCD")
+        elif self.smoothing_mode == "binned":
             d, dvar = self.calculate_fullABCD(h)
+        else:
+            raise ValueError("invalid choice of smoothing_mode")
 
         # set histogram in signal region
-        hSignal = hist.Hist(*h[{self.name_x: self.sel_x, self.name_y: self.sel_y}].axes, storage=hist.storage.Double() if variations_frf else h.storage_type())
+        hSignal = hist.Hist(*h[{self.name_x: self.sel_x, self.name_y: self.sel_y}].axes, storage=hist.storage.Double() if variations_smoothing else h.storage_type())
         hSignal.values(flow=flow)[...] = d
-        if variations_frf and self.smooth_fakerate:
+        if variations_smoothing and self.smoothing_mode != "binned":
             hSignal = self.get_syst_hist(hSignal, d, dvar, flow=flow)
         elif hSignal.storage_type == hist.storage.Weight:
             hSignal.variances(flow=flow)[...] = dvar
@@ -462,9 +466,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             y_var = bvar/a**2 + b**2*avar/a**4
             y_var[abs(a) < 1]=0
 
-        if self.smooth_fakerate:
+        if self.smoothing_mode == "fakerate":
             x = self.get_bin_centers_smoothing(hNew, flow=True) # the bins where the smoothing is performed (can be different to the bins in h)
-            y, y_var = self.smoothen_fakerate(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info, flow=flow)
+            y, y_var = self.smoothen(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info, flow=flow)
 
         # broadcast abcd-x axis and application axes
         slices=[slice(None) if n in ha.axes.name else np.newaxis for n in h[{self.name_x: self.sel_x}].axes.name if n != self.name_y]
@@ -473,7 +477,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
 
         return y, y_var
 
-    def smoothen_fakerate(self, h, x, y, y_var, syst_variations=False, auxiliary_info=False, flow=True):
+    def smoothen(self, h, x, y, y_var, syst_variations=False, auxiliary_info=False, flow=True):
         if h.storage_type == hist.storage.Weight:
             # transform with weights
             w = 1/np.sqrt(y_var)
@@ -495,7 +499,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
 
         # evaluate in range of original histogram
         x_smooth_orig = self.get_bin_centers_smoothing(h, flow=True)
-        y_smooth_orig = self.f_frf(x_smooth_orig, params)
+        y_smooth_orig = self.f_smoothing(x_smooth_orig, params)
 
         if syst_variations:
             y_smooth_var_orig = self.make_eigenvector_predictons_frf(params, cov, x_smooth_orig)
@@ -514,7 +518,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             logger.warning(f"Found {np.sum(y_smooth_var_orig<0)} bins with negative fake rate factor variations")
 
         if auxiliary_info:
-            y_pred = self.f_frf(x, params)
+            y_pred = self.f_smoothing(x, params)
             # flatten
             y_pred = y_pred.reshape(y.shape) 
             w = w.reshape(y.shape)
@@ -536,7 +540,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         hsyst.values(flow=flow)[...] = alternate-values[...,np.newaxis,np.newaxis]
 
         # decorrelate in fakerate axes
-        axes_names = [n for n in self.fakerate_axes if not self.smooth_fakerate or n != self.smoothing_axis_name]
+        axes_names = [n for n in self.fakerate_axes if self.smoothing_mode=="binned" or n != self.smoothing_axis_name]
         hsyst = hh.expand_hist_by_duplicate_axes(hsyst, axes_names, [f"_{n}" for n in axes_names])    
 
         # add nominal hist and broadcast
@@ -544,7 +548,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         return hNominal
 
     def make_eigenvector_predictons_frf(self, params, cov, x1, x2=None):
-        return make_eigenvector_predictons(params, cov, func=self.f_frf, x1=x1, x2=x2, force_positive=False)#self.polynomial=="bernstein")
+        return make_eigenvector_predictons(params, cov, func=self.f_smoothing, x1=x1, x2=x2, force_positive=False)#self.polynomial=="bernstein")
 
     def get_bin_centers_smoothing(self, h, flow=True):
         return self.get_bin_centers(h, self.smoothing_axis_name, self.smoothing_axis_min, self.smoothing_axis_max, flow=flow)
@@ -615,13 +619,12 @@ class FakeSelectorSimultaneousABCD(FakeSelectorSimpleABCD):
 class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
     # extrapolate the fakerate in the abcd x axis by finding an analytic description in the dx region
     def __init__(self, h, *args, 
-        smooth_fakerate=True,
         polynomial="power",
         extrapolation_order=1,
         rebin_x="automatic", # can be a list of bin edges, "automatic", or None
         **kwargs
     ):
-        super().__init__(h, *args, smooth_fakerate=smooth_fakerate, polynomial=polynomial, **kwargs)
+        super().__init__(h, *args, polynomial=polynomial, **kwargs)
         self.set_selections_x()
 
         self.extrapolation_order = extrapolation_order
@@ -635,10 +638,10 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
         if self.polynomial == "bernstein":
             logger.warning(f"It is not recommended to use {self.polynomial} polynomials for extrapolation.")
 
-        if self.smooth_fakerate:
+        if self.smoothing_mode != "binned":
             raise NotImplementedError("Smooting fakerate is not implemented")
 
-        self.f_frf = get_regression_function(self.extrapolation_order, pol=self.polynomial)
+        self.f_smoothing = get_regression_function(self.extrapolation_order, pol=self.polynomial)
 
     # set slices object for selection of sideband regions
     def set_selections_x(self):
@@ -647,7 +650,7 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
         self.sel_x = s[x0:x1:] if x0 is not None and x1.imag > x0.imag else s[x1:x0:]
         self.sel_dx = s[x1:x3:] if x3 is None or x3.imag > x1.imag else s[x3:x1:]
 
-    def get_hist(self, h, is_nominal=False, variations_frf=False, flow=True):
+    def get_hist(self, h, is_nominal=False, variations_smoothing=False, flow=True):
         h = self.transfer_variances(h, set_nominal=is_nominal)
         c, cvar = self.get_yields_applicationregion(h)
         if self.integrate_x:
@@ -666,8 +669,8 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
             else:
                 dvar = None
         else:
-            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_frf)
-            if variations_frf:
+            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_smoothing)
+            if variations_smoothing:
                 dvar = c[..., np.newaxis,np.newaxis] * y_frf_var
             else:
                 # only take bin by bin uncertainty from c region
@@ -676,9 +679,9 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
 
         # set histogram in signal region
         axes = h[{self.name_x: self.sel_x if not self.integrate_x else hist.sum, self.name_y: self.sel_y}].axes
-        hSignal = hist.Hist(*axes, storage=hist.storage.Double() if variations_frf else h.storage_type())
+        hSignal = hist.Hist(*axes, storage=hist.storage.Double() if variations_smoothing else h.storage_type())
         hSignal.values(flow=flow)[...] = d
-        if variations_frf:
+        if variations_smoothing:
             hSignal = self.get_syst_hist(hSignal, d, dvar, flow=flow)
         elif dvar is not None and hSignal.storage_type == hist.storage.Weight:
             hSignal.variances(flow=flow)[...] = dvar
@@ -758,7 +761,7 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
 
         # evaluate in range of application region of original histogram
         x_extrapolation = self.get_bin_centers(h, self.name_x, flow=flow)
-        y_extrapolation = self.f_frf(x_extrapolation, params)
+        y_extrapolation = self.f_smoothing(x_extrapolation, params)
 
         if syst_variations:
             y_extrapolation_var = self.make_eigenvector_predictons_frf(params, cov, x_extrapolation)
@@ -777,7 +780,7 @@ class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
             logger.warning(f"Found {np.sum(y_extrapolation_var<0)} bins with negative fake rate factor variations")
 
         if auxiliary_info:
-            y_pred = self.f_frf(x, params)
+            y_pred = self.f_smoothing(x, params)
             # flatten
             y_pred = y_pred.reshape(y.shape) 
             w = w.reshape(y.shape)
@@ -802,28 +805,33 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
         self.sel_dx = s[x1:x2:hist.sum] if x2.imag > x1.imag else s[x2:x1:hist.sum]
         self.sel_d2x = s[x2:x3:hist.sum] if x3.imag > x2.imag else s[x3:x2:hist.sum]
 
-    def get_hist(self, h, is_nominal=False, variations_frf=False, flow=True):
+    def get_hist(self, h, is_nominal=False, variations_smoothing=False, flow=True):
         idx_x = h.axes.name.index(self.name_x)
-        if self.smooth_fakerate:
+        if self.smoothing_mode == "fakerate":
             h = self.transfer_variances(h, set_nominal=is_nominal)
 
-            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_frf)
+            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_smoothing)
             c, cvar = self.get_yields_applicationregion(h)
             d = c * y_frf
 
-            if variations_frf:
+            if variations_smoothing:
                 dvar = c[..., np.newaxis,np.newaxis] * y_frf_var[...,:,:]
             else:
                 # only take bin by bin uncertainty from c region
                 dvar = y_frf**2 * cvar
-        else:
+        elif self.smoothing_mode == "full":
+            h = self.transfer_variances(h, set_nominal=is_nominal)
+            d, dvar = self.calculate_fullABCD_smoothed(h, flow=flow, syst_variations=variations_smoothing)
+        elif self.smoothing_mode == "binned":
             # no smoothing of rates
-            d, dvar = self.calculate_fullABCD(h)
+            d, dvar = self.calculate_fullABCD(h, flow=flow)
+        else:
+            raise ValueError("invalid choice of smoothing_mode")
 
         # set histogram in signal region
-        hSignal = hist.Hist(*h[{self.name_x: self.sel_x if not self.integrate_x else hist.sum, self.name_y: self.sel_y}].axes, storage=hist.storage.Double() if variations_frf else h.storage_type())
+        hSignal = hist.Hist(*h[{self.name_x: self.sel_x if not self.integrate_x else hist.sum, self.name_y: self.sel_y}].axes, storage=hist.storage.Double() if variations_smoothing else h.storage_type())
         hSignal.values(flow=flow)[...] = d
-        if variations_frf and self.smooth_fakerate:
+        if variations_smoothing and self.smoothing_mode != "binned":
             hSignal = self.get_syst_hist(hSignal, d, dvar, flow=flow)
         elif hSignal.storage_type == hist.storage.Weight:
             hSignal.variances(flow=flow)[...] = dvar
@@ -833,7 +841,7 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
 
         return hSignal
 
-    def calculate_fullABCD(self, h, flow=True):
+    def calculate_fullABCD(self, h, flow=True, syst_variations=False):
         if len(self.fakerate_integration_axes) > 0:
             logger.warning(f"Binned fake estimation is performed but fakerate integration axes {self.fakerate_integration_axes} are set, the bin-by-bin stat uncertainties are not correct along this axis.")
         if not self.integrate_x:
@@ -870,6 +878,64 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
             cvar = hc.variances(flow=flow)
             dvar = frf**2 * cvar + d**2 * (4 * bvar/b**2 + 4 * avar/a**2 + axvar/ax**2 + bxvar/bx**2)[*slices]
         
+        return d, dvar
+
+    def calculate_fullABCD_smoothed(self, h, flow=True, syst_variations=False):
+        hNew = hh.rebinHist(h, self.smoothing_axis_name, self.rebin_smoothing_axis) if self.rebin_smoothing_axis is not None else h
+
+        d, dvar = self.calculate_fullABCD(h, flow=flow)
+        dsel, dvarsel = self.calculate_fullABCD(hNew, flow=flow)
+
+        smoothidx = hNew.axes.name.index(self.smoothing_axis_name)
+        smoothing_axis = hNew.axes[self.smoothing_axis_name]
+        nax = len(d.shape)
+
+        # underflow and overflow are left unchanged along the smoothing axis
+        # so we need to exclude them if they have been otherwise included
+        if flow:
+            smoothstart = 1 if smoothing_axis.traits.underflow else 0
+            smoothstop = -1 if smoothing_axis.traits.overflow else None
+            smoothslice = slice(smoothstart, smoothstop)
+        else:
+            smoothslice = slice(None)
+
+        sel = nax*[slice(None)]
+        sel[smoothidx] = smoothslice
+
+        dsel =  dsel[*sel]
+        dvarsel = dvarsel[*sel]
+
+        xwidth = hNew.axes[self.smoothing_axis_name].widths
+        xwidthtgt = h.axes[self.smoothing_axis_name].widths
+
+        xwidth = xwidth[*smoothidx*[None], :, *(nax - smoothidx - 1)*[None]]
+        xwidthtgt = xwidthtgt[*smoothidx*[None], :, *(nax - smoothidx - 1)*[None]]#
+
+        dsel *= 1./xwidth
+        dvarsel *= 1./xwidth**2
+
+        logd = np.where(dsel>0., np.log(dsel), 0.)
+        logdvar = np.where(dsel>0., dvarsel/dsel**2, 1.)
+        x = smoothing_axis.centers
+
+        if syst_variations:
+            logd, logdvar = self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations)
+        else:
+            logd, logdvar, params, cov, chi2, ndf = self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations, auxiliary_info=True)
+            logger.debug("ndof", ndf)
+            logger.debug("chisq stats", np.mean(chi2), np.std(chi2), np.min(chi2), np.max(chi2))
+            # print(f"chisq/ndof = {chi2}/{ndf}")
+        # leave the underflow and overflow unchanged if present
+        d[*sel] = np.exp(logd)*xwidthtgt
+        if syst_variations:
+            # leave the underflow and overflow unchanged if present
+            dvar = dvar[..., None, None]*np.ones((*dvar.shape, *logdvar.shape[-2:]), dtype=dvar.dtype)
+            dvar[*sel, :, :] = np.exp(logdvar)*xwidthtgt[..., None, None]**2
+        else:
+            # with full smoothing all of the statistical uncertainty is included in the
+            # explicit variations, so the remaining binned uncertainty is zero
+            dvar = np.zeros_like(d)
+
         return d, dvar
 
     def compute_fakeratefactor(self, h, syst_variations=False, flow=True, auxiliary_info=False):
@@ -939,9 +1005,9 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
             logger.info("Done with toys")
 
 
-        if self.smooth_fakerate:
+        if self.smoothing_mode == "fakerate":
             x = self.get_bin_centers_smoothing(hNew, flow=True) # the bins where the smoothing is performed (can be different to the bin in h)
-            y, y_var = self.smoothen_fakerate(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info, flow=flow)
+            y, y_var = self.smoothen(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info, flow=flow)
 
         # broadcast abcd-x axis and application axes
         slices=[slice(None) if n in ha.axes.name else np.newaxis for n in h[{self.name_x: self.sel_x}].axes.name if n != self.name_y]
@@ -1010,14 +1076,14 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         self.sel_dy = s[y1:y2:hist.sum] if y2.imag > y1.imag else s[y2:y1:hist.sum]
         self.sel_d2y = s[y2:y3:hist.sum] if y3 is None or y3.imag > y2.imag else s[y3:y2:hist.sum]
 
-    def get_hist(self, h, is_nominal=False, variations_scf=False, variations_frf=False, variations_full=False, flow=True):
-        if variations_scf and variations_frf:
+    def get_hist(self, h, is_nominal=False, variations_scf=False, variations_smoothing=False, variations_full=False, flow=True):
+        if variations_scf and variations_smoothing:
             raise RuntimeError(f"Can only calculate vairances for fakerate factor or shape correction factor but not both")
 
-        if self.smooth_fakerate or self.interpolate_x or self.smooth_shapecorrection:
+        if self.smoothing_mode=="fakerate" or self.interpolate_x or self.smooth_shapecorrection:
             h = self.transfer_variances(h, set_nominal=is_nominal)
 
-            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_frf)
+            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_smoothing)
             y_scf, y_scf_var = self.compute_shapecorrection(h, syst_variations=variations_scf)
             c, cvar = self.get_yields_applicationregion(h)
 
@@ -1025,7 +1091,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
 
             if variations_scf and (self.interpolate_x or self.smooth_shapecorrection):
                 dvar = c[..., np.newaxis,np.newaxis] * y_frf[...,np.newaxis,np.newaxis] * y_scf_var[...,:,:]
-            elif variations_frf and self.smooth_fakerate:
+            elif variations_smoothing and self.smoothing_mode=="fakerate":
                 dvar = c[..., np.newaxis,np.newaxis] * y_scf[..., np.newaxis,np.newaxis] * y_frf_var[...,:,:]
             elif self.smooth_shapecorrection or self.interpolate_x:
                 # only take bin by bin uncertainty from c region
@@ -1038,15 +1104,20 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
                 idx_x = [n for n in h.axes.name if n != self.name_y].index(self.name_x)
                 d = d.sum(axis=idx_x)
                 dvar = dvar.sum(axis=idx_x)
-        else:
+        elif self.smoothing_mode == "full":
+            raise NotImplementedError()
+        elif self.smoothing_mode == "binned":
             # no smoothing of rates
-            d, dvar = self.calculate_fullABCD(h)            
+            d, dvar = self.calculate_fullABCD(h)
+        else:
+            raise ValueError("invalid choice of smoothing mode")
+
 
         # set histogram in signal region
         axes = [a for a in h[{self.name_x:self.sel_x if not self.integrate_x else hist.sum}].axes if a.name != self.name_y]
-        hSignal = hist.Hist(*axes, storage=hist.storage.Double() if variations_frf else h.storage_type())
+        hSignal = hist.Hist(*axes, storage=hist.storage.Double() if variations_smoothing else h.storage_type())
         hSignal.values(flow=flow)[...] = d
-        if variations_scf or variations_frf or variations_full:
+        if variations_scf or variations_smoothing or variations_full:
             hSignal = self.get_syst_hist(hSignal, d, dvar, flow=flow)
         elif hSignal.storage_type == hist.storage.Weight:
             hSignal.variances(flow=flow)[...] = dvar
@@ -1347,9 +1418,9 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
 
             logger.info("Done with toys")
 
-        if self.smooth_fakerate:
+        if self.smoothing_mode == "fakerate":
             x = self.get_bin_centers_smoothing(hNew, flow=True) # the bins where the smoothing is performed (can be different to the bin in h)
-            y, y_var = self.smoothen_fakerate(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info)
+            y, y_var = self.smoothen(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info)
 
         # broadcast abcd-x axis and application axes
         slices=[slice(None) if n in ha.axes.name else np.newaxis for n in h[{self.name_x: self.sel_x}].axes.name if n != self.name_y]

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -359,7 +359,6 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
     def __init__(self, h, *args, 
         smoothing_mode="full",
         smoothing_order_fakerate=2,
-        polynomial="power", # "power",
         throw_toys=None,#"normal", # None, 'normal' or 'poisson'
         global_scalefactor=1, # apply global correction factor on prediction
         **kwargs
@@ -373,8 +372,15 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         self.h_nominal = None
         self.global_scalefactor = global_scalefactor
 
-        ### interpolate/smooth in x-axis in application region
-        self.polynomial = polynomial 
+        # select appropriate polynomial depending on type of smoothing
+        if smoothing_mode == "fakerate":
+            self.polynomial = "bernstein"
+        else:
+            self.polynomial = "power"
+
+        # rebinning doesn't make sense for binned estimation
+        if smoothing_mode == "binned":
+            self.rebin_smoothing_axis = None
 
         self.throw_toys = throw_toys
 
@@ -619,12 +625,11 @@ class FakeSelectorSimultaneousABCD(FakeSelectorSimpleABCD):
 class FakeSelectorExtrapolateABCD(FakeSelectorSimpleABCD):
     # extrapolate the fakerate in the abcd x axis by finding an analytic description in the dx region
     def __init__(self, h, *args, 
-        polynomial="power",
         extrapolation_order=1,
         rebin_x="automatic", # can be a list of bin edges, "automatic", or None
         **kwargs
     ):
-        super().__init__(h, *args, polynomial=polynomial, **kwargs)
+        super().__init__(h, *args, **kwargs)
         self.set_selections_x()
 
         self.extrapolation_order = extrapolation_order

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -382,6 +382,10 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         if smoothing_mode == "binned":
             self.rebin_smoothing_axis = None
 
+        if hasattr(self, "fakerate_integration_axes"):
+            if smoothing_mode == "full" and self.fakerate_integration_axes:
+                raise NotImplementedError("Smoothing of full fake prediction is not currently supported together with integration axes.")
+
         self.throw_toys = throw_toys
 
         # fakerate factor


### PR DESCRIPTION
This implements smoothing of the full fake estimate with exp(pol2) by default.  This doesn't work in the presence of additional axes currently, so it's disabled e.g. when plotting other variables like mT etc (and we'll need to find a more general solution for this for the mT fit if we want to use it)

The rebinning used in the pt axis is the same as for the current fakerate smoothing.

The polynomial type and rebinning are now steered automatically as part of the --fakeSmoothingMode option by default. (bernstein with non-negative least squares for fakerate smoothing, and power basis with standard least squares for fake estimate smoothing since that is done in the log space)

There is also a technical change to the handling of the EW ISR and FSR uncertainties to move the selection of histograms before the fake estimate.  This does not change anything in the actual fit, but avoids warnings and misleading printouts about bad chisquared values from the smoothing, etc.

Note that this PR introduces some additional fluctuations in the fake estimate in the standard low stats ci, but it's been verified that the behaviour is good/smooth in the 1:1 data:mc stats case.

@davidwalter2 