### PR TITLE
Updates on fakes

### DIFF
--- a/scripts/combine/saturatedGOF.py
+++ b/scripts/combine/saturatedGOF.py
@@ -1,6 +1,9 @@
 import ROOT
 import scipy
 import argparse
+from utilities.io_tools import combinetf_input
+from narf import ioutils
+import numpy as np
 
 parser = argparse.ArgumentParser()
 parser.add_argument("infile", type=str, help="combinetf output ROOT file")
@@ -9,10 +12,14 @@ args = parser.parse_args()
 rtfile = ROOT.TFile(args.infile)
 tree = rtfile.Get("fitresults")
 tree.GetEntry(0)
-nbins = rtfile.Get("obs").GetNbinsX()
+
+fitresult_h5py = combinetf_input.get_fitresult(args.infile.replace(".root",".hdf5"))
+meta = ioutils.pickle_load_h5py(fitresult_h5py["meta"])
+nbins = sum([np.product([len(a) for a in info["axes"]]) for info in meta["channel_info"].values()])
+ndf = nbins - tree.ndofpartial
 
 print(f"-loglikelihood_{{full}} = {tree.nllvalfull}")
 print(f"-loglikelihood_{{saturated}} = {tree.satnllvalfull}")
 print(f"2*(nllfull-nllsat) = {2*(tree.nllvalfull-tree.satnllvalfull)}")
 print(f"nbins = {nbins}")
-print("chi2 probability =", scipy.stats.chi2.sf(2*(tree.nllvalfull-tree.satnllvalfull), nbins))
+print("chi2 probability =", scipy.stats.chi2.sf(2*(tree.nllvalfull-tree.satnllvalfull), ndf))

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -376,7 +376,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             pseudodataGroups.copyGroup("QCD", "QCDTruth")
             pseudodataGroups.set_histselectors(pseudodataGroups.getNames(), inputBaseName, 
                 mode=args.fakeEstimation, fake_processes=["QCD",], smoothing_mode=args.fakeSmoothingMode,
-                simultaneousABCD=simultaneousABCD, 
+                simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes,
                 )
         else:
             pseudodataGroups = Datagroups(args.pseudoDataFile if args.pseudoDataFile else inputFile, excludeGroups=excludeGroup, filterGroups=filterGroup)

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -83,7 +83,8 @@ def make_parser(parser=None):
     parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
-    parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
+    parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
+    parser.add_argument("--fakeSmoothingOrder", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
     parser.add_argument("--simultaneousABCD", action="store_true", help="Produce datacard for simultaneous fit of ABCD regions")
     parser.add_argument("--skipSumGroups", action="store_true", help="Don't add sum groups to the output to save time e.g. when computing impacts")
     parser.add_argument("--allowNegativeExpectation", action="store_true", help="Allow processes to have negative contributions")
@@ -284,10 +285,13 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
 
     if wmass and not xnorm:
         datagroups.fakerate_axes=args.fakerateAxes
-        datagroups.set_histselectors(datagroups.getNames(), inputBaseName, mode=args.fakeEstimation,
-                                     smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate,
-                                     integrate_x="mt" not in fitvar,
-                                     simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
+        datagroups.set_histselectors(
+            datagroups.getNames(), inputBaseName, mode=args.fakeEstimation,
+            smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.fakeSmoothingOrder,
+            mcCorr=args.fakeMCCorr,
+            integrate_x="mt" not in fitvar,
+            simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+            )
 
     # Start to create the CardTool object, customizing everything
     cardTool = CardTool.CardTool(xnorm=xnorm, simultaneousABCD=simultaneousABCD, real_data=args.realData)
@@ -360,10 +364,13 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
 
             if wmass and not xnorm:
                 pseudodataGroups.fakerate_axes=args.fakerateAxes
-                pseudodataGroups.set_histselectors(pseudodataGroups.getNames(), inputBaseName, mode=args.fakeEstimation,
-                smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate,
-                integrate_x="mt" not in fitvar,
-                simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
+                pseudodataGroups.set_histselectors(
+                    pseudodataGroups.getNames(), inputBaseName, mode=args.fakeEstimation,
+                    smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.fakeSmoothingOrder,
+                    mcCorr=args.fakeMCCorr,
+                    integrate_x="mt" not in fitvar,
+                    simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+                )
 
             cardTool.setPseudodataDatagroups(pseudodataGroups)
     if args.pseudoDataFakes:
@@ -374,8 +381,10 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             pseudodataGroups = Datagroups(args.pseudoDataFile if args.pseudoDataFile else inputFile, filterGroups=filterGroupFakes)
             pseudodataGroups.fakerate_axes=args.fakerateAxes
             pseudodataGroups.copyGroup("QCD", "QCDTruth")
-            pseudodataGroups.set_histselectors(pseudodataGroups.getNames(), inputBaseName, 
-                mode=args.fakeEstimation, fake_processes=["QCD",], smoothing_mode=args.fakeSmoothingMode,
+            pseudodataGroups.set_histselectors(
+                pseudodataGroups.getNames(), inputBaseName, mode=args.fakeEstimation, fake_processes=["QCD",],
+                smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.fakeSmoothingOrder,
+                mcCorr=args.fakeMCCorr,
                 simultaneousABCD=simultaneousABCD, forceGlobalScaleFakes=args.forceGlobalScaleFakes,
                 )
         else:

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -118,8 +118,8 @@ axis_fakes_eta = hist.axis.Regular(int((template_maxeta-template_mineta)*10/2), 
 
 axis_fakes_pt = hist.axis.Variable(common.get_binning_fakes_pt(template_minpt, template_maxpt), name = "pt", overflow=False, underflow=False)
 
-axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min), name = "mt", underflow=False, overflow=True)
-axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(), name = "relIso",underflow=False, overflow=True)
+axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=False), name = "mt", underflow=False, overflow=True)
+axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=False), name = "relIso",underflow=False, overflow=True)
 axes_abcd = [axis_mtCat, axis_isoCat]
 axes_fakerate = [axis_fakes_eta, axis_fakes_pt, axis_charge, *axes_abcd]
 columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "transverseMass", "goodMuons_relIso0"]
@@ -656,6 +656,10 @@ def build_graph(df, dataset):
 
     if not args.onlyMainHistograms:
         syst_tools.add_QCDbkg_jetPt_hist(results, df, axes, cols, jet_pt=30, storage_type=storage_type)
+
+    if isQCDMC:
+        unweighted = df.HistoBoost("unweighted", axes, cols)
+        results.append(unweighted)
 
     if dataset.is_data:
         nominal = df.HistoBoost("nominal", axes, cols)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -36,7 +36,7 @@ parser.add_argument("--vetoGenPartPt", type=float, default=15.0, help="Minimum p
 parser.add_argument("--selectVetoEventsMC", action="store_true", help="Select events which fail the veto, by enforcing at least two prompt preFSR muons in acceptance")
 parser.add_argument("--noTrigger", action="store_true", help="Just for test: remove trigger HLT bit selection and trigger matching (should also remove scale factors with --noScaleFactors for it to make sense)")
 parser.add_argument("--selectNonPromptFromSV", action="store_true", help="Test: define a non-prompt muon enriched control region")
-parser.add_argument("--selectNonPromptFromLighMesonDecay", action="store_true", help="Test: define a non-prompt muon enriched control region with muons from light meson decays")
+parser.add_argument("--selectNonPromptFromLightMesonDecay", action="store_true", help="Test: define a non-prompt muon enriched control region with muons from light meson decays")
 parser.add_argument("--useGlobalOrTrackerVeto", action="store_true", help="Use global-or-tracker veto definition and scale factors instead of global only")
 
 #
@@ -47,8 +47,8 @@ logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
 useGlobalOrTrackerVeto = args.useGlobalOrTrackerVeto
 
-if args.selectNonPromptFromLighMesonDecay and args.selectNonPromptFromSV:
-    raise ValueError("Options --selectNonPromptFromSV and --selectNonPromptFromLighMesonDecay cannot be used together.")
+if args.selectNonPromptFromLightMesonDecay and args.selectNonPromptFromSV:
+    raise ValueError("Options --selectNonPromptFromSV and --selectNonPromptFromLightMesonDecay cannot be used together.")
 
 isUnfolding = args.analysisMode == "unfolding"
 isTheoryAgnostic = args.analysisMode in ["theoryAgnosticNormVar", "theoryAgnosticPolVar"]
@@ -375,7 +375,7 @@ def build_graph(df, dataset):
     df = muon_selections.select_good_muons(df, template_minpt, template_maxpt, dataset.group, nMuons=1,
                                            use_trackerMuons=args.trackerMuons, use_isolation=False,
                                            nonPromptFromSV=args.selectNonPromptFromSV,
-                                           nonPromptFromLighMesonDecay=args.selectNonPromptFromLighMesonDecay,
+                                           nonPromptFromLighMesonDecay=args.selectNonPromptFromLightMesonDecay,
                                            requirePixelHits=args.requirePixelHits)
 
     # the corrected RECO muon kinematics, which is intended to be used as the nominal

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -44,8 +44,9 @@ parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify c
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
 parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
 parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
+parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
-parser.add_argument("--smoothingOrderFakerate", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate ")
+parser.add_argument("--fakeSmoothingOrder", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
 parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
 parser.add_argument("--fineGroups", action='store_true', help="Plot each group as a separate process, otherwise combine groups based on predefined dictionary")
 
@@ -132,7 +133,16 @@ else:
 
 groups.fakerate_axes=args.fakerateAxes
 if applySelection:
-    groups.set_histselectors(datasets, args.baseName, smoothing_mode=args.fakeSmoothingMode, smoothingOrderFakerate=args.smoothingOrderFakerate, integrate_x=all("mt" not in x.split("-") for x in args.hists), mode=args.fakeEstimation, forceGlobalScaleFakes=args.forceGlobalScaleFakes)
+    groups.set_histselectors(
+        datasets,
+        args.baseName,
+        smoothing_mode=args.fakeSmoothingMode,
+        smoothingOrderFakerate=args.fakeSmoothingOrder,
+        integrate_x=all("mt" not in x.split("-") for x in args.hists),
+        mode=args.fakeEstimation,
+        forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+        mcCorr=args.fakeMCCorr,
+        )
 
 if not args.nominalRef:
     nominalName = args.baseName.rsplit("_", 1)[0]

--- a/scripts/plotting/postfitPlots.py
+++ b/scripts/plotting/postfitPlots.py
@@ -11,6 +11,8 @@ import itertools
 
 from narf import ioutils
 
+import scipy.stats
+
 from utilities import common, logging, differential, boostHistHelpers as hh
 from utilities.styles import styles
 from wremnants import plot_tools
@@ -170,6 +172,7 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
     scale = max(1, np.divide(*ax1.get_figure().get_size_inches())*0.3)
 
     if chi2 is not None:
+        p_val = round(scipy.stats.chi2.sf(chi2[0], chi2[1])*100,1)
         if saturated_chi2:
             chi2_name = "\chi_{\mathrm{sat.}}^2/ndf"
         else:
@@ -177,10 +180,10 @@ def make_plot(h_data, h_inclusive, h_stack, axes, colors=None, labels=None, suff
         if len(h_data.values())<100:
             plt.text(0.05, 0.94, f"${chi2_name}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
                 fontsize=20*args.scaleleg*scale)  
-            plt.text(0.05, 0.86, f"$= {round(chi2[0],1)}/{chi2[1]}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
+            plt.text(0.05, 0.86, f"$= {round(chi2[0],1)}/{chi2[1]} (p={p_val}\%)$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
                 fontsize=20*args.scaleleg*scale)  
         else:
-            plt.text(0.05, 0.94, f"${chi2_name} = {round(chi2[0],1)}/{chi2[1]}$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
+            plt.text(0.05, 0.94, f"${chi2_name} = {round(chi2[0],1)}/{chi2[1]} (p={p_val}\%)$", horizontalalignment='left', verticalalignment='top', transform=ax1.transAxes,
                 fontsize=20*args.scaleleg*scale)
 
     plot_tools.redo_axis_ticks(ax1, "x")

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -761,6 +761,7 @@ class CardTool(object):
 
         # now load the nominal histograms
         # only load nominal histograms that are not already loaded
+        procDictFromNomi = self.datagroups.getDatagroups()
         processesFromNomiToLoad = [proc for proc in self.datagroups.groups.keys() if self.nominalName not in procDictFromNomi[proc].hists]
         if len(processesFromNomiToLoad):
             self.datagroups.loadHistsForDatagroups(
@@ -770,7 +771,6 @@ class CardTool(object):
                 lumiScaleVarianceLinearly=self.lumiScaleVarianceLinearly,
                 forceNonzero=forceNonzero,
                 sumFakesPartial=not self.simultaneousABCD)
-        procDictFromNomi = self.datagroups.getDatagroups()
 
         if "QCD" not in procDict:
             # use truth MC as QCD

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -176,7 +176,7 @@ class HDF5Writer(object):
                 axes = chanInfo.fit_axes[:]
                 nbinschan = None
 
-            # load data and nominal ans syst histograms
+            # load data and nominal and syst histograms
             dg.loadHistsForDatagroups(
                 baseName=chanInfo.nominalName, syst=chanInfo.nominalName,
                 procsToRead=dg.groups.keys(),
@@ -691,6 +691,7 @@ class HDF5Writer(object):
         kstat = np.square(sumw)/sumw2
         #numerical protection to avoid poorly defined constraint
         kstat = np.where(np.equal(sumw,0.), 1., kstat)
+        kstat = np.where(np.equal(sumw2,0.), 1., kstat)
 
         #write results to hdf5 file
         procSize = nproc*np.dtype(self.dtype).itemsize

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -197,7 +197,9 @@ def compute_chi2(y, y_pred, w=None, nparams=1):
     ndf = y.shape[-1] - nparams
     ndf_total = y.size - chi2.size*nparams
 
-    logger.info(f"Total chi2/ndf = {chi2_total}/{ndf_total} = {chi2_total/ndf_total}")
+    from scipy import stats
+
+    logger.info(f"Total chi2/ndf = {chi2_total}/{ndf_total} = {chi2_total/ndf_total} (p = {stats.chi2.sf(chi2_total, ndf_total)})")
     return chi2, ndf    
 
 def extend_edges(traits, x):
@@ -357,9 +359,9 @@ class SignalSelectorABCD(HistselectorABCD):
 class FakeSelectorSimpleABCD(HistselectorABCD):
     # simple ABCD method
     def __init__(self, h, *args, 
-        smoothing_mode="full",
+        smoothing_mode="full", # 'binned', 'fakerate', or 'full'
         smoothing_order_fakerate=2,
-        throw_toys=None,#"normal", # None, 'normal' or 'poisson'
+        throw_toys=None, #"normal", # None, 'normal' or 'poisson'
         global_scalefactor=1, # apply global correction factor on prediction
         **kwargs
     ):

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -980,7 +980,7 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
         
         return d, dvar
 
-    def compute_fakeratefactor(self, h, syst_variations=False, flow=True, auxiliary_info=False):
+    def compute_fakeratefactor(self, h, smoothing=False, syst_variations=False, flow=True, auxiliary_info=False):
         # rebin in smoothing axis to have stable ratios
         sel = {n: hist.sum for n in self.fakerate_integration_axes}
         hNew = hh.rebinHist(h[sel], self.smoothing_axis_name, self.rebin_smoothing_axis) if self.rebin_smoothing_axis is not None else h[sel]
@@ -1055,7 +1055,7 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
             logger.info("Done with toys")
 
 
-        if self.smoothing_mode == "fakerate":
+        if smoothing:
             x = self.get_bin_centers_smoothing(hNew, flow=True) # the bins where the smoothing is performed (can be different to the bin in h)
             y, y_var = self.smoothen(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info, flow=flow)
 
@@ -1133,7 +1133,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         if self.smoothing_mode=="fakerate" or self.interpolate_x or self.smooth_shapecorrection:
             h = self.transfer_variances(h, set_nominal=is_nominal)
 
-            y_frf, y_frf_var = self.compute_fakeratefactor(h, syst_variations=variations_smoothing)
+            y_frf, y_frf_var = self.compute_fakeratefactor(h, smoothing=True, syst_variations=variations_smoothing)
             y_scf, y_scf_var = self.compute_shapecorrection(h, syst_variations=variations_scf)
             c, cvar = self.get_yields_applicationregion(h)
 
@@ -1397,7 +1397,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
             return y, y_var
 
 
-    def compute_fakeratefactor(self, h, syst_variations=False, flow=True, auxiliary_info=False):
+    def compute_fakeratefactor(self, h, smoothing=False, syst_variations=False, flow=True, auxiliary_info=False):
         # rebin in smoothing axis to have stable ratios
         sel = {n: hist.sum for n in self.fakerate_integration_axes}
         hNew = hh.rebinHist(h[sel], self.smoothing_axis_name, self.rebin_smoothing_axis) if self.rebin_smoothing_axis is not None else h[sel]
@@ -1468,7 +1468,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
 
             logger.info("Done with toys")
 
-        if self.smoothing_mode == "fakerate":
+        if smoothing:
             x = self.get_bin_centers_smoothing(hNew, flow=True) # the bins where the smoothing is performed (can be different to the bin in h)
             y, y_var = self.smoothen(h, x, y, y_var, syst_variations=syst_variations, auxiliary_info=auxiliary_info)
 

--- a/wremnants/muon_selections.py
+++ b/wremnants/muon_selections.py
@@ -77,8 +77,11 @@ def select_good_muons(df, ptLow, ptHigh, datasetGroup, nMuons=1, use_trackerMuon
         # medium ID added afterwards
         df = select_good_secondary_vertices(df)
         # match by index
-        df = df.Define("Muon_goodSV", "ROOT::VecOps::Take(goodSV, Muon_svIdx, 0)")
-        goodMuonsSelection += " && Muon_sip3d > 4.0 && Muon_goodSV"
+        # FIXME: result is not as expected, somthing might be wrong here (either in nanoAOD or in accessing it) disabled for now
+        # df = df.Define("Muon_goodSV", "ROOT::VecOps::Take(goodSV, Muon_svIdx, 0)")
+        # goodMuonsSelection += " && Muon_sip3d > 4.0 && Muon_goodSV"
+
+        goodMuonsSelection += " && Muon_sip3d > 4.0 && wrem::hasMatchDR2(Muon_correctedEta,Muon_correctedPhi,SV_eta[goodSV],SV_phi[goodSV], 0.01)"
 
     if nonPromptFromLighMesonDecay:
         # looseID should be part of veto, but just in case, the global condition should also already exist

--- a/wremnants/plot_tools.py
+++ b/wremnants/plot_tools.py
@@ -239,8 +239,11 @@ def makeStackPlotWithRatio(
             raise ValueError("Can't normalize to data without a data histogram!")
 
         vals = [x.value if hasattr(x, "value") else x for x in (data_hist.sum(), hh.sumHists(stack).sum())]
+        varis = [x.variance if hasattr(x, "variance") else x**0.5 for x in (data_hist.sum(), hh.sumHists(stack).sum())]
         scale = vals[0]/vals[1]
-        logger.info(f"Rescaling all processes by {scale:0.3f} to match data norm")
+        unc = scale*(varis[0]/vals[0]**2 + varis[1]/vals[1]**2)**0.5
+        ndigits = -math.floor(math.log10(abs(unc))) + 1
+        logger.info(f"Rescaling all processes by {round(scale,ndigits)} +/- {round(unc,ndigits)} to match data norm")
         stack = [s*scale for s in stack]
 
     hep.histplot(


### PR DESCRIPTION
- Adapt the implementation of the full smoothing to make it work for simple and extended2D. This was mainly done by moving the functions into the ```FakeSelectorSimpleABCD``` class, that gets inherited by the extended methods. 
- Add nonclosure corrections in histselector class to be used with QCD MC histogram (off by default). In the future we could change to this to automatically scale the fakes and avoid hard coded scale factors (or even make a pT-eta dependent correction, to be decided)
- Reverting the muon selection for the secondary vertex control regions, as the new selection by index does not look as expected (seeing way more prompt contamination)
- Adding a protection in the hdf5 writer for bins with sumw2=0 (setting ```kstat = np.where(np.equal(sumw2,0.), 1., kstat)```)
- A few minor changes and changes on plotting scripts