### PR TITLE
Skip nuisance parameters that would affect no processes when preparing the fit setup 

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -54,6 +54,7 @@ def make_parser(parser=None):
     parser.add_argument("--sparse", action="store_true", help="Write out datacard in sparse mode (only for when using hdf5)")
     parser.add_argument("--excludeProcGroups", type=str, nargs="*", help="Don't run over processes belonging to these groups (only accepts exact group names)", default=["QCD"])
     parser.add_argument("--filterProcGroups", type=str, nargs="*", help="Only run over processes belonging to these groups", default=[])
+    parser.add_argument("--skipLnNSystWithNoProcs", action='store_true', help="Skip LnN systematics that would end up applied to no process (can happen when filtering or excluding them with --excludeProcGroups/--filterProcGroups), without raising errors.")
     parser.add_argument("-x", "--excludeNuisances", type=str, default="", help="Regular expression to exclude some systematics from the datacard")
     parser.add_argument("-k", "--keepNuisances", type=str, default="", help="Regular expression to keep some systematics, overriding --excludeNuisances. Can be used to keep only some systs while excluding all the others with '.*'")
     parser.add_argument("--absolutePathInCard", action="store_true", help="In the datacard, set Absolute path for the root file where shapes are stored")
@@ -300,7 +301,9 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     logger.debug(f"Making datacards with these processes: {cardTool.getProcesses()}")
     if args.absolutePathInCard:
         cardTool.setAbsolutePathShapeInCard()
-
+    if args.skipLnNSystWithNoProcs:
+        cardTool.setSkipLnNSystWithNoProcs()
+        
     if simultaneousABCD:
         # In case of ABCD we need to have different fake processes for e and mu to have uncorrelated uncertainties
         cardTool.setFakeName(datagroups.fakeName + (datagroups.flavor if datagroups.flavor else ""))

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -54,7 +54,6 @@ def make_parser(parser=None):
     parser.add_argument("--sparse", action="store_true", help="Write out datacard in sparse mode (only for when using hdf5)")
     parser.add_argument("--excludeProcGroups", type=str, nargs="*", help="Don't run over processes belonging to these groups (only accepts exact group names)", default=["QCD"])
     parser.add_argument("--filterProcGroups", type=str, nargs="*", help="Only run over processes belonging to these groups", default=[])
-    parser.add_argument("--skipLnNSystWithNoProcs", action='store_true', help="Skip LnN systematics that would end up applied to no process (can happen when filtering or excluding them with --excludeProcGroups/--filterProcGroups), without raising errors.")
     parser.add_argument("-x", "--excludeNuisances", type=str, default="", help="Regular expression to exclude some systematics from the datacard")
     parser.add_argument("-k", "--keepNuisances", type=str, default="", help="Regular expression to keep some systematics, overriding --excludeNuisances. Can be used to keep only some systs while excluding all the others with '.*'")
     parser.add_argument("--absolutePathInCard", action="store_true", help="In the datacard, set Absolute path for the root file where shapes are stored")
@@ -300,9 +299,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     logger.debug(f"Making datacards with these processes: {cardTool.getProcesses()}")
     if args.absolutePathInCard:
         cardTool.setAbsolutePathShapeInCard()
-    if args.skipLnNSystWithNoProcs:
-        cardTool.setSkipLnNSystWithNoProcs()
-        
+
     if simultaneousABCD:
         # In case of ABCD we need to have different fake processes for e and mu to have uncorrelated uncertainties
         cardTool.setFakeName(datagroups.fakeName + (datagroups.flavor if datagroups.flavor else ""))

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -71,7 +71,6 @@ class CardTool(object):
         self.simultaneousABCD = simultaneousABCD
         self.real_data = real_data
         self.absolutePathShapeFileInCard = False
-        self.skipLnNSystWithNoProcs = False
         self.excludeProcessForChannel = {} # can be used to exclue some POI when runnig a specific name (use case, force gen and reco charges to match)
         self.chargeIdDict = {"minus" : {"val" : -1, "id" : "q0", "badId" : "q1"},
                              "plus"  : {"val" : 1., "id" : "q1", "badId" : "q0"},
@@ -133,9 +132,6 @@ class CardTool(object):
 
     def setAbsolutePathShapeInCard(self, setRelative=False):
         self.absolutePathShapeFileInCard = False if setRelative else True
-
-    def setSkipLnNSystWithNoProcs(self, skip=True):
-        self.skipLnNSystWithNoProcs = skip
 
     def getProcsNoStatUnc(self):
         return self.noStatUncProcesses
@@ -1052,12 +1048,8 @@ class CardTool(object):
         for name,info in self.lnNSystematics.items():
             if self.isExcludedNuisance(name): continue
             if all(x not in info["processes"] for x in nondata):
-                message = f"Trying to add lnN uncertainty {name} for {info['processes']}, which are not valid processes; see predicted processes: {nondata}."
-                if self.skipLnNSystWithNoProcs:
-                    logger.warning(f"{message}. It will be skipped")
-                    continue
-                else:
-                    raise ValueError (f"{message}")
+                logger.warning(f"Trying to add lnN uncertainty {name} for {info['processes']}, which are not valid processes; see predicted processes: {nondata}.. It will be skipped")
+                continue
 
             group = info["group"]
             groupFilter = info["groupFilter"]

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -1044,12 +1044,13 @@ class CardTool(object):
         nondata_chan = {chan: nondata.copy() for chan in self.channels}
         for chan in self.excludeProcessForChannel.keys():
             nondata_chan[chan] = list(filter(lambda x: not self.excludeProcessForChannel[chan].match(x), nondata))
-        # exit this function when a syst is applied to no process (can happen when some are excluded)
+        # skip any syst that would be applied to no process (can happen when some are excluded)
         for name,info in self.lnNSystematics.items():
             if self.isExcludedNuisance(name): continue
             if all(x not in info["processes"] for x in nondata):
-                raise ValueError (f"Trying to add lnN uncertainty for {info['processes']}, which is not a valid process; see predicted processes: {nondata}")
-            
+                logger.warning(f"Trying to add lnN uncertainty {name} for {info['processes']}, which are not valid processes; see predicted processes: {nondata}. It will be skipped")
+                continue
+
             group = info["group"]
             groupFilter = info["groupFilter"]
             for chan in self.channels:


### PR DESCRIPTION
This PR partially reverts https://github.com/WMass/WRemnants/pull/492/files and fixes a bug that was in the previous version of the code.

Usually the code would skip any nuisance that ends up being applied to no process in the list of requested ones. Typically this can happen when excluding processes for tests (e.g. when running with signal only). For lnN syst the logic was bugged because the function deals with the whole set of defined LnN syst, and it was returning as soon as one lone nuisance applied to no process was appearing, while it should just continue and move to the next lnN.
For shape systs the logic is the same but in that case returning is fine, because the corresponding function deals with all nuisance handled by a single call to CardTool.addSystematics (e.g. all effStat, or all Pdfs, which can't be applied to different processes for specific nuisance parameters), so as soon as the first one is found with no associated processes it is necessarily going to find no processes for all the others in that group. 

The current code should properly work also for lowPU now.

**Note**: the part of the code concerned by this PR is entered only when using the root based version of setupCombine, not the hdf5 one. Hence, there is no point in having options to customise what the code should do when lone systematics are found (i.e. whether to raise errors or just continue with a warning). Continuing execution with a warning is the original intended behaviour, though, because this case is expected to happen only when running tests. 
