### PR TITLE
Theory systematics through helicity cross sections; W theory fit

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -26,7 +26,6 @@ import math
 import hist
 
 import narf
-import wremnants
 import wremnants.lowpu as lowpu
 from wremnants import (
     muon_selections,
@@ -141,13 +140,9 @@ columns_fakerate = [
     "transverseMass",
 ]  ## was transverseMass
 
-
-qcdScaleByHelicity_helpers = (
-    wremnants.theory_corrections.make_qcd_uncertainty_helpers_by_helicity()
-)
-
-axis_ptVgen = qcdScaleByHelicity_helpers["W"].hist.axes["ptVgen"]
-axis_chargeVgen = qcdScaleByHelicity_helpers["W"].hist.axes["chargeVgen"]
+theory_helpers_procs = theory_corrections.make_theory_helpers(args)
+axis_ptVgen = theory_helpers_procs["W"]["qcdScale"].hist.axes["ptVgen"]
+axis_chargeVgen = theory_helpers_procs["W"]["qcdScale"].hist.axes["chargeVgen"]
 
 groups_to_aggregate = args.aggregateGroups
 
@@ -196,7 +191,7 @@ def build_graph(df, dataset):
     isQCDMC = dataset.group == "QCD"
 
     if dataset.name in common.vprocs_lowpu:
-        qcdScaleByHelicity_helper = qcdScaleByHelicity_helpers[dataset.name[0]]
+        theory_helpers = theory_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -250,7 +245,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     [a for a in unfolding_axes[level] if a.name != "acceptance"],
                     [c for c in unfolding_cols[level] if c != f"{level}_acceptance"],
                     base_name=level,
@@ -528,7 +523,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     a,
                     c,
                     base_name=n,

--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -190,6 +190,7 @@ def build_graph(df, dataset):
     results = []
     isQCDMC = dataset.group == "QCD"
 
+    theory_helpers = None
     if dataset.name in common.vprocs_lowpu:
         theory_helpers = theory_helpers_procs[dataset.name[0]]
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -420,17 +420,10 @@ if args.unfolding:
         cutsmap=cutsmap,
     )
 
-    qcdScaleByHelicity_helpers = theory_corrections.make_qcd_uncertainty_helpers_by_helicity(
-        filename_z=f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_helicity.hdf5",
-        rebin_ptZgen=False,
-    )
-
     if args.fitresult:
         unfolding_corr_helper = unfolding_tools.reweight_to_fitresult(args.fitresult)
-else:
-    qcdScaleByHelicity_helpers = (
-        theory_corrections.make_qcd_uncertainty_helpers_by_helicity()
-    )
+
+theory_helpers_procs = theory_corrections.make_theory_helpers(args, procs=["Z", "W"])
 
 if args.theoryAgnostic:
     theoryAgnostic_axes, theoryAgnostic_cols = differential.get_theoryAgnostic_axes(
@@ -679,8 +672,9 @@ def build_graph(df, dataset):
         hist.storage.Double()
     )  # turn off sum weight square for systematic histograms
 
+    theory_helpers = {}
     if isWorZ:
-        qcdScaleByHelicity_helper = qcdScaleByHelicity_helpers[dataset.name[0]]
+        theory_helpers = theory_helpers_procs[dataset.name[0]]
 
     # disable auxiliary histograms when unfolding to reduce memory consumptions, or when doing the original theory agnostic without --poiAsNoi
     auxiliary_histograms = True
@@ -803,7 +797,7 @@ def build_graph(df, dataset):
                         args,
                         dataset.name,
                         corr_helpers,
-                        qcdScaleByHelicity_helper,
+                        theory_helpers,
                         [a for a in unfolding_axes[level] if a.name != "acceptance"],
                         [
                             c
@@ -824,7 +818,7 @@ def build_graph(df, dataset):
                         args,
                         dataset.name,
                         corr_helpers,
-                        qcdScaleByHelicity_helper,
+                        theory_helpers,
                         [a for a in unfolding_axes[level] if a.name != "acceptance"],
                         [
                             c
@@ -841,7 +835,7 @@ def build_graph(df, dataset):
         elif dataset.name == "ZmumuPostVFP":
             if args.unfolding and dataset.name == "ZmumuPostVFP":
                 df = unfolder_z.add_gen_histograms(
-                    args, df, results, dataset, corr_helpers, qcdScaleByHelicity_helper
+                    args, df, results, dataset, corr_helpers, theory_helpers
                 )
 
                 if not unfolder_z.poi_as_noi:
@@ -1987,7 +1981,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                qcdScaleByHelicity_helper,
+                theory_helpers,
                 axes,
                 cols,
                 for_wmass=True,

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -157,6 +157,7 @@ def build_graph(df, dataset):
     isW = dataset.name in common.wprocs_lowpu
     isZ = dataset.name in common.zprocs_lowpu
 
+    theory_helpers = None
     if dataset.name in common.vprocs_lowpu:
         theory_helpers = theory_helpers_procs[dataset.name[0]]
 

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -28,7 +28,6 @@ logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 import hist
 
 import narf
-import wremnants
 import wremnants.lowpu as lowpu
 from wremnants import (
     muon_selections,
@@ -109,11 +108,9 @@ axis_wlike_met = hist.axis.Regular(200, 0, 200, name="WlikeMET")
 axes_mt = [axis_mt]
 cols_mt = ["transverseMass"]
 
-qcdScaleByHelicity_helpers = (
-    wremnants.theory_corrections.make_qcd_uncertainty_helpers_by_helicity()
-)
-axis_ptVgen = qcdScaleByHelicity_helpers["Z"].hist.axes["ptVgen"]
-axis_chargeVgen = qcdScaleByHelicity_helpers["Z"].hist.axes["chargeVgen"]
+theory_helpers_procs = theory_corrections.make_theory_helpers(args)
+axis_ptVgen = theory_helpers_procs["Z"]["qcdScale"].hist.axes["ptVgen"]
+axis_chargeVgen = theory_helpers_procs["Z"]["qcdScale"].hist.axes["chargeVgen"]
 
 if args.unfolding:
 
@@ -161,7 +158,7 @@ def build_graph(df, dataset):
     isZ = dataset.name in common.zprocs_lowpu
 
     if dataset.name in common.vprocs_lowpu:
-        qcdScaleByHelicity_helper = qcdScaleByHelicity_helpers[dataset.name[0]]
+        theory_helpers = theory_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -176,7 +173,7 @@ def build_graph(df, dataset):
 
     if args.unfolding and dataset.name in sigProcs:
         df = unfolder_z.add_gen_histograms(
-            args, df, results, dataset, corr_helpers, qcdScaleByHelicity_helper
+            args, df, results, dataset, corr_helpers, theory_helpers
         )
 
         if not unfolder_z.poi_as_noi:
@@ -547,7 +544,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     a,
                     c,
                     base_name=n,

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -289,8 +289,8 @@ muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = 
     muon_prefiring.make_muon_prefiring_helpers(era=era)
 )
 
-qcdScaleByHelicity_helpers = theory_corrections.make_theory_helpers(
-    args, corrs=["qcdScale"]
+theory_helpers_procs = theory_corrections.make_theory_helpers(
+    args, corrs=["qcdScale", "alphaS", "pdf"]
 )
 
 # extra axes which can be used to label tensor_axes
@@ -447,7 +447,7 @@ def build_graph(df, dataset):
     isWorZ = isW or isZ
 
     if isWorZ:
-        qcdScaleByHelicity_helper = qcdScaleByHelicity_helpers[dataset.name[0]]
+        theory_helpers = theory_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -555,7 +555,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     [a for a in unfolding_axes[level] if a.name != "acceptance"],
                     [c for c in unfolding_cols[level] if c != f"{level}_acceptance"],
                     base_name=level,
@@ -1388,7 +1388,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                qcdScaleByHelicity_helper,
+                theory_helpers,
                 axes,
                 cols,
                 for_wmass=False,

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -289,8 +289,8 @@ muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = 
     muon_prefiring.make_muon_prefiring_helpers(era=era)
 )
 
-qcdScaleByHelicity_helpers = (
-    theory_corrections.make_qcd_uncertainty_helpers_by_helicity()
+qcdScaleByHelicity_helpers = theory_corrections.make_theory_helpers(
+    args, corrs=["qcdScale"]
 )
 
 # extra axes which can be used to label tensor_axes

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -209,12 +209,12 @@ def build_graph(df, dataset):
         axis_massZgen = hist.axis.Regular(1, 60.0, 120.0, name="massVgen")
     elif args.useCorrByHelicityBinning:
         axis_absYVgen = hist.axis.Variable(
-            common.yll_10quantiles_binning_corr,
+            common.absYVgen_binning_corr,
             name="absYVgen",
             underflow=False,
         )
         axis_ptVgen = hist.axis.Variable(
-            common.ptll_10quantiles_binning_corr,
+            common.ptVgen_binning_corr,
             name="ptVgen",
             underflow=False,
         )

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -47,7 +47,7 @@ parser.add_argument(
     help="Use unfolding binning to produce the gen results",
 )
 parser.add_argument(
-    "--genYBinningFine",
+    "--useCorrByHelicityBinning",
     action="store_true",
     help="Use finer absY binning to produce the gen results."
     "Used in particular to produce the smooth PDF corrections.",
@@ -188,11 +188,7 @@ def build_graph(df, dataset):
                 ["ptVGen", "absYVGen"],
                 {
                     "ptll": common.get_dilepton_ptV_binning(fine=False),
-                    "yll": (
-                        common.yll_10quantiles_binning_fine
-                        if args.genYBinningFine
-                        else common.yll_10quantiles_binning
-                    ),
+                    "yll": (common.yll_10quantiles_binning),
                 },
                 "prefsr",
                 add_out_of_acceptance_axis=False,
@@ -211,7 +207,18 @@ def build_graph(df, dataset):
         )
 
         axis_massZgen = hist.axis.Regular(1, 60.0, 120.0, name="massVgen")
-
+    elif args.useCorrByHelicityBinning:
+        axis_absYVgen = hist.axis.Variable(
+            common.yll_10quantiles_binning_corr,
+            name="absYVgen",
+            underflow=False,
+        )
+        axis_ptVgen = hist.axis.Variable(
+            common.ptll_10quantiles_binning_corr,
+            name="ptVgen",
+            underflow=False,
+        )
+        axis_massZgen = hist.axis.Regular(1, 60.0, 120.0, name="massVgen")
     elif args.useTheoryAgnosticBinning:
         axis_absYVgen = hist.axis.Variable(
             axis_yV_thag.edges,  # same axis as theory agnostic norms

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -821,6 +821,11 @@ def make_parser(parser=None):
         "e.g. --select 'ptll 0 10"
         "e.g. --select 'ptll 0j 10j",
     )
+    parser.add_argument(
+        "--noTheoryCorrsViaHelicities",
+        action="store_true",
+        help="Don't use theory correction histograms produced via smoothing through helicites.",
+    )
     parser = make_subparsers(parser)
 
     return parser
@@ -1540,11 +1545,13 @@ def setup(
             minnlo_unc=args.minnloScaleUnc,
             minnlo_scale=args.scaleMinnloScale,
             minnlo_symmetrize=args.symmetrizeMinnloScale,
+            from_hels=not args.noTheoryCorrsViaHelicities,
         )
 
         theory_helper.add_pdf_alphas_variation(
             noi=args.fitAlphaS,
             scale=args.scalePdf if not args.fitAlphaS else 1.0,
+            from_hels=not args.noTheoryCorrsViaHelicities,
         )
 
         if not stat_only and not args.noTheoryUnc:

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -180,6 +180,29 @@ absYV_binning = [
 ]
 
 yll_10quantiles_binning = [-2.5, -1.5, -1.0, -0.5, -0.25, 0, 0.25, 0.5, 1.0, 1.5, 2.5]
+yll_10quantiles_binning_fine = [
+    -2.5,
+    -2.25,
+    -2.0,
+    -1.75,
+    -1.5,
+    -1.25,
+    -1.0,
+    -0.75,
+    -0.5,
+    -0.25,
+    0,
+    0.25,
+    0.5,
+    0.75,
+    1,
+    1.25,
+    1.5,
+    1.75,
+    2,
+    2.25,
+    2.5,
+]
 
 # categorical axes in python bindings always have an overflow bin, so use a regular axis for the charge
 axis_charge = hist.axis.Regular(

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -180,7 +180,7 @@ absYV_binning = [
 ]
 
 yll_10quantiles_binning = [-2.5, -1.5, -1.0, -0.5, -0.25, 0, 0.25, 0.5, 1.0, 1.5, 2.5]
-yll_10quantiles_binning_fine = [
+yll_10quantiles_binning_corr = [
     -2.5,
     -2.25,
     -2.0,
@@ -202,6 +202,52 @@ yll_10quantiles_binning_fine = [
     2,
     2.25,
     2.5,
+]
+ptll_10quantiles_binning_corr = [
+    0,
+    1,
+    2,
+    2.5,
+    3,
+    3.5,
+    4,
+    4.5,
+    5,
+    5.5,
+    6,
+    6.5,
+    7,
+    7.5,
+    8,
+    8.5,
+    9,
+    9.5,
+    10,
+    10.5,
+    11,
+    11.5,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    33,
+    37,
+    44,
+    50,
+    60,
+    70,
+    80,
+    100,
 ]
 
 # categorical axes in python bindings always have an overflow bin, so use a regular axis for the charge

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -180,30 +180,11 @@ absYV_binning = [
 ]
 
 yll_10quantiles_binning = [-2.5, -1.5, -1.0, -0.5, -0.25, 0, 0.25, 0.5, 1.0, 1.5, 2.5]
-yll_10quantiles_binning_corr = [
-    -2.5,
-    -2.25,
-    -2.0,
-    -1.75,
-    -1.5,
-    -1.25,
-    -1.0,
-    -0.75,
-    -0.5,
-    -0.25,
-    0,
-    0.25,
-    0.5,
-    0.75,
-    1,
-    1.25,
-    1.5,
-    1.75,
-    2,
-    2.25,
-    2.5,
-]
-ptll_10quantiles_binning_corr = [
+
+absYVgen_binning_corr = np.concatenate(
+    (np.arange(0, 2.6, 0.25), [2.75, 3.0, 3.25, 3.5, 3.75, 4.0, 5.0])
+)
+ptVgen_binning_corr = [
     0,
     1,
     2,
@@ -243,11 +224,10 @@ ptll_10quantiles_binning_corr = [
     33,
     37,
     44,
-    50,
-    60,
-    70,
-    80,
+    54,
+    75,
     100,
+    1300,
 ]
 
 # categorical axes in python bindings always have an overflow bin, so use a regular axis for the charge

--- a/wremnants/include/theory_corrections.hpp
+++ b/wremnants/include/theory_corrections.hpp
@@ -168,7 +168,7 @@ public:
   using base_t::base_t;
 
   var_tensor_t operator()(double mV, double yV, double ptV, int qV,
-                          const CSVars &csvars, double nominal_weight) {
+                          const CSVars &csvars, double nominal_weight = 1.0) {
     static_assert(sizes.size() == 3);
     static_assert(nhelicity == NHELICITY);
     static_assert(ncorrs == 2);
@@ -185,8 +185,9 @@ public:
     const auto uncorr_hel = coeffs_with_angular.chip(0, 1);
     const auto corr_hel = coeffs_with_angular.chip(1, 1);
 
-    const var_tensor_t corr_weight_vars =
-        corr_hel.sum(reduceddims) / uncorr_hel.sum(reduceddims);
+    const var_tensor_t corr_weight_vars = corr_hel.sum(reduceddims) /
+                                          uncorr_hel.sum(reduceddims) *
+                                          nominal_weight;
 
     return corr_weight_vars; // dimensions: {nvars}
   }

--- a/wremnants/include/theory_corrections.hpp
+++ b/wremnants/include/theory_corrections.hpp
@@ -185,11 +185,26 @@ public:
     const auto uncorr_hel = coeffs_with_angular.chip(0, 1);
     const auto corr_hel = coeffs_with_angular.chip(1, 1);
 
-    const var_tensor_t corr_weight_vars = corr_hel.sum(reduceddims) /
-                                          uncorr_hel.sum(reduceddims) *
-                                          nominal_weight;
+    const var_tensor_t corr_weight_vars =
+        corr_hel.sum(reduceddims) / uncorr_hel.sum(reduceddims);
 
-    return corr_weight_vars;
+    // const var_tensor_t corr_weight_vars_clamped =
+    // corr_weight_vars.cwiseMax(0.9).cwiseMin(1.1) * nominal_weight;
+
+    // return corr_weight_vars_clamped; // dimensions: {nvars}
+
+    // Replace NaNs with 1.0 before clamping
+    const var_tensor_t corr_weight_vars_no_nan = corr_weight_vars.select(
+        corr_weight_vars.isnan().select(var_tensor_t().setConstant(1.0),
+                                        corr_weight_vars),
+        corr_weight_vars // needed for shape matching
+    );
+
+    // Clamp to [0.9, 1.1] and apply nominal weight
+    const var_tensor_t corr_weight_vars_clamped =
+        corr_weight_vars_no_nan.cwiseMax(0.9).cwiseMin(1.1) * nominal_weight;
+
+    return corr_weight_vars_clamped; // dimensions: {nvars}
   }
 };
 

--- a/wremnants/include/theory_corrections.hpp
+++ b/wremnants/include/theory_corrections.hpp
@@ -188,23 +188,7 @@ public:
     const var_tensor_t corr_weight_vars =
         corr_hel.sum(reduceddims) / uncorr_hel.sum(reduceddims);
 
-    // const var_tensor_t corr_weight_vars_clamped =
-    // corr_weight_vars.cwiseMax(0.9).cwiseMin(1.1) * nominal_weight;
-
-    // return corr_weight_vars_clamped; // dimensions: {nvars}
-
-    // Replace NaNs with 1.0 before clamping
-    const var_tensor_t corr_weight_vars_no_nan = corr_weight_vars.select(
-        corr_weight_vars.isnan().select(var_tensor_t().setConstant(1.0),
-                                        corr_weight_vars),
-        corr_weight_vars // needed for shape matching
-    );
-
-    // Clamp to [0.9, 1.1] and apply nominal weight
-    const var_tensor_t corr_weight_vars_clamped =
-        corr_weight_vars_no_nan.cwiseMax(0.9).cwiseMin(1.1) * nominal_weight;
-
-    return corr_weight_vars_clamped; // dimensions: {nvars}
+    return corr_weight_vars; // dimensions: {nvars}
   }
 };
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1697,8 +1697,12 @@ def add_qcdScaleByHelicityUnc_hist(
             "nominal_weight",
         ],
     )
+    safeTensorName = f"{tensorName}_clamped"
+    df = df.Define(
+        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
+    )
     add_syst_hist(
-        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
+        results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs
     )
 
 
@@ -1721,8 +1725,12 @@ def add_pdfUncertByHelicity_hist(
                 "nominal_weight",
             ],
         )
+    safeTensorName = f"{tensorName}_clamped"
+    df = df.Define(
+        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
+    )
     add_syst_hist(
-        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
+        results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs
     )
 
 

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1702,6 +1702,52 @@ def add_qcdScaleByHelicityUnc_hist(
     )
 
 
+def add_pdfUncertByHelicity_hist(
+    results, df, helper, pdf_name, axes, cols, base_name="nominal", **kwargs
+):
+    name = Datagroups.histName(base_name, syst=f"{pdf_name}UncertByHelicity")
+    tensorName = f"helicity{pdf_name}Weight_tensor"
+    if tensorName not in df.GetColumnNames():
+        # usually already defined when calculating central PDF weight
+        df = df.Define(
+            tensorName,
+            helper,
+            [
+                "massVgen",
+                "absYVgen",
+                "ptVgen",
+                "chargeVgen",
+                "csSineCosThetaPhigen",
+                "nominal_weight",
+            ],
+        )
+    add_syst_hist(
+        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
+    )
+
+
+def add_pdfAlphaSByHelicity_hist(
+    results, df, helper, axes, cols, base_name="nominal", **kwargs
+):
+    name = Datagroups.histName(base_name, syst="pdfAlphaSByHelicity")
+    tensorName = "helicityAlphaSWeight_tensor"
+    df = df.Define(
+        tensorName,
+        helper,
+        [
+            "massVgen",
+            "absYVgen",
+            "ptVgen",
+            "chargeVgen",
+            "csSineCosThetaPhigen",
+            "nominal_weight",
+        ],
+    )
+    add_syst_hist(
+        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
+    )
+
+
 def add_QCDbkg_jetPt_hist(
     results, df, axes, cols, base_name="nominal", jet_pt=30, **kwargs
 ):
@@ -2403,7 +2449,7 @@ def add_theory_hists(
     args,
     dataset_name,
     corr_helpers,
-    qcdScaleByHelicity_helper,
+    theory_helpers,
     axes,
     cols,
     base_name="nominal",
@@ -2470,13 +2516,40 @@ def add_theory_hists(
         )
 
     if for_wmass or isZ:
-        logger.debug(f"Make QCD scale histograms for {dataset_name}")
-        # there is no W backgrounds for the Wlike, make QCD scale histograms only for Z
-        # should probably remove the charge here, because the Z only has a single charge and the pt distribution does not depend on which charged lepton is selected
 
-        if qcdScaleByHelicity_helper is not None:
+        if theory_helpers.get("qcdScale") is not None:
+            logger.debug(f"Make QCD scale histograms for {dataset_name}")
+            # there is no W backgrounds for the Wlike, make QCD scale histograms only for Z
+            # should probably remove the charge here, because the Z only has a single charge and the pt distribution does not depend on which charged lepton is selected
             add_qcdScaleByHelicityUnc_hist(
-                results, df, qcdScaleByHelicity_helper, scale_axes, scale_cols, **info
+                results,
+                df,
+                theory_helpers.get("qcdScale"),
+                scale_axes,
+                scale_cols,
+                **info,
+            )
+        if theory_helpers.get("pdf") is not None:
+            pdf_helpers = theory_helpers.get("pdf")
+            for pdf in args.pdfs:
+                pdf_name = theory_tools.pdfMap[pdf]["name"]
+                if pdf_name not in pdf_helpers.keys():
+                    logger.warning(
+                        f"Did not find PDF uncertainty by helicity histograms for {dataset_name} and PDF set {pdf_name}"
+                    )
+                    continue
+                logger.debug(
+                    f"Make PDF uncertainty by helicity histograms for {dataset_name} and PDF set {pdf_name}"
+                )
+                add_pdfUncertByHelicity_hist(
+                    results, df, pdf_helpers[pdf_name], pdf_name, axes, cols, **info
+                )
+        if theory_helpers.get("alphaS") is not None:
+            logger.debug(
+                f"Make AlphaS uncertainty by helicity histograms for {dataset_name}"
+            )
+            add_pdfAlphaSByHelicity_hist(
+                results, df, theory_helpers.get("alphaS"), axes, cols, **info
             )
 
         if "MEParamWeight" not in df.GetColumnNames():

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1697,12 +1697,8 @@ def add_qcdScaleByHelicityUnc_hist(
             "nominal_weight",
         ],
     )
-    safeTensorName = f"{tensorName}_clamped"
-    df = df.Define(
-        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
-    )
     add_syst_hist(
-        results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs
+        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
     )
 
 
@@ -1751,8 +1747,12 @@ def add_pdfAlphaSByHelicity_hist(
             "nominal_weight",
         ],
     )
+    safeTensorName = f"{tensorName}_clamped"
+    df = df.Define(
+        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
+    )
     add_syst_hist(
-        results, df, name, axes, cols, tensorName, helper.tensor_axes, **kwargs
+        results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs
     )
 
 

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -414,7 +414,6 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
 
     theory_helpers_procs = {}
 
-    # TODO re-run these with W and Z and move them to wremnants-data
     if "Z" in procs:
         theory_helpers_procs["Z"] = {}
 
@@ -423,7 +422,7 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=True,
                     filename=(
-                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5"
+                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_helicity.hdf5"
                         if args.unfolding
                         else f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
                     ),
@@ -455,7 +454,7 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=False,
                     filename=(
-                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5"
+                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_helicity.hdf5"
                         if args.unfolding
                         else f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
                     ),

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -422,7 +422,11 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
             theory_helpers_procs["Z"]["qcdScale"] = (
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=True,
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5",
+                    filename=(
+                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5"
+                        if args.unfolding
+                        else f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
+                    ),
                     rebin_ptVgen=False,
                     return_tensor=True,
                 )
@@ -432,14 +436,14 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                 make_pdfs_uncertanties_helper_by_helicity(
                     proc="Z",
                     pdfs=[theory_tools.pdfMap[pdf]["name"] for pdf in args.pdfs],
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfByHelicity.hdf5",
+                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
                 )
             )
         if "alphaS" in corrs:
             theory_helpers_procs["Z"]["alphaS"] = (
                 make_pdfAlphaS_uncertainty_helper_by_helicity(
                     proc="Z",
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_asByHelicity.hdf5",
+                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_scetlib_dyturboCorr_maxFiles_m1_asByHelicity.hdf5",
                 )
             )
 
@@ -450,7 +454,11 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
             theory_helpers_procs["W"]["qcdScale"] = (
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=False,
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5",
+                    filename=(
+                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_qcdScaleByHelicity.hdf5"
+                        if args.unfolding
+                        else f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
+                    ),
                     rebin_ptVgen=False,
                     return_tensor=True,
                 )
@@ -460,14 +468,14 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                 make_pdfs_uncertanties_helper_by_helicity(
                     proc="W",
                     pdfs=[theory_tools.pdfMap[pdf]["name"] for pdf in args.pdfs],
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfByHelicity.hdf5",
+                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
                 )
             )
         if "alphaS" in corrs:
             theory_helpers_procs["W"]["alphaS"] = (
                 make_pdfAlphaS_uncertainty_helper_by_helicity(
                     proc="W",
-                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_asByHelicity.hdf5",
+                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_scetlib_dyturboCorr_maxFiles_m1_asByHelicity.hdf5",
                 )
             )
 
@@ -710,13 +718,22 @@ def make_pdfAlphaS_uncertainty_helper_by_helicity(
     corr_coeffs.values(flow=True)[...] = 1.0
 
     # set all helicity_xsecs equal to nominal
-    # corr_coeffs.values(flow=True)[...] = pdf_vars[{'alphasVar': 'as0118'}].values(flow=True)[..., None, None]
     corr_coeffs.values(flow=True)[...] = pdf_vars[{"vars": 0}].values(flow=True)[
         ..., None, None
     ]
 
     # set the variations
     corr_coeffs.values(flow=True)[..., 1, :] = pdf_vars.values(flow=True)
+
+    # if proc == 'W':
+    #     print()
+    #     print(corr_coeffs.values(flow=True))
+    #     print(np.isnan(pdf_vars.values(flow=True)))
+    #     print(np.isnan(np.sum(pdf_vars.values(flow=True))))
+    #     print(np.isnan(np.sum(corr_coeffs.values(flow=True))))
+    #     print(proc)
+    #     print()
+    #     exit()
 
     if return_tensor:
         helper = makeCorrectionsTensor(

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -454,9 +454,7 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=False,
                     filename=(
-                        f"{common.data_dir}/angularCoefficients/w_z_helicity_xsecs_maxFiles_m1_alphaSunfoldingBinning_helicity.hdf5"
-                        if args.unfolding
-                        else f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
+                        f"{common.data_dir}/angularCoefficients/w_z_moments.hdf5"
                     ),
                     rebin_ptVgen=False,
                     return_tensor=True,

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -832,20 +832,19 @@ def define_pdf_columns(df, dataset_name, pdfs, noAltUnc):
     return df
 
 
-def define_central_smooth_pdf_weight(df, dataset_name, pdf, pdf_helper={}):
+def define_central_boson_pdf_weight(df, dataset_name, pdf, pdf_helper={}):
 
     proc = dataset_name[0]
-    print(pdf_helper)
     if type(pdf_helper) is not dict or proc not in pdf_helper.keys():
         logger.warning(
             f"Did not find sample {proc} in the given pdf_helper! Using nominal PDF in sample."
         )
-        return df.DefinePerSample("central_smooth_pdf_weight", "1.0")
+        return df.DefinePerSample("central_boson_pdf_weight", "1.0")
     if pdf not in pdf_helper[proc].keys():
         logger.warning(
             f"Did not find PDF {pdf} for sample {proc}! Using nominal PDF in sample."
         )
-        return df.DefinePerSample("central_smooth_pdf_weight", "1.0")
+        return df.DefinePerSample("central_boson_pdf_weight", "1.0")
 
     tensorName = f"helicity{pdf}Weight_tensor"
     df = df.Define(
@@ -860,8 +859,8 @@ def define_central_smooth_pdf_weight(df, dataset_name, pdf, pdf_helper={}):
         ],
     )
     return df.Define(
-        "central_smooth_pdf_weight",
-        f"std::clamp<float>(helicityPDFWeight_tensor[0], -theory_weight_truncate, theory_weight_truncate)",
+        "central_boson_pdf_weight",
+        f"std::clamp<float>({tensorName}[0], -theory_weight_truncate, theory_weight_truncate)",
     )
 
 

--- a/wremnants/unfolding_tools.py
+++ b/wremnants/unfolding_tools.py
@@ -180,7 +180,7 @@ def add_xnorm_histograms(
     args,
     dataset_name,
     corr_helpers,
-    qcdScaleByHelicity_helper,
+    theory_helpers,
     unfolding_axes,
     unfolding_cols,
     base_name="xnorm",
@@ -191,7 +191,7 @@ def add_xnorm_histograms(
     df_xnorm = df_xnorm.DefinePerSample("exp_weight", "1.0")
 
     df_xnorm = theory_tools.define_theory_weights_and_corrs(
-        df_xnorm, dataset_name, corr_helpers, args
+        df_xnorm, dataset_name, corr_helpers, args, theory_helpers=theory_helpers
     )
 
     df_xnorm = df_xnorm.Define("xnorm", "0.5")
@@ -231,7 +231,7 @@ def add_xnorm_histograms(
         args,
         dataset_name,
         corr_helpers,
-        qcdScaleByHelicity_helper,
+        theory_helpers,
         xnorm_axes,
         xnorm_cols,
         base_name=base_name,
@@ -403,7 +403,7 @@ class UnfolderZ:
         )
 
     def add_gen_histograms(
-        self, args, df, results, dataset, corr_helpers, qcdScaleByHelicity_helper
+        self, args, df, results, dataset, corr_helpers, theory_helpers={}
     ):
         df = define_gen_level(
             df, dataset.name, self.unfolding_levels, mode=self.analysis_label
@@ -430,7 +430,7 @@ class UnfolderZ:
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     [a for a in self.unfolding_axes[level] if a.name != "acceptance"],
                     [
                         c
@@ -473,7 +473,7 @@ class UnfolderZ:
                     args,
                     dataset.name,
                     corr_helpers,
-                    qcdScaleByHelicity_helper,
+                    theory_helpers,
                     [a for a in self.unfolding_axes[level] if a.name != "acceptance"],
                     [
                         c


### PR DESCRIPTION
- implemented PDF, quark mass, alphaS systematics the same way we currently do the QCD scales: through the helicity cross sections in the Z and W and gen histmakers. PDF and alphaS variations by helicity are produced via the gen histmaker, with the same binning for W and Z.
- implemented option to use these boson-parametrized systematics in setupRabbit.py, which are now default. An option has been added to use the 'old' systematics from the MINNLO weights
- implemented W in the theory fit, can now fit Z & W together