### PR TITLE
Optionally add helicity axis to gen histograms

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -18,6 +18,7 @@ from wremnants import (
     combine_theoryAgnostic_helper,
     syst_tools,
     theory_corrections,
+    theory_tools,
 )
 from wremnants.datasets.datagroups import Datagroups
 from wremnants.histselections import FakeSelectorSimpleABCD
@@ -715,6 +716,11 @@ def make_parser(parser=None):
         action="store_true",
         help="apply exponential transformation to yields (useful for gen-level fits to helicity cross sections for example)",
     )
+    parser.add_argument(
+        "--angularCoeffs",
+        action="store_true",
+        help="convert helicity cross sections to angular coefficients",
+    )
     parser = make_subparsers(parser)
 
     return parser
@@ -753,6 +759,13 @@ def setup(
     datagroups = Datagroups(
         inputFile, excludeGroups=excludeGroup, filterGroups=filterGroup
     )
+
+    if args.angularCoeffs:
+        datagroups.setGlobalAction(
+            lambda h: theory_tools.helicity_xsec_to_angular_coeffs(
+                h, helicity_axis_name="helicitygen"
+            )
+        )
 
     if not xnorm and (args.axlim or args.rebin or args.absval):
         datagroups.set_rebin_action(

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -76,6 +76,9 @@ parser.add_argument(
 parser.add_argument(
     "--theoryCorrections", action="store_true", help="Apply default theory corrections"
 )
+parser.add_argument(
+    "--addHelicityAxis", action="store_true", help="Add helicity to nominal axes"
+)
 
 parser = parsing.set_parser_default(parser, "filterProcs", common.vprocs)
 args = parser.parse_args()
@@ -257,6 +260,27 @@ def build_graph(df, dataset):
         "ptqVgen" if args.ptqVgen else "ptVgen",
         "chargeVgen",
     ]
+
+    if args.addHelicityAxis:
+        # add helicity axis, indices, and weights
+
+        # make a new axis here to avoid name collision with histograms which otherwise already
+        # have a helicity axis
+        axis_helicitygen = hist.axis.Integer(
+            -1, 8, name="helicitygen", overflow=False, underflow=False
+        )
+
+        # since mutliple tensor weights are not currently supported, convert the helicity tensor to a std::array which
+        # will be looped over during the filling (together with the helicity indices)
+        df = df.DefinePerSample("helicity_idxs", "wrem::seq_idxs_array<9>(-1)")
+        df = df.Define(
+            "helicity_moments",
+            "wrem::tensor_to_array(wrem::csAngularMoments(csSineCosThetaPhigen))",
+        )
+
+        nominal_axes += [axis_helicitygen]
+        nominal_cols += ["helicity_idxs", "helicity_moments"]
+
     lep_cols = ["absEtaGen", "ptGen", "chargeVgen"]
 
     mode = f'{"z" if isZ else "w"}_{analysis_label}'
@@ -796,6 +820,7 @@ def build_graph(df, dataset):
             base_name="nominal_gen",
             propagateToHelicity=args.propagatePDFstoHelicity,
         )
+
         df = syst_tools.add_helicity_hists(
             results,
             df,
@@ -806,8 +831,6 @@ def build_graph(df, dataset):
             storage=hist.storage.Weight(),
         )
 
-    nominal_cols = [col_rapidity, "ptqVgen" if args.ptqVgen else "ptVgen"]
-    nominal_axes = [axis_rapidity, axis_ptqVgen if args.ptqVgen else axis_ptVgen]
     nominal_gen = df.HistoBoost(
         "nominal_gen",
         nominal_axes,
@@ -825,7 +848,9 @@ output_tools.write_analysis_output(
     resultdict, f"{os.path.basename(__file__).replace('py', 'hdf5')}", args
 )
 
-if not args.skipHelicityXsecs:
+# FIXME currently the addHelicityAxis functionality interferes with the prouduction
+# of these histograms, so skip them in that case
+if not args.addHelicityAxis and not args.skipHelicityXsecs:
     logger.info("Writing out helicity cross sections")
     z_helicity_xsecs = None
     w_helicity_xsecs = None

--- a/wremnants/include/utils.hpp
+++ b/wremnants/include/utils.hpp
@@ -434,6 +434,14 @@ auto vec_to_tensor_t(const V &vec, std::size_t start = 0) {
   return res;
 }
 
+template <typename T, std::ptrdiff_t N>
+std::array<T, N>
+tensor_to_array(const Eigen::TensorFixedSize<T, Eigen::Sizes<N>> &tensor) {
+  std::array<T, N> res;
+  std::copy(tensor.data(), tensor.data() + N, res.data());
+  return res;
+}
+
 template <typename V> auto array_view(const V &vec, std::size_t start = 0) {
   return Eigen::Map<
       const Eigen::Array<typename V::value_type, Eigen::Dynamic, 1>>(
@@ -785,6 +793,12 @@ enum class TriggerCat { nonTriggering = 0, triggering = 1 };
 
 std::vector<int> seq_idxs(const int size, const int start = 0) {
   std::vector<int> res(size);
+  std::iota(res.begin(), res.end(), start);
+  return res;
+}
+
+template <int N> std::array<int, N> seq_idxs_array(const int start = 0) {
+  std::array<int, N> res;
   std::iota(res.begin(), res.end(), start);
   return res;
 }

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1816,8 +1816,9 @@ def add_theory_corr_hists(
                     0, 1, name="chargeVgenNP", underflow=False, overflow=False
                 )
 
-            axes_FlavDepNP = [*axes, theory_tools.axis_absYVgen, axis_chargegen]
-            cols_FlavDepNP = [*cols, "absYVgen", "chargeVgen"]
+            # since the last column might be an additional weight, the extra columns and axes have to go at the beginning
+            axes_FlavDepNP = [theory_tools.axis_absYVgen, axis_chargegen, *axes]
+            cols_FlavDepNP = ["absYVgen", "chargeVgen", *cols]
             name = Datagroups.histName(base_name, syst=tensor_name)
             add_syst_hist(
                 results,

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1816,9 +1816,10 @@ def add_theory_corr_hists(
                     0, 1, name="chargeVgenNP", underflow=False, overflow=False
                 )
 
-            # since the last column might be an additional weight, the extra columns and axes have to go at the beginning
-            axes_FlavDepNP = [theory_tools.axis_absYVgen, axis_chargegen, *axes]
-            cols_FlavDepNP = ["absYVgen", "chargeVgen", *cols]
+            # since the last column might be an additional weight, the extra columns and axes have to go at the appropriate place
+            nax = len(axes)
+            axes_FlavDepNP = [*axes, theory_tools.axis_absYVgen, axis_chargegen]
+            cols_FlavDepNP = cols[:nax] + ["absYVgen", "chargeVgen"] + cols[nax:]
             name = Datagroups.histName(base_name, syst=tensor_name)
             add_syst_hist(
                 results,

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -1080,12 +1080,14 @@ def replace_by_neighbors(vals, replace):
     return vals[tuple(indices)]
 
 
-def helicity_xsec_to_angular_coeffs(hist_helicity_xsec_scales, cutoff=1e-5):
+def helicity_xsec_to_angular_coeffs(
+    hist_helicity_xsec_scales, cutoff=1e-5, helicity_axis_name="helicity"
+):
     if hist_helicity_xsec_scales.empty():
         raise ValueError("Cannot make coefficients from empty hist")
     # broadcasting happens right to left, so move to rightmost then move back
-    hel_ax = hist_helicity_xsec_scales.axes["helicity"]
-    hel_idx = hist_helicity_xsec_scales.axes.name.index("helicity")
+    hel_ax = hist_helicity_xsec_scales.axes[helicity_axis_name]
+    hel_idx = hist_helicity_xsec_scales.axes.name.index(helicity_axis_name)
     vals = np.moveaxis(hist_helicity_xsec_scales.view(flow=True), hel_idx, -1)
     values = vals.value if hasattr(vals, "value") else vals
 


### PR DESCRIPTION
This is done by adding the helicity weights as an extra column so that it is ~automatically added to all histograms.

Since multiple tensor weights are not supported yet, the helicity weights are added as an array together with an array of indices, so this could be made more computationally efficient in the future.

Example usage

`python $WREM_BASE/scripts/histmakers/w_z_gen_dists.py --theoryCorrections --maxFiles 100 --helicity --addHelicityAxis -p helicityqcd`

`python $WREM_BASE/scripts/combine/setupCombine.py -i w_z_gen_dists_scetlib_dyturboCorr_maxFiles_100_helicityqcd.hdf5 --fitvar ptVgen-absYVgen-helicitygen -n nominal_gen --filter Wmunu
`