### PR TITLE
Handling of nonperturbative parameter Lambda4, N3LO corrections support

### DIFF
--- a/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
@@ -18,8 +18,12 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
-    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfas": {"pdf": "msht20an3lo"},
-    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfas": {"pdf": "msht20an3lo"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfas": {
+        "pdf": "msht20an3lo"
+    },
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfas": {
+        "pdf": "msht20an3lo"
+    },
     "scetlib_nnlojet_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_MSHT20an3lo_N4p0LL_N3LO_pdfas": {"pdf": "msht20an3lo"},

--- a/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
@@ -16,6 +16,8 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N3p0LL_N2LO_pdfas": {"pdf": "ct18z"},
     "scetlib_dyturbo_LatticeNP_CT18Z_N3p1LL_N2LO_pdfas": {"pdf": "ct18z"},
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfas": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_MSHT20an3lo_N4p0LL_N3LO_pdfas": {"pdf": "msht20an3lo"},

--- a/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_alphaS_gen_hists.py
@@ -18,6 +18,8 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfas": {"pdf": "msht20an3lo"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfas": {"pdf": "msht20an3lo"},
     "scetlib_nnlojet_CT18Z_N3p1LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_CT18Z_N4p0LL_N3LO_pdfas": {"pdf": "ct18z"},
     "scetlib_nnlojet_MSHT20an3lo_N4p0LL_N3LO_pdfas": {"pdf": "msht20an3lo"},

--- a/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
@@ -18,8 +18,12 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfvars": {"pdf": "ct18z"},
-    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfvars": {"pdf": "msht20an3lo"},
-    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfvars": {"pdf": "msht20an3lo"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfvars": {
+        "pdf": "msht20an3lo"
+    },
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfvars": {
+        "pdf": "msht20an3lo"
+    },
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfvars": {"pdf": "ct18"},
     "scetlib_dyturbo_LatticeNP_HERAPDF20_N3p0LL_N2LO_pdfvars": {
         "pdf": "herapdf20 herapdf20ext"

--- a/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
@@ -18,6 +18,8 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfvars": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfvars": {"pdf": "msht20an3lo"},
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfvars": {"pdf": "msht20an3lo"},
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfvars": {"pdf": "ct18"},
     "scetlib_dyturbo_LatticeNP_HERAPDF20_N3p0LL_N2LO_pdfvars": {
         "pdf": "herapdf20 herapdf20ext"

--- a/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
+++ b/scripts/corrections/corrs_by_helicity/make_pdf_from_corr_gen_hists.py
@@ -16,6 +16,8 @@ THEORY_PREDS = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N3p0LL_N2LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_dyturbo_LatticeNP_CT18Z_N3p1LL_N2LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfvars": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfvars": {"pdf": "ct18z"},
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfvars": {"pdf": "ct18z"},
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfvars": {"pdf": "ct18"},
     "scetlib_dyturbo_LatticeNP_HERAPDF20_N3p0LL_N2LO_pdfvars": {
         "pdf": "herapdf20 herapdf20ext"

--- a/scripts/corrections/make_rescaled_theory_corr.py
+++ b/scripts/corrections/make_rescaled_theory_corr.py
@@ -4,6 +4,7 @@ import re
 
 import lz4.frame
 
+from wremnants.production import theory_corrections
 from wremnants.utilities import common, parsing
 from wums import logging, output_tools
 
@@ -91,6 +92,15 @@ def main():
         else "MC_data_ratio"
     )
     rescale_corr = rescale[proc][rescale_corr_name]
+    try:
+        refcorr, rescale_corr = theory_corrections.rebin_corr_hists(
+            [refcorr, rescale_corr],
+            ndim=min(refcorr.ndim, rescale_corr.ndim) - 1,
+        )
+    except ValueError as e:
+        raise ValueError(
+            f"Could not rebin histograms {refcorr.shape} and {rescale_corr.shape} to a common binning"
+        ) from e
 
     if refcorr.shape[:-1] != rescale_corr.shape[:-1]:
         raise ValueError(

--- a/scripts/corrections/make_rescaled_theory_corr.py
+++ b/scripts/corrections/make_rescaled_theory_corr.py
@@ -16,6 +16,25 @@ def corr_name(corrf):
     return match[1]
 
 
+def find_corr_hist_name(corr_dict, proc, corrf, suffix):
+    base = corr_name(corrf)
+    candidates = [
+        f"{base}{suffix}",
+        f"{base.rstrip('_')}_{suffix}",
+    ]
+    candidates = list(dict.fromkeys(candidates))
+
+    for candidate in candidates:
+        if candidate in corr_dict[proc]:
+            return candidate
+
+    available = [k for k in corr_dict[proc].keys() if k.endswith(suffix)]
+    raise KeyError(
+        f"Could not find histogram with suffix '{suffix}' for file {corrf}. "
+        f"Tried {candidates}. Available matches: {available}"
+    )
+
+
 def parse_args():
     parser = parsing.base_parser()
     parser.add_argument(
@@ -63,10 +82,11 @@ def main():
 
     proc = "Z" if "CorrZ" in args.refCorr else "W"
 
-    refcorr = ref[proc][corr_name(args.refCorr) + "_minnlo_ratio"]
+    refcorr_name = find_corr_hist_name(ref, proc, args.refCorr, "minnlo_ratio")
+    refcorr = ref[proc][refcorr_name]
 
     rescale_corr_name = (
-        f"{corr_name(args.rescaleCorr)}_minnlo_ratio"
+        find_corr_hist_name(rescale, proc, args.rescaleCorr, "minnlo_ratio")
         if "dataPtll" not in args.rescaleCorr
         else "MC_data_ratio"
     )
@@ -82,7 +102,7 @@ def main():
     # Broadcast syst axis
     new_corr[...] = (refcorr.view().T * central_val_corr.T).T
 
-    new_name = args.newCorrName + "_minnlo_ratio"
+    new_name = f"{args.newCorrName.rstrip('_')}_minnlo_ratio"
     if "dataPtll" in args.newCorrName:
         new_name = "MC_data_ratio"
         # Avoid overwriting

--- a/scripts/corrections/make_theory_corr.py
+++ b/scripts/corrections/make_theory_corr.py
@@ -128,12 +128,27 @@ def parse_args():
         help="Data set to process",
         default=["13TeVGen"],
     )
+    parser.add_argument(
+        "--nnlojetMassEdges",
+        nargs=2,
+        type=float,
+        default=None,
+        help="Explicit Q-axis edges to attach for NNLOjet inputs when Q is requested but not present in the raw NNLOjet histogram",
+    )
     args = parser.parse_args()
 
     return args
 
 
-def read_corr(procName, generator, corrFiles, axes, qt_cutoff=1.0, smooth=None):
+def read_corr(
+    procName,
+    generator,
+    corrFiles,
+    axes,
+    qt_cutoff=1.0,
+    smooth=None,
+    nnlojet_mass_edges=None,
+):
     logger = logging.child_logger("read_corr")
     charge = 0 if procName[0] == "Z" else (1 if "Wplus" in procName else -1)
     corr_file = corrFiles[0]
@@ -162,9 +177,11 @@ def read_corr(procName, generator, corrFiles, axes, qt_cutoff=1.0, smooth=None):
             fo_func = getattr(input_tools, f"read_matched_scetlib_{fo_generator}_hist")
 
             # TODO: Should probably be more general...
-            smooth_args = {}
+            fo_args = {}
             if smooth == "fo_sing":
-                smooth_args = {"smooth_nnlojet": True}
+                fo_args["smooth_nnlojet"] = True
+            if fo_generator == "nnlojet":
+                fo_args["mass_edges"] = nnlojet_mass_edges
             numh = fo_func(
                 resumf,
                 nnlo_singf,
@@ -174,7 +191,7 @@ def read_corr(procName, generator, corrFiles, axes, qt_cutoff=1.0, smooth=None):
                 zero_nons_bins=slice(
                     0j, complex(0, qt_cutoff)
                 ),  # set bins with qT < qtCutoff GeV to 0
-                **smooth_args,
+                **fo_args,
             )
         else:
             nons = "auto"
@@ -294,6 +311,7 @@ def main():
                 args.axes,
                 qt_cutoff=args.qtCutoff,
                 smooth=args.smooth,
+                nnlojet_mass_edges=args.nnlojetMassEdges,
             )
             for procName, corr_file in filesByProc.items()
         ]

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -725,6 +725,12 @@ def make_parser(parser=None, argv=None):
         help="Scale the minnlo qcd scale uncertainties by this factor",
     )
     parser.add_argument(
+        "--scaleNPLambda4",
+        default=1.0,
+        type=float,
+        help="Scale the nonperturbative lambda4 uncertainty by this factor",
+    )
+    parser.add_argument(
         "--symmetrizeTheoryUnc",
         default="quadratic",
         type=str,
@@ -1772,6 +1778,7 @@ def setup(
             pdf_from_corr=args.pdfUncFromCorr,
             as_from_corr=not args.asUncFromUncorr,
             scale_pdf_unc=args.scalePdf,
+            scale_np_lambda4=args.scaleNPLambda4,
             samples=theorySystSamples,
             minnlo_unc=args.minnloScaleUnc,
             minnlo_scale=args.scaleMinnloScale,

--- a/wremnants/postprocessing/rabbit_theory_helper.py
+++ b/wremnants/postprocessing/rabbit_theory_helper.py
@@ -81,6 +81,7 @@ class TheoryHelper(object):
         self.np_model = "Delta_Lambda"
         self.pdf_from_corr = False
         self.scale_pdf_unc = -1.0
+        self.scale_np_lambda4 = 1.0
         self.mirror_tnp = True
         self.minnlo_unc = "byHelicityPt"
         self.helicity_fit_unc = False
@@ -112,6 +113,7 @@ class TheoryHelper(object):
         pdf_operation=None,
         samples=[],
         scale_pdf_unc=-1.0,
+        scale_np_lambda4=1.0,
         minnlo_unc="byHelicityPt",
         minnlo_scale=1.0,
         from_hels=False,
@@ -131,6 +133,7 @@ class TheoryHelper(object):
         self.as_from_corr = pdf_from_corr or as_from_corr
         self.pdf_operation = pdf_operation
         self.scale_pdf_unc = scale_pdf_unc
+        self.scale_np_lambda4 = scale_np_lambda4
         self.samples = samples
         self.helicity_fit_unc = False
         self.minnlo_scale = minnlo_scale
@@ -824,7 +827,7 @@ class TheoryHelper(object):
             np_map = {
                 "lambda2": ["0.0", "0.5"],
                 "delta_lambda2": ["-0.02", "0.02"],
-                "lambda4": ["0.01", "0.16"],
+                "lambda4": ["0.01", "0.12"],
             }
         elif "Lambda" in self.np_model:
             np_map = {
@@ -860,6 +863,7 @@ class TheoryHelper(object):
         for nuisance, vals in np_map.items():
             entries = [nuisance + v for v in vals]
             rename = f"scetlibNP{nuisance}"
+            scale = self.scale_np_lambda4 if nuisance.lower() == "lambda4" else 1.0
             # operation = lambda h : h[{self.syst_ax : entries}]
             self.datagroups.addSystematic(
                 self.corr_hist_name,
@@ -870,6 +874,7 @@ class TheoryHelper(object):
                 preOp=operation,
                 preOpArgs=dict(entries=entries),
                 outNames=[f"{rename}Down", f"{rename}Up"],
+                scale=scale,
                 name=rename,
             )
 
@@ -878,7 +883,7 @@ class TheoryHelper(object):
             np_map = {
                 "lambda2": ["0.0", "0.5"],
                 "delta_lambda2": ["-0.02", "0.02"],
-                "lambda4": ["0.01", "0.16"],
+                "lambda4": ["0.01", "0.12"],
             }
         elif "Lambda" in self.np_model:
             np_map = {
@@ -945,6 +950,7 @@ class TheoryHelper(object):
             for nuisance, vals in np_map.items():
                 entries = [nuisance + v for v in vals]
                 rename = f"scetlibNP{label}{nuisance}"
+                scale = self.scale_np_lambda4 if nuisance.lower() == "lambda4" else 1.0
                 self.datagroups.addSystematic(
                     self.np_hist_name,
                     processes=[sample_group],
@@ -965,6 +971,7 @@ class TheoryHelper(object):
                         (entries[0], f"{rename}Down"),
                     ],
                     skipEntries=[{self.syst_ax: ["central", "pdf0"]}],
+                    scale=scale,
                     name=rename,
                 )
 

--- a/wremnants/production/theory_corrections.py
+++ b/wremnants/production/theory_corrections.py
@@ -95,6 +95,12 @@ theory_corr_weight_map = {
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfas": make_theory_corr_weight_info(
         "ct18z", alphas=True, renorm=True
     ),
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfas": make_theory_corr_weight_info(
+        "ct18z", alphas=True, renorm=True
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfas": make_theory_corr_weight_info(
+        "ct18z", alphas=True, renorm=True
+    ),
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfas": make_theory_corr_weight_info(
         "ct18", alphas=True, renorm=True
     ),
@@ -126,6 +132,12 @@ theory_corr_weight_map = {
         "ct18z"
     ),
     "scetlib_dyturbo_LatticeNP_CT18Z_N4p0LL_N2LO_pdfvars": make_theory_corr_weight_info(
+        "ct18z"
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N3p1LL_N3LO_pdfvars": make_theory_corr_weight_info(
+        "ct18z"
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfvars": make_theory_corr_weight_info(
         "ct18z"
     ),
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfvars": make_theory_corr_weight_info(
@@ -199,6 +211,7 @@ def load_corr_helpers(
                 (generator == generators[0])
                 and ("nnlojet" in generator.lower())
                 and ("pdfas" not in generator.lower())
+                and ("pdfvars" not in generator.lower())
             ):
                 logger.info(
                     f"Adding statistical uncertainties for correction {generator}"

--- a/wremnants/production/theory_corrections.py
+++ b/wremnants/production/theory_corrections.py
@@ -101,6 +101,12 @@ theory_corr_weight_map = {
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfas": make_theory_corr_weight_info(
         "ct18z", alphas=True, renorm=True
     ),
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfas": make_theory_corr_weight_info(
+        "msht20an3lo", alphas=True, renorm=True
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfas": make_theory_corr_weight_info(
+        "msht20an3lo", alphas=True, renorm=True
+    ),
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfas": make_theory_corr_weight_info(
         "ct18", alphas=True, renorm=True
     ),
@@ -139,6 +145,12 @@ theory_corr_weight_map = {
     ),
     "scetlib_nnlojet_LatticeNPCoarse_CT18Z_N4p0LL_N3LO_pdfvars": make_theory_corr_weight_info(
         "ct18z"
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N3p1LL_N3LO_pdfvars": make_theory_corr_weight_info(
+        "msht20an3lo"
+    ),
+    "scetlib_nnlojet_LatticeNPCoarse_MSHT20aN3LO_N4p0LL_N3LO_pdfvars": make_theory_corr_weight_info(
+        "msht20an3lo"
     ),
     "scetlib_dyturbo_LatticeNP_CT18_N3p0LL_N2LO_pdfvars": make_theory_corr_weight_info(
         "ct18"

--- a/wremnants/utilities/io_tools/input_tools.py
+++ b/wremnants/utilities/io_tools/input_tools.py
@@ -275,13 +275,32 @@ def read_nnlojet_file(
     return h * 1e-3
 
 
-def read_nnlojet_ybin(refname, ybins, charge=None):
+def resolve_nnlojet_ybin_filename(refname, ybins):
     format_decimal = lambda x: (
         "0" if x == 0 else f"{round(x, 1+(x % 1 in [0.25, 0.75]))}".replace(".", "p")
     )
+
+    def alternate_decimal(value):
+        formatted = format_decimal(value)
+        return formatted[:-1] if formatted.endswith("p0") else formatted
+
+    bounds = tuple(format_decimal(y) for y in ybins)
+    candidates = [
+        f"{refname}__{bounds[0]}__{bounds[1]}.dat",
+        f"{refname}__{alternate_decimal(ybins[0])}__{bounds[1]}.dat",
+        f"{refname}__{bounds[0]}__{alternate_decimal(ybins[1])}.dat",
+        f"{refname}__{alternate_decimal(ybins[0])}__{alternate_decimal(ybins[1])}.dat",
+    ]
+    for candidate in dict.fromkeys(candidates):
+        if os.path.isfile(candidate):
+            return candidate
+    return candidates[0]
+
+
+def read_nnlojet_ybin(refname, ybins, charge=None):
     yax = hist.axis.Variable(ybins, name="Y")
     return read_nnlojet_file(
-        f"{refname}__{format_decimal(ybins[0])}__{format_decimal(ybins[1])}.dat",
+        resolve_nnlojet_ybin_filename(refname, ybins),
         other_axes=[yax],
         charge=charge,
     )

--- a/wremnants/utilities/io_tools/input_tools.py
+++ b/wremnants/utilities/io_tools/input_tools.py
@@ -578,6 +578,7 @@ def read_matched_scetlib_nnlojet_hist(
     zero_nons_bins=0,
     coeff=None,
     smooth_nnlojet=False,
+    mass_edges=None,
 ):
     hresum, hfo_sing = read_scetlib_resum_and_fosing(
         scetlib_resum,
@@ -596,6 +597,28 @@ def read_matched_scetlib_nnlojet_hist(
         )
     else:
         nnlojeth = read_nnlojet_file(nnlojet_fo, axnames=axes, charge=charge)
+
+    if "Q" in axes and "Q" not in nnlojeth.axes.name:
+        if mass_edges is None:
+            raise ValueError(
+                "Requested axis 'Q' for matched NNLOjet input, but the raw NNLOjet histogram "
+                "does not contain a Q axis. Pass explicit edges with --nnlojetMassEdges, "
+                "for example '--nnlojetMassEdges 60 120'."
+            )
+        if len(mass_edges) != 2 or mass_edges[0] >= mass_edges[1]:
+            raise ValueError(
+                f"Invalid NNLOjet mass edges {mass_edges}; expected two increasing values"
+            )
+
+        insert_idx = hfo_sing.axes.name.index("Q")
+        qax = hist.axis.Variable(mass_edges, name="Q", flow=False)
+        new_axes = list(nnlojeth.axes)
+        new_axes.insert(insert_idx, qax)
+        nnlojeth = hist.Hist(
+            *new_axes,
+            storage=nnlojeth.storage_type(),
+            data=np.expand_dims(nnlojeth.view(flow=True), insert_idx),
+        )
 
     if smooth_nnlojet:
         if "Y" in axes:
@@ -618,7 +641,10 @@ def read_matched_scetlib_hist(
     hfo,
     zero_nons_bins=0,
 ):
-    for ax in ["Y", "Q"]:
+    # Rebin shared physics axes to the common edge intersection so a coarser
+    # fixed-order input can be combined with finer SCETlib histograms without
+    # interpolation.
+    for ax in ["Y", "Q", "qT"]:
         if ax in set(hfo.axes.name).intersection(set(hfo_sing.axes.name)).intersection(
             set(hresum.axes.name)
         ):


### PR DESCRIPTION
- Adds an option to scale the variation of the NP parameter Lambda4
  - Defaults to 1.0 for the moment, until we decide for a different value
- Default variations are 0.01 and 0.12 (with 0.06 as central value)