### PR TITLE
Update Wlike histmaker allowing iso-mt axes to be added to the list of nominal axes

### DIFF
--- a/scripts/analysisTools/w_mass_13TeV/validateIsoMtRegionsWithZ.py
+++ b/scripts/analysisTools/w_mass_13TeV/validateIsoMtRegionsWithZ.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+from wremnants.datasets.datagroups import Datagroups
+from wremnants import histselections as sel
+#from wremnants import plot_tools,theory_tools,syst_tools
+from utilities import boostHistHelpers as hh
+from utilities import common, logging
+from utilities.io_tools import input_tools, output_tools
+
+import narf
+import wremnants
+from wremnants import theory_tools,syst_tools
+import hist
+
+import numpy as np
+
+import pickle
+import lz4.frame
+
+import argparse
+import os
+import shutil
+import re
+
+## safe batch mode
+import sys
+args = sys.argv[:]
+sys.argv = ['-b']
+import ROOT
+sys.argv = args
+ROOT.gROOT.SetBatch(True)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from copy import *
+
+from scripts.analysisTools.plotUtils.utility import *
+from scripts.analysisTools.w_mass_13TeV.plotPrefitTemplatesWRemnants import plotPrefitHistograms
+
+if __name__ == "__main__":
+    parser = common_plot_parser()
+    parser.add_argument("inputfile", type=str, nargs=1, help="Input file with histograms (pkl.lz4 or hdf5 file)")
+    parser.add_argument("outdir",   type=str, nargs=1, help="Output folder")
+    parser.add_argument("-n", "--baseName", type=str, help="Histogram name in the file (it depends on what study you run)", default="nominal_testIsoMtFakeRegions")
+    parser.add_argument('-p','--processes', default=None, nargs='*', type=str,
+                        help='Choose what processes to plot, otherwise all are done')
+    parser.add_argument("--isoBinEdges", type=int, nargs='+', default=[0, 0.15, 0.3], help="Bins to test (overflow added automatically)")
+    parser.add_argument("--mtBinEdges", type=float, nargs='+', default=[0,22,45], help="mT bins to test (overflow added automatically)")
+    parser.add_argument("--charge", type=int, default=1, choices=[-1, 0, 1], help="Triggering muon charge selection (0 integrates both charges)")
+    parser.add_argument("--rr", "--ratio-range", dest="ratioRange", default=(0.9,1.1), type=float, nargs=2, help="Range for ratio plot")
+    args = parser.parse_args()
+
+    logger = logging.setup_logger(os.path.basename(__file__), args.verbose)
+
+    charges = { -1 : "minus", 0: "both", 1 : "plus" }
+    chargeTag = charges[args.charge]
+    chargeBin = 0 if args.charge == -1 else 1
+    outdirTag = f"trigMuonCharge_{chargeTag}_nonTrigMuonPassIso/"
+    ###############################################################################################
+    fname = args.inputfile[0]
+    outdir_original = f"{args.outdir[0]}/{outdirTag}/"
+    outdir = createPlotDirAndCopyPhp(outdir_original, eoscp=args.eoscp)
+    
+    ROOT.TH1.SetDefaultSumw2()
+    
+    canvas = ROOT.TCanvas("canvas", "", 800, 700)
+    cwide = ROOT.TCanvas("cwide","",2400,600)                      
+    adjustSettings_CMS_lumi()
+    canvas1D = ROOT.TCanvas("canvas1D", "", 800, 900)
+
+    groups = Datagroups(fname)
+    datasets = groups.getNames()
+    if args.processes is not None and len(args.processes):
+        datasets = list(filter(lambda x: x in args.processes, datasets))
+    else:
+        datasets = list(filter(lambda x: x != "QCD", datasets))
+
+    logger.debug(f"Using these processes: {datasets}")
+    inputHistName = args.baseName
+    groups.setNominalName(inputHistName)
+    groups.loadHistsForDatagroups(inputHistName, syst="", procsToRead=datasets, applySelection=False)
+    histInfo = groups.getDatagroups() # keys are same as returned by groups.getNames()
+    s = hist.tag.Slicer()
+    chargeSlice = s[chargeBin] if args.charge != 0 else s[::hist.sum]
+    eps = 0.0001
+    isoBinEdges = args.isoBinEdges
+    mtBinEdges = args.mtBinEdges
+    
+    for jiso, iso in enumerate(isoBinEdges):
+        isoLow = round(iso,2)
+        isoLowStr = str(isoLow).replace(".","p")
+        maxJiso = len(isoBinEdges) - 1 
+        isoHighStr = str(round(isoBinEdges[jiso+1],2)) if jiso < maxJiso else "Inf"
+        isoHighStr = isoHighStr.replace(".","p")
+        isoTag = f"iso{isoLowStr}To{isoHighStr}"
+        for jmt,mt in enumerate(mtBinEdges):
+            mtLowStr = str(round(mt))
+            maxJmt = len(mtBinEdges) - 1 
+            mtHighStr = str(round(mtBinEdges[jmt+1])) if jmt < maxJmt else "Inf"
+            mtTag = f"mt{mtLowStr}To{mtHighStr}"
+            logger.info(f"Processing bin: {isoLowStr} < relIso < {isoHighStr} && {mtLowStr} < mT < {mtHighStr} GeV")
+            #
+            hdata2D = None
+            hmc2D = []
+            binTag = f"{isoTag}_{mtTag}"
+            outdirBin = f"{outdir}/{binTag}/"
+            createPlotDirAndCopyPhp(outdirBin, eoscp=args.eoscp)
+            for d in datasets:
+                logger.info(f"Running on process {d}")
+                hin = histInfo[d].hists[inputHistName]
+                # logger.debug(hin.axes)
+                ###
+                # the edges we use might require integrating more bins, so can't just use the jxxx index
+                mtSlice = s[complex(0,mt+eps)::hist.sum]
+                if jmt < maxJmt:
+                    mtSlice = s[complex(0,mt+eps):complex(0,mtBinEdges[jmt+1]+eps):hist.sum]
+                isoSlice = s[complex(0,iso+eps)::hist.sum]
+                if jiso < maxJiso:
+                    isoSlice = s[complex(0,iso+eps):complex(0,isoBinEdges[jiso+1]+eps):hist.sum]
+                h = hin[{"mt"     : mtSlice,
+                         "relIso" : isoSlice,
+                         "charge": chargeSlice}]
+                #logger.debug(h.axes)
+                if d =="Data":
+                    hdata2D = narf.hist_to_root(h)
+                    hdata2D.SetName(f"{d}_{chargeTag}")
+                    hdata2D.SetTitle(f"{d} {binTag} {chargeTag}")
+                else:
+                    hmc2D.append(narf.hist_to_root(h))
+                    hmc2D[-1].SetName(f"{d}_{chargeTag}")
+                    hmc2D[-1].SetTitle(f"{d} {binTag} {chargeTag}")
+            # end of process loop
+            plotPrefitHistograms(hdata2D, hmc2D, outdirBin, xAxisName="Triggering muon #eta", yAxisName="Triggering muon p_{T} (GeV)",
+                                 chargeLabel=chargeTag, canvas=canvas, canvasWide=cwide, canvas1D=canvas1D,
+                                 ratioRange=args.ratioRange, lumi=16.8)
+
+    copyOutputToEos(outdir, outdir_original, eoscp=args.eoscp)

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -104,7 +104,7 @@ else:
 # for isoMt region validation and related tests
 # use very high upper edge as a proxy for infinity (cannot exploit overflow bins in the fit)
 # can probably use numpy infinity, but this is compatible with the root conversion
-axis_mtCat = hist.axis.Variable([0, 22, 45, 1000], name = "mt", underflow=False, overflow=False)
+axis_mtCat = hist.axis.Variable([0, int(args.mtCut/2.), args.mtCut, 1000], name = "mt", underflow=False, overflow=False)
 axis_isoCat = hist.axis.Variable([0, 0.15, 0.3, 100], name = "relIso",underflow=False, overflow=False)
 
 nominal_axes = [axis_eta, axis_pt, common.axis_charge]

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -69,8 +69,8 @@ axis_eta = hist.axis.Regular(template_neta, template_mineta, template_maxeta, na
 axis_pt = hist.axis.Regular(template_npt, template_minpt, template_maxpt, name = "pt", overflow=False, underflow=False)
 
 # for isoMt region validation and related tests
-#axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=True), name = "mt", underflow=False, overflow=True)
-#axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=True), name = "relIso",underflow=False, overflow=True)
+# use very high upper edge as a proxy for infinity (cannot exploit overflow bins in the fit)
+# can probably use numpy infinity, but this is compatible with the root conversion
 axis_mtCat = hist.axis.Variable([0, 22, 45, 1000], name = "mt", underflow=False, overflow=False)
 axis_isoCat = hist.axis.Variable([0, 0.15, 0.3, 100], name = "relIso",underflow=False, overflow=False)
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -202,8 +202,10 @@ def build_graph(df, dataset):
     if not passIsoBoth:
         df = muon_selections.apply_iso_muons(df, args.muonIsolation[0], args.muonIsolation[1], isoBranch, isoThreshold)
 
-    df = df.Define("trigMuons_passIso0", f"{isoBranch}[trigMuons][0] < {isoThreshold}")
-    df = df.Define("nonTrigMuons_passIso0", f"{isoBranch}[nonTrigMuons][0] < {isoThreshold}")
+    df = df.Define("trigMuons_relIso0", f"{isoBranch}[trigMuons][0]")
+    df = df.Define("nonTrigMuons_relIso0", f"{isoBranch}[nonTrigMuons][0]")
+    df = df.Define("trigMuons_passIso0", f"trigMuons_relIso0 < {isoThreshold}")
+    df = df.Define("nonTrigMuons_passIso0", f"nonTrigMuons_relIso0 < {isoThreshold}")
 
     df = muon_selections.select_z_candidate(df, mass_min, mass_max)
 
@@ -298,6 +300,11 @@ def build_graph(df, dataset):
 
         nominal_bin = df.HistoBoost("nominal_isoMtBins", [*axes, axis_trigPassIso, axis_nonTrigPassIso, axis_mt_coarse], [*cols, "trigMuons_passIso0", "nonTrigMuons_passIso0", "transverseMass", "nominal_weight"])
         results.append(nominal_bin)
+
+        axis_mtCat = hist.axis.Variable(common.get_binning_fakes_mt(mtw_min, high_mt_bins=True), name = "mt", underflow=False, overflow=True)
+        axis_isoCat = hist.axis.Variable(common.get_binning_fakes_relIso(high_iso_bins=True), name = "relIso",underflow=False, overflow=True)
+        nominal_testIsoMtFakeRegions = df.HistoBoost("nominal_testIsoMtFakeRegions", [*axes, axis_isoCat, axis_mtCat], [*cols, "trigMuons_relIso0", "transverseMass", "nominal_weight"])
+        results.append(nominal_testIsoMtFakeRegions)
 
         axis_eta_nonTrig = hist.axis.Regular(template_neta, template_mineta, template_maxeta, name = "etaNonTrig", overflow=False, underflow=False)
         axis_pt_nonTrig = hist.axis.Regular(template_npt, template_minpt, template_maxpt, name = "ptNonTrig", overflow=False, underflow=False)

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -44,7 +44,7 @@ if isFloatingPOIsTheoryAgnostic:
 
 parser = common.set_parser_default(parser, "aggregateGroups", ["Diboson", "Top", "Wtaunu", "Wmunu"])
 parser = common.set_parser_default(parser, "excludeProcs", ["QCD"])
-if initargs.addIsoMtAxes:
+if args.addIsoMtAxes:
     parser = common.set_parser_default(parser, "muonIsolation", [0, 1])
 
 if isTheoryAgnostic:
@@ -52,6 +52,8 @@ if isTheoryAgnostic:
     if args.genAbsYVbinEdges and any(x < 0.0 for x in args.genAbsYVbinEdges):
         raise ValueError("Option --genAbsYVbinEdges requires all positive values. Please check")
 
+args = parser.parse_args() # parse again or new defaults won't be propagated
+    
 if args.useRefinedVeto and args.useGlobalOrTrackerVeto:
     raise NotImplementedError("Options --useGlobalOrTrackerVeto and --useRefinedVeto cannot be used together at the moment.")
 if args.validateVetoSF:


### PR DESCRIPTION
This is used for the validation of muon SF with Wlike events, using the same isolation and mt bins relevant for the mW analysis.

Nothing should change for the standard workflows, but it is useful to have these features implemented in the main code for future iterations. Given the histograms, one can them even fit single bins selected in setupCombine using the already existing options --fitvar and --axlim options, adding isolation and mT in the list of fit axes and using specific bins.