### PR TITLE
Update of fakes

### DIFF
--- a/scripts/combine/saturatedGOF.py
+++ b/scripts/combine/saturatedGOF.py
@@ -18,8 +18,8 @@ meta = ioutils.pickle_load_h5py(fitresult_h5py["meta"])
 nbins = sum([np.product([len(a) for a in info["axes"]]) for info in meta["channel_info"].values()])
 ndf = nbins - tree.ndofpartial
 
+print(f"nbins = {nbins}")
 print(f"-loglikelihood_{{full}} = {tree.nllvalfull}")
 print(f"-loglikelihood_{{saturated}} = {tree.satnllvalfull}")
-print(f"2*(nllfull-nllsat) = {2*(tree.nllvalfull-tree.satnllvalfull)}")
-print(f"nbins = {nbins}")
-print("chi2 probability =", scipy.stats.chi2.sf(2*(tree.nllvalfull-tree.satnllvalfull), ndf))
+print(f"2*(nllfull-nllsat)/ndf = {2*(tree.nllvalfull-tree.satnllvalfull)}/{ndf}")
+print("chi2 probability =", scipy.stats.chi2.sf(2*(tree.nllvalfull-tree.satnllvalfull), ndf)*100, "%")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -84,7 +84,7 @@ def make_parser(parser=None):
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
-    parser.add_argument("--fakeSmoothingOrder", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
+    parser.add_argument("--fakeSmoothingOrder", type=int, default=3, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
     parser.add_argument("--simultaneousABCD", action="store_true", help="Produce datacard for simultaneous fit of ABCD regions")
     parser.add_argument("--skipSumGroups", action="store_true", help="Don't add sum groups to the output to save time e.g. when computing impacts")
     parser.add_argument("--allowNegativeExpectation", action="store_true", help="Allow processes to have negative contributions")
@@ -122,7 +122,7 @@ def make_parser(parser=None):
     parser.add_argument("--binnedScaleFactors", action='store_true', help="Use binned scale factors (different helpers and nuisances)")
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
     parser.add_argument("--logNormalWmunu", default=-1, type=float, help="Add lnN uncertainty for W signal (mainly for tests wifakes in control regions, where W is a subdominant background). If negative nothing is added")
-    parser.add_argument("--logNormalFake", default=1.02, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative nothing is added")
+    parser.add_argument("--logNormalFake", default=1.05, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative, treat as free floating, if 0 nothing is added")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -719,6 +719,8 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background", splitGroup = {"experiment": ".*"})
         if args.logNormalFake > 0.0:
             cardTool.addLnNSystematic(f"CMS_{cardTool.getFakeName()}", processes=[cardTool.getFakeName()], size=args.logNormalFake, group="Fake", splitGroup = {"experiment": ".*"})
+        elif args.logNormalFake < 0.0:
+            cardTool.datagroups.unconstrainedProcesses.append(cardTool.getFakeName())
         cardTool.addLnNSystematic("CMS_Top", processes=["Top"], size=1.06, group="CMS_background", splitGroup = {"experiment": ".*"})
         cardTool.addLnNSystematic("CMS_VV", processes=["Diboson"], size=1.16, group="CMS_background", splitGroup = {"experiment": ".*"})
         cardTool.addSystematic("luminosity",

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -80,7 +80,7 @@ def make_parser(parser=None):
     parser.add_argument("--fitresult", type=str, default=None ,help="Use data and covariance matrix from fitresult (for making a theory fit)")
     parser.add_argument("--noMCStat", action='store_true', help="Do not include MC stat uncertainty in covariance for theory fit (only when using --fitresult)")
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
-    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
+    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -80,7 +80,7 @@ def make_parser(parser=None):
     parser.add_argument("--fitresult", type=str, default=None ,help="Use data and covariance matrix from fitresult (for making a theory fit)")
     parser.add_argument("--noMCStat", action='store_true', help="Do not include MC stat uncertainty in covariance for theory fit (only when using --fitresult)")
     parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
-    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
+    parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["closure", "simple", "extrapolate", "extended1D", "extended2D"])
     parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
     parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
     parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
@@ -123,7 +123,7 @@ def make_parser(parser=None):
     parser.add_argument("--isoEfficiencySmoothing", action='store_true', help="If isolation SF was derived from smooth efficiencies instead of direct smoothing")
     parser.add_argument("--scaleZmuonVeto", default=1, type=float, help="Scale the second muon veto uncertainties by this factor for Wmass")
     parser.add_argument("--logNormalWmunu", default=-1, type=float, help="Add lnN uncertainty for W signal (mainly for tests wifakes in control regions, where W is a subdominant background). If negative nothing is added")
-    parser.add_argument("--logNormalFake", default=1.15, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative nothing is added")
+    parser.add_argument("--logNormalFake", default=1.02, type=float, help="Specify lnN uncertainty for Fake background (for W analysis). If negative nothing is added")
     # pseudodata
     parser.add_argument("--pseudoData", type=str, nargs="+", help="Histograms to use as pseudodata")
     parser.add_argument("--pseudoDataAxes", type=str, nargs="+", default=[None], help="Variation axes to use as pseudodata for each of the histograms")
@@ -746,7 +746,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             systNamePrepend=subgroup,
             actionArgs=dict(variations_smoothing=True),
         )
-        if args.fakeEstimation in ["extended2D",]:
+        if args.fakeEstimation in ["extended2D",] and args.fakeSmoothingMode != "full":
             subgroup = f"{cardTool.getFakeName()}Shape"
             cardTool.addSystematic(**info,
                 rename=subgroup,

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -118,8 +118,8 @@ axis_fakes_eta = hist.axis.Regular(int((template_maxeta-template_mineta)*10/2), 
 
 axis_fakes_pt = hist.axis.Variable(common.get_binning_fakes_pt(template_minpt, template_maxpt), name = "pt", overflow=False, underflow=False)
 
-axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=False), name = "mt", underflow=False, overflow=True)
-axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=False), name = "relIso",underflow=False, overflow=True)
+axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=True), name = "mt", underflow=False, overflow=True)
+axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=True), name = "relIso",underflow=False, overflow=True)
 axes_abcd = [axis_mtCat, axis_isoCat]
 axes_fakerate = [axis_fakes_eta, axis_fakes_pt, axis_charge, *axes_abcd]
 columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "transverseMass", "goodMuons_relIso0"]

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -118,8 +118,8 @@ axis_fakes_eta = hist.axis.Regular(int((template_maxeta-template_mineta)*10/2), 
 
 axis_fakes_pt = hist.axis.Variable(common.get_binning_fakes_pt(template_minpt, template_maxpt), name = "pt", overflow=False, underflow=False)
 
-axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=True), name = "mt", underflow=False, overflow=True)
-axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=True), name = "relIso",underflow=False, overflow=True)
+axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=False), name = "mt", underflow=False, overflow=True)
+axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=False), name = "relIso",underflow=False, overflow=True)
 axes_abcd = [axis_mtCat, axis_isoCat]
 axes_fakerate = [axis_fakes_eta, axis_fakes_pt, axis_charge, *axes_abcd]
 columns_fakerate = ["goodMuons_eta0", "goodMuons_pt0", "goodMuons_charge0", "transverseMass", "goodMuons_relIso0"]

--- a/scripts/plotting/fakerate.py
+++ b/scripts/plotting/fakerate.py
@@ -414,15 +414,159 @@ def plot_chi2_extnededABCD_scf(syst_variations=False, auxiliary_info=True,  poly
     plot_chi2(chi2_scf2.ravel(), ndf_scf2, outdirSCF, xlim=(0,35), suffix=proc, outfile="chi2_pol2")
     plot_chi2(chi2_scf3.ravel(), ndf_scf3, outdirSCF, xlim=(0,35), suffix=proc, outfile="chi2_pol3")
 
-def plot_diagnostics_extnededABCD(h, syst_variations=False, auxiliary_info=True, polynomial="power",
-    #polynomial="bernstein"
+def plot_diagnostics_extnededABCD(
+    h, outdir, syst_variations=False, auxiliary_info=True,
 ):
+    # plot the fake distribution in the signal region
+
+    smoothing_axis_name = "pt"
+    fakerate_axes = ["eta", "pt", "charge"]
+
+    # h = h[{"eta":hist.rebin(48),"charge":hist.rebin(2)}]
+
+    # selector = sel.FakeSelectorSimpleABCD
+    selector = sel.FakeSelector2DExtendedABCD
+
+    rebin_x_old=[26,27,28,29,30,31,33,36,40,46,56]
+    rebin_x_new=[26,27,28,29,30,31,32,35,38,41,44,47,50,53,56]
+
+    throw_toys = None
+
+    # fake selector binned w/o rebinning
+    logger.info("Make binned fake prediction")
+    hSel_binned = selector(h, 
+        fakerate_axes=fakerate_axes, rebin_smoothing_axis=None, smoothing_mode="binned", 
+        rebin_x=None, interpolate_x=False, smooth_shapecorrection=False, throw_toys=throw_toys)
+    h_binned = hSel_binned.get_hist(h)
+
+    logger.info("Make fakerate fake prediction w/ old binning")
+    hSel_fakerate = selector(h, fakerate_axes=fakerate_axes, smoothing_mode="fakerate", 
+        rebin_smoothing_axis=rebin_x_old, throw_toys=throw_toys)
+    h_fakerate = hSel_fakerate.get_hist(h)
+
+    logger.info("Make fakerate fake prediction w/ new binning")
+    hSel_fakerate_new = selector(h, fakerate_axes=fakerate_axes, smoothing_mode="fakerate", 
+        rebin_smoothing_axis=rebin_x_new, throw_toys=throw_toys)
+    h_fakerate_new = hSel_fakerate_new.get_hist(h)
+
+    logger.info("Make full fake prediction w/o rebinning")
+    hSel_full = selector(h, 
+        fakerate_axes=fakerate_axes, smoothing_order_fakerate=1, smoothing_mode="full", rebin_x=None, 
+        rebin_smoothing_axis=None, interpolate_x=False, smooth_shapecorrection=False, throw_toys=throw_toys)
+    h_full = hSel_full.get_hist(h)
+
+    logger.info("Make full fake prediction w/ old rebinning")
+    hSel_full_rebin = selector(h, 
+        fakerate_axes=fakerate_axes, smoothing_order_fakerate=1, smoothing_mode="full", 
+        rebin_smoothing_axis=rebin_x_old, interpolate_x=False, smooth_shapecorrection=False, throw_toys=throw_toys)
+    h_full_rebin = hSel_full_rebin.get_hist(h)
+
+    logger.info("Make full fake prediction w/ new rebinning")
+    hSel_full_rebin_new = selector(h, 
+        fakerate_axes=fakerate_axes, smoothing_order_fakerate=1, smoothing_mode="full", 
+        rebin_smoothing_axis=rebin_x_new, interpolate_x=False, smooth_shapecorrection=False, throw_toys=throw_toys)
+    h_full_rebin_new = hSel_full_rebin_new.get_hist(h)
+
+
+    etavar="\eta"
+    logy=True
+
+    # ylim = [1e4, 1e6]
+    ylim = [1e0, 1e6]
+
+    x_edges = h.axes[smoothing_axis_name].edges
+    x_widths = np.diff(x_edges)/2
+    x_centers = x_edges[:-1]+x_widths
+
+    for idx_charge, charge_bins in enumerate(h.axes["charge"]):
+        for idx_eta, eta_bins in enumerate(h.axes["eta"]):
+            slices = {"eta":idx_eta, "charge":idx_charge}
+
+            linestyles = ["-", "-", "--", "--", ":"]
+            colors = mpl.colormaps["tab10"]
+            outfile = f"charge{idx_charge}_eta{idx_eta}"
+            binlabel=f"${round(eta_bins[0],1)} < {etavar} < {round(eta_bins[1],1)}$"
+            
+            h1d_binned = h_binned[slices]
+            y_binned = h1d_binned.values()
+            yerr_binned = h1d_binned.variances()**0.5
+
+            h1d_fakerate = h_fakerate[slices]
+            y_fakerate = h1d_fakerate.values()
+            yerr_fakerate = h1d_fakerate.variances()**0.5
+
+            h1d_fakerate_new = h_fakerate_new[slices]
+            y_fakerate_new = h1d_fakerate_new.values()
+            yerr_fakerate_new = h1d_fakerate_new.variances()**0.5
+
+            h1d_full = h_full[slices]
+            y_full = h1d_full.values()
+            yerr_full = h1d_full.variances()**0.5
+
+            h1d_full_rebin = h_full_rebin[slices]
+            y_full_rebin = h1d_full_rebin.values()
+            yerr_full_rebin = h1d_full_rebin.variances()**0.5
+
+            h1d_full_rebin_new = h_full_rebin_new[slices]
+            y_full_rebin_new = h1d_full_rebin_new.values()
+            yerr_full_rebin_new = h1d_full_rebin_new.variances()**0.5
+
+            if logy:
+                # ylim = [max(0.1, min(y_binned)*0.5), max(y_binned+yerr_binned)*2]
+                pass
+            else:
+                ylim=None
+            #     # ylim = [max(0, min(y-yerr)*0.9), min(5,max(y+yerr))*1.1]
+            #     ylim = [0,5]
+            xlim=None
+
+            fig, ax1, ax2 = plot_tools.figureWithRatio(
+                h1d_binned, ylabel="Events", xlabel=styles.xlabels.get(smoothing_axis_name,smoothing_axis_name), 
+                cms_label=args.cmsDecor, xlim=xlim, ylim=ylim, logy=logy, rrange=[0.9,1.1], rlabel="1/binned")
+
+            ax1.errorbar(x_centers, y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_binned[:len(x_centers)], marker="", linestyle='none', color="k", label="binned")
+
+            ax1.errorbar(x_centers, y_fakerate[:len(x_centers)], xerr=x_widths, yerr=yerr_fakerate[:len(x_centers)], marker="", linestyle='none', color=colors(0), label="fakerate old rebinned")
+            ax1.errorbar(x_centers, y_fakerate_new[:len(x_centers)], xerr=x_widths, yerr=yerr_fakerate_new[:len(x_centers)], marker="", linestyle='none', color=colors(1), label="fakerate new rebinned")
+
+            ax1.errorbar(x_centers, y_full[:len(x_centers)], xerr=x_widths, yerr=yerr_full[:len(x_centers)], marker="", linestyle='none', color=colors(2), label="full")
+            ax1.errorbar(x_centers, y_full_rebin[:len(x_centers)], xerr=x_widths, yerr=yerr_full_rebin[:len(x_centers)], marker="", linestyle='none', color=colors(3), label="full old rebinned")
+            ax1.errorbar(x_centers, y_full_rebin_new[:len(x_centers)], xerr=x_widths, yerr=yerr_full_rebin_new[:len(x_centers)], marker="", linestyle='none', color=colors(4), label="full new rebinned")
+
+            #ratios
+            ax2.errorbar(x_centers, y_fakerate[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_fakerate[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color=colors(0))
+            ax2.errorbar(x_centers, y_fakerate_new[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_fakerate_new[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color=colors(1))
+            ax2.errorbar(x_centers, y_full[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_full[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color=colors(2))
+            ax2.errorbar(x_centers, y_full_rebin[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_full_rebin[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color=colors(3))
+            ax2.errorbar(x_centers, y_full_rebin_new[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_full_rebin_new[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color=colors(4))
+
+            ax2.errorbar(x_centers, y_binned[:len(x_centers)]/y_binned[:len(x_centers)], xerr=x_widths, yerr=yerr_binned[:len(x_centers)]/y_binned[:len(x_centers)], marker="", linestyle='none', color="k")
+
+            ax1.text(0.94, 0.9, binlabel, transform=ax1.transAxes, fontsize=20,
+                    verticalalignment='bottom', horizontalalignment="right")
+
+            ax1.text(1.0, 1.003, styles.process_labels[proc], transform=ax1.transAxes, fontsize=20,
+                    verticalalignment='bottom', horizontalalignment="right")
+            plot_tools.addLegend(ax1, ncols=2, text_size=20, loc="upper left")
+            plot_tools.fix_axes(ax1, ax2, logy=logy)
+
+            if args.postfix:
+                outfile += f"_{args.postfix}"
+
+            plot_tools.save_pdf_and_png(outdir, outfile)
+            plot_tools.write_index_and_log(outdir, outfile, args=args)
+
+        #     break
+        # break
+
+    return
+
     # smoothing_axis_name = "muonJetPt" #"pt"
     # fakerate_axes = ["abseta", "charge", "muonJetPt"]
     # h = hh.rebinHist(h[{"pt":hist.sum}], "muonJetPt", [26, 42, 46, 48, 54, 76])
 
     smoothing_axis_name = "pt"
-    fakerate_axes = ["abseta", "pt", "charge"]
+    fakerate_axes = ["eta", "pt", "charge"]
     h = hh.rebinHist(h[{"muonJetPt":hist.sum}], "pt", [28, 30, 33, 40, 56])
 
     hSel_simple_binned = sel.FakeSelectorSimpleABCD(h, fakerate_axes=fakerate_axes, smoothing_axis_name=smoothing_axis_name,
@@ -1091,18 +1235,16 @@ if __name__ == '__main__':
     for proc in args.procFilters:
         h = histInfo[proc].hists[args.baseName]
 
-        if proc != groups.fakeName:
-            plot_closure(h, outdir, suffix=f"{proc}", proc=proc, smoothing_mode="binned")
-            plot_closure(h, outdir, suffix=f"{proc}_normalized", proc=proc, smoothing_mode="binned", normalized=True)
-            plot_closure(h, outdir, suffix=f"{proc}_smooth_fakerate", proc=proc, smoothing_mode="fakerate")
-            plot_closure(h, outdir, suffix=f"{proc}_smooth_full", proc=proc, smoothing_mode="full")
+        # if proc != groups.fakeName:
+        #     plot_closure(h, outdir, suffix=f"{proc}", proc=proc, smoothing_mode="binned")
+        #     plot_closure(h, outdir, suffix=f"{proc}_normalized", proc=proc, smoothing_mode="binned", normalized=True)
+        #     plot_closure(h, outdir, suffix=f"{proc}_smooth_fakerate", proc=proc, smoothing_mode="fakerate")
+        #     plot_closure(h, outdir, suffix=f"{proc}_smooth_full", proc=proc, smoothing_mode="full")
 
-        continue
+        # continue
 
         # plot fakerate factors for full extended ABCD method
-        outdirFRF = output_tools.make_plot_dir(args.outpath, args.outfolder, eoscp=args.eoscp)
-        # outdirSCF = output_tools.make_plot_dir(args.outpath, args.outfolder, eoscp=args.eoscp)
-        plot_diagnostics_extnededABCD(h, outdirFRF)
+        plot_diagnostics_extnededABCD(h, outdir)
 
         continue
 

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -42,7 +42,7 @@ parser.add_argument("--noRatioErr", action='store_false', dest="ratioError", hel
 parser.add_argument("--selection", type=str, help="Specify custom selections as comma seperated list (e.g. '--selection passIso=0,passMT=[2::hist.sum]' )")
 parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
-parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
+parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
 parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
 parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -42,7 +42,7 @@ parser.add_argument("--noRatioErr", action='store_false', dest="ratioError", hel
 parser.add_argument("--selection", type=str, help="Specify custom selections as comma seperated list (e.g. '--selection passIso=0,passMT=1' )")
 parser.add_argument("--presel", type=str, nargs="*", default=[], help="Specify custom selections on input histograms to integrate some axes, giving axis name and min,max (e.g. '--presel pt=ptmin,ptmax' ) or just axis name for bool axes")
 parser.add_argument("--normToData", action='store_true', help="Normalize MC to data")
-parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended1D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
+parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fake estimation", default="extended2D", choices=["simple", "extrapolate", "extended1D", "extended2D"])
 parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
 parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")

--- a/scripts/plotting/makeDataMCStackPlot.py
+++ b/scripts/plotting/makeDataMCStackPlot.py
@@ -46,7 +46,7 @@ parser.add_argument("--fakeEstimation", type=str, help="Set the mode for the fak
 parser.add_argument("--fakeSmoothingMode", type=str, default="full", choices=["binned", "fakerate", "full"], help="Smoothing mode for fake estimate.")
 parser.add_argument("--fakeMCCorr", type=str, default=[None], nargs="*", choices=["none", "pt", "eta", "mt"], help="axes to apply nonclosure correction from QCD MC. Leave empty for inclusive correction, use'none' for no correction")
 parser.add_argument("--forceGlobalScaleFakes", default=None, type=float, help="Scale the fakes  by this factor (overriding any custom one implemented in datagroups.py in the fakeSelector).")
-parser.add_argument("--fakeSmoothingOrder", type=int, default=2, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
+parser.add_argument("--fakeSmoothingOrder", type=int, default=3, help="Order of the polynomial for the smoothing of the fake rate or full prediction, depending on the smoothing mode")
 parser.add_argument("--fakerateAxes", nargs="+", help="Axes for the fakerate binning", default=["eta","pt","charge"])
 parser.add_argument("--fineGroups", action='store_true', help="Plot each group as a separate process, otherwise combine groups based on predefined dictionary")
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -116,9 +116,11 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 
 def get_binning_fakes_pt(min_pt, max_pt):
-    edges = np.arange(min_pt,32,1)
-    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
-    edges = np.append(edges, [max_pt])
+    edges = np.arange(min_pt, max_pt+3, 3)
+    # edges = np.arange(min_pt,32,1)
+    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -117,17 +117,17 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 def get_binning_fakes_pt(min_pt, max_pt):
     edges = np.arange(min_pt,32,1)
-    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
     edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
+    # edges = np.arange(min_pt,32,1)
+    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    # edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt,32,2)
     #edges = np.append(edges, [e for e in [32, 36, 40, 46, 56] if e<max_pt][:-1])
-    #edges = np.append(edges, [max_pt])
-    #edges = np.arange(min_pt,32,1)
-    #edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
     #edges = np.arange(min_pt, max_pt, 3)
     #edges = np.append(edges, [max_pt])

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -116,11 +116,9 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 
 def get_binning_fakes_pt(min_pt, max_pt):
-    edges = np.arange(min_pt, max_pt+3, 3)
-    # edges = np.arange(min_pt,32,1)
-    # edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
-    # edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
-    # edges = np.append(edges, [max_pt])
+    edges = np.arange(min_pt,32,1)
+    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
+    edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
     #edges = np.arange(min_pt,32.1,1.2)  
     #edges = np.append(edges, [e for e in [34.4, 38, 44, 56] if e<max_pt][:-1])
@@ -128,6 +126,12 @@ def get_binning_fakes_pt(min_pt, max_pt):
     #edges = np.arange(min_pt,32,2)
     #edges = np.append(edges, [e for e in [32, 36, 40, 46, 56] if e<max_pt][:-1])
     #edges = np.append(edges, [max_pt])
+    #edges = np.arange(min_pt,32,1)
+    #edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
+    #edges = np.append(edges, [max_pt])
+    #edges = np.arange(min_pt, max_pt, 3)
+    #edges = np.append(edges, [max_pt])
+
     return edges
 
 

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -203,6 +203,7 @@ class Datagroups(object):
         mode="extended1D",
         smoothing_mode="full",
         smoothingOrderFakerate=2,
+        integrate_shapecorrection_x=True, # integrate the abcd x-axis or not, only relevant for extended2D
         simultaneousABCD=False,
         forceGlobalScaleFakes=None,
         mcCorr=["pt","eta"],
@@ -218,8 +219,13 @@ class Datagroups(object):
             fakeselector = sel.FakeSelector1DExtendedABCD
         elif mode == "extended2D":
             fakeselector = sel.FakeSelector2DExtendedABCD
-            smoothen = smoothing_mode == "fakerate"
-            auxiliary_info.update(dict(smooth_shapecorrection=smoothen, interpolate_x=smoothen, rebin_x="automatic" if smoothen else None))
+
+            auxiliary_info["integrate_shapecorrection_x"]=integrate_shapecorrection_x
+
+            if smoothing_mode == "fakerate" and not integrate_shapecorrection_x:
+                auxiliary_info.update(dict(smooth_shapecorrection=True, interpolate_x=True, rebin_x="automatic"))
+            else:
+                auxiliary_info.update(dict(smooth_shapecorrection=False, interpolate_x=False, rebin_x=None))
         elif mode == "extrapolate":
             fakeselector = sel.FakeSelectorExtrapolateABCD
         elif mode == "simple":

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -216,12 +216,12 @@ class Datagroups(object):
         signalselector = sel.SignalSelectorABCD
         scale = 1
         if mode == "extended1D":
+            scale = 0.85
             fakeselector = sel.FakeSelector1DExtendedABCD
         elif mode == "extended2D":
+            scale = 1.15
             fakeselector = sel.FakeSelector2DExtendedABCD
-
             auxiliary_info["integrate_shapecorrection_x"]=integrate_shapecorrection_x
-
             if smoothing_mode == "fakerate" and not integrate_shapecorrection_x:
                 auxiliary_info.update(dict(smooth_shapecorrection=True, interpolate_x=True, rebin_x="automatic"))
             else:
@@ -229,6 +229,7 @@ class Datagroups(object):
         elif mode == "extrapolate":
             fakeselector = sel.FakeSelectorExtrapolateABCD
         elif mode == "simple":
+            scale = 0.85
             if simultaneousABCD:
                 fakeselector = sel.FakeSelectorSimultaneousABCD
             else:

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -216,7 +216,6 @@ class Datagroups(object):
         scale = 1
         if mode == "extended1D":
             fakeselector = sel.FakeSelector1DExtendedABCD
-            scale = 1/1.15
         elif mode == "extended2D":
             fakeselector = sel.FakeSelector2DExtendedABCD
             smoothen = smoothing_mode == "fakerate"
@@ -224,7 +223,6 @@ class Datagroups(object):
         elif mode == "extrapolate":
             fakeselector = sel.FakeSelectorExtrapolateABCD
         elif mode == "simple":
-            scale = 1/1.2
             if simultaneousABCD:
                 fakeselector = sel.FakeSelectorSimultaneousABCD
             else:
@@ -242,7 +240,7 @@ class Datagroups(object):
             h = self.results[base_member]["output"][histToRead].get()
             if g in fake_processes:
                 self.groups[g].histselector = fakeselector(
-                    h[{"charge": hist.sum}],
+                    h,
                     global_scalefactor=scale,
                     fakerate_axes=self.fakerate_axes,
                     smoothing_mode=smoothing_mode,
@@ -260,7 +258,7 @@ class Datagroups(object):
                     hQCD = self.results["QCDmuEnrichPt15PostVFP"]["output"]["unweighted"].get()
                     self.groups[g].histselector.set_correction(hQCD, axes_names=mcCorr)
             else:
-                self.groups[g].histselector = signalselector(h[{"charge": hist.sum}], fakerate_axes=self.fakerate_axes, **kwargs)
+                self.groups[g].histselector = signalselector(h, fakerate_axes=self.fakerate_axes, **kwargs)
 
     def setGlobalAction(self, action):
         # To be used for applying a selection, rebinning, etc.

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -752,7 +752,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             goodbin = (dsel > 0.) & (dvarsel > 0.)
 
             logd = np.where(goodbin, np.log(dsel), 0.)
-            logdvar = np.where(goodbin, dvarsel/dsel**2, 1e6)
+            logdvar = np.where(goodbin, dvarsel/dsel**2, 1.)
             x = smoothing_axis.centers
 
             if syst_variations:
@@ -764,8 +764,10 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
                 # print(f"chisq/ndof = {chi2}/{ndf}")
 
             dsel = np.exp(logd)*xwidthtgt
+            dsel = np.where(np.isfinite(dsel), dsel, 0.)
             if syst_variations:
                 dvarsel = np.exp(logdvar)*xwidthtgt[..., None, None]**2
+                dvarsel = np.where((dsel[..., None, None] > 0.) & np.isfinite(dvarsel), dvarsel,  dsel[..., None, None])
 
         # get output shape from original hist axes, but as for result histogram
         d = np.zeros([a.extent if flow else a.shape for a in h[{self.name_x:self.sel_x if not self.integrate_x else hist.sum}].axes if a.name != self.name_y], dtype=dsel.dtype)

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -245,9 +245,9 @@ def get_rebinning(edges, axis_name):
 
 def divide_arrays(num, den, cutoff=1):
     r = num/den
-    criteria = abs(den) < cutoff
+    criteria = abs(den) <= cutoff
     if np.sum(criteria) > 0:
-        logger.warning(f"Found {np.sum(criteria)} values in denominator below {cutoff}, the ratio will be set to 0 for those")
+        logger.warning(f"Found {np.sum(criteria)} values in denominator less than or equal to {cutoff}, the ratio will be set to 0 for those")
     r[abs(den) < cutoff] = 0 # if denumerator is close to 0 set ratio to zero to avoid large negative/positive values
     return r
 
@@ -1270,7 +1270,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         # shape correction factor
         y_num = c**2 if apply else c
         y_den = cy
-        y = divide_arrays(y_num,y_den)
+        y = divide_arrays(y_num,y_den, cutoff=0.)
 
         if self.throw_toys:
             logger.info("Throw toys")
@@ -1483,7 +1483,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         # fakerate factor
         y_num = (ax*ay*b)**2
         y_den = a**4 * axy * bx
-        y = divide_arrays(y_num,y_den)
+        y = divide_arrays(y_num,y_den, cutoff=0.)
 
         if h.storage_type == hist.storage.Weight:
             # full variances

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -280,13 +280,17 @@ def spline_smooth(binvals, edges, edges_out, axis, binvars=None, syst_variations
 
     yvars = np.zeros((*ynom.shape, nvars, 2), dtype=ynom.dtype)
 
+    binerrs = np.sqrt(binvars)
+
     # fluctuate the bin contents one by one to build the variations
     for ivar in range(nvars):
         for iupdown in range(2):
             scale = 1. if iupdown==0 else -1.
 
             binvalsvar = binvals.copy()
-            binvalsvar[ivar] += scale*np.sqrt(binvars[ivar])
+            varsel = binvals.ndim*[slice(None)]
+            varsel[axis] = ivar
+            binvalsvar[*varsel] += scale*binerrs[*varsel]
 
             yvars[..., ivar, iupdown] = spline_smooth_nominal(binvalsvar, edges, edges_out, axis=axis)
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -426,8 +426,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         else:
             self.polynomial = "power"
 
-        # rebinning doesn't make sense for binned estimation
-        if smoothing_mode == "binned":
+        # rebinning doesn't make sense for binned estimation and causes issues
+        # for full smoothing
+        if smoothing_mode in ["binned", "full"]:
             self.rebin_smoothing_axis = None
 
         if hasattr(self, "fakerate_integration_axes"):

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -426,9 +426,8 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         else:
             self.polynomial = "power"
 
-        # rebinning doesn't make sense for binned estimation and causes issues
-        # for full smoothing
-        if smoothing_mode in ["binned", "full"]:
+        # rebinning doesn't make sense for binned estimation
+        if smoothing_mode in ["binned"]:
             self.rebin_smoothing_axis = None
 
         if hasattr(self, "fakerate_integration_axes"):


### PR DESCRIPTION
This is a continuation of #502 

- Implement full smoothing by smoothing each sideband region independently and implicitly evaluate signal region 
- Monotonic smoothing based on integrated Bernstein polynomials is used to have a stable smoothing
- Smoothing order is set to 3
- Fake normalization is scaled by 0.85 and the uncertainty is set to 5% (for extended 1D, which is still the default)