### PR TITLE
Utility options for W histmaker to test veto SF 

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -842,7 +842,7 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
                             systNameReplace=[("effSystTnP", "effSyst"), ("etaDecorr0", "fullyCorr")],
                             scale=scale,
                         )
-            if wmass or wlike_vetoValidation:
+            if (wmass and not input_tools.args_from_metadata(cardTool, "noVetoSF")) or wlike_vetoValidation:
                 useGlobalOrTrackerVeto = input_tools.args_from_metadata(cardTool, "useGlobalOrTrackerVeto")
                 useRefinedVeto = input_tools.args_from_metadata(cardTool, "useRefinedVeto")
                 allEffTnP_veto = ["effStatTnP_veto_sf", "effSystTnP_veto"]

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -41,7 +41,6 @@ parser.add_argument("--useGlobalOrTrackerVeto", action="store_true", help="Use g
 parser.add_argument("--useRefinedVeto", action="store_true", help="Temporary option, it uses a different computation of the veto SF (only implemented for global muons)")
 parser.add_argument("--noVetoSF", action="store_true", help="Don't use SF for the veto, for tests")
 parser.add_argument("--scaleDYvetoFraction", type=float, default=-1.0, help="Scale fraction of DY background that should receive veto SF by this amount. Negative values do nothing")
-parser.add_argument("--scaleDYfull", type=float, default=-1.0, help="Scale inclusive DY background (as if scaling the cross section). Negative values do nothing")
 #
 
 args = parser.parse_args()
@@ -52,9 +51,6 @@ useGlobalOrTrackerVeto = args.useGlobalOrTrackerVeto
 
 if args.selectNonPromptFromLightMesonDecay and args.selectNonPromptFromSV:
     raise ValueError("Options --selectNonPromptFromSV and --selectNonPromptFromLightMesonDecay cannot be used together.")
-
-if args.scaleDYfull > 0.0 and args.scaleDYvetoFraction > 0.0:
-    raise ValueError("Options --scaleDYfull and --scaleDYvetoFraction cannot be used together.")
 
 if args.useRefinedVeto and args.useGlobalOrTrackerVeto:
     raise NotImplementedError("Options --useGlobalOrTrackerVeto and --useRefinedVeto cannot be used together at the moment.")
@@ -501,9 +497,6 @@ def build_graph(df, dataset):
                 if args.scaleDYvetoFraction > 0.0:
                     # weight different from 1 only for events with >=2 gen muons in acceptance but only 1 reco muon
                     df = df.Define("weight_DY", f"(vetoMuons_charge0 > -99) ? {args.scaleDYvetoFraction} : 1.0")
-                    weight_expr += "*weight_DY"
-                elif args.scaleDYfull > 0.0:
-                    df = df.DefinePerSample("weight_DY", f"{args.scaleDYfull}")
                     weight_expr += "*weight_DY"
 
                 if not args.noVetoSF:

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -722,7 +722,7 @@ def build_graph(df, dataset):
                 for es in common.muonEfficiency_altBkgSyst_effSteps:
                     df = syst_tools.add_muon_efficiency_unc_hists_altBkg(results, df, muon_efficiency_helper_syst_altBkg[es], axes, cols, 
                                                                          what_analysis=thisAnalysis, step=es, storage_type=storage_type)
-                if isZveto and not args.noGenMatchMC:
+                if isZveto and not args.noGenMatchMC and not args.noVetoSF:
                     df = syst_tools.add_muon_efficiency_veto_unc_hists(results, df, muon_efficiency_veto_helper_stat, muon_efficiency_veto_helper_syst, axes, cols, storage_type=storage_type)
 
             df = syst_tools.add_L1Prefire_unc_hists(results, df, muon_prefiring_helper_stat, muon_prefiring_helper_syst, axes, cols, storage_type=storage_type)


### PR DESCRIPTION
Simple updates to run some tests, which might be needed also in the future.
One option allows the user to remove veto SF (whatever their definition is), while the other two permits the scaling of the DY backgrounds by a constant, either the full background or only the fraction that would be affected by the veto SF (these two options can be used in conjunction with the one that removes the veto SF).
For consistency, when removing veto SF the corresponding uncertainties are also not created.

No change is expected for the main workflows