### PR TITLE
Fix norm uncertainties

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -1227,7 +1227,8 @@ def setup(
     )
     cardTool.addProcessGroup(
         "MCnoQCD",
-        lambda x: x not in ["QCD", "Data"] + (["Fake"] if simultaneousABCD else []),
+        lambda x: x
+        not in ["QCD", "Data", "Fake"] + (["Fake"] if simultaneousABCD else []),
     )
     # FIXME/FOLLOWUP: the following groups may actually not exclude the OOA when it is not defined as an independent process with specific name
     cardTool.addProcessGroup(
@@ -1315,7 +1316,8 @@ def setup(
             cardTool.nominalName,
             rename="dummy",
             processes=["MCnoQCD"],
-            action=lambda h: hh.scaleHist(h, 1.0001),
+            preOp=hh.scaleHist,
+            preOpArgs={"scale": 1.0001},
             mirror=True,
         )
 
@@ -1608,14 +1610,14 @@ def setup(
         splitGroup={"experiment": ".*", "expNoCalib": ".*"},
         passToFakes=passSystToFakes,
         mirror=True,
-        action=lambda h: hh.scaleHist(
-            h,
-            (
-                args.lumiUncertainty
-                if args.lumiUncertainty is not None
-                else cardTool.datagroups.lumi_uncertainty
-            ),
-        ),
+        preOp=hh.scaleHist,
+        preOpArgs={
+            "scale": (
+                cardTool.datagroups.lumi_uncertainty
+                if args.lumiUncertainty is None
+                else args.lumiUncertainty
+            )
+        },
     )
 
     if not lowPU:  # lowPU does not include PhotonInduced as a process. skip it:
@@ -1627,7 +1629,8 @@ def setup(
             splitGroup={"experiment": ".*", "expNoCalib": ".*"},
             passToFakes=passSystToFakes,
             mirror=True,
-            action=lambda h: hh.scaleHist(h, 2.0),
+            preOp=hh.scaleHist,
+            preOpArgs={"scale": 2.0},
         )
     if wmass:
         if args.logNormalWmunu > 0.0:
@@ -1639,7 +1642,8 @@ def setup(
                 splitGroup={"experiment": ".*", "expNoCalib": ".*"},
                 passToFakes=passSystToFakes,
                 mirror=True,
-                action=lambda h: hh.scaleHist(h, args.logNormalWmunu),
+                preOp=hh.scaleHist,
+                preOpArgs={"scale": args.logNormalWmunu},
             )
         if args.logNormalFake > 0.0:
             cardTool.addSystematic(
@@ -1650,7 +1654,8 @@ def setup(
                 splitGroup={"experiment": ".*", "expNoCalib": ".*"},
                 passToFakes=False,
                 mirror=True,
-                action=lambda h: hh.scaleHist(h, args.logNormalFake),
+                preOp=hh.scaleHist,
+                preOpArgs={"scale": args.logNormalFake},
             )
         elif args.logNormalFake < 0.0:
             cardTool.datagroups.unconstrainedProcesses.append(cardTool.getFakeName())
@@ -1663,7 +1668,8 @@ def setup(
             splitGroup={"experiment": ".*", "expNoCalib": ".*"},
             passToFakes=passSystToFakes,
             mirror=True,
-            action=lambda h: hh.scaleHist(h, 1.06),
+            preOp=hh.scaleHist,
+            preOpArgs={"scale": 1.06},
         )
         cardTool.addSystematic(
             cardTool.nominalName,
@@ -1673,7 +1679,8 @@ def setup(
             splitGroup={"experiment": ".*", "expNoCalib": ".*"},
             passToFakes=passSystToFakes,
             mirror=True,
-            action=lambda h: hh.scaleHist(h, 1.16),
+            preOp=hh.scaleHist,
+            preOpArgs={"scale": 1.16},
         )
     else:
         cardTool.addSystematic(
@@ -1684,7 +1691,8 @@ def setup(
             splitGroup={"experiment": ".*", "expNoCalib": ".*"},
             passToFakes=passSystToFakes,
             mirror=True,
-            action=lambda h: hh.scaleHist(h, 1.15),
+            preOp=hh.scaleHist,
+            preOpArgs={"scale": 1.15},
         )
 
     if (

--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -487,12 +487,6 @@ def build_graph(df, dataset):
             "Eigen::TensorFixedSize<double, Eigen::Sizes<2>> res; auto w = nominal_weight*prefireCorr_syst; std::copy(std::begin(w), std::end(w), res.data()); return res;",
         )
 
-        # luminosity, done here as shape variation despite being a flat scaling so to facilitate propagating to fakes afterwards
-        df = df.Define(
-            "luminosityScaling",
-            f"wrem::constantScaling(nominal_weight, {args.lumiUncertainty})",
-        )
-
         for n, c, a in (("nominal", cols, axes), ("transverseMass", cols_mt, axes_mt)):
             results.append(
                 df.HistoBoost(

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -39,12 +39,6 @@ from wremnants.helicity_utils_polvar import makehelicityWeightHelper_polvar
 from wremnants.histmaker_tools import aggregate_groups, scale_to_data
 
 parser.add_argument(
-    "--lumiUncertainty",
-    type=float,
-    help=r"Uncertainty for luminosity in excess to 1 (e.g. 1.012 means 1.2%)",
-    default=1.012,
-)
-parser.add_argument(
     "--noGenMatchMC",
     action="store_true",
     help="Don't use gen match filter for prompt muons with MC samples (note: QCD MC never has it anyway)",
@@ -1189,6 +1183,7 @@ def build_graph(df, dataset):
                 axis_leadjetPt_fakes,
                 axis_dphi_fakes,
             ]
+
             df = df.Define("goodMuons_hasJet0", "Muon_jetIdx[goodMuons][0] != -1 ")
             df = df.Define(
                 "goodMuons_jetpt0",
@@ -1782,10 +1777,6 @@ def build_graph(df, dataset):
                 axes,
                 cols,
                 storage_type=storage_type,
-            )
-            # luminosity, as shape variation despite being a flat scaling to facilitate propagation to fakes
-            df = syst_tools.add_luminosity_unc_hists(
-                results, df, args, axes, cols, storage_type=storage_type
             )
 
         # n.b. this is the W analysis so mass weights shouldn't be propagated

--- a/scripts/plotting/mass_summary_modeling.py
+++ b/scripts/plotting/mass_summary_modeling.py
@@ -84,7 +84,7 @@ fig = plot_tools.make_summary_plot(
     central_val,
     central["err_total"],
     central["err_standard_pTModeling"],
-    "Main result",
+    "N$^{3{+}0}$LL+NNLO\n (nominal)",
     dfs.iloc[1:, :],
     colors="auto",
     xlim=xlim,

--- a/scripts/plotting/pdf_results_summary.py
+++ b/scripts/plotting/pdf_results_summary.py
@@ -86,7 +86,7 @@ central = dfs.iloc[0, :]
 
 xlabel = r"$\mathit{m}_{" + ("W" if isW else "Z") + "}$ (MeV)"
 
-xlim = [91160, 91220] if not isW else [80334, 80374]
+xlim = [91160, 91220] if not isW else [80329, 80374]
 
 central_val = central["value"]
 if args.diffToCentral:
@@ -103,7 +103,7 @@ fig = plot_tools.make_summary_plot(
     central_val,
     central["err_total"],
     central["err_pdf"],
-    "Main result",
+    "CT18Z (nominal)",
     dfs.iloc[1:, :],
     colors=args.colors[1:] if args.colors[0] != "auto" else args.colors[0],
     center_color="black",

--- a/scripts/plotting/plot_decorr_params.py
+++ b/scripts/plotting/plot_decorr_params.py
@@ -436,7 +436,7 @@ if __name__ == "__main__":
             loc=args.legPos,
             text_size=args.legSize,
             extra_handles=extra_handles,
-            extra_labels=["Main result"],
+            extra_labels=["Nominal"],
             custom_handlers=["tripleband"],
         )
 

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -405,54 +405,6 @@ class HDF5Writer(object):
             # initialize dictionaties for systematics
             self.init_data_dicts_channel(chan, procs_chan)
 
-            # lnN systematics
-            for var_name, syst in chanInfo.lnNSystematics.items():
-                logger.info(f"Now in channel {chan} at lnN systematic {var_name}")
-
-                if chanInfo.isExcludedNuisance(var_name):
-                    continue
-                procs_syst = [p for p in syst["processes"] if p in procs_chan]
-                if len(procs_syst) == 0:
-                    continue
-
-                ksyst = syst["size"]
-                asymmetric = type(ksyst) is list
-                if asymmetric:
-                    ksystup = ksyst[1]
-                    ksystdown = ksyst[0]
-                    if ksystup == 0.0 and ksystdown == 0.0:
-                        continue
-                    if ksystup == 0.0:
-                        ksystup = 1.0
-                    if ksystdown == 0.0:
-                        ksystdown = 1.0
-                    logkup_proc = math.log(ksystup) * np.ones(
-                        [nbinschan], dtype=self.dtype
-                    )
-                    logkdown_proc = -math.log(ksystdown) * np.ones(
-                        [nbinschan], dtype=self.dtype
-                    )
-                    logkavg_proc = 0.5 * (logkup_proc + logkdown_proc)
-                    logkhalfdiff_proc = 0.5 * (logkup_proc - logkdown_proc)
-                    logkup_proc = None
-                    logkdown_proc = None
-                else:
-                    if ksyst == 0.0:
-                        continue
-                    logkavg_proc = math.log(ksyst) * np.ones(
-                        [nbinschan], dtype=self.dtype
-                    )
-
-                for proc in procs_syst:
-                    logger.debug(f"Now at proc {proc}!")
-
-                    self.book_logk_avg(logkavg_proc, chan, proc, var_name)
-
-                    if asymmetric:
-                        self.book_logk_halfdiff(logkhalfdiff_proc, chan, proc, var_name)
-
-                self.book_systematic(syst, var_name, masked=masked)
-
             # shape systematics
             for systKey, syst in chanInfo.systematics.items():
                 logger.info(

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -81,12 +81,14 @@ class Datagroups(object):
             )
 
             self.era = "2017H"
+            self.lumi_uncertainty = 1.017
         else:
             from wremnants.datasets.datagroups2016 import (
                 make_datagroups_2016 as make_datagroups,
             )
 
             self.era = "2016postVFP"
+            self.lumi_uncertainty = 1.012
 
         make_datagroups(self, **kwargs)
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1704,28 +1704,6 @@ def add_QCDbkg_jetPt_hist(
     add_syst_hist(results, dQCDbkGVar, name, axes, cols, "nominal_weight", **kwargs)
 
 
-def add_luminosity_unc_hists(
-    results, df, args, axes, cols, base_name="nominal", **kwargs
-):
-    name = Datagroups.histName(base_name, syst="luminosity")
-    df = df.Define(
-        "luminosityScaling",
-        f"wrem::constantScaling(nominal_weight, {args.lumiUncertainty})",
-    )
-    add_syst_hist(
-        results,
-        df,
-        name,
-        axes,
-        cols,
-        "luminosityScaling",
-        common.down_up_axis,
-        **kwargs,
-    )
-
-    return df
-
-
 def add_theory_corr_hists(
     results,
     df,


### PR DESCRIPTION
Previously norm uncertainties were added via "addLnNSystematic" but not propagated into the sideband regions for the fake estimation. 

- The LnN systematics are now removed and norm uncertainties are instead added as shape uncertainties (that was already the case before once converted to hdf5 tensor). Now the same interface is used, via "addSystematic". I validated that it is equivalent. 

- The luminosity histogram for the W is removed as well and this variation is added in the same way with "addSystematic" in setupCombine on the fly. Small numerical differences are expected.