### PR TITLE
Support alpha_s decorrelation across rapidity bins

### DIFF
--- a/scripts/plotting/plot_alphaS_rapidity_decorr.py
+++ b/scripts/plotting/plot_alphaS_rapidity_decorr.py
@@ -1,0 +1,339 @@
+import numpy as np
+import pandas as pd
+from matplotlib.patches import Polygon
+from scipy.stats import chi2
+
+import rabbit.io_tools
+from wremnants.utilities import parsing
+from wremnants.utilities.io_tools import rabbit_input
+from wums import logging, output_tools, plot_tools
+
+ALPHA_S_SCALE_IMPACTS = 2
+
+
+def get_values_and_impacts_as_panda(
+    input_file,
+    partial_impacts_to_read=None,
+    global_impacts=False,
+    scale=1.0,
+    result=None,
+):
+    fitres, meta = rabbit.io_tools.get_fitresult(input_file, meta=True, result=result)
+    poi_names = rabbit.io_tools.get_poi_names(meta)
+    poi_values = []
+    totals = []
+    uncertainties = {}
+    for poi in poi_names:
+        impacts, labels = rabbit.io_tools.read_impacts_poi(
+            fitres,
+            poi,
+            grouped=True,
+            impact_type="global" if global_impacts else "traditional",
+        )
+        impacts = scale * impacts
+        totals.append([impacts[i] for i, k in enumerate(labels) if k == "Total"][0])
+        if uncertainties == {}:
+            uncertainties = {
+                f"err_{k}": [impacts[i]]
+                for i, k in enumerate(labels)
+                if (partial_impacts_to_read is None or k in partial_impacts_to_read)
+            }
+        else:
+            for i, k in enumerate(labels):
+                if partial_impacts_to_read and k not in partial_impacts_to_read:
+                    continue
+                uncertainties[f"err_{k}"].append(impacts[i])
+        poi_values.append(scale * fitres["parms"].get()[poi].value)
+
+    df = pd.DataFrame(
+        {"Name": poi_names, "value": poi_values, "err_Total": totals, **uncertainties}
+    )
+    return df
+
+
+def get_yll_bin_edges(meta):
+    ch_info = meta["meta_info_input"]["channel_info"]
+    # take the first channel
+    ch = list(ch_info.values())[0]
+    axes = ch["axes"]
+    for ax in axes:
+        if ax.name == "yll":
+            return list(ax.edges)
+    return None
+
+
+if __name__ == "__main__":
+    parser = parsing.plot_parser()
+    parser.add_argument("infile", help="Fitresult file from decorrelated alphaS fit")
+    parser.add_argument(
+        "--infileInclusive",
+        type=str,
+        default=None,
+        help="Fitresult file from inclusive (non-decorrelated) alphaS fit",
+    )
+    parser.add_argument(
+        "--result",
+        default=None,
+        type=str,
+        help="fitresults key in file (e.g. 'asimov'). Leave empty for data fit result.",
+    )
+    parser.add_argument(
+        "--data",
+        action="store_true",
+        help="Specify if the fit is performed on data",
+    )
+    parser.add_argument(
+        "--decorrAxis",
+        type=str,
+        default="yll_decorr",
+        help="Name of the decorrelation axis in POI names",
+    )
+    parser.add_argument(
+        "--widthScale",
+        type=float,
+        default=1.5,
+        help="Scale the width of the figure",
+    )
+    parser.add_argument(
+        "--partialImpact",
+        nargs=2,
+        type=str,
+        default=["pdfCT18ZNoAlphaS", "PDF unc."],
+        help="Uncertainty group to plot as partial error bar",
+    )
+    parser.add_argument(
+        "--globalImpacts",
+        action="store_true",
+        help="Use the global impacts to plot uncertainties",
+    )
+    parser.add_argument(
+        "--poiScale",
+        type=float,
+        default=ALPHA_S_SCALE_IMPACTS,
+        help="Scale POI values and uncertainties by this factor",
+    )
+
+    parser = parsing.set_parser_default(parser, "legCols", 1)
+
+    args = parser.parse_args()
+    logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
+
+    outdir = output_tools.make_plot_dir(args.outpath, args.outfolder, eoscp=args.eoscp)
+
+    partialImpact, partialImpactLegend = args.partialImpact
+    partial_impacts_to_read = ["stat", partialImpact]
+
+    fitresult, meta = rabbit.io_tools.get_fitresult(args.infile, meta=True)
+    poi_names = rabbit.io_tools.get_poi_names(meta)
+    meta_info = meta["meta_info"]
+    lumi = sum([c["lumi"] for c in meta["meta_info_input"]["channel_info"].values()])
+
+    nll = fitresult["nllvalreduced"]
+
+    yll_edges = get_yll_bin_edges(meta)
+    if yll_edges is not None:
+        logger.info(f"Found yll bin edges: {yll_edges}")
+
+    if args.infileInclusive:
+        dfInclusive = get_values_and_impacts_as_panda(
+            args.infileInclusive,
+            partial_impacts_to_read=partial_impacts_to_read,
+            global_impacts=args.globalImpacts,
+            scale=args.poiScale,
+            result=args.result,
+        )
+        fInclusive = rabbit.io_tools.get_fitresult(args.infileInclusive)
+        nll_inclusive = fInclusive["nllvalreduced"]
+
+    df = get_values_and_impacts_as_panda(
+        args.infile,
+        partial_impacts_to_read=partial_impacts_to_read,
+        global_impacts=args.globalImpacts,
+        scale=args.poiScale,
+        result=args.result,
+    )
+
+    # extract bin index from POI name using the decorrelation axis
+    df["bin_idx"] = df["Name"].apply(
+        lambda x: rabbit_input.decode_poi_bin(x, args.decorrAxis)
+    )
+    df.dropna(subset=["bin_idx"], inplace=True)
+    df["bin_idx"] = df["bin_idx"].astype(int)
+    df.sort_values(by="bin_idx", inplace=True)
+
+    # build y-tick labels from bin edges
+    if yll_edges is not None and len(yll_edges) == len(df) + 1:
+        df["yticks"] = [
+            f"${yll_edges[i]:.2g} < y_{{\\ell\\ell}} < {yll_edges[i+1]:.2g}$"
+            for i in df["bin_idx"].values
+        ]
+    else:
+        df["yticks"] = [f"bin {i}" for i in df["bin_idx"].values]
+
+    scale = args.poiScale
+    xlabel = r"$\Delta\alpha_S$"
+
+    val = df["value"].values
+    err = df["err_Total"].values
+    err_stat = df["err_stat"].values
+    err_part = df[f"err_{partialImpact}"].values
+
+    if args.xlim is None:
+        xlim = min(val - err), max(val + err)
+        xwidth = xlim[1] - xlim[0]
+        xlim = -0.05 * xwidth + xlim[0], 0.05 * xwidth + xlim[1]
+    else:
+        xlim = args.xlim
+
+    ylim = (0.0, len(df))
+    y = np.arange(0, len(df)) + 0.5
+
+    fig, ax1 = plot_tools.figure(
+        None,
+        xlabel=xlabel,
+        ylabel=None,
+        grid=True,
+        automatic_scale=False,
+        width_scale=args.widthScale,
+        height=4 + 0.24 * len(df),
+        xlim=xlim,
+        ylim=ylim,
+    )
+
+    if args.infileInclusive:
+        ndf = len(df) - 1
+
+        logger.info(f"nll_inclusive = {nll_inclusive}; nll = {nll}")
+
+        chi2_stat = 2 * (nll_inclusive - nll)
+        chi2_label = r"\mathit{\chi}^2/\mathit{ndf}"
+        if args.result == "asimov":
+            chi2_stat = 0
+        elif not args.data:
+            chi2_stat += ndf
+            chi2_label = f"<{chi2_label}>"
+
+        p_value = 1 - chi2.cdf(chi2_stat, ndf)
+        logger.info(f"ndf = {ndf}; Chi2 = {chi2_stat}; p-value={p_value}")
+
+        plot_tools.wrap_text(
+            [
+                f"${chi2_label} = {str(round(chi2_stat, 1))}/{ndf}$",
+                rf"$\mathit{{p}} = {str(round(p_value * 100))}\,\%$",
+            ],
+            ax1,
+            0.06,
+            0.15,
+            text_size=args.legSize,
+        )
+
+        c = dfInclusive["value"].values[0]
+        c_err = dfInclusive["err_Total"].values[0]
+        c_err_stat = dfInclusive["err_stat"].values[0]
+        c_err_part = dfInclusive[f"err_{partialImpact}"].values[0]
+
+        ax1.fill_between(
+            [c - c_err, c + c_err], ylim[0], ylim[1], color="gray", alpha=0.3
+        )
+        ax1.fill_between(
+            [c - c_err_stat, c + c_err_stat],
+            ylim[0],
+            ylim[1],
+            color="gray",
+            alpha=0.3,
+        )
+        ax1.fill_between(
+            [c - c_err_part, c + c_err_part],
+            ylim[0],
+            ylim[1],
+            color="gray",
+            alpha=0.3,
+        )
+        ax1.plot([c, c], ylim, color="black", linewidth=2, linestyle="-")
+
+        val -= c
+
+    yticks = df["yticks"].values
+    ax1.set_yticks(y, labels=yticks)
+    ax1.minorticks_off()
+
+    ax1.errorbar(
+        val,
+        y,
+        xerr=err_stat,
+        color="red",
+        marker="",
+        linestyle="",
+        label="Stat. unc.",
+        zorder=3,
+    )
+    ax1.errorbar(
+        val,
+        y,
+        xerr=err_part,
+        color="orange",
+        marker="",
+        linestyle="",
+        linewidth=5,
+        label=partialImpactLegend,
+        zorder=2,
+    )
+    ax1.errorbar(
+        val,
+        y,
+        xerr=err,
+        color="black",
+        marker="o",
+        linestyle="",
+        label="Measurement",
+        zorder=1,
+        capsize=10,
+        linewidth=3,
+    )
+    ax1.plot(val, y, color="black", marker="o", linestyle="", zorder=4)
+
+    extra_handles = [
+        (
+            Polygon(
+                [[0, 0], [0, 0], [0, 0], [0, 0]],
+                facecolor="gray",
+                linestyle="solid",
+                edgecolor="black",
+                linewidth=2,
+                alpha=0.3,
+            ),
+        )
+    ]
+
+    plot_tools.add_cms_decor(
+        ax1,
+        args.cmsDecor,
+        data=True,
+        lumi=lumi,
+        loc=args.logoPos,
+        text_size=args.cmsDecorSize,
+    )
+    plot_tools.addLegend(
+        ax1,
+        ncols=args.legCols,
+        loc=args.legPos,
+        text_size=args.legSize,
+        extra_handles=extra_handles,
+        extra_labels=["Inclusive"],
+        custom_handlers=["tripleband"],
+    )
+
+    outfile = "alphaS_rapidity_decorr"
+    if args.postfix:
+        outfile += f"_{args.postfix}"
+
+    plot_tools.save_pdf_and_png(outdir, outfile)
+    output_tools.write_index_and_log(
+        outdir,
+        outfile,
+        analysis_meta_info={"AnalysisOutput": meta_info},
+        args=args,
+    )
+
+    if output_tools.is_eosuser_path(args.outpath) and args.eoscp:
+        output_tools.copy_to_eos(outdir, args.outpath, args.outfolder)

--- a/scripts/plotting/plot_alphaS_rapidity_decorr.py
+++ b/scripts/plotting/plot_alphaS_rapidity_decorr.py
@@ -48,6 +48,7 @@ def get_values_and_impacts_as_panda(
     df = pd.DataFrame(
         {"Name": poi_names, "value": poi_values, "err_Total": totals, **uncertainties}
     )
+    print(df)
     return df
 
 
@@ -114,6 +115,8 @@ if __name__ == "__main__":
     )
 
     parser = parsing.set_parser_default(parser, "legCols", 1)
+    parser = parsing.set_parser_default(parser, "logoPos", 0)
+    parser = parsing.set_parser_default(parser, "legPos", (1.01, 0))
 
     args = parser.parse_args()
     logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
@@ -171,7 +174,8 @@ if __name__ == "__main__":
         df["yticks"] = [f"bin {i}" for i in df["bin_idx"].values]
 
     scale = args.poiScale
-    xlabel = r"$\Delta\alpha_S$"
+    impact_label = "Global impacts" if args.globalImpacts else "Traditional impacts"
+    xlabel = r"$\Delta\alpha_S$" + f" ({impact_label})"
 
     val = df["value"].values
     err = df["err_Total"].values
@@ -206,25 +210,29 @@ if __name__ == "__main__":
         logger.info(f"nll_inclusive = {nll_inclusive}; nll = {nll}")
 
         chi2_stat = 2 * (nll_inclusive - nll)
-        chi2_label = r"\mathit{\chi}^2/\mathit{ndf}"
+        chi2_label = r"\chi^2/\mathrm{ndf}"
         if args.result == "asimov":
             chi2_stat = 0
         elif not args.data:
             chi2_stat += ndf
-            chi2_label = f"<{chi2_label}>"
+            chi2_label = rf"\langle {chi2_label} \rangle"
 
         p_value = 1 - chi2.cdf(chi2_stat, ndf)
         logger.info(f"ndf = {ndf}; Chi2 = {chi2_stat}; p-value={p_value}")
 
-        plot_tools.wrap_text(
-            [
-                f"${chi2_label} = {str(round(chi2_stat, 1))}/{ndf}$",
-                rf"$\mathit{{p}} = {str(round(p_value * 100))}\,\%$",
-            ],
-            ax1,
-            0.06,
-            0.15,
-            text_size=args.legSize,
+        ax1.text(
+            1.01,
+            0.8,
+            "\n".join(
+                [
+                    rf"${chi2_label} = {chi2_stat:.1f}/{ndf}$",
+                    rf"$\mathit{{p}} = {p_value * 100:.0f}\,\%$",
+                ]
+            ),
+            ha="left",
+            va="center",
+            transform=ax1.transAxes,
+            fontsize=args.legSize,
         )
 
         c = dfInclusive["value"].values[0]
@@ -313,15 +321,21 @@ if __name__ == "__main__":
         loc=args.logoPos,
         text_size=args.cmsDecorSize,
     )
-    plot_tools.addLegend(
-        ax1,
-        ncols=args.legCols,
-        loc=args.legPos,
-        text_size=args.legSize,
-        extra_handles=extra_handles,
-        extra_labels=["Inclusive"],
-        custom_handlers=["tripleband"],
-    )
+    leg_args = {
+        "ax": ax1,
+        "ncols": args.legCols,
+        "loc": args.legPos,
+        "text_size": args.legSize,
+    }
+    if args.infileInclusive:
+        leg_args.update(
+            {
+                "extra_handles": extra_handles,
+                "extra_labels": ["Inclusive"],
+                "custom_handlers": ["tripleband"],
+            }
+        )
+    plot_tools.addLegend(**leg_args)
 
     outfile = "alphaS_rapidity_decorr"
     if args.postfix:

--- a/scripts/plotting/plot_alphaS_rapidity_decorr.py
+++ b/scripts/plotting/plot_alphaS_rapidity_decorr.py
@@ -1,55 +1,14 @@
 import numpy as np
-import pandas as pd
 from matplotlib.patches import Polygon
 from scipy.stats import chi2
 
 import rabbit.io_tools
+from scripts.plotting.plot_decorr_params import get_values_and_impacts_as_panda
 from wremnants.utilities import parsing
 from wremnants.utilities.io_tools import rabbit_input
 from wums import logging, output_tools, plot_tools
 
 ALPHA_S_SCALE_IMPACTS = 2
-
-
-def get_values_and_impacts_as_panda(
-    input_file,
-    partial_impacts_to_read=None,
-    global_impacts=False,
-    scale=1.0,
-    result=None,
-):
-    fitres, meta = rabbit.io_tools.get_fitresult(input_file, meta=True, result=result)
-    poi_names = rabbit.io_tools.get_poi_names(meta)
-    poi_values = []
-    totals = []
-    uncertainties = {}
-    for poi in poi_names:
-        impacts, labels = rabbit.io_tools.read_impacts_poi(
-            fitres,
-            poi,
-            grouped=True,
-            impact_type="global" if global_impacts else "traditional",
-        )
-        impacts = scale * impacts
-        totals.append([impacts[i] for i, k in enumerate(labels) if k == "Total"][0])
-        if uncertainties == {}:
-            uncertainties = {
-                f"err_{k}": [impacts[i]]
-                for i, k in enumerate(labels)
-                if (partial_impacts_to_read is None or k in partial_impacts_to_read)
-            }
-        else:
-            for i, k in enumerate(labels):
-                if partial_impacts_to_read and k not in partial_impacts_to_read:
-                    continue
-                uncertainties[f"err_{k}"].append(impacts[i])
-        poi_values.append(scale * fitres["parms"].get()[poi].value)
-
-    df = pd.DataFrame(
-        {"Name": poi_names, "value": poi_values, "err_Total": totals, **uncertainties}
-    )
-    print(df)
-    return df
 
 
 def get_yll_bin_edges(meta):

--- a/scripts/plotting/plot_alphaS_rapidity_decorr.py
+++ b/scripts/plotting/plot_alphaS_rapidity_decorr.py
@@ -132,6 +132,10 @@ if __name__ == "__main__":
     lumi = sum([c["lumi"] for c in meta["meta_info_input"]["channel_info"].values()])
 
     nll = fitresult["nllvalreduced"]
+    try:
+        nll_full = fitresult["nllvalfull"]
+    except (KeyError, IndexError):
+        nll_full = None
 
     yll_edges = get_yll_bin_edges(meta)
     if yll_edges is not None:
@@ -147,6 +151,10 @@ if __name__ == "__main__":
         )
         fInclusive = rabbit.io_tools.get_fitresult(args.infileInclusive)
         nll_inclusive = fInclusive["nllvalreduced"]
+        try:
+            nll_inclusive_full = fInclusive["nllvalfull"]
+        except (KeyError, IndexError):
+            nll_inclusive_full = None
 
     df = get_values_and_impacts_as_panda(
         args.infile,
@@ -235,6 +243,39 @@ if __name__ == "__main__":
             fontsize=args.legSize,
         )
 
+        if nll_full is not None and nll_inclusive_full is not None:
+            logger.info(
+                f"nll_inclusive_full = {nll_inclusive_full}; nll_full = {nll_full}"
+            )
+
+            chi2_stat_full = 2 * (nll_inclusive_full - nll_full)
+            chi2_label_full = r"\chi^2_\mathrm{full}/\mathrm{ndf}"
+            if args.result == "asimov":
+                chi2_stat_full = 0
+            elif not args.data:
+                chi2_stat_full += ndf
+                chi2_label_full = rf"\langle {chi2_label_full} \rangle"
+
+            p_value_full = 1 - chi2.cdf(chi2_stat_full, ndf)
+            logger.info(
+                f"ndf = {ndf}; Chi2 (full) = {chi2_stat_full}; p-value={p_value_full}"
+            )
+
+            ax1.text(
+                1.01,
+                0.65,
+                "\n".join(
+                    [
+                        rf"${chi2_label_full} = {chi2_stat_full:.1f}/{ndf}$",
+                        rf"$\mathit{{p}}_\mathrm{{full}} = {p_value_full * 100:.0f}\,\%$",
+                    ]
+                ),
+                ha="left",
+                va="center",
+                transform=ax1.transAxes,
+                fontsize=args.legSize,
+            )
+
         c = dfInclusive["value"].values[0]
         c_err = dfInclusive["err_Total"].values[0]
         c_err_stat = dfInclusive["err_stat"].values[0]
@@ -259,7 +300,7 @@ if __name__ == "__main__":
         )
         ax1.plot([c, c], ylim, color="black", linewidth=2, linestyle="-")
 
-        val -= c
+        # val -= c # TODO I don't think this should be here
 
     yticks = df["yticks"].values
     ax1.set_yticks(y, labels=yticks)
@@ -298,6 +339,7 @@ if __name__ == "__main__":
         capsize=10,
         linewidth=3,
     )
+    print(val, y)
     ax1.plot(val, y, color="black", marker="o", linestyle="", zorder=4)
 
     extra_handles = [

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -375,7 +375,7 @@ def make_parser(parser=None, argv=None):
     parser.add_argument(
         "--lumiUncertainty",
         type=float,
-        help=r"Uncertainty for luminosity in excess to 1 (e.g. 1.012 means 1.2%%); automatic by default",
+        help=r"Uncertainty for luminosity in excess to 1 (e.g. 1.012 means 1.2%%); automatic by default; if 0, treat as unconstrained with the automatic uncertainty as the size of the variation",
         default=None,
     )
     parser.add_argument(
@@ -948,12 +948,6 @@ def make_parser(parser=None, argv=None):
         default=1.05,
         type=float,
         help="Specify normalization uncertainty for Fake background (for W analysis). If negative, treat as free floating, if 0 nothing is added",
-    )
-    parser.add_argument(
-        "--fakelumi",
-        type=float,
-        default=0,
-        help="fake, unconstrained lumi.",
     )
     # pseudodata
     parser.add_argument(
@@ -1952,6 +1946,14 @@ def setup(
 
     # Below: experimental uncertainties
 
+    # lumiUncertainty of 0 means unconstrained, with the automatic uncertainty as the size of the variation
+    lumi_unconstrained = args.lumiUncertainty == 0
+    lumi_uncertainty = (
+        datagroups.lumi_uncertainty
+        if args.lumiUncertainty is None or lumi_unconstrained
+        else args.lumiUncertainty
+    )
+
     if wmass:
         # mirror hist in linear scale, this was done in the old definition of luminosity uncertainty from a histogram
         if "lumi" in args.decorrSystByVar and decorr_syst_var in fitvar:
@@ -1970,13 +1972,8 @@ def setup(
                     newDecorrAxesNames=[f"{decorr_syst_var}_"],
                 ),
                 preOp=scale_hist_up_down,
-                preOpArgs={
-                    "scale": (
-                        datagroups.lumi_uncertainty
-                        if args.lumiUncertainty is None
-                        else args.lumiUncertainty
-                    )
-                },
+                preOpArgs={"scale": lumi_uncertainty},
+                noConstraint=lumi_unconstrained,
             )
         else:
             datagroups.addSystematic(
@@ -1988,13 +1985,8 @@ def setup(
                 systAxes=["downUpVar"],
                 labelsByAxis=["downUpVar"],
                 preOp=scale_hist_up_down,
-                preOpArgs={
-                    "scale": (
-                        datagroups.lumi_uncertainty
-                        if args.lumiUncertainty is None
-                        else args.lumiUncertainty
-                    )
-                },
+                preOpArgs={"scale": lumi_uncertainty},
+                noConstraint=lumi_unconstrained,
             )
     else:
         datagroups.addNormSystematic(
@@ -2002,21 +1994,8 @@ def setup(
             processes=["MCwithLumiNorm"],
             groups=[f"luminosity", "experiment", "expNoCalib"],
             passToFakes=passSystToFakes,
-            norm=(
-                datagroups.lumi_uncertainty
-                if args.lumiUncertainty is None
-                else args.lumiUncertainty
-            ),
-        )
-
-    if args.fakelumi:
-        datagroups.addNormSystematic(
-            name="fakelumi",
-            processes=["MCwithLumiNorm"],
-            groups=["fakelumi", "experiment", "expNoCalib"],
-            passToFakes=passSystToFakes,
-            norm=args.fakelumi,
-            noConstraint=True,
+            norm=lumi_uncertainty,
+            noConstraint=lumi_unconstrained,
         )
 
     # add norm variations for decorrelated variable bins on each process

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -768,6 +768,18 @@ def make_parser(parser=None, argv=None):
         "Example: --scaleParams 'lambda4=5' 'mb_up|pdfMSHT20mbrange=10'",
     )
     parser.add_argument(
+        "--noConstrainParams",
+        nargs="*",
+        default=None,
+        metavar="REGEX",
+        help="Remove the Gaussian prior on shape systematics whose "
+        "per-direction name matches REGEX (re.search), turning them into "
+        "free-floating nuisances. Multiple regexes may be supplied. "
+        "Mirrors --scaleParams / --noSymmetrize wiring. "
+        "Example: --noConstrainParams 'scetlibNP' "
+        "(unconstrains all SCETlib NP nuisances).",
+    )
+    parser.add_argument(
         "--symmetrizePdfUnc",
         default="quadratic",
         type=str,
@@ -934,6 +946,12 @@ def make_parser(parser=None, argv=None):
         default=1.05,
         type=float,
         help="Specify normalization uncertainty for Fake background (for W analysis). If negative, treat as free floating, if 0 nothing is added",
+    )
+    parser.add_argument(
+        "--fakelumi",
+        type=float,
+        default=0,
+        help="fake, unconstrained lumi.",
     )
     # pseudodata
     parser.add_argument(
@@ -1190,6 +1208,18 @@ def setup(
             + ", ".join(f"'{p.pattern}'×{f}" for p, f in scale_params_pairs)
         )
     datagroups.scale_params_patterns = scale_params_pairs
+
+    # --noConstrainParams: list of compiled regexes applied at
+    # add_systematic time. Mirrors --scaleParams.
+    no_constraint_patterns = []
+    if args.noConstrainParams:
+        no_constraint_patterns = [re.compile(p) for p in args.noConstrainParams]
+        logger.info(
+            f"--noConstrainParams: {len(no_constraint_patterns)} pattern(s) "
+            f"registered: "
+            + ", ".join(f"'{p.pattern}'" for p in no_constraint_patterns)
+        )
+    datagroups.no_constraint_patterns = no_constraint_patterns
 
     preselection_specs = _build_preselection_specs(args.presel, fitvar)
     if preselection_specs:
@@ -1972,6 +2002,16 @@ def setup(
                 if args.lumiUncertainty is None
                 else args.lumiUncertainty
             ),
+        )
+
+    if args.fakelumi:
+        datagroups.addNormSystematic(
+            name="fakelumi",
+            processes=["MCwithLumiNorm"],
+            groups=["fakelumi", "experiment", "expNoCalib"],
+            passToFakes=passSystToFakes,
+            norm=args.fakelumi,
+            noConstraint=True,
         )
 
     # add norm variations for decorrelated variable bins on each process

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -482,9 +482,11 @@ def make_parser(parser=None, argv=None):
         help="Decorrelate POI for given axes, fit multiple POIs for the different POIs",
     )
     parser.add_argument(
-        "--fitAlphaSRapidityDecorr",
-        action="store_true",
-        help="Decorrelate alphaS POI by rapidity bins, fitting independent alphaS per rapidity bin",
+        "--fitAlphasDecorr",
+        type=str,
+        default=[],
+        nargs="*",
+        help="Decorrelate POI for given axes, fit multiple POIs for the different POIs",
     )
     parser.add_argument(
         "--decorrRebin",
@@ -1875,7 +1877,10 @@ def setup(
 
         theory_helper.add_pdf_alphas_variation(
             noi="alphaS" in args.noi,
-            fitAlphaSRapidityDecorr=args.fitAlphaSRapidityDecorr,
+            decorr_axes=args.fitAlphasDecorr,
+            decorr_axlim=args.decorrAxlim,
+            decorr_rebin=args.decorrRebin,
+            decorr_absval=args.decorrAbsval,
         )
 
         if not stat_only and not args.noTheoryUnc:

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -482,6 +482,11 @@ def make_parser(parser=None, argv=None):
         help="Decorrelate POI for given axes, fit multiple POIs for the different POIs",
     )
     parser.add_argument(
+        "--fitAlphaSRapidityDecorr",
+        action="store_true",
+        help="Decorrelate alphaS POI by rapidity bins, fitting independent alphaS per rapidity bin",
+    )
+    parser.add_argument(
         "--decorrRebin",
         type=int,
         nargs="*",
@@ -1840,6 +1845,7 @@ def setup(
 
         theory_helper.add_pdf_alphas_variation(
             noi="alphaS" in args.noi,
+            fitAlphaSRapidityDecorr=args.fitAlphaSRapidityDecorr,
         )
 
         if not stat_only and not args.noTheoryUnc:

--- a/wremnants/postprocessing/datagroups/datagroups.py
+++ b/wremnants/postprocessing/datagroups/datagroups.py
@@ -144,6 +144,13 @@ class Datagroups(object):
         # ValueError.
         self.scale_params_patterns = []
 
+        # List of compiled regex patterns. For each systematic variation
+        # written via addSystematic, if its per-direction name matches any
+        # pattern (re.search), the Gaussian prior on that nuisance is
+        # removed (noConstraint=True). Mirrors the --scaleParams /
+        # --noSymmetrize wiring.
+        self.no_constraint_patterns = []
+
         self.writer = None
 
     def get_members_from_results(self, startswith=[], not_startswith=[], is_data=False):
@@ -1391,7 +1398,9 @@ class Datagroups(object):
             else:
                 name = histname
 
-        logger.info(f"Now in channel {self.channel} at shape systematic group {name}")
+        logger.info(
+            f"Now in channel {self.channel} at shape systematic group {name} (constraint: {not noConstraint})"
+        )
 
         if self.isExcludedNuisance(name):
             return
@@ -1522,6 +1531,18 @@ class Datagroups(object):
                         f"{effective_scale} (pattern '{pat.pattern}' x {fac})"
                     )
 
+                # --noConstrainParams: remove Gaussian prior for matching
+                # nuisances. Mirrors --scaleParams / --noSymmetrize.
+                effective_noConstraint = noConstraint
+                no_const_patterns = getattr(self, "no_constraint_patterns", [])
+                nc_matched = [p for p in no_const_patterns if p.search(var_name)]
+                if nc_matched and not noConstraint:
+                    effective_noConstraint = True
+                    logger.info(
+                        f"noConstrainParams: removing prior on {var_name} "
+                        f"(pattern(s) {[p.pattern for p in nc_matched]})"
+                    )
+
                 if lastAction is not None:
                     if lastActionRequiresNomi:
                         hnom = self.groups[proc].hists[self.nominalName]
@@ -1546,7 +1567,7 @@ class Datagroups(object):
                     symmetrize=effective_symmetrize,
                     kfactor=effective_scale,
                     noi=noi,
-                    constrained=not noConstraint,
+                    constrained=not effective_noConstraint,
                     add_to_data_covariance=self.isAbsorbedNuisance(name),
                 )
 

--- a/wremnants/postprocessing/rabbit_theory_helper.py
+++ b/wremnants/postprocessing/rabbit_theory_helper.py
@@ -4,6 +4,7 @@ import hist
 import numpy as np
 
 from wremnants.postprocessing import syst_tools
+from wremnants.postprocessing.rabbit_helpers import decorrelateByAxes
 from wremnants.postprocessing.theory_variation_labels import (
     BC_QUARK_MASS_VARIATIONS,
     LATTICE_GAMMA_NP_UNCERTAINTIES,
@@ -1078,7 +1079,7 @@ class TheoryHelper(object):
                     **tmp_pdf_args,
                 )
 
-    def add_pdf_alphas_variation(self, noi=False):
+    def add_pdf_alphas_variation(self, noi=False, fitAlphaSRapidityDecorr=False):
         pdf = self.datagroups.args_from_metadata("pdfs")[0]
         pdfInfo = theory_utils.pdf_info_map("Zmumu_2016PostVFP", pdf)
         pdfName = pdfInfo["name"]
@@ -1146,6 +1147,42 @@ class TheoryHelper(object):
         else:
             as_args["systNameReplace"] = as_replace
             as_args["skipEntries"] = [{"alphasVar": "as0118"}]
+
+        if fitAlphaSRapidityDecorr:
+            rapidity_axes = {"yll", "absYVGen", "absEtaGen", "absY", "yVGen"}
+            rapidity_axis = next(
+                (v for v in self.datagroups.fit_axes if v in rapidity_axes), None
+            )
+            if rapidity_axis is None:
+                raise ValueError(
+                    f"Cannot decorrelate alphaS by rapidity: no rapidity axis found in fit variables {self.datagroups.fit_axes}"
+                )
+            new_name = f"{rapidity_axis}_decorr"
+            as_args["systAxes"] = [*as_args["systAxes"], new_name]
+            as_args["name"] = "pdfAlphaSDecorrRapidity"
+            as_args["group"] = "pdfAlphaSDecorr"
+            as_args["isPoiHistDecorr"] = 1
+            as_args["actionRequiresNomi"] = True
+            as_args["action"] = decorrelateByAxes
+            as_args["actionArgs"] = dict(
+                axesToDecorrNames=[rapidity_axis],
+                newDecorrAxesNames=[new_name],
+                axlim=[],
+                rebin=[],
+                absval=[],
+            )
+            # outNames is positional (fixed length 3) and can't handle the
+            # expanded rapidity bins; switch to systNameReplace + skipEntries
+            # which work with any number of variations
+            if self.as_from_corr:
+                as_args.pop("outNames")
+                if as_range == "002":
+                    as_corr_replace = [("0116", "Down"), ("0120", "Up")]
+                elif as_range == "001":
+                    as_corr_replace = [("0117", "Down"), ("0119", "Up")]
+                as_args["systNameReplace"] = as_corr_replace
+                as_args["skipEntries"] = [{"vars": ".*0118"}]
+
         logger.info(f"Using alphaS variation {asname}, applying scaling of {scale}")
         self.datagroups.addSystematic(**as_args)
 

--- a/wremnants/postprocessing/rabbit_theory_helper.py
+++ b/wremnants/postprocessing/rabbit_theory_helper.py
@@ -1079,7 +1079,14 @@ class TheoryHelper(object):
                     **tmp_pdf_args,
                 )
 
-    def add_pdf_alphas_variation(self, noi=False, fitAlphaSRapidityDecorr=False):
+    def add_pdf_alphas_variation(
+        self,
+        noi=False,
+        decorr_axes=[],
+        decorr_axlim=[],
+        decorr_rebin=[],
+        decorr_absval=[],
+    ):
         pdf = self.datagroups.args_from_metadata("pdfs")[0]
         pdfInfo = theory_utils.pdf_info_map("Zmumu_2016PostVFP", pdf)
         pdfName = pdfInfo["name"]
@@ -1148,31 +1155,29 @@ class TheoryHelper(object):
             as_args["systNameReplace"] = as_replace
             as_args["skipEntries"] = [{"alphasVar": "as0118"}]
 
-        if fitAlphaSRapidityDecorr:
-            rapidity_axes = {"yll", "absYVGen", "absEtaGen", "absY", "yVGen"}
-            rapidity_axis = next(
-                (v for v in self.datagroups.fit_axes if v in rapidity_axes), None
-            )
-            if rapidity_axis is None:
+        if decorr_axes:
+            missing = [a for a in decorr_axes if a not in self.datagroups.fit_axes]
+            if missing:
                 raise ValueError(
-                    f"Cannot decorrelate alphaS by rapidity: no rapidity axis found in fit variables {self.datagroups.fit_axes}"
+                    f"Cannot decorrelate alphaS: axes {missing} not found in fit variables {self.datagroups.fit_axes}"
                 )
-            new_name = f"{rapidity_axis}_decorr"
-            as_args["systAxes"] = [*as_args["systAxes"], new_name]
-            as_args["name"] = "pdfAlphaSDecorrRapidity"
+            suffix = "".join([a.capitalize() for a in decorr_axes])
+            new_names = [f"{a}_decorr" for a in decorr_axes]
+            as_args["systAxes"] = [*as_args["systAxes"], *new_names]
+            as_args["name"] = f"pdfAlphaSDecorr{suffix}"
             as_args["group"] = "pdfAlphaSDecorr"
-            as_args["isPoiHistDecorr"] = 1
+            as_args["isPoiHistDecorr"] = len(decorr_axes)
             as_args["actionRequiresNomi"] = True
             as_args["action"] = decorrelateByAxes
             as_args["actionArgs"] = dict(
-                axesToDecorrNames=[rapidity_axis],
-                newDecorrAxesNames=[new_name],
-                axlim=[],
-                rebin=[],
-                absval=[],
+                axesToDecorrNames=decorr_axes,
+                newDecorrAxesNames=new_names,
+                axlim=decorr_axlim,
+                rebin=decorr_rebin,
+                absval=decorr_absval,
             )
             # outNames is positional (fixed length 3) and can't handle the
-            # expanded rapidity bins; switch to systNameReplace + skipEntries
+            # expanded decorrelation bins; switch to systNameReplace + skipEntries
             # which work with any number of variations
             if self.as_from_corr:
                 as_args.pop("outNames")

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -834,7 +834,7 @@ def plot_parser():
         help="Base path for output",
     )
     parser.add_argument(
-        "-f", "--outfolder", type=str, default="./test", help="Subfolder for output"
+        "-f", "--outfolder", type=str, default=".", help="Subfolder for output"
     )
     parser.add_argument(
         "-p", "--postfix", type=str, help="Postfix for output file name"

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -834,7 +834,7 @@ def plot_parser():
         help="Base path for output",
     )
     parser.add_argument(
-        "-f", "--outfolder", type=str, default=".", help="Subfolder for output"
+        "-f", "--outfolder", type=str, default="./test", help="Subfolder for output"
     )
     parser.add_argument(
         "-p", "--postfix", type=str, help="Postfix for output file name"


### PR DESCRIPTION
Adds support for decorrelating the alpha_s nuisance across rapidity bins (`setupRabbit.py` option + `TheoryHelper`), with a plotting script for the decorrelated parameters.

The SCETlib NP continuous parameter model originally in this PR has been split out into its own PR.