### PR TITLE
Enhancements for dxybs

### DIFF
--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -106,9 +106,6 @@ gatherProcesses_ = {
 }
 
 
-#########################################################################
-
-
 def common_plot_parser():
     parser = parsing.base_parser()
     parser.add_argument(

--- a/scripts/analysisTools/plotUtils/utility.py
+++ b/scripts/analysisTools/plotUtils/utility.py
@@ -1951,6 +1951,7 @@ def drawNTH1(
     yAxisExtendConstant=1.2,
     markerStyleFirstHistogram=20,
     useLineFirstHistogram=False,
+    colorFirstHistogram=None,
     fillStyleSecondHistogram=3004,
     fillColorSecondHistogram=None,
     colorVec=None,
@@ -2034,6 +2035,8 @@ def drawNTH1(
     if useLineFirstHistogram:
         h1.SetMarkerSize(0)
         h1.SetLineWidth(lineWidth)
+        if colorFirstHistogram:
+            h1.SetLineColor(colorFirstHistogram)
     else:
         h1.SetMarkerColor(ROOT.kBlack)
         h1.SetMarkerStyle(markerStyleFirstHistogram)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -38,6 +38,7 @@ from wremnants.production.histmaker_tools import (
     aggregate_groups,
     define_norm_weight_nRecoVtx,
     get_run_lumi_edges,
+    make_muon_dxybs_axis,
     make_muon_phi_axis,
     scale_to_data,
     write_analysis_output,
@@ -177,10 +178,8 @@ if args.useRefinedVeto and args.useGlobalOrTrackerVeto:
         "Options --useGlobalOrTrackerVeto and --useRefinedVeto cannot be used together at the moment."
     )
 
-if args.useRefinedVeto:
-    pass
-else:
-    pass
+if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
+    raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
 
 if args.unfolding or args.theoryAgnostic:
     if args.theoryAgnostic:
@@ -481,7 +480,7 @@ axis_dxybs = hist.axis.Regular(
     args.dxybs,
     name="dxybs",
     underflow=False,
-    overflow=True,
+    overflow=False,
 )
 axis_hasjet_fakes = hist.axis.Boolean(
     name="hasJets"
@@ -769,6 +768,10 @@ def build_graph(df, dataset):
     axes = nominal_axes
     cols = nominal_cols
 
+    if args.addMuonDxybsAxis is not None:
+        axes = [*axes, make_muon_dxybs_axis(args.addMuonDxybsAxis)]
+        cols = [*cols, "goodMuons_dxybs0"]
+
     if args.addMuonPhiAxis is not None:
         axes = [*axes, make_muon_phi_axis(args.addMuonPhiAxis)]
         cols = [*cols, "goodMuons_phi0"]
@@ -998,7 +1001,7 @@ def build_graph(df, dataset):
         ptCut=args.vetoRecoPt,
         etaCut=args.vetoRecoEta,
         staPtCut=args.vetoRecoStaPt,
-        dxybsCut=args.dxybs,
+        dxybsCut=args.dxybsVeto if args.dxybsVeto > 0 else args.dxybs,
         useGlobalOrTrackerVeto=useGlobalOrTrackerVeto,
     )
     df = muon_selections.select_good_muons(
@@ -1012,6 +1015,7 @@ def build_graph(df, dataset):
         nonPromptFromSV=args.selectNonPromptFromSV,
         nonPromptFromLighMesonDecay=args.selectNonPromptFromLightMesonDecay,
         requirePixelHits=args.requirePixelHits,
+        dxybsCut=args.dxybs,
     )
 
     # the corrected RECO muon kinematics, which is intended to be used as the nominal
@@ -1716,8 +1720,9 @@ def build_graph(df, dataset):
 
         # Defined as Threshold - |dxybs| so that for signal it peaks at Threshold instead of 0
         # for convenience in the later study
+        df = df.Define("goodMuons_dxybs0", f"std::abs(Muon_dxybs[goodMuons][0])")
         df = df.Define(
-            "goodMuons_dxybs0", f"{args.dxybs} - abs(Muon_dxybs[goodMuons][0])"
+            "goodMuons_dxybsFlip0", f"{args.dxybs} - std::abs(goodMuons_dxybs0)"
         )
 
         mTStudyForFakes = df.HistoBoost(
@@ -1743,7 +1748,7 @@ def build_graph(df, dataset):
                 "goodMuons_eta0",
                 "goodMuons_pt0",
                 "goodMuons_charge0",
-                "goodMuons_dxybs0",
+                "goodMuons_dxybsFlip0",
                 "passIso",
                 "passMT",
                 "nominal_weight",

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -1721,9 +1721,7 @@ def build_graph(df, dataset):
         # Defined as Threshold - |dxybs| so that for signal it peaks at Threshold instead of 0
         # for convenience in the later study
         df = df.Define("goodMuons_dxybs0", f"std::abs(Muon_dxybs[goodMuons][0])")
-        df = df.Define(
-            "goodMuons_dxybsFlip0", f"{args.dxybs} - std::abs(goodMuons_dxybs0)"
-        )
+        df = df.Define("goodMuons_dxybsFlip0", f"{args.dxybs} - goodMuons_dxybs0")
 
         mTStudyForFakes = df.HistoBoost(
             "mTStudyForFakes",

--- a/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
@@ -39,6 +39,9 @@ logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
 args = parser.parse_args()
 
+if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
+    raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
+
 thisAnalysis = ROOT.wrem.AnalysisType.Wmass
 
 era = args.era
@@ -214,6 +217,7 @@ def build_graph(df, dataset):
         etaCut=3.0,
         useGlobalOrTrackerVeto=False,
         tightGlobalOrTracker=True,
+        dxybsCut=args.dxybsVeto if args.dxybsVeto > 0 else args.dxybs,
     )
     # might have more veto muons, but will look for at least one gen matched to the only gen muon
     df = df.Define("oneOrMoreVetoMuons", "Sum(vetoMuons) > 0")

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -128,6 +128,9 @@ args = parser.parse_args()
 
 logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
+if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
+    raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
+
 thisAnalysis = (
     ROOT.wrem.AnalysisType.Dilepton
     if args.useDileptonTriggerSelection
@@ -629,7 +632,13 @@ def build_graph(df, dataset):
         df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper
     )
 
-    df = muon_selections.select_veto_muons(df, nMuons=2)
+    df = muon_selections.select_veto_muons(
+        df,
+        nMuons=2,
+        etaCut=args.vetoRecoEta,
+        staPtCut=args.vetoRecoStaPt,
+        dxybsCut=args.dxybsVeto if args.dxybsVeto > 0 else args.dxybs,
+    )
     isoThreshold = args.isolationThreshold
     passIsoBoth = args.muonIsolation[0] + args.muonIsolation[1] == 2
     df = muon_selections.select_good_muons(
@@ -643,6 +652,7 @@ def build_graph(df, dataset):
         isoBranch=isoBranch,
         isoThreshold=isoThreshold,
         requirePixelHits=args.requirePixelHits,
+        dxybsCut=args.dxybs,
     )
 
     df = muon_selections.define_trigger_muons(

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -131,6 +131,10 @@ if args.useRefinedVeto and args.useGlobalOrTrackerVeto:
     raise NotImplementedError(
         "Options --useGlobalOrTrackerVeto and --useRefinedVeto cannot be used together at the moment."
     )
+
+if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
+    raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
+
 if args.validateVetoSF:
     if args.useGlobalOrTrackerVeto or not args.useRefinedVeto:
         raise NotImplementedError(
@@ -311,7 +315,9 @@ theory_helpers_procs = theory_corrections.make_theory_helpers(
 )
 
 # extra axes which can be used to label tensor_axes
-if args.binnedScaleFactors:
+if args.noScaleFactors:
+    logger.info("Running with no scale factors")
+elif args.binnedScaleFactors:
     logger.info("Using binned scale factors and uncertainties")
     # add usePseudoSmoothing=True for tests with Asimov
     muon_efficiency_helper, muon_efficiency_helper_syst, muon_efficiency_helper_stat = (
@@ -336,18 +342,19 @@ else:
 logger.info(f"SF file: {args.sfFile}")
 
 muon_efficiency_helper_syst_altBkg = {}
-for es in common.muonEfficiency_altBkgSyst_effSteps:
-    altSFfile = args.sfFile.replace(".root", "_altBkg.root")
-    logger.info(f"Additional SF file for alternate syst with {es}: {altSFfile}")
-    muon_efficiency_helper_syst_altBkg[es] = (
-        muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth_altSyst(
-            filename=altSFfile,
-            era=era,
-            what_analysis=thisAnalysis,
-            max_pt=axis_pt.edges[-1],
-            effStep=es,
+if not args.noScaleFactors:
+    for es in common.muonEfficiency_altBkgSyst_effSteps:
+        altSFfile = args.sfFile.replace(".root", "_altBkg.root")
+        logger.info(f"Additional SF file for alternate syst with {es}: {altSFfile}")
+        muon_efficiency_helper_syst_altBkg[es] = (
+            muon_efficiencies_smooth.make_muon_efficiency_helpers_smooth_altSyst(
+                filename=altSFfile,
+                era=era,
+                what_analysis=thisAnalysis,
+                max_pt=axis_pt.edges[-1],
+                effStep=es,
+            )
         )
-    )
 
 if args.validateVetoSF:
     logger.warning(
@@ -624,7 +631,14 @@ def build_graph(df, dataset):
         df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper
     )
 
-    df = muon_selections.select_veto_muons(df, nMuons=2, ptCut=args.vetoRecoPt)
+    df = muon_selections.select_veto_muons(
+        df,
+        nMuons=2,
+        ptCut=args.vetoRecoPt,
+        etaCut=args.vetoRecoEta,
+        staPtCut=args.vetoRecoStaPt,
+        dxybsCut=args.dxybsVeto if args.dxybsVeto > 0 else args.dxybs,
+    )
 
     isoThreshold = args.isolationThreshold
 
@@ -645,6 +659,7 @@ def build_graph(df, dataset):
             isoThreshold=isoThreshold,
             requirePixelHits=args.requirePixelHits,
             requireID=False,
+            dxybsCut=args.dxybs,
         )
         df = muon_selections.define_trigger_muons(df)
         # apply lower pt cut and medium ID on triggering muon
@@ -1388,38 +1403,39 @@ def build_graph(df, dataset):
 
     if not dataset.is_data and not args.onlyMainHistograms:
 
-        df = systematics.add_muon_efficiency_unc_hists(
-            results,
-            df,
-            muon_efficiency_helper_stat,
-            muon_efficiency_helper_syst,
-            axes,
-            cols,
-            what_analysis=thisAnalysis,
-            singleMuonCollection="trigMuons",
-            smooth3D=args.smooth3dsf,
-        )
-        for es in common.muonEfficiency_altBkgSyst_effSteps:
-            df = systematics.add_muon_efficiency_unc_hists_altBkg(
+        if not args.noScaleFactors:
+            df = systematics.add_muon_efficiency_unc_hists(
                 results,
                 df,
-                muon_efficiency_helper_syst_altBkg[es],
+                muon_efficiency_helper_stat,
+                muon_efficiency_helper_syst,
                 axes,
                 cols,
-                singleMuonCollection="trigMuons",
                 what_analysis=thisAnalysis,
-                step=es,
+                singleMuonCollection="trigMuons",
+                smooth3D=args.smooth3dsf,
             )
-        if args.validateVetoSF:
-            df = systematics.add_muon_efficiency_veto_unc_hists(
-                results,
-                df,
-                muon_efficiency_veto_helper_stat,
-                muon_efficiency_veto_helper_syst,
-                axes,
-                cols,
-                muons="nonTrigMuons",
-            )
+            for es in common.muonEfficiency_altBkgSyst_effSteps:
+                df = systematics.add_muon_efficiency_unc_hists_altBkg(
+                    results,
+                    df,
+                    muon_efficiency_helper_syst_altBkg[es],
+                    axes,
+                    cols,
+                    singleMuonCollection="trigMuons",
+                    what_analysis=thisAnalysis,
+                    step=es,
+                )
+            if args.validateVetoSF:
+                df = systematics.add_muon_efficiency_veto_unc_hists(
+                    results,
+                    df,
+                    muon_efficiency_veto_helper_stat,
+                    muon_efficiency_veto_helper_syst,
+                    axes,
+                    cols,
+                    muons="nonTrigMuons",
+                )
 
         if era == "2016PostVFP" and args.addRunAxis and not args.randomizeDataByRun:
             # to simplify the code, use helper with largest uncertainty for all eras when splitting data

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -26,6 +26,9 @@ args = parser.parse_args()
 
 logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
+if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
+    raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
+
 datasets = getDatasets(
     maxFiles=args.maxFiles,
     filt=args.filterProcs,
@@ -133,9 +136,16 @@ def build_graph(df, dataset):
         df, cvh_helper, jpsi_helper, args, dataset, smearing_helper, bias_helper
     )
 
-    df = muon_selections.select_veto_muons(df, nMuons=-1)
+    df = muon_selections.select_veto_muons(
+        df,
+        nMuons=-1,
+        ptCut=args.vetoRecoPt,
+        etaCut=args.vetoRecoEta,
+        staPtCut=args.vetoRecoStaPt,
+        dxybsCut=args.dxybsVeto if args.dxybsVeto > 0 else args.dxybs,
+    )
     df = muon_selections.select_good_muons(
-        df, ptLow=0.0, ptHigh=1e6, nMuons=-1, datasetGroup=None
+        df, ptLow=0.0, ptHigh=1e6, nMuons=-1, datasetGroup=None, dxybsCut=args.dxybs
     )
 
     df = df.Define(

--- a/wremnants/production/histmaker_tools.py
+++ b/wremnants/production/histmaker_tools.py
@@ -353,6 +353,14 @@ def make_muon_phi_axis(phi_bins, ax_name="phi", flows=False):
     return phi_axis
 
 
+def make_muon_dxybs_axis(edges, ax_name="dxybs", overflow=True):
+    ret_axis = hist.axis.Variable(
+        np.array(edges), name=ax_name, underflow=False, overflow=overflow
+    )
+
+    return ret_axis
+
+
 def define_norm_weight_nRecoVtx(
     df, vtx_axis_edges, vtx_norm_weight, flows_to_unit=False
 ):

--- a/wremnants/production/muon_efficiencies_smooth.py
+++ b/wremnants/production/muon_efficiencies_smooth.py
@@ -20,7 +20,9 @@ narf.clingutils.Declare('#include "muon_efficiencies_smooth.hpp"')
 data_dir = common.data_dir
 
 
-def cloneAxis(ax, overflow=False, underflow=False, newName=None):
+def cloneAxis(
+    ax, overflow=False, underflow=False, newName=None, raiseNotImplemented=True
+):
     axName = newName if newName else ax.name
     if isinstance(ax, bh.axis.Regular):
         newax = hist.axis.Regular(
@@ -36,10 +38,15 @@ def cloneAxis(ax, overflow=False, underflow=False, newName=None):
             ax.edges, name=axName, overflow=overflow, underflow=underflow
         )
     else:
-        logger.error(
-            f"In cloneAxis(): only Regular and Variable axes are supported for now"
-        )
-        quit()
+        msg = "In cloneAxis(): only Regular and Variable axes are supported for now"
+        if raiseNotImplemented:
+            raise NotImplementedError(msg)
+        else:
+            logger.warning(msg)
+            logger.warning(
+                f"Returning original axis {ax.name} since raiseNotImplemented=False"
+            )
+            newax = ax
     return newax
 
 

--- a/wremnants/production/muon_selections.py
+++ b/wremnants/production/muon_selections.py
@@ -76,7 +76,7 @@ def select_veto_muons(
     # tightGlobalOrTracker relevant only when useGlobalOrTrackerVeto = True
     df = df.Define(
         "vetoMuonsPre",
-        f"Muon_looseId && std::abs(Muon_dxybs) < {dxybsCut} && Muon_correctedCharge != -99",
+        f"Muon_looseId && abs(Muon_dxybs) < {dxybsCut} && Muon_correctedCharge != -99",
     )
     nHitsSA = common.muonEfficiency_standaloneNumberOfValidHits
     df = df.Define(
@@ -135,7 +135,7 @@ def select_good_muons(
         df = df.Define("Muon_category", "Muon_isGlobal && Muon_highPurity")
 
     goodMuonsSelection = f"Muon_correctedPt > {ptLow} && Muon_correctedPt < {ptHigh} && vetoMuons && Muon_category"
-    goodMuonsSelection += f" std::abs(Muon_dxybs) < {dxybsCut}"  # apply here as well because threshold might differ from the one in vetoMuons
+    goodMuonsSelection += f" abs(Muon_dxybs) < {dxybsCut}"  # apply here as well because threshold might differ from the one in vetoMuons
 
     if nonPromptFromSV:
         # medium ID added afterwards

--- a/wremnants/production/muon_selections.py
+++ b/wremnants/production/muon_selections.py
@@ -76,7 +76,7 @@ def select_veto_muons(
     # tightGlobalOrTracker relevant only when useGlobalOrTrackerVeto = True
     df = df.Define(
         "vetoMuonsPre",
-        f"Muon_looseId && abs(Muon_dxybs) < {dxybsCut} && Muon_correctedCharge != -99",
+        f"Muon_looseId && std::abs(Muon_dxybs) < {dxybsCut} && Muon_correctedCharge != -99",
     )
     nHitsSA = common.muonEfficiency_standaloneNumberOfValidHits
     df = df.Define(
@@ -122,6 +122,7 @@ def select_good_muons(
     nonPromptFromLighMesonDecay=False,
     requirePixelHits=False,
     requireID=True,
+    dxybsCut=0.05,
 ):
 
     # requireID can be set to False to remove ID from the selection (it doesn't override the nonprompt control regions with light mesons decay though)
@@ -134,12 +135,13 @@ def select_good_muons(
         df = df.Define("Muon_category", "Muon_isGlobal && Muon_highPurity")
 
     goodMuonsSelection = f"Muon_correctedPt > {ptLow} && Muon_correctedPt < {ptHigh} && vetoMuons && Muon_category"
+    goodMuonsSelection += f" std::abs(Muon_dxybs) < {dxybsCut}"  # apply here as well because threshold might differ from the one in vetoMuons
 
     if nonPromptFromSV:
         # medium ID added afterwards
         df = select_good_secondary_vertices(df)
         # match by index
-        # FIXME: result is not as expected, somthing might be wrong here (either in nanoAOD or in accessing it) disabled for now
+        # FIXME: result is not as expected, something might be wrong here (either in nanoAOD or in accessing it) disabled for now
         # df = df.Define("Muon_goodSV", "ROOT::VecOps::Take(goodSV, Muon_svIdx, 0)")
         # goodMuonsSelection += " && Muon_sip3d > 4.0 && Muon_goodSV"
 

--- a/wremnants/production/muon_selections.py
+++ b/wremnants/production/muon_selections.py
@@ -135,7 +135,7 @@ def select_good_muons(
         df = df.Define("Muon_category", "Muon_isGlobal && Muon_highPurity")
 
     goodMuonsSelection = f"Muon_correctedPt > {ptLow} && Muon_correctedPt < {ptHigh} && vetoMuons && Muon_category"
-    goodMuonsSelection += f" abs(Muon_dxybs) < {dxybsCut}"  # apply here as well because threshold might differ from the one in vetoMuons
+    goodMuonsSelection += f" && abs(Muon_dxybs) < {dxybsCut}"  # apply here as well because threshold might differ from the one in vetoMuons
 
     if nonPromptFromSV:
         # medium ID added afterwards

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -594,6 +594,17 @@ def common_parser(analysis_label=""):
             Specify a list of weights (one less item than --addNvtxAxis)
             """,
         )
+        parser.add_argument(
+            "--addMuonDxybsAxis",
+            type=float,
+            default=None,
+            nargs="+",
+            help="""
+            Add another fit axis with the muon dxybs (absolute value).
+            Specify a list of bin edges (the number of bins is inferred accordingly).
+            The overflow bin is created to contain everything above the last edge.
+        """,
+        )
 
     commonargs, _ = parser.parse_known_args()
 

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -529,6 +529,13 @@ def common_parser(analysis_label=""):
             help="Upper threshold for muon absolute dxy with respect to beamspot",
         )
         parser.add_argument(
+            "--dxybsVeto",
+            default=-1,
+            type=float,
+            help="""Upper threshold for muon absolute dxy with respect to beamspot for veto muons.
+            If negative, use the same value as in --dxybs""",
+        )
+        parser.add_argument(
             "--oneMCfileEveryN",
             type=int,
             default=None,


### PR DESCRIPTION
This PR adds a configurable dxybs threshold for the muon veto, making it possible to use a different value with respect to the final muons.
Also, adding an option to add one more axis with |dxybs|. Eventually this might replace mT in the ABCD method, but for now it is just an additional axis which can be used with few bins to reproduce different selections on the fly (e.g. with option --presel in setupRabbit.py)