### PR TITLE
Fix lumi scaling

### DIFF
--- a/scripts/analysisTools/tests/testPlots1D.py
+++ b/scripts/analysisTools/tests/testPlots1D.py
@@ -31,7 +31,6 @@ from scripts.analysisTools.plotUtils.utility import (
     createPlotDirAndCopyPhp,
     drawCorrelationPlot,
     drawTH1dataMCstack,
-    h,
     legEntries_plots_,
 )
 
@@ -122,6 +121,13 @@ if __name__ == "__main__":
         nargs="*",
         type=str,
         help="Choose what processes to plot, otherwise all are done",
+    )
+    parser.add_argument(
+        "--excludeProcesses",
+        default=None,
+        nargs="*",
+        type=str,
+        help="Don't run over processes belonging to these groups (only accepts exact group names)",
     )
     parser.add_argument(
         "--plot", nargs="+", type=str, help="Choose what distribution to plot by name"
@@ -244,7 +250,7 @@ if __name__ == "__main__":
             if args.project1D:
                 if args.project1D not in hnarf.axes.name:
                     raise ValueError(
-                        f"Histogram has axes {h.axes.name} but requested axis for projection is {args.project1D}"
+                        f"Histogram has axes {hnarf.axes.name} but requested axis for projection is {args.project1D}"
                     )
                 else:
                     if any(ax != args.project1D for ax in hnarf.axes.name):

--- a/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
+++ b/scripts/analysisTools/w_mass_13TeV/makeImpactsOnMW.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-x",
         "--excludeNuisgroups",
-        default=".*Fake.+|.*eff_(stat|syst)|.*AlphaS$|.*nonClosure|.*resolutionCrctn|.*scaleCrctn|.*scaleClos|.*polVar|.*QCDscale$|.*QCDscale(W|Z)|.*resum|.*(muon|ecal)Prefire|FakeRate|theory_ew_|.*pixel|theory$|experiment$|bcQuark|helicity_shower|.*widthW|.*ZmassAndWidth|.*sin2thetaZ",
+        default=".*expNoCalib|.*Fake.+|.*eff_(stat|syst).+|.*eff_all|.*AlphaS$|.*nonClosure|.*resolutionCrctn|.*scaleCrctn|.*scaleClos|.*polVar|.*QCDscale$|.*QCDscale(W|Z)|.*resum|.*(muon|ecal)Prefire|FakeRate|theory_ew_|.*pixel|theory$|experiment$|bcQuark|helicity_shower|.*widthW|.*ZmassAndWidth|.*sin2thetaZ",
         type=str,
         help="Regular expression for nuisances to be excluded (note that it wins against --keepNuisgroups since evaluated before it",
     )

--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -193,7 +193,7 @@ def make_parser(parser=None):
         "--qcdProcessName",
         type=str,
         default=None,
-        help="Name for QCD process (by default taken from datagroups object",
+        help="Name for QCD process (by default taken from datagroups object)",
     )
     # setting on the fit behaviour
     parser.add_argument(
@@ -247,7 +247,7 @@ def make_parser(parser=None):
         nargs="*",
         default=[],
         choices=["data", "mc"],
-        help="When using --lumiScale, scale variance linearly instead of quadratically, to pretend there is really more data or MC (can specify both as well). Note that statistical fluctuations in histograms cannot be lifted, so this option can lead to spurious constraints of systematic uncertainties when the argument of lumiScale is larger than unity, because bin-by-bin fluctuations will not be covered by the assumed uncertainty.",
+        help="When using --lumiScale, scale variance linearly instead of quadratically, to pretend there is really more data or MC (can specify both as well). Note that statistical fluctuations in histograms cannot be lifted, so this option can lead to spurious constraints of systematic uncertainties when the argument of lumiScale is larger than unity, because bin-by-bin fluctuations will not be covered by the assumed uncertainty. For data, this only has an effect for the data-driven estimate of the QCD multijet background through the uncertainty propagation from them data-MC subtraction.",
     )
     parser.add_argument(
         "--sumChannels", action="store_true", help="Only use one channel"

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -44,11 +44,6 @@ parser.add_argument(
     help="Don't use gen match filter for prompt muons with MC samples (note: QCD MC never has it anyway)",
 )
 parser.add_argument(
-    "--halfStat",
-    action="store_true",
-    help="Test half data and MC stat, selecting odd events, just for tests",
-)
-parser.add_argument(
     "--makeMCefficiency",
     action="store_true",
     help="Save yields vs eta-pt-ut-passMT-passIso-passTrigger to derive 3D efficiencies for MC isolation and trigger (can run also with --onlyMainHistograms)",
@@ -829,9 +824,6 @@ def build_graph(df, dataset):
     if not args.makeMCefficiency and not args.noTrigger:
         # remove trigger, it will be part of the efficiency selection for passing trigger
         df = df.Filter(muon_selections.hlt_string(era))
-
-    if args.halfStat:
-        df = df.Filter("event % 2 == 1")  # test with odd/even events
 
     df = muon_calibration.define_corrected_muons(
         df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper

--- a/wremnants/HDF5Writer.py
+++ b/wremnants/HDF5Writer.py
@@ -213,6 +213,7 @@ class HDF5Writer(object):
                 procsToRead=dg.groups.keys(),
                 label=chanInfo.nominalName,
                 scaleToNewLumi=chanInfo.lumiScale,
+                lumiScaleVarianceLinearly=chanInfo.lumiScaleVarianceLinearly,
                 forceNonzero=forceNonzero,
                 sumFakesPartial=not chanInfo.simultaneousABCD,
             )
@@ -447,6 +448,7 @@ class HDF5Writer(object):
                     # Needed to avoid always reading the variation for the fakes, even for procs not specified
                     forceToNominal=forceToNominal,
                     scaleToNewLumi=chanInfo.lumiScale,
+                    lumiScaleVarianceLinearly=chanInfo.lumiScaleVarianceLinearly,
                     nominalIfMissing=not chanInfo.xnorm,  # for masked channels not all systematics exist (we can skip loading nominal since Fake does not exist)
                     sumFakesPartial=not chanInfo.simultaneousABCD,
                 )

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -546,7 +546,7 @@ class Datagroups(object):
                     (procName == self.dataName and "data" in lumiScaleVarianceLinearly)
                     or (procName != self.dataName and "mc" in lumiScaleVarianceLinearly)
                 ):
-                    logger.warning(
+                    logger.debug(
                         f"Scale {procName} hist by {scaleToNewLumi} as a multiplicative luminosity factor, with variance scaled linearly"
                     )
                     h = hh.scaleHist(


### PR DESCRIPTION
The option to scale histogram variance linearly to make projections to different luminosities was not correctly propagated to the HDF5 writer from CardTool. This PR fixes that.

This PR also removes the obsolete option --halfStat from the W histmaker, which was running with half stat by directly cutting on the event parity. This option didn't really work as it was originally intended, because the data histogram is effectively cut in half, but the target luminosity doesn't change because it is computed before selections, so the MC is eventually scaled to the original data set resulting in twice the yields than in data.

There are few minor fixes in other plotting scripts.

No change is expected from CI