### PR TITLE
Update on fakes

### DIFF
--- a/scripts/combine/pullsAndImpacts.py
+++ b/scripts/combine/pullsAndImpacts.py
@@ -213,6 +213,7 @@ def plotImpacts(df, impact_title="", pulls=False, normalize=False, oneSidedImpac
         if include_ref:
             fig.add_trace(
                 go.Bar(
+                    base=df['pull_ref'],
                     x=df['constraint_ref'],
                     y=labels,
                     orientation='h',
@@ -223,6 +224,7 @@ def plotImpacts(df, impact_title="", pulls=False, normalize=False, oneSidedImpac
             )
             fig.add_trace(
                 go.Bar(
+                    base=df['pull_ref'],
                     x=-1*df['constraint_ref'],
                     y=labels,
                     orientation='h',

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -719,8 +719,8 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if not lowPU: # lowPU does not include PhotonInduced as a process. skip it:
         cardTool.addLnNSystematic("CMS_PhotonInduced", processes=["PhotonInduced"], size=2.0, group="CMS_background", splitGroup = {"experiment": ".*"},)
     if wmass:
-        # if args.logNormalWmunu > 0.0:
-        #     cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background", splitGroup = {"experiment": ".*"})
+        if args.logNormalWmunu > 0.0:
+            cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background", splitGroup = {"experiment": ".*"})
         if args.logNormalFake > 0.0:
             cardTool.addLnNSystematic(f"CMS_{cardTool.getFakeName()}", processes=[cardTool.getFakeName()], size=args.logNormalFake, group="Fake", splitGroup = {"experiment": ".*"})
         elif args.logNormalFake < 0.0:

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -130,7 +130,7 @@ def make_parser(parser=None):
     parser.add_argument("--pseudoDataIdxs", type=str, nargs="+", default=[None], help="Variation indices to use as pseudodata for each of the histograms")
     parser.add_argument("--pseudoDataFile", type=str, help="Input file for pseudodata (if it should be read from a different file)", default=None)
     parser.add_argument("--pseudoDataProcsRegexp", type=str, default=".*", help="Regular expression for processes taken from pseudodata file (all other processes are automatically got from the nominal file). Data is excluded automatically as usual")
-    parser.add_argument("--pseudoDataFakes", type=str, nargs="+", choices=["truthMC", "closure", "simple", "extrapolate", "extended1D", "extended2D"],
+    parser.add_argument("--pseudoDataFakes", type=str, nargs="+", choices=["truthMC", "closure", "simple", "extrapolate", "extended1D", "extended2D", "dataClosure", "mcClosure", "simple-binned", "extended1D-fakerate"],
         help="Pseudodata for fakes are using QCD MC (closure), or different estimation methods (simple, extended1D, extended2D)")
     parser.add_argument("--addTauToSignal", action='store_true', help="Events from the same process but from tau final states are added to the signal")
     parser.add_argument("--noPDFandQCDtheorySystOnSignal", action='store_true', help="Removes PDF and theory uncertainties on signal processes")
@@ -719,8 +719,8 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if not lowPU: # lowPU does not include PhotonInduced as a process. skip it:
         cardTool.addLnNSystematic("CMS_PhotonInduced", processes=["PhotonInduced"], size=2.0, group="CMS_background", splitGroup = {"experiment": ".*"},)
     if wmass:
-        if args.logNormalWmunu > 0.0:
-            cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background", splitGroup = {"experiment": ".*"})
+        # if args.logNormalWmunu > 0.0:
+        #     cardTool.addLnNSystematic(f"CMS_Wmunu", processes=["Wmunu"], size=args.logNormalWmunu, group="CMS_background", splitGroup = {"experiment": ".*"})
         if args.logNormalFake > 0.0:
             cardTool.addLnNSystematic(f"CMS_{cardTool.getFakeName()}", processes=[cardTool.getFakeName()], size=args.logNormalFake, group="Fake", splitGroup = {"experiment": ".*"})
         elif args.logNormalFake < 0.0:
@@ -740,6 +740,17 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
         cardTool.addLnNSystematic("lumi", processes=['MCnoQCD'], size=1.017 if lowPU else 1.012, group="luminosity", splitGroup = {"experiment": ".*"},)
 
     if cardTool.getFakeName() != "QCD" and cardTool.getFakeName() in datagroups.groups.keys() and not xnorm and (args.fakeSmoothingMode != "binned" or (args.fakeEstimation in ["extrapolate"] and "mt" in fitvar)):
+        
+        # add stat uncertainty from QCD MC nonclosure to smoothing parameter covariance
+        hist_fake = datagroups.results["QCDmuEnrichPt15PostVFP"]["output"]["unweighted"].get()
+
+        fakeselector = cardTool.datagroups.groups[cardTool.getFakeName()].histselector
+
+        _0, _1, params, cov, _chi2, _ndf = fakeselector.calculate_fullABCD_smoothed(hist_fake, auxiliary_info=True)
+        _0, _1, params_d, cov_d, _chi2_d, _ndf_d = fakeselector.calculate_fullABCD_smoothed(hist_fake, auxiliary_info=True, signal_region=True)
+
+        fakeselector.external_cov = cov + cov_d
+
         syst_axes = ["eta", "charge"] if (args.fakeSmoothingMode != "binned" or args.fakeEstimation not in ["extrapolate"]) else ["eta", "pt", "charge"]
         info=dict(
             name=inputBaseName, 
@@ -749,7 +760,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
             mirror=False,
             scale=1,
             applySelection=False, # don't apply selection, all regions will be needed for the action
-            action=cardTool.datagroups.groups[cardTool.getFakeName()].histselector.get_hist,
+            action=fakeselector.get_hist,
             systAxes=[f"_{x}" for x in syst_axes if x in args.fakerateAxes]+["_param", "downUpVar"])
         subgroup = f"{cardTool.getFakeName()}Rate"
         cardTool.addSystematic(**info,
@@ -765,6 +776,46 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
                 splitGroup = {subgroup: f".*", "experiment": ".*"},
                 systNamePrepend=subgroup,
                 actionArgs=dict(variations_scf=True),
+            )
+
+        if args.fakeSmoothingMode == "full":
+            # add nominal nonclosure of QCD MC as single systematic
+            def fake_nonclosure(h, axesToDecorrNames, *args, **kwargs):
+                # apply QCD MC nonclosure by adding parameters (assumes log space, e.g. in full smoothing)
+                fakeselector.external_params = params_d - params
+                hvar = fakeselector.get_hist(h, *args, **kwargs)
+                # reset external parameters
+                fakeselector.external_params = None
+
+                if len(axesToDecorrNames) == 0:
+                    # inclusive
+                    hvar = hist.Hist(
+                        *hvar.axes, hist.axis.Integer(0, 1, name="var", underflow=False, overflow=False), 
+                        storage=hist.storage.Double(),
+                        data = hvar.values(flow=True)[...,np.newaxis]
+                    )
+                else:
+                    hnom = fakeselector.get_hist(h, *args, **kwargs)
+                    hvar = syst_tools.decorrelateByAxes(hvar, hnom, axesToDecorrNames)
+
+                return hvar
+
+            for axesToDecorrNames in [[], ["eta"]]:
+                subgroup = f"{cardTool.getFakeName()}QCDMCNonclosure"
+                cardTool.addSystematic(
+                    name=inputBaseName, 
+                    group="Fake",
+                    rename=subgroup+ (f"_{'_'.join(axesToDecorrNames)}" if len(axesToDecorrNames) else ""),
+                    splitGroup = {subgroup: f".*", "experiment": ".*"},
+                    systNamePrepend=subgroup,
+                    processes=cardTool.getFakeName(),
+                    noConstraint=False,
+                    mirror=True,
+                    scale=1,
+                    applySelection=False, # don't apply selection, external parameters need to be added
+                    action=fake_nonclosure,
+                    actionArgs=dict(axesToDecorrNames=axesToDecorrNames),
+                    systAxes=["var"] if len(axesToDecorrNames)==0 else [f"{n}_decorr" for n in axesToDecorrNames],
             )
 
     if not args.noEfficiencyUnc:

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -690,7 +690,7 @@ def build_graph(df, dataset):
             results.append(yieldsForWeffMC)
 
         if not args.noRecoil and args.recoilUnc:
-            df = recoilHelper.add_recoil_unc_W(df, results, dataset, cols, axes, base_name="nominal", storage_type=storage_type)
+            df = recoilHelper.add_recoil_unc_W(df, results, dataset, cols, axes, "nominal", storage_type=storage_type)
         if apply_theory_corr:
             syst_tools.add_theory_corr_hists(results, df, axes, cols, corr_helpers[dataset.name], theory_corrs, base_name="nominal", 
                 modify_central_weight=not args.theoryCorrAltOnly, isW = isW, storage_type=storage_type)

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -117,7 +117,7 @@ axis_relIsoCat = hist.axis.Variable([0,0.15,0.3], name = "relIso",underflow=Fals
 
 def get_binning_fakes_pt(min_pt, max_pt):
     edges = np.arange(min_pt,32,1)
-    edges = np.append(edges, [e for e in [35,38,41,44,47,50,53,56] if e<max_pt][:-1])
+    edges = np.append(edges, [e for e in [33,36,40,46,56] if e<max_pt][:-1])
     edges = np.append(edges, [max_pt])
     ## the following lines are used to replace the previous ones when studying different pT binning and the MC stat
     # edges = np.arange(min_pt,32,1)

--- a/utilities/styles/nuisance_translate.json
+++ b/utilities/styles/nuisance_translate.json
@@ -9,7 +9,7 @@
     "QCDscaleWPtHelicityMiNNLO": "$\\mu_\\mathrm{R} \\mu_\\mathrm{F} \\ \\mathrm{scale (W)}$",
     "QCDscaleZPtChargeHelicityMiNNLO": "$\\mu_\\mathrm{R} \\mu_\\mathrm{F} \\ \\mathrm{scale (Z)}$",
     "QCDscaleWPtChargeHelicityMiNNLO": "$\\mu_\\mathrm{R} \\mu_\\mathrm{F} \\ \\mathrm{scale (W)}$",
-    "binByBinStat": "Bin-by-bin stat.",
+    "binByBinStat": "Simulated samples stat.",
     "recoil": "recoil",
     "CMS_background": "Bkg.",
     "FakeHighMT": "FakeHighMT",
@@ -48,6 +48,7 @@
     "Fake": "Fakes",
     "widthW": "W width", 
     "widthZ": "Z width",
+    "ZmassAndWidth": "Z mass & width",
     "bcQuarkMass" : "b,c quark masses",
     "experiment": "Experiment",
     "theory": "Theory"

--- a/utilities/styles/styles.py
+++ b/utilities/styles/styles.py
@@ -23,9 +23,15 @@ process_colors = {
     "Fake": "#9C9CA1",
     "Fake_e": "#9C9CA1",
     "Fake_mu": "#9C9CA1",
+    "Prompt": "#E42536",
 }
 
 process_supergroups = {
+    "sv":{
+        "Prompt": ["Wmunu", "Wtaunu", "Ztautau", "Zmumu", "DYlowMass", "PhotonInduced", "Top", "Diboson"],
+        "Fake": ["Fake"],
+        "QCD": ["QCD"],
+    },
     "w_mass":{
         "Z": ["Ztautau", "Zmumu", "DYlowMass"],
         "Rare": ["PhotonInduced", "Top", "Diboson"],
@@ -55,11 +61,12 @@ process_labels = {
     "PhotonInduced": r"$\gamma$-induced",
     "Top": "Top",
     "Diboson": "Diboson",
-    "QCD": "QCD MC",
+    "QCD": "QCD MC (predicted)",
     "Other": "Other",
     "Fake": "Nonprompt",
     "Fake_e": "Nonprompt (e)",
     "Fake_mu": r"Nonprompt (\mu)",
+    "Prompt": "Prompt",
 }
 
 xlabels = {
@@ -308,7 +315,7 @@ def get_systematics_label(key, idx=0):
 
 def get_labels_colors_procs_sorted(procs):
     # order of the processes in the plots
-    procs_sort = ["Wmunu", "Fake", "Zmumu", "Wtaunu", "Top", "DYlowMass", "Other", "Ztautau", "Diboson", "PhotonInduced"][::-1]
+    procs_sort = ["Wmunu", "Fake", "QCD", "Zmumu", "Wtaunu", "Top", "DYlowMass", "Other", "Ztautau", "Diboson", "PhotonInduced", "Prompt"][::-1]
 
     procs = sorted(procs, key=lambda x: procs_sort.index(x) if x in procs_sort else len(procs_sort))
     logger.info(f"Found processes {procs} in fitresult")

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -903,11 +903,11 @@ class CardTool(object):
             procDict = datagroups.getDatagroups()
             hists = [procDict[proc].hists[pseudoData] for proc in processes if proc not in processesFromNomi]
 
-            # add BBB stat on top of nominal
-            hist_fake = self.datagroups.getDatagroups()[self.getFakeName()].hists[self.nominalName]
-            hist_fake.variances(flow=True)[...] = datagroups.getDatagroups()[self.getFakeName()].hists[pseudoData].variances(flow=True)
-
-            self.datagroups.getDatagroups()[self.getFakeName()].hists[self.nominalName] = hist_fake
+            if pseudoData.split("-")[0] in ["simple", "extended1D", "extended2D"]:
+                # add BBB stat on top of nominal
+                hist_fake = self.datagroups.getDatagroups()[self.getFakeName()].hists[self.nominalName]
+                hist_fake.variances(flow=True)[...] = datagroups.getDatagroups()[self.getFakeName()].hists[pseudoData].variances(flow=True)
+                self.datagroups.getDatagroups()[self.getFakeName()].hists[self.nominalName] = hist_fake
 
             # now add possible processes from nominal
             logger.warning(f"Making pseudodata summing these processes: {processes}")

--- a/wremnants/CardTool.py
+++ b/wremnants/CardTool.py
@@ -855,33 +855,12 @@ class CardTool(object):
                     integrate_x=True,
                 )
 
-                d_true, dval_true = fakeselector.calculate_fullABCD_smoothed(hist_fake)
-
-                h_obs = fakeselector.get_hist_passX_passY(hist_fake)
-                d_obs = h_obs.values()
-                dvar_obs = h_obs.variances()
-
-                corr = d_true.sum()/d_obs.sum()
-                logger.info(f"Got corr={corr}")
-
-                logger.info(f"calculate_fullABCD_smoothed pred for {pseudoData}")
                 _0, _1, params, cov, _chi2, _ndf = fakeselector.calculate_fullABCD_smoothed(hist_fake, auxiliary_info=True)
-
                 hist_fake = hh.scaleHist(hist_fake, 1./0.85)
-
-                logger.info(f"calculate_fullABCD_smoothed true for {pseudoData}")
                 _0, _1, params_d, cov_d, _chi2_d, _ndf_d = fakeselector.calculate_fullABCD_smoothed(hist_fake, auxiliary_info=True, signal_region=True)
 
                 cov = cov + cov_d
                 params = params_d - params
-
-                # cov_inv = np.linalg.inv(cov)
-
-                # cp = np.einsum('...ij,...j->...i', cov_inv, params)
-                # pcp = params * cp
-
-                # print(pcp.sum())
-                # chi2 = params.T @ cov_inv @ params
 
                 self.datagroups.getDatagroups()[self.getFakeName()].histselector.external_params = params
                 self.datagroups.getDatagroups()[self.getFakeName()].histselector.external_cov = cov
@@ -911,6 +890,8 @@ class CardTool(object):
                     mcCorr=[None],
                     )
                 syst=self.nominalName
+            else:
+                syst=pseudoData
 
             datagroups.loadHistsForDatagroups(
                 baseName=self.nominalName, syst=syst, label=pseudoData,

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -869,7 +869,6 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             svar *= 1./xwidth**2
 
             goodbin = (sval > 0.) & (svar > 0.)
-            goodbin = goodbin & ~((sval < 1.) & (svar/sval**2 <= 1.)) # exclude bins with 0 data entries but negative prompt MC subtraction
             if goodbin.size-np.sum(goodbin) > 0:
                 logger.warning(f"Found {goodbin.size-np.sum(goodbin)} of {goodbin.size} bins with 0 or negative bin content, those will be set to 0 and a large error")
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -191,8 +191,10 @@ def solve_nonnegative_leastsquare(X, XTY, exclude_idx=None):
     if exclude_idx is not None and np.sum(params[...,exclude_idx]==0):
         mask = params[...,exclude_idx]==0
         mask_flat = mask.flatten()
-        params_negative = [nnls(xtx, xty)[0] for xtx, xty in zip(XTX_flat[mask_flat], XTY_flat[mask_flat] * np.array([-1,1,1,1]))]
-        params[mask] = np.array(params_negative) * np.array([-1,1,1,1])
+        w_flip = np.ones(XTY.shape[-1])
+        w_flip[0] = -1
+        params_negative = [nnls(xtx, xty)[0] for xtx, xty in zip(XTX_flat[mask_flat], XTY_flat[mask_flat] * w_flip)]
+        params[mask] = np.array(params_negative) * w_flip
         logger.info(f"Found {mask.sum()} parameters that are excluded in nnls and negative")
     return params, XTXinv
 
@@ -211,6 +213,7 @@ def compute_chi2(y, y_pred, w=None, nparams=1):
     from scipy import stats
 
     logger.debug(f"Total chi2/ndf = {chi2_total}/{ndf_total} = {chi2_total/ndf_total} (p = {stats.chi2.sf(chi2_total, ndf_total)})")
+    logger.debug(f"Min chi2 = {chi2.min()}; max chi2 = {chi2.max()}")
     return chi2, ndf    
 
 def extend_edges(traits, x):
@@ -473,6 +476,9 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         # histogram with nonclosure corrections
         self.hCorr = None
 
+        self.external_params = None
+        self.external_cov = None
+
     def set_correction(self, hQCD, axes_names=False, mirror_axes=["eta"], flow=True):
         # hQCD is QCD MC histogram before selection (should contain variances)
         # axes_names: the axes names to bin the correction in. If empty make an inclusive correction (i.e. a single number)
@@ -621,7 +627,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
 
         return y, y_var
 
-    def smoothen(self, h, x, y, y_var, syst_variations=False, auxiliary_info=False, flow=True):
+    def smoothen(self, h, x, y, y_var, syst_variations=False, auxiliary_info=False, signal_region=False, flow=True):
         if h.storage_type == hist.storage.Weight:
             # transform with weights
             w = 1/np.sqrt(y_var)
@@ -640,8 +646,17 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         X, XTY = get_parameter_matrices(x, y, w, self.smoothing_order_fakerate, pol=self.polynomial)
         params, cov = self.solve(X, XTY)
 
-        if self.smoothing_mode == "full":
-            # add up parameters from smoothing of individual regions
+        if self.smoothing_mode == "full" and not signal_region:
+            if auxiliary_info:
+                # compute chi2 from individual sideband regions
+                y_pred = self.f_smoothing(x, params)
+                y_pred = y_pred.reshape(y.shape) # flatten
+                w = w.reshape(y.shape)
+                chi2, ndf = compute_chi2(y, y_pred, w, nparams=params.shape[-1])
+
+                # return y, y_var, y_pred, params, cov, chi2, ndf
+
+            # add up parameters from smoothing of individual sideband regions
             if type(self) == FakeSelectorSimpleABCD:
                 # exp(-a + b + c)
                 # ['a', 'b', 'c']
@@ -657,8 +672,13 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
 
             params = np.sum(params*w_region[*[np.newaxis]*(params.ndim-2), slice(None), np.newaxis], axis=-2)
             
-            if syst_variations:
+            if syst_variations or auxiliary_info:
                 cov = np.sum(cov*w_region[*[np.newaxis]*(params.ndim-2), slice(None), np.newaxis, np.newaxis]**2, axis=-3)
+
+        if self.external_cov is not None and syst_variations:
+            cov = cov + self.external_cov[..., *[np.newaxis for n in range(cov.ndim - self.external_cov.ndim)],:,:]
+        if self.external_params is not None:
+            params = params + self.external_params[..., *[np.newaxis for n in range(params.ndim - self.external_params.ndim)],:]
 
         # evaluate in range of original histogram
         x_smooth_orig = self.get_bin_centers_smoothing(h, flow=True)
@@ -681,11 +701,12 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             logger.warning(f"Found {np.sum(y_smooth_var_orig<0)} bins with negative values from smoothing variations")
 
         if auxiliary_info:
-            y_pred = self.f_smoothing(x, params)
-            # flatten
-            y_pred = y_pred.reshape(y.shape) 
-            w = w.reshape(y.shape)
-            chi2, ndf = compute_chi2(y, y_pred, w, nparams=params.shape[-1])
+            if self.smoothing_mode != "full" or signal_region:
+                y_pred = self.f_smoothing(x, params)
+                y_pred = y_pred.reshape(y.shape) # flatten
+                w = w.reshape(y.shape)
+                chi2, ndf = compute_chi2(y, y_pred, w, nparams=params.shape[-1])
+
             return y_smooth_orig, y_smooth_var_orig, params, cov, chi2, ndf
         else:
             return y_smooth_orig, y_smooth_var_orig
@@ -760,7 +781,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         
         return d, dvar
 
-    def calculate_fullABCD_smoothed(self, h, syst_variations=False, use_spline=False, flow=True):
+    def calculate_fullABCD_smoothed(self, h, syst_variations=False, use_spline=False, auxiliary_info=False, signal_region=False, flow=True):
 
         if type(self) in [FakeSelectorSimpleABCD, FakeSelector1DExtendedABCD]:
             # sum up high abcd-y axis bins
@@ -785,9 +806,13 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         sval = np.flip(sval, axis=-1)
         svar = np.flip(svar, axis=-1)
 
-        # make abcd axes flat, take all but last bin (i.e. signal region D)
-        sval = sval.reshape((*sval.shape[:-2], sval.shape[-2]*sval.shape[-1]))[...,:-1]
-        svar = svar.reshape((*svar.shape[:-2], svar.shape[-2]*svar.shape[-1]))[...,:-1]
+        if signal_region:
+            sval = sval.reshape((*sval.shape[:-2], sval.shape[-2]*sval.shape[-1]))[...,-1]
+            svar = svar.reshape((*svar.shape[:-2], svar.shape[-2]*svar.shape[-1]))[...,-1]
+        else:
+            # make abcd axes flat, take all but last bin (i.e. signal region D)
+            sval = sval.reshape((*sval.shape[:-2], sval.shape[-2]*sval.shape[-1]))[...,:-1]
+            svar = svar.reshape((*svar.shape[:-2], svar.shape[-2]*svar.shape[-1]))[...,:-1]
 
         smoothidx = [n for n in h.axes.name if n not in [self.name_x, self.name_y]].index(self.smoothing_axis_name)
         smoothing_axis = h.axes[self.smoothing_axis_name]
@@ -813,21 +838,28 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         else:
             xwidth = h.axes[self.smoothing_axis_name].widths
 
-            xwidthtgt = xwidth[*smoothidx*[None], :, *(nax - smoothidx - 2)*[None]]
+            xwidthtgt = xwidth[*smoothidx*[None], :, *(nax - smoothidx - 2 + signal_region)*[None]]
             xwidth = xwidth[*smoothidx*[None], :, *(nax - smoothidx - 1)*[None]]
 
             sval *= 1./xwidth
             svar *= 1./xwidth**2
 
             goodbin = (sval > 0.) & (svar > 0.)
-            if np.sum(goodbin)-goodbin.size > 0:
-                logger.warning(f"Found {np.sum(goodbin)-goodbin.size} of {goodbin.size} bins with 0 or negative bin content, those will be set to 0 and a large error")
+            if goodbin.size-np.sum(goodbin) > 0:
+                logger.warning(f"Found {goodbin.size-np.sum(goodbin)} of {goodbin.size} bins with 0 or negative bin content, those will be set to 0 and a large error")
 
             logd = np.where(goodbin, np.log(sval), 0.)
-            logdvar = np.where(goodbin, svar/sval**2, 1.)
+            logdvar = np.where(goodbin, svar/sval**2, np.inf)
             x = self.get_bin_centers_smoothing(h, flow=True) # the bins where the smoothing is performed (can be different to the bins in h)
 
-            logd, logdvar = self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations)
+            if auxiliary_info:
+                # # TODO: remove
+                # return self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations, signal_region=signal_region, auxiliary_info=True
+                # )
+                logd, logdvar, params, cov, chi2, ndf = self.smoothen(
+                    h, x, logd, logdvar, syst_variations=syst_variations, signal_region=signal_region, auxiliary_info=True)
+            else:
+                logd, logdvar = self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations)
 
             sval = np.exp(logd)*xwidthtgt
             sval = np.where(np.isfinite(sval), sval, 0.)
@@ -849,7 +881,10 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             # explicit variations, so the remaining binned uncertainty is zero
             dvar = np.zeros_like(d)
 
-        return d, dvar
+        if auxiliary_info:
+            return d, dvar, params, cov, chi2, ndf
+        else:
+            return d, dvar
 
 class FakeSelectorSimultaneousABCD(FakeSelectorSimpleABCD):
     # simple ABCD method simultaneous fitting all regions

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -843,6 +843,7 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             svar *= 1./xwidth**2
 
             goodbin = (sval > 0.) & (svar > 0.)
+            goodbin = goodbin & ~((sval < 1.) & (svar/sval**2 <= 1.)) # exclude bins with 0 data entries but negative prompt MC subtraction
             if goodbin.size-np.sum(goodbin) > 0:
                 logger.warning(f"Found {goodbin.size-np.sum(goodbin)} of {goodbin.size} bins with 0 or negative bin content, those will be set to 0 and a large error")
 

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -654,8 +654,6 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
                 w = w.reshape(y.shape)
                 chi2, ndf = compute_chi2(y, y_pred, w, nparams=params.shape[-1])
 
-                # return y, y_var, y_pred, params, cov, chi2, ndf
-
             # add up parameters from smoothing of individual sideband regions
             if type(self) == FakeSelectorSimpleABCD:
                 # exp(-a + b + c)
@@ -853,9 +851,6 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
             x = self.get_bin_centers_smoothing(h, flow=True) # the bins where the smoothing is performed (can be different to the bins in h)
 
             if auxiliary_info:
-                # # TODO: remove
-                # return self.smoothen(h, x, logd, logdvar, syst_variations=syst_variations, signal_region=signal_region, auxiliary_info=True
-                # )
                 logd, logdvar, params, cov, chi2, ndf = self.smoothen(
                     h, x, logd, logdvar, syst_variations=syst_variations, signal_region=signal_region, auxiliary_info=True)
             else:


### PR DESCRIPTION
- For monotonic polynomials (integrated bernstein polynomials) allow integration constant to flip sign by repeating non-negative least squares. For the signal region the distribution could still be non monotonic, thus, the non-negative least squares is evaluated on the linearly combined parameters and covariance matrices to impose monotonicity, again, with excluding the integration constant. 
- Set variance to inf for log if events are 0, this results in a weight of 0
- adding uncertainties from QCD MC nonclosure