### PR TITLE
use proper prefiring uncertainties for years which are not 2016postVFP

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -1031,6 +1031,8 @@ def setup(
 
     cardTool.setExponentialTransform(args.exponentialTransform)
 
+    era = input_tools.args_from_metadata(cardTool, "era")
+
     logger.debug(f"Making datacards with these processes: {cardTool.getProcesses()}")
     if args.absolutePathInCard:
         cardTool.setAbsolutePathShapeInCard()
@@ -2271,8 +2273,12 @@ def setup(
         group="muonPrefire",
         splitGroup={f"prefire": f".*", "experiment": ".*", "expNoCalib": ".*"},
         baseName="CMS_prefire_stat_m_",
-        systAxes=["downUpVar", "etaPhiRegion"],
-        labelsByAxis=["downUpVar", "etaPhiReg"],
+        systAxes=(
+            ["downUpVar", "etaPhiRegion"] if era == "2016PostVFP" else ["downUpVar"]
+        ),
+        labelsByAxis=(
+            ["downUpVar", "etaPhiReg"] if era == "2016PostVFP" else ["downUpVar"]
+        ),
         passToFakes=passSystToFakes,
     )
     cardTool.addSystematic(

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -419,16 +419,9 @@ axis_recoWpt = hist.axis.Regular(
 )
 
 # define helpers
-if era == "2016PostVFP":
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-        muon_prefiring.make_muon_prefiring_helpers(era=era)
-    )
-else:
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
-        None,
-        None,
-        None,
-    ]
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+    muon_prefiring.make_muon_prefiring_helpers(era=era)
+)
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -419,9 +419,16 @@ axis_recoWpt = hist.axis.Regular(
 )
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-    muon_prefiring.make_muon_prefiring_helpers(era=era)
-)
+if era == "2016PostVFP":
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+        muon_prefiring.make_muon_prefiring_helpers(era=era)
+    )
+else:
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
+        None,
+        None,
+        None,
+    ]
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity()
 
@@ -994,19 +1001,18 @@ def build_graph(df, dataset):
     else:
         df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
         df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
-        df = df.Define(
-            "weight_newMuonPrefiringSF",
-            muon_prefiring_helper,
-            [
-                "Muon_correctedEta",
-                "Muon_correctedPt",
-                "Muon_correctedPhi",
-                "Muon_correctedCharge",
-                "Muon_looseId",
-            ],
-        )
-
         if era == "2016PostVFP":
+            df = df.Define(
+                "weight_newMuonPrefiringSF",
+                muon_prefiring_helper,
+                [
+                    "Muon_correctedEta",
+                    "Muon_correctedPt",
+                    "Muon_correctedPhi",
+                    "Muon_correctedCharge",
+                    "Muon_looseId",
+                ],
+            )
             weight_expr = (
                 "weight_pu*weight_newMuonPrefiringSF*L1PreFiringWeight_ECAL_Nom"
             )
@@ -1772,10 +1778,10 @@ def build_graph(df, dataset):
             df = syst_tools.add_L1Prefire_unc_hists(
                 results,
                 df,
-                muon_prefiring_helper_stat,
-                muon_prefiring_helper_syst,
                 axes,
                 cols,
+                helper_stat=muon_prefiring_helper_stat,
+                helper_syst=muon_prefiring_helper_syst,
                 storage_type=storage_type,
             )
 

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -274,16 +274,9 @@ if args.csVarsHist:
 nominal_axes = [all_axes[a] for a in nominal_cols]
 
 # define helpers
-if era == "2016PostVFP":
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-        muon_prefiring.make_muon_prefiring_helpers(era=era)
-    )
-else:
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
-        None,
-        None,
-        None,
-    ]
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+    muon_prefiring.make_muon_prefiring_helpers(era=era)
+)
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(
     is_w_like=True

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -274,9 +274,16 @@ if args.csVarsHist:
 nominal_axes = [all_axes[a] for a in nominal_cols]
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-    muon_prefiring.make_muon_prefiring_helpers(era=era)
-)
+if era == "2016PostVFP":
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+        muon_prefiring.make_muon_prefiring_helpers(era=era)
+    )
+else:
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
+        None,
+        None,
+        None,
+    ]
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(
     is_w_like=True
@@ -656,19 +663,19 @@ def build_graph(df, dataset):
     else:
         df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
         df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
-        df = df.Define(
-            "weight_newMuonPrefiringSF",
-            muon_prefiring_helper,
-            [
-                "Muon_correctedEta",
-                "Muon_correctedPt",
-                "Muon_correctedPhi",
-                "Muon_correctedCharge",
-                "Muon_looseId",
-            ],
-        )
 
         if era == "2016PostVFP":
+            df = df.Define(
+                "weight_newMuonPrefiringSF",
+                muon_prefiring_helper,
+                [
+                    "Muon_correctedEta",
+                    "Muon_correctedPt",
+                    "Muon_correctedPhi",
+                    "Muon_correctedCharge",
+                    "Muon_looseId",
+                ],
+            )
             weight_expr = (
                 "weight_pu*weight_newMuonPrefiringSF*L1PreFiringWeight_ECAL_Nom"
             )
@@ -1071,10 +1078,10 @@ def build_graph(df, dataset):
         df = syst_tools.add_L1Prefire_unc_hists(
             results,
             df,
-            muon_prefiring_helper_stat,
-            muon_prefiring_helper_syst,
             axes,
             cols,
+            helper_stat=muon_prefiring_helper_stat,
+            helper_syst=muon_prefiring_helper_syst,
         )
 
         # n.b. this is the W analysis so mass weights shouldn't be propagated

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -266,9 +266,16 @@ axis_mt = hist.axis.Regular(200, 0.0, 200.0, name="mt", underflow=False, overflo
 axis_eta_mT = hist.axis.Variable([-2.4, 2.4], name="eta")
 
 # define helpers
-muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-    muon_prefiring.make_muon_prefiring_helpers(era=era)
-)
+if era == "2016PostVFP":
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+        muon_prefiring.make_muon_prefiring_helpers(era=era)
+    )
+else:
+    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
+        None,
+        None,
+        None,
+    ]
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(
     is_w_like=True
@@ -591,19 +598,19 @@ def build_graph(df, dataset):
     else:
         df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
         df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
-        df = df.Define(
-            "weight_newMuonPrefiringSF",
-            muon_prefiring_helper,
-            [
-                "Muon_correctedEta",
-                "Muon_correctedPt",
-                "Muon_correctedPhi",
-                "Muon_correctedCharge",
-                "Muon_looseId",
-            ],
-        )
 
         if era == "2016PostVFP":
+            df = df.Define(
+                "weight_newMuonPrefiringSF",
+                muon_prefiring_helper,
+                [
+                    "Muon_correctedEta",
+                    "Muon_correctedPt",
+                    "Muon_correctedPhi",
+                    "Muon_correctedCharge",
+                    "Muon_looseId",
+                ],
+            )
             weight_expr = (
                 "weight_pu*weight_newMuonPrefiringSF*L1PreFiringWeight_ECAL_Nom"
             )
@@ -1140,10 +1147,10 @@ def build_graph(df, dataset):
         df = syst_tools.add_L1Prefire_unc_hists(
             results,
             df,
-            muon_prefiring_helper_stat,
-            muon_prefiring_helper_syst,
             axes,
             cols,
+            helper_stat=muon_prefiring_helper_stat,
+            helper_syst=muon_prefiring_helper_syst,
         )
 
         # n.b. this is the W analysis so mass weights shouldn't be propagated

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -266,16 +266,9 @@ axis_mt = hist.axis.Regular(200, 0.0, 200.0, name="mt", underflow=False, overflo
 axis_eta_mT = hist.axis.Variable([-2.4, 2.4], name="eta")
 
 # define helpers
-if era == "2016PostVFP":
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
-        muon_prefiring.make_muon_prefiring_helpers(era=era)
-    )
-else:
-    muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = [
-        None,
-        None,
-        None,
-    ]
+muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
+    muon_prefiring.make_muon_prefiring_helpers(era=era)
+)
 
 qcdScaleByHelicity_helper = theory_corrections.make_qcd_uncertainty_helper_by_helicity(
     is_w_like=True

--- a/wremnants/muon_prefiring.py
+++ b/wremnants/muon_prefiring.py
@@ -14,6 +14,9 @@ def make_muon_prefiring_helpers(
     era=None,
 ):
 
+    if not (era is None or "2016" in era):
+        return None, None, None
+
     fin = ROOT.TFile.Open(filename)
 
     eradict = {

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -2123,56 +2123,105 @@ def add_muon_efficiency_veto_unc_hists(
     return df
 
 
-def add_L1Prefire_unc_hists(
-    results, df, helper_stat, helper_syst, axes, cols, base_name="nominal", **kwargs
+def add_Muon_L1Prefire_unc_hists(
+    results,
+    df,
+    axes,
+    cols,
+    base_name="nominal",
+    helper_stat=None,
+    helper_syst=None,
+    **kwargs,
 ):
-    df = df.Define(
-        "muonL1PrefireStat_tensor",
-        helper_stat,
-        [
-            "Muon_correctedEta",
-            "Muon_correctedPt",
-            "Muon_correctedPhi",
-            "Muon_correctedCharge",
-            "Muon_looseId",
-            "nominal_weight",
-        ],
-    )
-    name = Datagroups.histName(base_name, syst="muonL1PrefireStat")
-    add_syst_hist(
-        results,
-        df,
-        name,
-        axes,
-        cols,
-        "muonL1PrefireStat_tensor",
-        helper_stat.tensor_axes,
-        **kwargs,
-    )
 
-    df = df.Define(
-        "muonL1PrefireSyst_tensor",
-        helper_syst,
-        [
-            "Muon_correctedEta",
-            "Muon_correctedPt",
-            "Muon_correctedPhi",
-            "Muon_correctedCharge",
-            "Muon_looseId",
-            "nominal_weight",
-        ],
-    )
-    name = Datagroups.histName(base_name, syst="muonL1PrefireSyst")
-    add_syst_hist(
-        results,
-        df,
-        name,
-        axes,
-        cols,
-        "muonL1PrefireSyst_tensor",
-        common.down_up_axis,
-        **kwargs,
-    )
+    if helper_stat is None:
+        df = df.Define(
+            "muonL1Prefire_stat_tensor",
+            "wrem::twoPointScaling(nominal_weight/L1PreFiringWeight_Muon_Nom, L1PreFiringWeight_Muon_StatDn, L1PreFiringWeight_Muon_StatUp)",
+        )
+        name = Datagroups.histName(base_name, syst="muonL1PrefireStat")
+        add_syst_hist(
+            results,
+            df,
+            name,
+            axes,
+            cols,
+            "muonL1Prefire_stat_tensor",
+            common.down_up_axis,
+            **kwargs,
+        )
+    else:
+        df = df.Define(
+            "muonL1PrefireStat_tensor",
+            helper_stat,
+            [
+                "Muon_correctedEta",
+                "Muon_correctedPt",
+                "Muon_correctedPhi",
+                "Muon_correctedCharge",
+                "Muon_looseId",
+                "nominal_weight",
+            ],
+        )
+        name = Datagroups.histName(base_name, syst="muonL1PrefireStat")
+        add_syst_hist(
+            results,
+            df,
+            name,
+            axes,
+            cols,
+            "muonL1PrefireStat_tensor",
+            helper_stat.tensor_axes,
+            **kwargs,
+        )
+
+    if helper_syst is None:
+        df = df.Define(
+            "muonL1Prefire_syst_tensor",
+            "wrem::twoPointScaling(nominal_weight/L1PreFiringWeight_Muon_Nom, L1PreFiringWeight_Muon_SystDn, L1PreFiringWeight_Muon_SystUp)",
+        )
+        name = Datagroups.histName(base_name, syst="muonL1PrefireSyst")
+        add_syst_hist(
+            results,
+            df,
+            name,
+            axes,
+            cols,
+            "muonL1Prefire_syst_tensor",
+            common.down_up_axis,
+            **kwargs,
+        )
+    else:
+        df = df.Define(
+            "muonL1PrefireSyst_tensor",
+            helper_syst,
+            [
+                "Muon_correctedEta",
+                "Muon_correctedPt",
+                "Muon_correctedPhi",
+                "Muon_correctedCharge",
+                "Muon_looseId",
+                "nominal_weight",
+            ],
+        )
+        name = Datagroups.histName(base_name, syst="muonL1PrefireSyst")
+        add_syst_hist(
+            results,
+            df,
+            name,
+            axes,
+            cols,
+            "muonL1PrefireSyst_tensor",
+            common.down_up_axis,
+            **kwargs,
+        )
+
+    return df
+
+
+def add_ECAL_L1Prefire_unc_hists(
+    results, df, axes, cols, base_name="nominal", **kwargs
+):
 
     df = df.Define(
         "ecalL1Prefire_tensor",
@@ -2190,6 +2239,24 @@ def add_L1Prefire_unc_hists(
         **kwargs,
     )
 
+    return df
+
+
+def add_L1Prefire_unc_hists(
+    results,
+    df,
+    axes,
+    cols,
+    base_name="nominal",
+    helper_stat=None,
+    helper_syst=None,
+    **kwargs,
+):
+
+    df = add_Muon_L1Prefire_unc_hists(
+        results, df, axes, cols, base_name, helper_stat, helper_syst, **kwargs
+    )
+    df = add_ECAL_L1Prefire_unc_hists(results, df, axes, cols, base_name, **kwargs)
     return df
 
 


### PR DESCRIPTION
Muon prefiring for 2017 and 2018 is expected to be very small.
So far we were propagating the same uncertainties as in 2016 postVFP, but this is too conservative.
This PR changes it to use the uncertainties stored in the NanoAOD, which for these cases should be sufficient (can be decorrelated in setupCombine if needed, but for now it is not done).

The functions in syst_tools to define the prefire uncertainties are updated to include this change, and also made more modular.

No change is expected for the main analysis or the low PU (the latter already uses its own code for the prefiring)