### PR TITLE
Parametrize central PDF weights via the boson helicities

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -416,7 +416,7 @@ def build_graph(df, dataset):
 
         df = df.Define("exp_weight", "SFMC")
         df = theory_tools.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args
+            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
         )
     else:
         df = df.DefinePerSample("nominal_weight", "1.0")

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -1237,7 +1237,7 @@ def build_graph(df, dataset):
         logger.debug(f"Exp weight defined: {weight_expr}")
         df = df.Define("exp_weight", weight_expr)
         df = theory_tools.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args
+            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
         )
 
         if (

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -568,7 +568,7 @@ def build_graph(df, dataset):
         df_gen = df
         df_gen = df_gen.DefinePerSample("exp_weight", "1.0")
         df_gen = theory_tools.define_theory_weights_and_corrs(
-            df_gen, dataset.name, corr_helpers, args
+            df_gen, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
         )
 
         for obs in auxiliary_gen_axes:

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -362,7 +362,7 @@ def build_graph(df, dataset):
 
         df = df.Define("exp_weight", "SFMC")
         df = theory_tools.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args
+            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
         )
     else:
         df = df.DefinePerSample("nominal_weight", "1.0")

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -878,7 +878,7 @@ def build_graph(df, dataset):
         logger.debug(f"Exp weight defined: {weight_expr}")
         df = df.Define("exp_weight", weight_expr)
         df = theory_tools.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args
+            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
         )
 
     results.append(

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -446,6 +446,7 @@ def build_graph(df, dataset):
     isZ = dataset.name in common.zprocs
     isWorZ = isW or isZ
 
+    theory_helpers = None
     if isWorZ:
         theory_helpers = theory_helpers_procs[dataset.name[0]]
 

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -904,8 +904,15 @@ def build_graph(df, dataset):
         [*nominal_cols, "nominal_weight"],
         storage=hist.storage.Weight(),
     )
-
     results.append(nominal_gen)
+
+    nominal_gen_pdf_uncorr = df.HistoBoost(
+        "nominal_gen_pdf_uncorr",
+        nominal_axes,
+        [*nominal_cols, "nominal_weight_pdf_uncorr"],
+        storage=hist.storage.Weight(),
+    )
+    results.append(nominal_gen_pdf_uncorr)
 
     return results, weightsum
 

--- a/wremnants/include/histHelpers.hpp
+++ b/wremnants/include/histHelpers.hpp
@@ -18,6 +18,17 @@
 
 namespace wrem {
 
+template <typename T> class HistHelper1D {
+public:
+  HistHelper1D(T &&resource)
+      : resourceHist_(std::make_shared<const T>(std::move(resource))) {}
+
+  double operator()(double x1) { return narf::get_value(*resourceHist_, x1); }
+
+private:
+  std::shared_ptr<const T> resourceHist_;
+};
+
 template <typename T> class HistHelper3D {
 public:
   HistHelper3D(T &&resource)

--- a/wremnants/include/theory_corrections.hpp
+++ b/wremnants/include/theory_corrections.hpp
@@ -168,7 +168,7 @@ public:
   using base_t::base_t;
 
   var_tensor_t operator()(double mV, double yV, double ptV, int qV,
-                          const CSVars &csvars, double nominal_weight = 1.0) {
+                          const CSVars &csvars, double nominal_weight) {
     static_assert(sizes.size() == 3);
     static_assert(nhelicity == NHELICITY);
     static_assert(ncorrs == 2);

--- a/wremnants/syst_tools.py
+++ b/wremnants/syst_tools.py
@@ -1718,12 +1718,13 @@ def add_pdfUncertByHelicity_hist(
                 "ptVgen",
                 "chargeVgen",
                 "csSineCosThetaPhigen",
-                "nominal_weight",
+                "unity",
             ],
         )
     safeTensorName = f"{tensorName}_clamped"
     df = df.Define(
-        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
+        safeTensorName,
+        f"auto res = wrem::clamp_tensor_safe({tensorName}, -theory_weight_truncate, theory_weight_truncate, 1.0); res = nominal_weight*res; return res;",
     )
     add_syst_hist(
         results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs
@@ -1744,12 +1745,13 @@ def add_pdfAlphaSByHelicity_hist(
             "ptVgen",
             "chargeVgen",
             "csSineCosThetaPhigen",
-            "nominal_weight",
+            "unity",
         ],
     )
     safeTensorName = f"{tensorName}_clamped"
     df = df.Define(
-        safeTensorName, f"wrem::clamp_tensor_safe({tensorName}, 0.9, 1.1, 1.0)"
+        safeTensorName,
+        f"auto res = wrem::clamp_tensor_safe({tensorName}, -theory_weight_truncate, theory_weight_truncate, 1.0); res = nominal_weight*res; return res;",
     )
     add_syst_hist(
         results, df, name, axes, cols, safeTensorName, helper.tensor_axes, **kwargs

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -457,7 +457,9 @@ def make_theory_helpers(
         if "pdf_central" in corrs:
             theory_helpers_procs[proc]["pdf_central"] = (
                 make_pdf_weight_helper_by_helicity(
-                    proc=proc, pdf=theory_tools.pdfMap[args.pdfs[0]]["name"]
+                    proc=proc,
+                    pdf=theory_tools.pdfMap[args.pdfs[0]]["name"],
+                    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
                 )
             )
 
@@ -668,7 +670,7 @@ def make_pdf_uncertainty_helper_by_helicity(
 def make_pdf_weight_helper_by_helicity(
     proc,
     pdf,
-    filename=f"/ceph/submit/data/group/cms/store/user/lavezzo/alphaS/250821_gen_pdfsByHelicity/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
+    filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
     var_ax_name="pdfVar",
     return_tensor=True,
 ):

--- a/wremnants/theory_corrections.py
+++ b/wremnants/theory_corrections.py
@@ -410,7 +410,9 @@ def make_corr_by_helicity(
     return corr_coeffs
 
 
-def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alphaS"]):
+def make_theory_helpers(
+    args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alphaS", "pdf_central"]
+):
 
     theory_helpers_procs = {p: {} for p in procs}
 
@@ -450,6 +452,12 @@ def make_theory_helpers(args, procs=["Z", "W"], corrs=["qcdScale", "pdf", "alpha
                     pdf="scetlib_dyturboCT18Z_pdfasCorr",
                     var_ax_name="vars",
                     filename=f"{common.data_dir}/angularCoefficients/w_z_gen_dists_scetlib_dyturboCorr_maxFiles_m1_asByHelicity.hdf5",
+                )
+            )
+        if "pdf_central" in corrs:
+            theory_helpers_procs[proc]["pdf_central"] = (
+                make_pdf_weight_helper_by_helicity(
+                    proc=proc, pdf=theory_tools.pdfMap[args.pdfs[0]]["name"]
                 )
             )
 
@@ -643,6 +651,76 @@ def make_pdf_uncertainty_helper_by_helicity(
 
     # set the variations
     corr_coeffs.values(flow=True)[..., 1, :] = pdf_vars.values(flow=True)
+
+    if return_tensor:
+        helper = makeCorrectionsTensor(
+            corr_coeffs, ROOT.wrem.CentralCorrByHelicityHelper, tensor_rank=3
+        )
+
+        # override tensor_axes since the output is different here
+        helper.tensor_axes = [vars_ax]
+
+        return helper
+    else:
+        return corr_coeffs
+
+
+def make_pdf_weight_helper_by_helicity(
+    proc,
+    pdf,
+    filename=f"/ceph/submit/data/group/cms/store/user/lavezzo/alphaS/250821_gen_pdfsByHelicity/w_z_gen_dists_maxFiles_m1_pdfsByHelicity.hdf5",
+    var_ax_name="pdfVar",
+    return_tensor=True,
+):
+
+    # load helicity cross sections from file
+    with h5py.File(filename, "r") as h5file:
+        results = input_tools.load_results_h5py(h5file)
+        if proc == "Z":
+            if f"nominal_gen_{pdf}" not in results["ZmumuPostVFP"]["output"].keys():
+                logger.warning(
+                    f"Did not find PDF set {pdf} in {filename}. Not creating histogram of PDF variations by helicities for this set."
+                )
+                return None
+            pdf_vars = results["ZmumuPostVFP"]["output"][f"nominal_gen_{pdf}"].get()
+            pdf_central = results["ZmumuPostVFP"]["output"][
+                f"nominal_gen_pdf_uncorr"
+            ].get()
+        elif proc == "W":
+            if f"nominal_gen_{pdf}" not in results["WplusmunuPostVFP"]["output"].keys():
+                logger.warning(
+                    f"Did not find PDF set {pdf} in {filename}. Not creating histogram of PDF variations by helicities for this set."
+                )
+                return None
+            pdf_vars_Wp = results["WplusmunuPostVFP"]["output"][
+                f"nominal_gen_{pdf}"
+            ].get()
+            pdf_vars_Wm = results["WminusmunuPostVFP"]["output"][
+                f"nominal_gen_{pdf}"
+            ].get()
+            pdf_vars = hh.addHists(pdf_vars_Wp, pdf_vars_Wm)
+            pdf_central_Wm = results["WminusmunuPostVFP"]["output"][
+                f"nominal_gen_pdf_uncorr"
+            ].get()
+            pdf_central_Wp = results["WplusmunuPostVFP"]["output"][
+                f"nominal_gen_pdf_uncorr"
+            ].get()
+            pdf_central = hh.addHists(pdf_central_Wp, pdf_central_Wm)
+
+    # construct the correction tensor
+    corr_ax = hist.axis.Boolean(name="corr")
+    vars_ax = pdf_vars.axes[var_ax_name]
+    new_vars_ax = hist.axis.StrCategory(["nominal"], name="vars")
+    axes_no_scale = pdf_vars.axes[:-1]
+    corr_coeffs = hist.Hist(*axes_no_scale, corr_ax, new_vars_ax)
+
+    # set all helicity_xsecs equal to nominal uncorrected
+    corr_coeffs.values(flow=True)[...] = pdf_central.values(flow=True)[..., None, None]
+
+    # set the nominal corrected
+    corr_coeffs.values(flow=True)[..., 1, :] = pdf_vars[{var_ax_name: 0}].values(
+        flow=True
+    )[..., None]
 
     if return_tensor:
         helper = makeCorrectionsTensor(

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -5,6 +5,7 @@ from scipy import ndimage
 
 import narf.clingutils
 from utilities import common
+from wremnants import theory_tools
 from wums import boostHistHelpers as hh
 from wums import logging
 
@@ -773,6 +774,10 @@ def pdf_info_map(dataset, pdfset):
 
 
 def define_pdf_columns(df, dataset_name, pdfs, noAltUnc):
+    df = df.Define(
+        f"nominal_weight_pdf_uncorr",
+        build_weight_expr(df, exclude_weights=["central_pdf_weight"]),
+    )
     if (
         len(pdfs) == 0
         or dataset_name not in common.vprocs_all
@@ -832,39 +837,35 @@ def define_pdf_columns(df, dataset_name, pdfs, noAltUnc):
     return df
 
 
-def define_central_boson_pdf_weight(df, dataset_name, pdf, pdf_helper={}):
+def define_central_boson_pdf_weight(df, dataset_name, pdf, theory_helpers):
 
-    proc = dataset_name[0]
-    if type(pdf_helper) is not dict or proc not in pdf_helper.keys():
-        logger.warning(
-            f"Did not find sample {proc} in the given pdf_helper! Using nominal PDF in sample."
-        )
-        return df.DefinePerSample("central_boson_pdf_weight", "1.0")
-    if pdf not in pdf_helper[proc].keys():
-        logger.warning(
-            f"Did not find PDF {pdf} for sample {proc}! Using nominal PDF in sample."
-        )
-        return df.DefinePerSample("central_boson_pdf_weight", "1.0")
+    logger.info("Using boson-parametrized PDF weights for the central PDF weight")
+    pdf_name = theory_tools.pdfMap[pdf]["name"]
 
-    tensorName = f"helicity{pdf}Weight_tensor"
+    tensorName = f"helicity{pdf_name}CentralWeight_tensor"
+    if "unity" not in df.GetColumnNames():
+        df = df.DefinePerSample("unity", "1.")
     df = df.Define(
         tensorName,
-        pdf_helper[proc][pdf],
+        theory_helpers["pdf_central"],
         [
             "massVgen",
             "absYVgen",
             "ptVgen",
             "chargeVgen",
             "csSineCosThetaPhigen",
+            "unity",
         ],
     )
     return df.Define(
-        "central_boson_pdf_weight",
-        f"std::clamp<float>({tensorName}[0], -theory_weight_truncate, theory_weight_truncate)",
+        "central_pdf_weight",
+        f"wrem::clamp_tensor_safe({tensorName}, -theory_weight_truncate, theory_weight_truncate, 1.0)[0]",
     )
 
 
 def define_central_pdf_weight(df, dataset_name, pdf):
+
+    logger.info("Using event PDF weights for the central PDF weight")
     try:
         pdfInfo = pdf_info_map(dataset_name, pdf)
     except ValueError:
@@ -901,9 +902,17 @@ def define_theory_weights_and_corrs(df, dataset_name, helpers, args, theory_help
         df = define_ew_vars(df)
 
     df = df.DefinePerSample("theory_weight_truncate", "10.")
-    df = define_central_pdf_weight(
-        df, dataset_name, args.pdfs[0] if len(args.pdfs) >= 1 else None
-    )
+    if "pdf_central" in theory_helpers.keys():
+        df = define_central_boson_pdf_weight(
+            df,
+            dataset_name,
+            args.pdfs[0] if len(args.pdfs) >= 1 else None,
+            theory_helpers,
+        )
+    else:  # if no boson-parametrized weights are available
+        df = define_central_pdf_weight(
+            df, dataset_name, args.pdfs[0] if len(args.pdfs) >= 1 else None
+        )
     df = define_theory_corr(
         df,
         dataset_name,

--- a/wremnants/theory_tools.py
+++ b/wremnants/theory_tools.py
@@ -902,7 +902,7 @@ def define_theory_weights_and_corrs(df, dataset_name, helpers, args, theory_help
         df = define_ew_vars(df)
 
     df = df.DefinePerSample("theory_weight_truncate", "10.")
-    if "pdf_central" in theory_helpers.keys():
+    if theory_helpers and "pdf_central" in theory_helpers.keys():
         df = define_central_boson_pdf_weight(
             df,
             dataset_name,


### PR DESCRIPTION
- The central PDF weights are parametrized via the boson helicity cross sections. This is a similar procedure as is already applied to the PDF, alphaS, QCD scale variations
- Fix from previous PR: the PDF variations times the nominal weight were being clipped, now clipping PDF variations only. Although, this doesn't really matter now that we don't use event weights to get the variations.