### PR TITLE
Updates to implentation of MiNNLO muR/muF polynomial variations (also to use them for unfolding and theory agnostic for OOA) 

### DIFF
--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -635,23 +635,20 @@ def build_graph(df, dataset):
         # End graph here only for standard theory agnostic analysis, otherwise use same loop as traditional analysis
         return results, weightsum
 
-    if isWorZ and not hasattr(dataset, "out_of_acceptance"):
+    if isWorZ: #this needs to be created also for out-of-acceptance, when present (e.g. unfolding, theory-agnostic, etc.)
         theoryAgnostic_helpers_cols = ["qtOverQ", "absYVgen", "chargeVgen", "csSineCosThetaPhigen", "nominal_weight"]
         # assume to have same coeffs for plus and minus (no reason for it not to be the case)
         if dataset.name == "WplusmunuPostVFP" or dataset.name == "WplustaunuPostVFP":
             helpers_class = muRmuFPolVar_helpers_plus
-            process_name = "W"
         elif dataset.name == "WminusmunuPostVFP" or dataset.name == "WminustaunuPostVFP":
             helpers_class = muRmuFPolVar_helpers_minus
-            process_name = "W"
         elif dataset.name == "ZmumuPostVFP" or dataset.name == "ZtautauPostVFP":
             helpers_class = muRmuFPolVar_helpers_Z
-            process_name = "Z"
         for coeffKey in helpers_class.keys():
             logger.debug(f"Creating muR/muF histograms with polynomial variations for {coeffKey}")
             helperQ = helpers_class[coeffKey]
             df = df.Define(f"muRmuFPolVar_{coeffKey}_tensor", helperQ, theoryAgnostic_helpers_cols)
-            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar{process_name}_{coeffKey}")
+            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar_{coeffKey}")
             results.append(df.HistoBoost(noiAsPoiWithPolHistName, nominal_axes, [*nominal_cols, f"muRmuFPolVar_{coeffKey}_tensor"], tensor_axes=helperQ.tensor_axes, storage=hist.storage.Double()))
 
     if not args.onlyMainHistograms:

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -329,17 +329,16 @@ def build_graph(df, dataset):
     nominal = df.HistoBoost("nominal", axes, [*cols, "nominal_weight"])
     results.append(nominal)
 
-    if isZ and not hasattr(dataset, "out_of_acceptance"):
+    if isZ: #this needs to be created also for out-of-acceptance, when present (e.g. unfolding, theory-agnostic, etc.)
         theoryAgnostic_helpers_cols = ["qtOverQ", "absYVgen", "chargeVgen", "csSineCosThetaPhigen", "nominal_weight"]
         # assume to have same coeffs for plus and minus (no reason for it not to be the case)
         if dataset.name == "ZmumuPostVFP" or dataset.name == "ZtautauPostVFP":
             helpers_class = muRmuFPolVar_helpers_Z
-            process_name = "Z"
         for coeffKey in helpers_class.keys():
             logger.debug(f"Creating muR/muF histograms with polynomial variations for {coeffKey}")
             helperQ = helpers_class[coeffKey]
             df = df.Define(f"muRmuFPolVar_{coeffKey}_tensor", helperQ, theoryAgnostic_helpers_cols)
-            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar{process_name}_{coeffKey}")
+            noiAsPoiWithPolHistName = Datagroups.histName("nominal", syst=f"muRmuFPolVar_{coeffKey}")
             results.append(df.HistoBoost(noiAsPoiWithPolHistName, nominal_axes, [*nominal_cols, f"muRmuFPolVar_{coeffKey}_tensor"], tensor_axes=helperQ.tensor_axes, storage=hist.storage.Double()))
 
     if not args.noRecoil and args.recoilUnc:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -360,7 +360,7 @@ def common_parser(analysis_label=""):
     parser.add_argument("--noScaleToData", action="store_true", help="Do not scale the MC histograms with xsec*lumi/sum(gen weights) in the postprocessing step")
     parser.add_argument("--aggregateGroups", type=str, nargs="*", default=["Diboson", "Top"], help="Sum up histograms from members of given groups in the postprocessing step")
     parser.add_argument("--muRmuFPolVarFilePath", type=str, default=f"{data_dir}/MiNNLOmuRmuFPolVar/", help="Path where input files are stored")
-    parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_ConstrPol5ExtYdep_Trad", choices=["x0p50_y4p00_ConstrPol5ExtYdep_Trad","x0p50_y4p00_ConstrPol5Ext_Trad"],help="Tag for input files")
+    parser.add_argument("--muRmuFPolVarFileTag", type=str, default="x0p50_y4p00_Fix_Trad", choices=["x0p50_y4p00_Fix_Trad","x0p50_y4p00_FixYdep_Trad"],help="Tag for input files")
     parser.add_argument("--nToysMC", type=int, help="random toys for data and MC", default=-1)
     parser.add_argument("--varianceScalingForToys", type=int, default=1, help="Scaling of variance for toys (effective mc statistics corresponds to 1./scaling)")
     parser.add_argument("--randomSeedForToys", type=int, default=0, help="random seed for toys")

--- a/wremnants/combine_theory_helper.py
+++ b/wremnants/combine_theory_helper.py
@@ -155,7 +155,8 @@ class TheoryHelper(object):
 
                         self.add_minnlo_scale_uncertainty(sample_group, extra_name = "fine", rebin_pt=fine_pt_binning, helicities_to_exclude=helicities_to_exclude)
 
-                    self.add_minnlo_scale_uncertainty(sample_group, extra_name = "inclusive", rebin_pt=[common.ptV_binning[0], common.ptV_binning[-1]], helicities_to_exclude=helicities_to_exclude, scale = scale_inclusive)
+                    if not (self.args.muRmuFPolVar and self.args.muRmuFFullyCorr):
+                        self.add_minnlo_scale_uncertainty(sample_group, extra_name = "inclusive", rebin_pt=[common.ptV_binning[0], common.ptV_binning[-1]], helicities_to_exclude=helicities_to_exclude, scale = scale_inclusive)
 
             # additional uncertainty for effect of shower and intrinsic kt on angular coeffs
             self.add_helicity_shower_kt_uncertainty()

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -361,6 +361,24 @@ def hist_to_variations(hist_in, gen_axes = [], sum_axes = [], rebin_axes=[], reb
 
     return variation_hist
 
+def muRmuFFullyCorrelatedVariations(hist_in):
+
+    if hist_in.name is None:
+        out_name = "hist_variations"
+    else:
+        out_name = hist_in.name + "_variations"
+
+    variation_hist = hist.Hist(*hist_in.axes, name = out_name, storage = hist.storage.Double())
+    variation_hist = variation_hist[...,0:1,:]
+
+    for i in range(len(hist_in.axes[len(hist_in.axes)-2])):
+        variation_hist.values(flow=True)[...,0,0] = variation_hist.values(flow=True)[...,0,0] + hist_in.values(flow=True)[...,i,0] - (hist_in.values(flow=True)[...,0,0]+hist_in.values(flow=True)[...,0,1])/2 #this average which is subtracted is the nominal histogram (by construction, it's directly related to how the weights are defined)
+        variation_hist.values(flow=True)[...,0,1] = variation_hist.values(flow=True)[...,0,1] + hist_in.values(flow=True)[...,i,1] - (hist_in.values(flow=True)[...,0,0]+hist_in.values(flow=True)[...,0,1])/2
+    variation_hist.values(flow=True)[...,0,0] = variation_hist.values(flow=True)[...,0,0] + (hist_in.values(flow=True)[...,0,0]+hist_in.values(flow=True)[...,0,1])/2
+    variation_hist.values(flow=True)[...,0,1] = variation_hist.values(flow=True)[...,0,1] + (hist_in.values(flow=True)[...,0,0]+hist_in.values(flow=True)[...,0,1])/2
+
+    return variation_hist
+
 
 def uncertainty_hist_from_envelope(h, proj_ax, entries):
     hdown = hh.syst_min_or_max_env_hist(h, proj_ax, "vars", entries, no_flow=["ptVgen"], do_min=True)


### PR DESCRIPTION
This is still a work in progress, but it contains updates to the MiNNLO muRmuFPolVar. We noticed that the variations we had before were underestimated, we were computing them incorrectly (we were varying only the denominator instead of only the numerator in the ratio sigma_i/sigma_UL). This PR also contains a first implementation of fully correlated variations in a smooth way, at the moment (but it might change, since this is not giving us what we want) the are derived from the combination of the individual uncorrelated variations, directly in the pt-eta plane and not from the Ais directly, but given how these variations are defined it is mathematically the same. The default is still to use the binned ones, but the can be enabled with the "--muRmuFFullyCorr" option is setupCombine (to be given with "--muRmuFPolVar", which changes only the uncorrelated component).