### PR TITLE
Improve fake smoothing and switch to Extended2D by default

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -80,7 +80,7 @@ def make_parser(parser=None):
     parser.add_argument("--fitresult", type=str, default=None ,help="Use data and covariance matrix from fitresult (for making a theory fit)")
     parser.add_argument("--noMCStat", action='store_true', help="Do not include MC stat uncertainty in covariance for theory fit (only when using --fitresult)")
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
-    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
+    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -80,7 +80,7 @@ def make_parser(parser=None):
     parser.add_argument("--fitresult", type=str, default=None ,help="Use data and covariance matrix from fitresult (for making a theory fit)")
     parser.add_argument("--noMCStat", action='store_true', help="Do not include MC stat uncertainty in covariance for theory fit (only when using --fitresult)")
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
-    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
+    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
@@ -123,7 +123,7 @@ def make_parser(parser=None):
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
     parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor for Wmass")
     parser.add_argument("--logNormalWmunu", default=-1, type=float, help="Add lnN uncertainty for W signal (mainly for tests wifakes in control regions, where W is a subdominant background). If negative nothing is added")
-    parser.add_argument("--logNormalFake", default=1.15, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative nothing is added")
+    parser.add_argument("--logNormalFake", default=1.02, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative nothing is added")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -746,7 +746,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             systNamePrepend=subgroup,
             actionArgs=dict(variations_smoothing=True),
         )
-        if args.fakeEstimation in ["extended2D",]:
+        if args.fakeEstimation in ["extended2D",] and args.fakeSmoothingMode != "full":
             subgroup = f"{cardTool.getFakeName()}Shape"
             cardTool.addSystematic(**info,
                 rename=subgroup,

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -118,8 +118,8 @@ axis_fakes_eta = hist.axis.Regular(int((template_maxeta-template_mineta)*10/2), 
 
 axis_fakes_pt = hist.axis.Variable(common.get_binning_fakes_pt(template_minpt, template_maxpt), name = "pt", overflow=False, underflow=False)
 
-axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=False), name = "mt", underflow=False, overflow=True)
-axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=False), name = "relIso",underflow=False, overflow=True)
+axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=True), name = "mt", underflow=False, overflow=True)
+axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=True), name = "relIso",underflow=False, overflow=True)
 axes_abcd = [axis_mtCat, axis_isoCat]
 axes_fakerate = [axis_fakes_eta, axis_fakes_pt, axis_charge, *axes_abcd]
 columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "transverseMass", "goodMuons_relIso0"]

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -42,7 +42,7 @@ parser.add_argument("--noRatioErr", action='store_false', dest="ratioError", hel
 parser.add_argument("--selection", type=str, help="Specify custom selections as comma seperated list (e.g. '--selection passIso=0,passMT=1' )")
 parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
-parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
+parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
 parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
 parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -116,9 +116,11 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 
 def get_binning_fakes_pt(min_pt, max_pt):
-    edges = np.arange(min_pt,32,1)
-    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
-    edges = np.append(edges, [max_pt])
+    edges = np.arange(min_pt, max_pt+3, 3)
+    # edges = np.arange(min_pt,32,1)
+    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -117,17 +117,17 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 def get_binning_fakes_pt(min_pt, max_pt):
     edges = np.arange(min_pt,32,1)
-    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
     edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
+    # edges = np.arange(min_pt,32,1)
+    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt,32,2)
     #edges = np.append(edges, [e for e in [32, 36, 40, 46, 56] if e<max_pt][:-1])
-    #edges = np.append(edges, [max_pt])
-    #edges = np.arange(min_pt,32,1)
-    #edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt, max_pt, 3)
     #edges = np.append(edges, [max_pt])

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -116,11 +116,9 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 
 def get_binning_fakes_pt(min_pt, max_pt):
-    edges = np.arange(min_pt, max_pt+3, 3)
-    # edges = np.arange(min_pt,32,1)
-    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
-    # edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
-    # edges = np.append(edges, [max_pt])
+    edges = np.arange(min_pt,32,1)
+    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])
@@ -128,6 +126,12 @@ def get_binning_fakes_pt(min_pt, max_pt):
     #edges = np.arange(min_pt,32,2)
     #edges = np.append(edges, [e for e in [32, 36, 40, 46, 56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
+    #edges = np.arange(min_pt,32,1)
+    #edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
+    #edges = np.append(edges, [max_pt])
+    #edges = np.arange(min_pt, max_pt, 3)
+    #edges = np.append(edges, [max_pt])
+
     return edges
 
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -752,7 +752,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             goodbin = (dsel > 0.) & (dvarsel > 0.)
 
             logd = np.where(goodbin, np.log(dsel), 0.)
-            logdvar = np.where(goodbin, dvarsel/dsel**2, 1e6)
+            logdvar = np.where(goodbin, dvarsel/dsel**2, 1.)
             x = smoothing_axis.centers
 
             if syst_variations:
@@ -764,8 +764,10 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
                 # print(f"chisq/ndof = {chi2}/{ndf}")
 
             dsel = np.exp(logd)*xwidthtgt
+            dsel = np.where(np.isfinite(dsel), dsel, 0.)
             if syst_variations:
                 dvarsel = np.exp(logdvar)*xwidthtgt[..., None, None]**2
+                dvarsel = np.where((dsel[..., None, None] > 0.) & np.isfinite(dvarsel), dvarsel,  dsel[..., None, None])
 
         # get output shape from original hist axes, but as for result histogram
         d = np.zeros([a.extent if flow else a.shape for a in h[{self.name_x:self.sel_x if not self.integrate_x else hist.sum}].axes if a.name != self.name_y], dtype=dsel.dtype)

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -245,9 +245,9 @@ def get_rebinning(edges, axis_name):
 
 def divide_arrays(num, den, cutoff=1):
     r = num/den
-    criteria = abs(den) < cutoff
+    criteria = abs(den) <= cutoff
     if np.sum(criteria) > 0:
-        logger.warning(f"Found {np.sum(criteria)} values in denominator below {cutoff}, the ratio will be set to 0 for those")
+        logger.warning(f"Found {np.sum(criteria)} values in denominator less than or equal to {cutoff}, the ratio will be set to 0 for those")
     r[abs(den) < cutoff] = 0 # if denumerator is close to 0 set ratio to zero to avoid large negative/positive values
     return r
 
@@ -1270,7 +1270,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         # shape correction factor
         y_num = c**2 if apply else c
         y_den = cy
-        y = divide_arrays(y_num,y_den)
+        y = divide_arrays(y_num,y_den, cutoff=0.)
 
         if self.throw_toys:
             logger.info("Throw toys")
@@ -1483,7 +1483,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         # fakerate factor
         y_num = (ax*ay*b)**2
         y_den = a**4 * axy * bx
-        y = divide_arrays(y_num,y_den)
+        y = divide_arrays(y_num,y_den, cutoff=0.)
 
         if h.storage_type == hist.storage.Weight:
             # full variances

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -280,13 +280,17 @@ def spline_smooth(binvals, edges, edges_out, axis, binvars=None, syst_variations
 
     yvars = np.zeros((*ynom.shape, nvars, 2), dtype=ynom.dtype)
 
+    binerrs = np.sqrt(binvars)
+
     # fluctuate the bin contents one by one to build the variations
     for ivar in range(nvars):
         for iupdown in range(2):
             scale = 1. if iupdown==0 else -1.
 
             binvalsvar = binvals.copy()
-            binvalsvar[ivar] += scale*np.sqrt(binvars[ivar])
+            varsel = binvals.ndim*[slice(None)]
+            varsel[axis] = ivar
+            binvalsvar[*varsel] += scale*binerrs[*varsel]
 
             yvars[..., ivar, iupdown] = spline_smooth_nominal(binvalsvar, edges, edges_out, axis=axis)
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -426,8 +426,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         else:
             self.polynomial = "power"
 
-        # rebinning doesn't make sense for binned estimation
-        if smoothing_mode == "binned":
+        # rebinning doesn't make sense for binned estimation and causes issues
+        # for full smoothing
+        if smoothing_mode in ["binned", "full"]:
             self.rebin_smoothing_axis = None
 
         if hasattr(self, "fakerate_integration_axes"):

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -426,9 +426,8 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         else:
             self.polynomial = "power"
 
-        # rebinning doesn't make sense for binned estimation and causes issues
-        # for full smoothing
-        if smoothing_mode in ["binned", "full"]:
+        # rebinning doesn't make sense for binned estimation
+        if smoothing_mode in ["binned"]:
             self.rebin_smoothing_axis = None
 
         if hasattr(self, "fakerate_integration_axes"):


### PR DESCRIPTION
It turns out that the exp(pol) smoothing is significantly improved when not rebinning for the fake rate estimate, since this makes it harder to correctly model the shape (especially in the last bins where extrapolation kicks in)

The pathological behaviour of smoothing order 3 is now fixed, but I have left the default at 2 for the moment since it's not clear if higher orders are actually needed with the change in binning.

I think the issue of the Gaussian error propagation with poor statistics is also partly or fully mitigated by smoothing in the log space, since there is effectively no ratio anymore.  The behaviour of the cutoff protections for the extended2D method have also been adjust accordingly.

The Extended2D fake estimate is now the default and the fake normalization uncertainty has been reduced from 15% to 2% (the exact number might still need to be refined)

This clearly needs significant additional checks  and validation.

@davidwalter2 