### PR TITLE
Make massDiff and mass constraint behaviour more configurable

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -75,7 +75,8 @@ def make_parser(parser=None):
     parser.add_argument("--sumChannels", action='store_true', help="Only use one channel")
     parser.add_argument("--fitXsec", action='store_true', help="Fit signal inclusive cross section")
     parser.add_argument("--fitWidth", action='store_true', help="Fit boson width")
-    parser.add_argument("--fitMassDiff", type=str, default=None, choices=["charge", "cosThetaStarll", "eta-sign", "eta-range", "etaRegion", "etaRegionSign", "etaRegionRange"], help="Fit an additional POI for the difference in the boson mass")
+    parser.add_argument("--fitMassDiffW", type=str, default=None, choices=["charge", "cosThetaStarll", "eta-sign", "eta-range", "etaRegion", "etaRegionSign", "etaRegionRange"], help="Fit an additional POI for the difference in the W boson mass")
+    parser.add_argument("--fitMassDiffZ", type=str, default=None, choices=["charge", "cosThetaStarll", "eta-sign", "eta-range", "etaRegion", "etaRegionSign", "etaRegionRange"], help="Fit an additional POI for the difference in the W boson mass")
     parser.add_argument("--fitMassDecorr", type=str, default=[], nargs='*', help="Decorrelate POI for given axes, fit multiple POIs for the different POIs")
     parser.add_argument("--decorrRebin", type=int, nargs='*', default=[], help="Rebin axis by this value (default, 1, does nothing)")
     parser.add_argument("--decorrAbsval", type=int, nargs='*', default=[], help="Take absolute value of axis if 1 (default, 0, does nothing)")
@@ -138,7 +139,8 @@ def make_parser(parser=None):
     parser.add_argument("--addTauToSignal", action='store_true', help="Events from the same process but from tau final states are added to the signal")
     parser.add_argument("--noPDFandQCDtheorySystOnSignal", action='store_true', help="Removes PDF and theory uncertainties on signal processes")
     parser.add_argument("--recoCharge", type=str, default=["plus", "minus"], nargs="+", choices=["plus", "minus"], help="Specify reco charge to use, default uses both. This is a workaround for unfolding/theory-agnostic fit when running a single reco charge, as gen bins with opposite gen charge have to be filtered out")
-    parser.add_argument("--massConstraintMode", choices=["automatic", "constrained", "unconstrained"], default="automatic", help="Whether mass is constrained within PDG value and uncertainty or unconstrained in the fit")
+    parser.add_argument("--massConstraintModeW", choices=["automatic", "constrained", "unconstrained"], default="automatic", help="Whether W mass is constrained within PDG value and uncertainty or unconstrained in the fit")
+    parser.add_argument("--massConstraintModeZ", choices=["automatic", "constrained", "unconstrained"], default="automatic", help="Whether Z mass is constrained within PDG value and uncertainty or unconstrained in the fit")
     parser.add_argument("--decorMassWidth", action='store_true', help="remove width variations from mass variations")
     parser.add_argument("--muRmuFPolVar", action="store_true", help="Use polynomial variations (like in theoryAgnosticPolVar) instead of binned variations for muR and muF (of course in setupCombine these are still constrained nuisances)")
     parser.add_argument("--binByBinStatScaleForMW", type=float, default=1.26, help="scaling of bin by bin statistical uncertainty for W mass analysis")
@@ -192,10 +194,12 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
 
     simultaneousABCD = wmass and args.simultaneousABCD and not xnorm
 
-    if args.massConstraintMode == "automatic":
+    massConstraintMode = args.massConstraintModeW if wmass else args.massConstraintModeZ
+
+    if massConstraintMode == "automatic":
         constrainMass = args.fitXsec or (dilepton and not "mll" in fitvar) or genfit
     else:
-        constrainMass = True if args.massConstraintMode == "constrained" else False
+        constrainMass = True if massConstraintMode == "constrained" else False
     logger.debug(f"constrainMass = {constrainMass}")
 
     if wmass:
@@ -495,11 +499,12 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
     if not (args.doStatOnly and constrainMass):
         if args.massVariation != 0:
             if len(args.fitMassDecorr)==0:
+                massVariation = 2.1 if (not wmass and constrainMass) else args.massVariation
                 cardTool.addSystematic(f"{massWeightName}{label}",
                                     processes=signal_samples_forMass,
                                     group=f"massShift",
                                     noi=not constrainMass,
-                                    skipEntries=massWeightNames(proc=label, exclude=args.massVariation),
+                                    skipEntries=massWeightNames(proc=label, exclude=massVariation),
                                     mirror=False,
                                     noConstraint=not constrainMass,
                                     systAxes=["massShift"],
@@ -531,11 +536,13 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
                         )
                 )
 
-        if args.fitMassDiff:
-            suffix = "".join([a.capitalize() for a in args.fitMassDiff.split("-")])
+        fitMassDiff = args.fitMassDiffW if wmass else args.fitMassDiffZ
+
+        if fitMassDiff:
+            suffix = "".join([a.capitalize() for a in fitMassDiff.split("-")])
             combine_helpers.add_mass_diff_variations(
                 cardTool, 
-                args.fitMassDiff,
+                fitMassDiff,
                 name=f"{massWeightName}{label}",
                 processes=signal_samples_forMass, 
                 constrain=constrainMass,
@@ -632,16 +639,39 @@ def setup(args, inputFile, inputBaseName, inputLumiScale, fitvar, genvar=None, x
 
     if not args.noTheoryUnc:
         if wmass and not xnorm:
+            if args.massConstraintModeZ == "automatic":
+                constrainMassZ = True
+            else:
+                constrainMassZ = True if args.massConstraintModeZ == "constrained" else False
+
+            massVariationZ = 2.1 if constrainMassZ else args.massVariation
+
             cardTool.addSystematic(f"massWeightZ",
                                     processes=['single_v_nonsig_samples'],
                                     group="ZmassAndWidth",
                                     splitGroup = {"theory": ".*"},
-                                    skipEntries=massWeightNames(proc="Z", exclude=2.1),
+                                    skipEntries=massWeightNames(proc="Z", exclude=massVariationZ),
                                     mirror=False,
-                                    noConstraint=False,
+                                    noi=not constrainMassZ,
+                                    noConstraint=not constrainMassZ,
                                     systAxes=["massShift"],
                                     passToFakes=passSystToFakes,
             )
+
+
+            fitMassDiff = args.fitMassDiffZ
+            if fitMassDiff:
+                suffix = "".join([a.capitalize() for a in fitMassDiff.split("-")])
+                combine_helpers.add_mass_diff_variations(
+                    cardTool,
+                    fitMassDiff,
+                    name=f"{massWeightName}Z",
+                    processes=['single_v_nonsig_samples'],
+                    constrain=constrainMass,
+                    suffix=suffix,
+                    label="Z",
+                    passSystToFakes=passSystToFakes,
+                )
 
         # Experimental range
         #widthVars = (42, ['widthW2p043GeV', 'widthW2p127GeV']) if wmass else (2.3, ['widthZ2p4929GeV', 'widthZ2p4975GeV'])
@@ -1290,6 +1320,9 @@ if __name__ == "__main__":
         args.doStatOnly = True
 
     if not args.root:
+        if len(args.inputFile)>1 and (args.fitWidth or args.decorMassWidth):
+            raise ValueError("Fitting multiple channels with fitWidth or decorMassWidth is not currently supported since this can lead to inconsistent treatment of mass variations between channels.")
+
         writer = HDF5Writer.HDF5Writer(sparse=args.sparse)
 
         if args.baseName == "xnorm":

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -84,7 +84,7 @@ all_axes = {
     "ewMlly": hist.axis.Variable(ewMassBins, name = "ewMlly", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
     "ewLogDeltaM": hist.axis.Regular(100, -10, 4, name = "ewLogDeltaM", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
     "trigMuons_abseta0" : hist.axis.Regular(3, 0., 2.4, name = "trigMuons_abseta0", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
-    "nonTrigMuons_eta0" : hist.axis.Regular(args.eta[0], args.eta[1], args.eta[2], name = "nonTrigMuons_eta0", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
+    "nonTrigMuons_eta0" : hist.axis.Regular(int(args.eta[0]), args.eta[1], args.eta[2], name = "nonTrigMuons_eta0", overflow=not args.excludeFlow, underflow=not args.excludeFlow),
     "nonTrigMuons_pt0" : hist.axis.Regular(int(args.pt[0]), args.pt[1], args.pt[2], name = "nonTrigMuons_pt0"),
     "nonTrigMuons_charge0" : hist.axis.Regular(2, -2., 2., underflow=False, overflow=False, name = "nonTrigMuons_charge0"),
 }
@@ -300,8 +300,8 @@ def build_graph(df, dataset):
     else:
         cvhName = "cvhideal"
 
-    axis_eta = hist.axis.Regular(args.eta[0], args.eta[1], args.eta[2], name = "eta")
-    axis_pt = hist.axis.Regular(args.pt[0], args.pt[1], args.pt[2], name = "pt")
+    axis_eta = hist.axis.Regular(int(args.eta[0]), args.eta[1], args.eta[2], name = "eta")
+    axis_pt = hist.axis.Regular(int(args.pt[0]), args.pt[1], args.pt[2], name = "pt")
     axis_charge = common.axis_charge
     axis_nvalidpixel = hist.axis.Integer(0, 10, name="nvalidpixel")
 


### PR DESCRIPTION
This is needed to facilitate different combinations of W+Z simultaneous fits for some of the cross checks.

There is also what is technically a fix here to the default/automatic behaviour for the yll-ptll (or yll-ptll+W combined fit) where previously although mZ was correctly constrained, it was constrained with a 100MeV uncertainty instead of the 2.1MeV PDG uncertainty.  Of course when fitting non-mass-sensitive observables this should make very little difference.

This PR should have zero change to the nominal fit or the CI.