### PR TITLE
Automatic deletion of old kerberos credentials

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: setup kerberos
         run: |
+          kdestroy
           kinit -kt ~/private/.keytab cmsmwbot@CERN.CH
           klist -k -t -e ~/private/.keytab
           klist

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,9 +13,18 @@ jobs:
 
     # delete old folders, keep the 5 newest ones
     steps:
+      - name: delete old kerberos credentials
+        run: |
+          FILE_PATH="/tmp/krb5cc_158524"
+          if [ -f "$FILE_PATH" ]; then
+            echo "Delete $FILE_PATH and create new one"
+            rm "$FILE_PATH"
+          else
+            echo "File $FILE_PATH does not yet exist, create it."
+          fi
+
       - name: setup kerberos
         run: |
-          kdestroy
           kinit -kt ~/private/.keytab cmsmwbot@CERN.CH
           klist -k -t -e ~/private/.keytab
           klist


### PR DESCRIPTION
When the old kerberos ticket expires a /tmp/krb5cc_158524 remains and has to be manually deleted to create a new one. 
Added the deletion in the cleanup workflow now that is run once a week.