### PR TITLE
set ABCD thresholds based on histogram axis's edges

### DIFF
--- a/scripts/combine/setupCombine.py
+++ b/scripts/combine/setupCombine.py
@@ -378,6 +378,17 @@ def make_parser(parser=None):
         help="Order of the polynomial for the smoothing of the application region or full prediction, depending on the smoothing mode",
     )
     parser.add_argument(
+        "--ABCDedgesByAxis",
+        type=str,
+        nargs="+",
+        default=[],
+        help="""
+        Edges for ABCD method given an axis. Syntax is --ABCDedgesByAxis 'nameX=x1,x2,x3' 'nameY=y1,y2,y3'
+        Values after = are converted into float internally.
+        Can specify only one axis or two (potentially more).
+        """,
+    )
+    parser.add_argument(
         "--allowNegativeExpectation",
         action="store_true",
         help="Allow processes to have negative contributions",
@@ -988,6 +999,12 @@ def setup(
     if args.qcdProcessName:
         datagroups.fakeName = args.qcdProcessName
 
+    abcdExplicitAxisEdges = {}
+    if len(args.ABCDedgesByAxis):
+        for item in args.ABCDedgesByAxis:
+            ax_name, ax_edges = item.split("=")
+            abcdExplicitAxisEdges[ax_name] = [float(x) for x in ax_edges.split(",")]
+
     if wmass and not xnorm:
         datagroups.fakerate_axes = args.fakerateAxes
         histselector_kwargs = dict(
@@ -998,6 +1015,7 @@ def setup(
             mcCorr=args.fakeMCCorr,
             integrate_x="mt" not in fitvar,
             forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+            abcdExplicitAxisEdges=abcdExplicitAxisEdges,
         )
         datagroups.set_histselectors(
             datagroups.getNames(), inputBaseName, **histselector_kwargs

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -260,6 +260,7 @@ class Datagroups(object):
         simultaneousABCD=False,
         forceGlobalScaleFakes=None,
         mcCorr=["pt", "eta"],
+        abcdExplicitAxisEdges={},
         **kwargs,
     ):
         logger.info(f"Set histselector")
@@ -317,6 +318,7 @@ class Datagroups(object):
                     smoothing_order_fakerate=smoothingOrderFakerate,
                     smoothing_order_spectrum=smoothingOrderSpectrum,
                     smoothing_polynomial_spectrum=smoothingPolynomialSpectrum,
+                    abcdExplicitAxisEdges=abcdExplicitAxisEdges,
                     **auxiliary_info,
                     **kwargs,
                 )

--- a/wremnants/datasets/datagroups.py
+++ b/wremnants/datasets/datagroups.py
@@ -266,7 +266,7 @@ class Datagroups(object):
         logger.info(f"Set histselector")
         if self.mode[0] != "w":
             return  # histselectors only implemented for single lepton (with fakes)
-        auxiliary_info = {}
+        auxiliary_info = {"ABCDmode": mode}
         signalselector = sel.SignalSelectorABCD
         scale = 1
         if mode == "extended1D":
@@ -347,7 +347,7 @@ class Datagroups(object):
                     self.groups[g].histselector.set_correction(hQCD, axes_names=mcCorr)
             else:
                 self.groups[g].histselector = signalselector(
-                    h, fakerate_axes=self.fakerate_axes, **kwargs
+                    h, fakerate_axes=self.fakerate_axes, **auxiliary_info, **kwargs
                 )
 
     def setGlobalAction(self, action):

--- a/wremnants/histselections.py
+++ b/wremnants/histselections.py
@@ -9,43 +9,54 @@ from wums import logging
 
 logger = logging.child_logger(__name__)
 
-# thresholds,
-abcd_thresholds = {
-    "pt": [26, 28, 30],
-    "mt": [0, 20, 40],
-    "iso": [0, 4, 8, 12],
-    "relIso": [0, 0.15, 0.3, 0.45],
-    "relJetLeptonDiff": [0, 0.2, 0.35, 0.5],
-    "dxy": [0, 0.01, 0.02, 0.03],
-}
+# # thresholds,
+# abcd_thresholds = {
+#     "pt": [26, 28, 30],
+#     "mt": [0, 20, 40],
+#     "iso": [0, 4, 8, 12],
+#     "relIso": [0, 0.15, 0.3, 0.45],
+#     "relJetLeptonDiff": [0, 0.2, 0.35, 0.5],
+#     "dxy": [0, 0.01, 0.02, 0.03],
+# }
 
-# default abcd_variables to look for
-abcd_variables = (
-    ("mt", "passMT"),
-    ("relIso", "passIso"),
-    ("iso", "passIso"),
-    ("relJetLeptonDiff", "passIso"),
-    ("dxy", "passDxy"),
-)
+# # default abcd_variables to look for
+# abcd_variables = (
+#     ("mt", "passMT"),
+#     ("relIso", "passIso"),
+#     ("iso", "passIso"),
+#     ("relJetLeptonDiff", "passIso"),
+#     ("dxy", "passDxy"),
+# )
 
 
-def get_selection_edges(axis_name, upper_bound=False):
-    # returns edges from pass to fail regions [x0, x1, x2, x3] e.g. x=[x0,x1], dx=[x1,x2], d2x=[x2,x3]
-    if axis_name in abcd_thresholds:
-        ts = abcd_thresholds[axis_name]
-        if axis_name in ["mt", "pt"]:
-            # low: failing, high: passing, no upper bound
-            return None, complex(0, ts[2]), complex(0, ts[1]), complex(0, ts[0])
-        if axis_name in ["dxy", "iso", "relIso", "relJetLeptonDiff"]:
-            # low: passing, high: failing, no upper bound
-            return (
-                complex(0, ts[0]),
-                complex(0, ts[1]),
-                complex(0, ts[2]),
-                (complex(0, ts[3]) if upper_bound else None),
-            )
-    else:
-        raise RuntimeError(f"Can not find threshold for abcd axis {axis_name}")
+# def get_selection_edges(axis_name, upper_bound=False, hist_axis_edges=None):
+#     # returns edges from pass to fail regions [x0, x1, x2, x3] e.g. x=[x0,x1], dx=[x1,x2], d2x=[x2,x3]
+#     if axis_name in abcd_thresholds:
+#         ts = abcd_thresholds[axis_name]
+#         # TODO: should subsets of edges be accepted ?
+#         # It probably only makes sense to accept it when hist_axis_edges is a subset, but ts already has only 2 bins
+#         if hist_axis_edges is not None and (
+#                 len(ts) != len(hist_axis_edges)
+#                 or any(tsi != hist_axis_edges[i] for i,tsi in enumerate(ts))
+#         ):
+#             # raise RuntimeError(f"Found inconsistent edges {ts} for axis {axis_name}: histogram axis has {hist_axis_edges}")
+#             logger.warning(f"Found inconsistent edges {ts} for axis {axis_name}: histogram axis has {hist_axis_edges}")
+#             ts = [x for x in hist_axis_edges]
+#             logger.warning(f"Setting {axis_name} edges to {ts} in the following calculations")
+
+#         if axis_name in ["mt", "pt"]:
+#             # low: failing, high: passing, no upper bound
+#             return None, complex(0, ts[2]), complex(0, ts[1]), complex(0, ts[0])
+#         if axis_name in ["dxy", "iso", "relIso", "relJetLeptonDiff"]:
+#             # low: passing, high: failing, no upper bound
+#             return (
+#                 complex(0, ts[0]),
+#                 complex(0, ts[1]),
+#                 complex(0, ts[2]),
+#                 (complex(0, ts[3]) if upper_bound else None),
+#             )
+#     else:
+#         raise RuntimeError(f"Can not find threshold for abcd axis {axis_name}")
 
 
 def extend_edges(traits, x):
@@ -166,6 +177,26 @@ class HistselectorABCD(object):
         upper_bound_y=None,  # using an upper bound on the abcd y-axis (e.g. isolation)
         integrate_x=True,  # integrate the abcd x-axis in final histogram (allows simplified procedure e.g. for extrapolation method)
     ):
+
+        # default thresholds, modifed later based on actual axis edges
+        self.abcd_thresholds = {
+            "pt": [26, 28, 30],
+            "mt": [0, 20, 40],
+            "iso": [0, 4, 8, 12],
+            "relIso": [0, 0.15, 0.3, 0.45],
+            "relJetLeptonDiff": [0, 0.2, 0.35, 0.5],
+            "dxy": [0, 0.01, 0.02, 0.03],
+        }
+
+        # default abcd_variables to look for
+        self.abcd_variables = (
+            ("mt", "passMT"),
+            ("relIso", "passIso"),
+            ("iso", "passIso"),
+            ("relJetLeptonDiff", "passIso"),
+            ("dxy", "passDxy"),
+        )
+
         self.upper_bound_y = upper_bound_y
         self.integrate_x = integrate_x
 
@@ -209,6 +240,41 @@ class HistselectorABCD(object):
         self.smoothing_axis_min = edges[0]
         self.smoothing_axis_max = edges[-1]
 
+    def get_selection_edges(self, axis_name, upper_bound=False, hist_axis_edges=None):
+        # returns edges from pass to fail regions [x0, x1, x2, x3] e.g. x=[x0,x1], dx=[x1,x2], d2x=[x2,x3]
+        if axis_name in self.abcd_thresholds:
+            # ts = self.abcd_thresholds[axis_name]
+            # if hist_axis_edges is not None and (
+            #         len(ts) != len(hist_axis_edges)
+            #         or any(tsi != hist_axis_edges[i] for i,tsi in enumerate(ts))
+            # ):
+            #     logger.warning(f"Found inconsistent edges {ts} for axis {axis_name}: histogram axis has {hist_axis_edges}")
+            #     ts = [x for x in hist_axis_edges]
+            #     logger.warning(f"Setting {axis_name} edges to {ts} in the following calculations")
+            ts = (
+                self.abcd_thresholds[axis_name]
+                if hist_axis_edges is None
+                else [x for x in hist_axis_edges]
+            )
+
+            if axis_name in ["mt", "pt"]:
+                # low: failing, high: passing, no upper bound
+                return None, complex(0, ts[2]), complex(0, ts[1]), complex(0, ts[0])
+            if axis_name in ["dxy", "iso", "relIso", "relJetLeptonDiff"]:
+                # need a hack because later on the code expects 4 values, but there might be
+                # only 2 or 3: extend the array with None times the missing items
+                if len(ts) < 4:
+                    ts.extend([None] * (4 - len(ts)))
+                # low: passing, high: failing, no upper bound
+                return (
+                    complex(0, ts[0]),
+                    complex(0, ts[1]),
+                    (complex(0, ts[2]) if ts[2] is not None else None),
+                    (complex(0, ts[3]) if upper_bound and ts[3] is not None else None),
+                )
+        else:
+            raise RuntimeError(f"Can not find threshold for abcd axis {axis_name}")
+
     # A
     def get_hist_failX_failY(self, h):
         return h[{self.name_x: self.sel_dx, self.name_y: self.sel_dy}]
@@ -226,7 +292,7 @@ class HistselectorABCD(object):
         return h[{self.name_x: self.sel_x, self.name_y: self.sel_y}]
 
     def set_abcd_axes(self, h):
-        for a, b in abcd_variables:
+        for a, b in self.abcd_variables:
             if self.name_x is None and a in h.axes.name:
                 self.name_x = a
                 continue
@@ -251,7 +317,9 @@ class HistselectorABCD(object):
             self.sel_x = 1
             self.sel_dx = 0
         else:
-            x0, x1, x2, x3 = get_selection_edges(self.name_x)
+            x0, x1, x2, x3 = self.get_selection_edges(
+                self.name_x, hist_axis_edges=self.axis_x.edges
+            )
             s = hist.tag.Slicer()
             do = hist.sum if self.integrate_x else None
             self.sel_x = (
@@ -268,8 +336,10 @@ class HistselectorABCD(object):
             self.sel_y = 1
             self.sel_dy = 0
         else:
-            y0, y1, y2, y3 = get_selection_edges(
-                self.name_y, upper_bound=self.upper_bound_y
+            y0, y1, y2, y3 = self.get_selection_edges(
+                self.name_y,
+                upper_bound=self.upper_bound_y,
+                hist_axis_edges=self.axis_y.edges,
             )
             s = hist.tag.Slicer()
             self.sel_y = (
@@ -981,7 +1051,9 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
 
     # set slices object for selection of sideband regions
     def set_selections_x(self, integrate_x=True):
-        x0, x1, x2, x3 = get_selection_edges(self.name_x)
+        x0, x1, x2, x3 = self.get_selection_edges(
+            self.name_x, hist_axis_edges=self.axis_x.edges
+        )
         s = hist.tag.Slicer()
         do = hist.sum if integrate_x else None
         self.sel_x = (
@@ -1220,7 +1292,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
                     axis_x_max = extend_edges(h.axes[self.name_x].traits, edges)[-1]
                 elif self.name_x in ["iso", "relIso", "relJetLeptonDiff", "dxy"]:
                     # iso and dxy have a finite lower and upper bound in the application region
-                    axis_x_max = abcd_thresholds[self.name_x][1]
+                    axis_x_max = self.abcd_thresholds[self.name_x][1]
                 else:
                     axis_x_max = self.axis_x.edges[-1]
                 mins_x.append(axis_x_min)
@@ -1250,8 +1322,10 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
 
     # set slices object for selection of sideband regions
     def set_selections_y(self):
-        y0, y1, y2, y3 = get_selection_edges(
-            self.name_y, upper_bound=self.upper_bound_y
+        y0, y1, y2, y3 = self.get_selection_edges(
+            self.name_y,
+            upper_bound=self.upper_bound_y,
+            hist_axis_edges=self.axis_y.edges,
         )
         s = hist.tag.Slicer()
         self.sel_y = (
@@ -1260,7 +1334,9 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
             else s[y1 : y0 : hist.sum]
         )
         self.sel_dy = (
-            s[y1 : y2 : hist.sum] if y2.imag > y1.imag else s[y2 : y1 : hist.sum]
+            s[y1 : y2 : hist.sum]
+            if y2 is None or y2.imag > y1.imag
+            else s[y2 : y1 : hist.sum]
         )
         self.sel_d2y = (
             s[y2 : y3 : hist.sum]


### PR DESCRIPTION
This PR allows the ABCD method to run whatever thresholds are used for the ABCD axes in the input histograms. The previous code was hardcoding those values internally in histselections.py

The nominal analysis does not change, since the hardcoded edges were tuned for that.

This PR also adds a new option --ABCDedgesByAxis to setupCombine.py to explicitly set the edges to be used for any axis in the ABCD method (for example, --ABCDedgesByAxis "mt=0,20,40", where the signal region is just everything above 40). This is useful when the necessary axis contains more edges than needed for the ABCD method itself and it is not possible to automatically choose those that should be used for the ABCD method (usually they are evaluated based on a set of default values, to ensure the axis can be rebinned accordingly, but if this is not possible then one has to explicitly set the thresholds for the ABCD method).