### PR TITLE
muon_calibration: ONNX-backed shift+smear reweight pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
       - name: setup 1:1 data:mc events
         if: github.event_name != 'pull_request' && github.event.schedule != '30 5 * * 1-5'
         run: |
-          echo "NTHREADS=128" >> $GITHUB_ENV
+          echo "NTHREADS=64" >> $GITHUB_ENV
           echo "MAX_FILES=-2" >> $GITHUB_ENV
           echo "LUMI_SCALE=1" >> $GITHUB_ENV
           echo "NOMINAL_FAKE_SMOOTHING=full" >> $GITHUB_ENV
@@ -1304,9 +1304,9 @@ jobs:
 
       - name: dilepton ptll from wlike
         run: >-
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py
-          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors
-          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB --noHessian
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py 
+          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors 
+          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB
           -o $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ --postfix from_ZMassWLike_eta_pt_charge --pseudoData uncorr
 
       - name: dilepton ptll from wlike postfit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
       - name: setup 1:1 data:mc events
         if: github.event_name != 'pull_request' && github.event.schedule != '30 5 * * 1-5'
         run: |
-          echo "NTHREADS=64" >> $GITHUB_ENV
+          echo "NTHREADS=128" >> $GITHUB_ENV
           echo "MAX_FILES=-2" >> $GITHUB_ENV
           echo "LUMI_SCALE=1" >> $GITHUB_ENV
           echo "NOMINAL_FAKE_SMOOTHING=full" >> $GITHUB_ENV
@@ -1304,9 +1304,9 @@ jobs:
 
       - name: dilepton ptll from wlike
         run: >-
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py 
-          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors 
-          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py
+          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors
+          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB --noHessian
           -o $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ --postfix from_ZMassWLike_eta_pt_charge --pseudoData uncorr
 
       - name: dilepton ptll from wlike postfit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Environment Setup
+
+Commands in this repository must be run inside the apptainer/singularity container at:
+
+```
+/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling
+```
+
+Check whether you are already inside the container by verifying the `SINGULARITY_CONTAINER` environment variable is set.
+
+If not inside the container, prefix commands with `scripts/ci/run_with_singularity.sh`:
+
+```bash
+scripts/ci/run_with_singularity.sh bash -c "source setup.sh && <command>"
+```
+
+If already inside the container, then commands can be run directly.
+
+## Verification
+
+To verify the environment is correctly set up, run:
+
+```bash
+python scripts/tests/testenv.py
+```
+
+Expected output ends with:
+```
+Successfully imported relevant packages
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ Commands in this repository must be run inside the apptainer/singularity contain
 /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling
 ```
 
-Check whether you are already inside the container by verifying the `SINGULARITY_CONTAINER` environment variable is set.
+or the corresponding docker/podman container at
+
+```
+gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling
+```
+
+Check whether you are already inside the container by checking if the `SINGULARITY_CONTAINER` or $container environment variable is set.
 
 If not inside the container, prefix commands with `scripts/ci/run_with_singularity.sh`:
 
@@ -14,7 +20,7 @@ If not inside the container, prefix commands with `scripts/ci/run_with_singulari
 scripts/ci/run_with_singularity.sh bash -c "source setup.sh && <command>"
 ```
 
-If already inside the container, then commands can be run directly.
+If already inside the container, then commands can be run directly (but still sourcing setup.sh).
 
 ## Verification
 

--- a/scripts/corrections/muon_calibration/arrow_shard_loader.py
+++ b/scripts/corrections/muon_calibration/arrow_shard_loader.py
@@ -24,14 +24,13 @@ from __future__ import annotations
 
 import json
 import os
-from typing import List, Sequence, Tuple
+from typing import List, Sequence
 
 import numpy as np
 import pyarrow as pa
 import pyarrow.ipc as ipc
 import torch
 import torch.utils.data as torch_data
-
 
 # ---------------------------------------------------------------------------
 # Per-muon schema (fp32 columns the snapshot script writes, plus int32
@@ -40,8 +39,13 @@ import torch.utils.data as torch_data
 # ---------------------------------------------------------------------------
 
 _RAW_FEATURE_COLUMNS = (
-    "eta_reco", "phi_reco", "eta_gen", "phi_gen",
-    "kappa_reco", "kappa_gen", "nominal_weight",
+    "eta_reco",
+    "phi_reco",
+    "eta_gen",
+    "phi_gen",
+    "kappa_reco",
+    "kappa_gen",
+    "nominal_weight",
     # ``muon_source`` is an int32 column on the shards (1, 15 or 443)
     # but enters the loader as a float feature in the cond vector.
     "muon_source",
@@ -50,7 +54,11 @@ _RAW_FEATURE_COLUMNS = (
 
 _TARGET_NAMES = ("r_kappa", "dlambda", "dphi")
 _COND_NAMES = (
-    "log_pt_gen", "charge", "lambda_gen", "sin_phi_gen", "cos_phi_gen",
+    "log_pt_gen",
+    "charge",
+    "lambda_gen",
+    "sin_phi_gen",
+    "cos_phi_gen",
     "muon_source",
 )
 
@@ -120,13 +128,9 @@ def split_batch_range(
     if split == "all":
         return 0, int(n_record_batches)
     if split not in _SPLIT_NAMES:
-        raise ValueError(
-            f"split must be one of {_SPLIT_NAMES}, got {split!r}"
-        )
+        raise ValueError(f"split must be one of {_SPLIT_NAMES}, got {split!r}")
     if not (0.0 <= val_fraction < 1.0):
-        raise ValueError(
-            f"val_fraction must be in [0, 1), got {val_fraction!r}"
-        )
+        raise ValueError(f"val_fraction must be in [0, 1), got {val_fraction!r}")
     if not (0.0 <= holdout_fraction < 1.0):
         raise ValueError(
             f"holdout_fraction must be in [0, 1), got {holdout_fraction!r}"
@@ -173,14 +177,13 @@ class TimedLoader:
 
     def __iter__(self):
         import time
+
         n_print = self.n_print
         label = self.label
         it = iter(self.loader)
         idx = 0
         if n_print > 0:
-            print(
-                f"[{label}] data-pipeline profile (first {n_print} batches):"
-            )
+            print(f"[{label}] data-pipeline profile (first {n_print} batches):")
         while True:
             t_req = time.perf_counter()
             try:
@@ -226,6 +229,7 @@ class StepProfiler:
 
     def __init__(self, enabled: bool, label: str, device: str = "cpu"):
         import time as _time
+
         self.enabled = bool(enabled)
         self.label = str(label)
         self.use_cuda = (
@@ -286,11 +290,13 @@ def dataloader_worker_init(worker_id: int):
     the worker count, not threads per worker).
     """
     import os
+
     os.environ["OMP_NUM_THREADS"] = "1"
     os.environ["MKL_NUM_THREADS"] = "1"
     os.environ["OPENBLAS_NUM_THREADS"] = "1"
     os.environ["NUMEXPR_NUM_THREADS"] = "1"
     import torch as _torch
+
     _torch.set_num_threads(1)
     try:
         _torch.set_num_interop_threads(1)
@@ -327,7 +333,8 @@ def _apply_weight_mode(w, mode):
 
 
 def resolve_shard_files(
-    input_files: Sequence[str], return_counts: bool = False,
+    input_files: Sequence[str],
+    return_counts: bool = False,
 ):
     """Expand the trainer's ``--input-files`` contract to a flat list
     of ``.arrow`` shard paths. Accepts:
@@ -433,10 +440,7 @@ def count_rows(shard_files: Sequence[str]) -> List[int]:
             if isinstance(r, ipc.RecordBatchFileReader):
                 # Sum num_rows per batch — read_all() would
                 # materialize the whole table.
-                n = sum(
-                    r.get_batch(i).num_rows
-                    for i in range(r.num_record_batches)
-                )
+                n = sum(r.get_batch(i).num_rows for i in range(r.num_record_batches))
             else:
                 n = r.read_all().num_rows
             counts.append(n)
@@ -480,9 +484,7 @@ def _per_batch_target_cond(cols: dict):
     lam_g = np.arctan(np.sinh(eta_g))
 
     r_kappa = kappa_r / kappa_g - 1.0
-    dphi = np.arctan2(
-        np.sin(phi_r - phi_g), np.cos(phi_r - phi_g)
-    )
+    dphi = np.arctan2(np.sin(phi_r - phi_g), np.cos(phi_r - phi_g))
     dlambda = lam_r - lam_g
 
     target = np.stack([r_kappa, dlambda, dphi], axis=1).astype(np.float32)
@@ -555,14 +557,14 @@ def _stats_chunk(arg):
                     if i >= batch_stop:
                         return
                     yield b
+
             batches = _walk()
 
         for batch in batches:
             cols = _read_raw_columns(batch)
             target, cond, w = _per_batch_target_cond(cols)
-            target_finite = (
-                np.isfinite(target).all(axis=1)
-                & np.isfinite(cond).all(axis=1)
+            target_finite = np.isfinite(target).all(axis=1) & np.isfinite(cond).all(
+                axis=1
             )
             w_out, w_keep = _apply_weight_mode(w, weight_mode)
             keep = target_finite & w_keep
@@ -581,13 +583,16 @@ def _stats_chunk(arg):
             abs_w_sum += float(np.fabs(w_out, dtype=np.float64).sum())
             n_kept += target.shape[0]
     finally:
-        if hasattr(reader, "close"): reader.close()
+        if hasattr(reader, "close"):
+            reader.close()
         src.close()
     return n_kept, t_sum, t_sq, c_sum, c_sq, w_sum, abs_w_sum, n_filt
 
 
 def _enumerate_chunks(
-    shard_files, batches_per_chunk: int, weight_mode: str,
+    shard_files,
+    batches_per_chunk: int,
+    weight_mode: str,
     split: str = "train",
     val_fraction: float = DEFAULT_VAL_FRACTION,
     holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
@@ -608,12 +613,16 @@ def _enumerate_chunks(
                 # Stream — count by walking (cheap-ish; metadata only).
                 n_b = sum(1 for _ in reader)
         finally:
-            if hasattr(reader, "close"): reader.close()
+            if hasattr(reader, "close"):
+                reader.close()
             src.close()
         if n_b == 0:
             continue
         lo, hi = split_batch_range(
-            n_b, split, val_fraction, holdout_fraction,
+            n_b,
+            split,
+            val_fraction,
+            holdout_fraction,
         )
         if hi <= lo:
             continue
@@ -666,7 +675,10 @@ def _compute_stats_robust(
             if isinstance(reader, ipc.RecordBatchFileReader):
                 n_b = reader.num_record_batches
                 lo, hi = split_batch_range(
-                    n_b, split, val_fraction, holdout_fraction,
+                    n_b,
+                    split,
+                    val_fraction,
+                    holdout_fraction,
                 )
                 batches_iter = (reader.get_batch(i) for i in range(lo, hi))
             else:
@@ -676,9 +688,8 @@ def _compute_stats_robust(
                     break
                 cols = _read_raw_columns(batch)
                 target, cond, w = _per_batch_target_cond(cols)
-                target_finite = (
-                    np.isfinite(target).all(axis=1)
-                    & np.isfinite(cond).all(axis=1)
+                target_finite = np.isfinite(target).all(axis=1) & np.isfinite(cond).all(
+                    axis=1
                 )
                 w_out, w_keep = _apply_weight_mode(w, weight_mode)
                 keep = target_finite & w_keep
@@ -704,7 +715,9 @@ def _compute_stats_robust(
             src.close()
 
     if n_total == 0:
-        raise RuntimeError("compute_stats_streaming(robust): zero rows survived filters")
+        raise RuntimeError(
+            "compute_stats_streaming(robust): zero rows survived filters"
+        )
 
     target_arr = np.concatenate(t_chunks, axis=0)
     cond_arr = np.concatenate(c_chunks, axis=0)
@@ -790,18 +803,17 @@ def compute_stats_streaming(
     bit of overshoot is possible.
     """
     # ``PreprocStats`` lives in the sibling trainer script.
-    from train_muon_response_flow import PreprocStats
-    from concurrent.futures import ProcessPoolExecutor
     import multiprocessing as mp
+    from concurrent.futures import ProcessPoolExecutor
+
+    from train_muon_response_flow import PreprocStats
 
     if weight_mode not in _WEIGHT_MODES:
         raise ValueError(
             f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
         )
     if split not in _SPLIT_NAMES:
-        raise ValueError(
-            f"split must be one of {_SPLIT_NAMES}, got {split!r}"
-        )
+        raise ValueError(f"split must be one of {_SPLIT_NAMES}, got {split!r}")
     if robust:
         # Dispatch to the sample-based median + 1.4826·MAD path.
         # Tail mass (e.g. r_kappa charge-mismeasurement peak) doesn't
@@ -809,7 +821,10 @@ def compute_stats_streaming(
         # width — what you actually want when the trainer's δ=1
         # perturbation is meant to span ~1 typical-event width.
         return _compute_stats_robust(
-            shard_files, int(robust_sample_rows), weight_mode, progress,
+            shard_files,
+            int(robust_sample_rows),
+            weight_mode,
+            progress,
             split=split,
             val_fraction=val_fraction,
             holdout_fraction=holdout_fraction,
@@ -826,7 +841,9 @@ def compute_stats_streaming(
         )
 
     tasks = _enumerate_chunks(
-        shard_files, batches_per_chunk, weight_mode,
+        shard_files,
+        batches_per_chunk,
+        weight_mode,
         split=split,
         val_fraction=val_fraction,
         holdout_fraction=holdout_fraction,
@@ -854,7 +871,7 @@ def compute_stats_streaming(
     ctx = mp.get_context("fork")
     with ProcessPoolExecutor(max_workers=n_workers, mp_context=ctx) as ex:
         for partial in ex.map(_stats_chunk, tasks):
-            (p_n, p_ts, p_tsq, p_cs, p_csq, p_ws, p_abs_ws, p_filt) = partial
+            p_n, p_ts, p_tsq, p_cs, p_csq, p_ws, p_abs_ws, p_filt = partial
             t_sum += p_ts
             t_sq += p_tsq
             c_sum += p_cs
@@ -898,7 +915,7 @@ def compute_stats_streaming(
 
     if progress:
         drop_label = {
-            "abs":  "w==0 or non-finite",
+            "abs": "w==0 or non-finite",
             "keep": "non-finite",
             "drop": "w<=0 or non-finite",
         }[weight_mode]
@@ -906,8 +923,11 @@ def compute_stats_streaming(
             f"  scanned {n_total:,} rows"
             + (f" (dropped {n_filt:,} {drop_label})" if n_filt else "")
             + f"; |weight| mean = {weight_mean:.4g}"
-            + (f", signed weight mean = {w_sum/n_total:.4g}"
-               if weight_mode == "keep" else "")
+            + (
+                f", signed weight mean = {w_sum/n_total:.4g}"
+                if weight_mode == "keep"
+                else ""
+            )
         )
 
     return (
@@ -973,13 +993,13 @@ class ArrowShardLoader(torch_data.IterableDataset):
     def __init__(
         self,
         shard_files: Sequence[str],
-        stats,                                 # PreprocStats
+        stats,  # PreprocStats
         weight_mean: float,
         *,
         world_size: int,
         rank: int,
         batch_size: int,
-        split: str = "train",                  # "train" | "val" | "holdout" | "all"
+        split: str = "train",  # "train" | "val" | "holdout" | "all"
         val_fraction: float = DEFAULT_VAL_FRACTION,
         holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
         shuffle: bool = True,
@@ -992,9 +1012,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
         num_workers_hint: int = 1,
     ):
         if split not in _SPLIT_NAMES:
-            raise ValueError(
-                f"split must be one of {_SPLIT_NAMES}, got {split!r}"
-            )
+            raise ValueError(f"split must be one of {_SPLIT_NAMES}, got {split!r}")
         if weight_mode not in _WEIGHT_MODES:
             raise ValueError(
                 f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
@@ -1045,9 +1063,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
         if self._my_row_counts is not None:
             per_shard_rows = self._my_row_counts
         else:
-            per_shard_rows = (
-                count_rows(self.my_shards) if self.my_shards else []
-            )
+            per_shard_rows = count_rows(self.my_shards) if self.my_shards else []
         my_rows = sum(per_shard_rows)
         # Row-count estimate matches the per-shard contiguous record-
         # batch range each split actually iterates. Train rounds up
@@ -1072,9 +1088,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
         # multi-worker total can exceed the single-process estimate
         # by up to ``num_workers``. tqdm reaches 100 % a handful of
         # iterations before the epoch finishes — fine.
-        ceil_len = (
-            (my_rows_split + self.batch_size - 1) // self.batch_size
-        )
+        ceil_len = (my_rows_split + self.batch_size - 1) // self.batch_size
         self._approx_len = max(
             ceil_len + self.num_workers_hint,
             1,
@@ -1117,8 +1131,10 @@ class ArrowShardLoader(torch_data.IterableDataset):
                     reader.close()
                 src.close()
             lo, hi = split_batch_range(
-                n_b, self.split,
-                self.val_fraction, self.holdout_fraction,
+                n_b,
+                self.split,
+                self.val_fraction,
+                self.holdout_fraction,
             )
             for b in range(lo, hi):
                 layout.append((s_idx, b))
@@ -1253,9 +1269,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
         # Distinct RNG per (rank, epoch) — independent shuffles across
         # workers but reproducible per (seed, rank, epoch).
         rng = np.random.default_rng(
-            (self.seed * 1_000_003)
-            ^ (self.rank * 7919 + 1)
-            ^ (epoch * 2_654_435_761)
+            (self.seed * 1_000_003) ^ (self.rank * 7919 + 1) ^ (epoch * 2_654_435_761)
         )
 
         if chunks is None:
@@ -1277,8 +1291,10 @@ class ArrowShardLoader(torch_data.IterableDataset):
                         reader.close()
                     src.close()
                 lo, hi = split_batch_range(
-                    n_b, self.split,
-                    self.val_fraction, self.holdout_fraction,
+                    n_b,
+                    self.split,
+                    self.val_fraction,
+                    self.holdout_fraction,
                 )
                 if hi > lo:
                     chunks.append((s_idx, list(range(lo, hi))))
@@ -1338,9 +1354,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
                     # re-decompresses earlier batches just to skip
                     # them), but functional.
                     idx_set = set(batch_indices)
-                    batches_iter = (
-                        b for i, b in enumerate(reader) if i in idx_set
-                    )
+                    batches_iter = (b for i, b in enumerate(reader) if i in idx_set)
                 for batch in batches_iter:
                     cols = _read_raw_columns(batch)
                     target, cond, w = _per_batch_target_cond(cols)
@@ -1353,10 +1367,9 @@ class ArrowShardLoader(torch_data.IterableDataset):
                     # applied at the record-batch level upstream (the
                     # caller hands us exactly the batches assigned to
                     # ``self.split``).
-                    target_finite = (
-                        np.isfinite(target).all(axis=1)
-                        & np.isfinite(cond).all(axis=1)
-                    )
+                    target_finite = np.isfinite(target).all(axis=1) & np.isfinite(
+                        cond
+                    ).all(axis=1)
                     w_out, w_keep = _apply_weight_mode(w, self.weight_mode)
                     keep = target_finite & w_keep
                     if not keep.all():
@@ -1381,7 +1394,8 @@ class ArrowShardLoader(torch_data.IterableDataset):
                     while buf_n >= bs:
                         yield _flush_one()
             finally:
-                if hasattr(reader, "close"): reader.close()
+                if hasattr(reader, "close"):
+                    reader.close()
                 src.close()
 
         if buf_n > 0 and not self.drop_last:

--- a/scripts/corrections/muon_calibration/arrow_shard_loader.py
+++ b/scripts/corrections/muon_calibration/arrow_shard_loader.py
@@ -1,0 +1,1208 @@
+"""Streaming per-batch iterator over Arrow IPC training shards.
+
+Companion to the snapshot-side sharder
+(``wremnants/production/arrow_shard_export.py`` /
+``flow_training_snapshot.py --shard-only``): that step produces
+LZ4-compressed Arrow IPC stream files (one record batch ~= 16k rows)
+carrying the per-muon training schema. The trainers used to
+``load_ntuples`` the entire dataset into RAM up front; at the scale
+of the merged J/psi + W/Z snapshot that's tens of GB of resident
+data and minutes of cold-start latency. This module streams instead:
+a single pre-pass computes the preprocessing mean/std, then each
+training epoch reads record batches on demand from disk.
+
+Lives alongside the training scripts in
+``scripts/corrections/muon_calibration/`` so the trainer ecosystem
+stays standalone (no ``wremnants`` package import on the read path).
+The exposed API mirrors :class:`InMemoryLoader` in
+``train_muon_response_flow.py`` so the trainer's training/validation
+loops don't have to change. ``compute_stats_streaming`` is the
+one-pass helper for ``PreprocStats`` + a global ``weight_mean``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Sequence, Tuple
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.ipc as ipc
+import torch
+import torch.utils.data as torch_data
+
+
+# ---------------------------------------------------------------------------
+# Per-muon schema (fp32 columns the snapshot script writes, plus int32
+# ``source_id`` which we don't currently feed to the flow but is
+# preserved on the shards).
+# ---------------------------------------------------------------------------
+
+_RAW_FEATURE_COLUMNS = (
+    "eta_reco", "phi_reco", "eta_gen", "phi_gen",
+    "kappa_reco", "kappa_gen", "nominal_weight",
+)
+
+
+_TARGET_NAMES = ("r_kappa", "dlambda", "dphi")
+_COND_NAMES = (
+    "log_pt_gen", "charge", "lambda_gen", "sin_phi_gen", "cos_phi_gen",
+)
+
+
+_WEIGHT_MODES = ("abs", "keep", "drop")
+
+
+class TimedLoader:
+    """Wrap a data loader and emit per-iteration timing for the first
+    ``n_print`` batches. Splits each step into:
+
+    * ``loader_wait`` — time the trainer thread blocked on
+      ``next(loader_iter)``; this is the worker-queue wait. Large
+      values mean the workers can't keep up.
+    * ``trainer_step`` — time between successive ``next`` calls, i.e.
+      everything the trainer does between batches (H2D copy + model
+      forward + backward + optimizer step + any GPU sync). Large
+      values mean the consumer is the bottleneck and worker CPU%
+      can't be improved by adding more workers.
+
+    Counts are emitted once at the start of each ``iter()`` so they
+    appear once per epoch (or once per validation pass).
+    """
+
+    def __init__(self, loader, n_print: int = 20, label: str = "loader"):
+        self.loader = loader
+        self.n_print = int(n_print)
+        self.label = str(label)
+
+    def __len__(self):
+        return len(self.loader)
+
+    def __iter__(self):
+        import time
+        n_print = self.n_print
+        label = self.label
+        it = iter(self.loader)
+        idx = 0
+        if n_print > 0:
+            print(
+                f"[{label}] data-pipeline profile (first {n_print} batches):"
+            )
+        while True:
+            t_req = time.perf_counter()
+            try:
+                item = next(it)
+            except StopIteration:
+                return
+            t_got = time.perf_counter()
+            loader_wait_ms = (t_got - t_req) * 1e3
+            # Time the consumer's hold on this batch by sampling
+            # ``perf_counter`` right before yielding and right after
+            # the generator resumes (= consumer asked for the next
+            # batch). The print happens after the consumer is done
+            # with this iteration, so output appears one step
+            # delayed relative to the trainer's progress bar — fine
+            # for a diagnostic.
+            t_yield = time.perf_counter()
+            yield item
+            t_resume = time.perf_counter()
+            trainer_step_ms = (t_resume - t_yield) * 1e3
+            if idx < n_print:
+                print(
+                    f"[{label}] iter {idx:>3d}  "
+                    f"loader_wait={loader_wait_ms:7.2f}ms  "
+                    f"trainer_step={trainer_step_ms:7.2f}ms"
+                )
+            idx += 1
+
+
+class StepProfiler:
+    """Time labelled checkpoints inside a training step.
+
+    Companion to :class:`TimedLoader`: ``TimedLoader`` splits the
+    epoch into (loader_wait, trainer_step); this class splits the
+    ``trainer_step`` into its components — H2D copy, forward,
+    backward, optimizer, bookkeeping — so you can localise where the
+    main-process budget is being spent.
+
+    On CUDA, calls ``torch.cuda.synchronize()`` between marks so
+    that async kernel queues are attributed to the right section.
+    Sync itself costs ~tens of microseconds and is only inserted
+    when profiling, so it doesn't slow steady-state training.
+    """
+
+    def __init__(self, enabled: bool, label: str, device: str = "cpu"):
+        import time as _time
+        self.enabled = bool(enabled)
+        self.label = str(label)
+        self.use_cuda = (
+            self.enabled
+            and isinstance(device, str)
+            and device.startswith("cuda")
+            and torch.cuda.is_available()
+        )
+        self._time = _time
+        self._marks: list = []
+
+    def start(self):
+        """Reset and capture the start timestamp. Call once per step
+        before any work."""
+        if not self.enabled:
+            return
+        if self.use_cuda:
+            torch.cuda.synchronize()
+        self._marks = [("__start", self._time.perf_counter())]
+
+    def mark(self, section: str):
+        """Record the end of a section. Inserts ``cuda.synchronize``
+        so async GPU work issued during the section is included."""
+        if not self.enabled:
+            return
+        if self.use_cuda:
+            torch.cuda.synchronize()
+        self._marks.append((section, self._time.perf_counter()))
+
+    def report(self, iter_idx: int):
+        """Emit one line summarising this step's sections."""
+        if not self.enabled or len(self._marks) < 2:
+            return
+        deltas = []
+        prev = self._marks[0][1]
+        for name, t in self._marks[1:]:
+            deltas.append(f"{name}={(t - prev) * 1e3:6.2f}ms")
+            prev = t
+        total = (self._marks[-1][1] - self._marks[0][1]) * 1e3
+        print(
+            f"[{self.label}] iter {iter_idx:>3d}  total={total:6.2f}ms  "
+            + "  ".join(deltas)
+        )
+
+
+def dataloader_worker_init(worker_id: int):
+    """``DataLoader(worker_init_fn=...)`` hook.
+
+    Pin each DataLoader worker subprocess to a single CPU thread for
+    numpy / BLAS / pyarrow / torch ops. The wmassdevrolling container
+    inherits ``OMP_NUM_THREADS`` from the entry-point env (often
+    ~all cores, see memory note); without this hook every one of the
+    N DataLoader workers spins up an N-way thread pool of its own,
+    and the resulting N×N oversubscription gives each worker ~1/N
+    of a single core — the signature of "every worker at ~25 %
+    CPU" we hit at scale. Single-threaded workers + many of them is
+    the right shape for this pipeline (the parallelism comes from
+    the worker count, not threads per worker).
+    """
+    import os
+    os.environ["OMP_NUM_THREADS"] = "1"
+    os.environ["MKL_NUM_THREADS"] = "1"
+    os.environ["OPENBLAS_NUM_THREADS"] = "1"
+    os.environ["NUMEXPR_NUM_THREADS"] = "1"
+    import torch as _torch
+    _torch.set_num_threads(1)
+    try:
+        _torch.set_num_interop_threads(1)
+    except RuntimeError:
+        # Already set — interop threads can't be changed after the
+        # first torch op in the worker.
+        pass
+
+
+def _apply_weight_mode(w, mode):
+    """Return ``(w_out, keep_mask)`` after applying the weight policy.
+
+    * ``abs``  (default): take ``|w|`` and drop rows with w == 0 or
+      non-finite. Loses the destructive-interference signal of
+      MC@NLO-style signed samples but keeps the magnitude information
+      and makes the trainer behave as if every row had positive
+      weight. Matches the historical J/psi training where weights
+      were always positive.
+    * ``keep``: pass ``w`` through unchanged (signed). Only drops
+      non-finite. Use this for an unbiased weighted-NLL fit where
+      negative weights cancel positive ones in expectation.
+    * ``drop``: drop rows with w <= 0 or non-finite. Legacy
+      behaviour; loses ~5% of W/Z rows in MC@NLO samples.
+    """
+    finite = np.isfinite(w)
+    if mode == "abs":
+        keep = finite & (w != 0.0)
+        return np.fabs(w), keep
+    if mode == "keep":
+        return w, finite
+    if mode == "drop":
+        return w, finite & (w > 0.0)
+    raise ValueError(f"weight_mode must be one of {_WEIGHT_MODES}, got {mode!r}")
+
+
+def resolve_shard_files(
+    input_files: Sequence[str], return_counts: bool = False,
+):
+    """Expand the trainer's ``--input-files`` contract to a flat list
+    of ``.arrow`` shard paths. Accepts:
+
+    * a directory containing ``manifest.json`` (auto-expanded);
+    * a list of explicit ``.arrow`` shard files;
+
+    Anything else (notably ``.root``) raises.
+
+    When ``return_counts=True`` returns ``(paths, row_counts_or_None)``.
+    ``row_counts`` is a per-shard list of row counts (same length as
+    ``paths``) read from the manifest's ``shard_row_counts`` block —
+    avoids the trainer having to walk every record batch later just
+    to estimate ``__len__``. ``None`` if any input came from an
+    explicit ``.arrow`` path (no manifest) or the manifest is
+    missing the counts.
+    """
+    paths: List[str] = []
+    counts: List[int] = []
+    have_counts = True
+    for p in input_files:
+        if os.path.isdir(p):
+            manifest = os.path.join(p, "manifest.json")
+            if not os.path.exists(manifest):
+                raise FileNotFoundError(
+                    f"resolve_shard_files: {p!r} is a directory but "
+                    f"contains no manifest.json"
+                )
+            with open(manifest) as f:
+                m = json.load(f)
+            count_map = {
+                int(entry["shard"]): int(entry["n_rows"])
+                for entry in m.get("shard_row_counts", [])
+            }
+            for i, fn in enumerate(m["shard_files"]):
+                paths.append(os.path.join(p, fn))
+                if i in count_map:
+                    counts.append(count_map[i])
+                else:
+                    counts.append(0)
+                    have_counts = False
+        elif p.endswith(".arrow"):
+            paths.append(p)
+            counts.append(0)
+            have_counts = False
+        else:
+            raise ValueError(
+                f"resolve_shard_files: only .arrow shards or a shard "
+                f"directory are supported; got {p!r}"
+            )
+    if return_counts:
+        return paths, (counts if have_counts else None)
+    return paths
+
+
+_ARROW_FILE_MAGIC = b"ARROW1"
+
+
+def _open_ipc(path: str):
+    """Open an Arrow IPC shard for reading. Auto-detects file vs
+    stream format by sniffing the magic header — the sharder writes
+    file-format now (random-access via footer index), but older
+    stream-format shards from earlier runs are still supported.
+    Returns ``(memory_map_handle, reader)``. The caller owns both;
+    closing the reader does not close the underlying mmap.
+    """
+    src = pa.memory_map(path, "r")
+    head = src.read(len(_ARROW_FILE_MAGIC))
+    src.seek(0)
+    if head == _ARROW_FILE_MAGIC:
+        return src, ipc.open_file(src)
+    return src, ipc.open_stream(src)
+
+
+def _iter_record_batches(reader):
+    """Uniform iteration interface over file or stream readers.
+    ``open_file`` returns a ``RecordBatchFileReader`` with
+    ``num_record_batches`` + ``get_batch(i)``; ``open_stream``
+    returns a ``RecordBatchStreamReader`` that's itself iterable.
+    """
+    if isinstance(reader, ipc.RecordBatchFileReader):
+        for i in range(reader.num_record_batches):
+            yield reader.get_batch(i)
+    else:
+        yield from reader
+
+
+def _num_record_batches(reader) -> int:
+    if isinstance(reader, ipc.RecordBatchFileReader):
+        return reader.num_record_batches
+    # Stream readers don't expose a count without walking; fall back.
+    return -1
+
+
+def count_rows(shard_files: Sequence[str]) -> List[int]:
+    """Row count per shard. For file-format shards, reads only the
+    footer index (cheap). For stream-format shards, walks the whole
+    file (cost on the order of one full scan)."""
+    counts: List[int] = []
+    for p in shard_files:
+        src, r = _open_ipc(p)
+        try:
+            if isinstance(r, ipc.RecordBatchFileReader):
+                # Sum num_rows per batch — read_all() would
+                # materialize the whole table.
+                n = sum(
+                    r.get_batch(i).num_rows
+                    for i in range(r.num_record_batches)
+                )
+            else:
+                n = r.read_all().num_rows
+            counts.append(n)
+        finally:
+            if hasattr(r, "close"):
+                r.close()
+            src.close()
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Per-batch numpy compute: same identities as
+# ``compute_targets_and_conditioning`` and ``apply_preproc`` in
+# ``train_muon_response_flow.py``, fused into one pass for streaming.
+# ---------------------------------------------------------------------------
+
+
+def _per_batch_target_cond(cols: dict):
+    """Return (target [N, 3], cond [N, 5], weight [N]) in fp32 from
+    the raw fp32 columns of one Arrow record batch.
+
+    Mirrors :func:`compute_targets_and_conditioning` exactly:
+
+    * ``r_kappa = kappa_reco / kappa_gen - 1``
+    * ``dlambda = arctan(sinh(eta_reco)) - arctan(sinh(eta_gen))``
+    * ``dphi = atan2(sin(phi_r - phi_g), cos(phi_r - phi_g))``
+    * conditioning: log_pt_gen (from kappa_gen+eta_gen),
+      sign(kappa_gen), lambda_gen, sin/cos(phi_gen).
+    """
+    eta_r = cols["eta_reco"]
+    phi_r = cols["phi_reco"]
+    eta_g = cols["eta_gen"]
+    phi_g = cols["phi_gen"]
+    kappa_r = cols["kappa_reco"]
+    kappa_g = cols["kappa_gen"]
+
+    lam_r = np.arctan(np.sinh(eta_r))
+    lam_g = np.arctan(np.sinh(eta_g))
+
+    r_kappa = kappa_r / kappa_g - 1.0
+    dphi = np.arctan2(
+        np.sin(phi_r - phi_g), np.cos(phi_r - phi_g)
+    )
+    dlambda = lam_r - lam_g
+
+    target = np.stack([r_kappa, dlambda, dphi], axis=1).astype(np.float32)
+
+    log_pt_gen = -np.log(np.fabs(kappa_g) * np.cosh(eta_g))
+    cond = np.stack(
+        [
+            log_pt_gen,
+            np.sign(kappa_g),
+            lam_g,
+            np.sin(phi_g),
+            np.cos(phi_g),
+        ],
+        axis=1,
+    ).astype(np.float32)
+
+    w = cols["nominal_weight"].astype(np.float32, copy=False)
+
+    return target, cond, w
+
+
+def _read_raw_columns(batch: pa.RecordBatch) -> dict:
+    return {c: batch.column(c).to_numpy() for c in _RAW_FEATURE_COLUMNS}
+
+
+# ---------------------------------------------------------------------------
+# Single-pass preproc stats + weight mean
+# ---------------------------------------------------------------------------
+
+
+def _stats_chunk(arg):
+    """Worker: read a (shard, [batch_start, batch_stop), weight_mode)
+    slice and return partial (n_kept, t_sum, t_sq, c_sum, c_sq,
+    w_sum, abs_w_sum, n_filt). ``abs_w_sum`` is the sum of ``|w|``
+    over the kept rows — used as the normalisation scale by the
+    streaming loader regardless of weight_mode, so signed-weight
+    training (``mode=keep``) doesn't divide by a near-zero mean(w)
+    when positive and negative contributions cancel.
+    """
+    path, batch_start, batch_stop, weight_mode = arg
+    n_target = len(_TARGET_NAMES)
+    n_cond = len(_COND_NAMES)
+    t_sum = np.zeros(n_target, dtype=np.float64)
+    t_sq = np.zeros(n_target, dtype=np.float64)
+    c_sum = np.zeros(n_cond, dtype=np.float64)
+    c_sq = np.zeros(n_cond, dtype=np.float64)
+    w_sum = 0.0
+    abs_w_sum = 0.0
+    n_kept = 0
+    n_filt = 0
+
+    src, reader = _open_ipc(path)
+    try:
+        if isinstance(reader, ipc.RecordBatchFileReader):
+            indices = range(batch_start, min(batch_stop, reader.num_record_batches))
+            batches = (reader.get_batch(i) for i in indices)
+        else:
+            # Stream: walk sequentially, only accumulate in range.
+            def _walk():
+                for i, b in enumerate(reader):
+                    if i < batch_start:
+                        continue
+                    if i >= batch_stop:
+                        return
+                    yield b
+            batches = _walk()
+
+        for batch in batches:
+            cols = _read_raw_columns(batch)
+            target, cond, w = _per_batch_target_cond(cols)
+            target_finite = (
+                np.isfinite(target).all(axis=1)
+                & np.isfinite(cond).all(axis=1)
+            )
+            w_out, w_keep = _apply_weight_mode(w, weight_mode)
+            keep = target_finite & w_keep
+            if not keep.all():
+                target = target[keep]
+                cond = cond[keep]
+                w_out = w_out[keep]
+                n_filt += int(np.size(keep) - keep.sum())
+            if target.shape[0] == 0:
+                continue
+            t_sum += target.sum(axis=0, dtype=np.float64)
+            t_sq += np.square(target, dtype=np.float64).sum(axis=0)
+            c_sum += cond.sum(axis=0, dtype=np.float64)
+            c_sq += np.square(cond, dtype=np.float64).sum(axis=0)
+            w_sum += float(w_out.sum(dtype=np.float64))
+            abs_w_sum += float(np.fabs(w_out, dtype=np.float64).sum())
+            n_kept += target.shape[0]
+    finally:
+        if hasattr(reader, "close"): reader.close()
+        src.close()
+    return n_kept, t_sum, t_sq, c_sum, c_sq, w_sum, abs_w_sum, n_filt
+
+
+def _enumerate_chunks(shard_files, batches_per_chunk: int, weight_mode: str):
+    """Build a list of (shard, batch_start, batch_stop, weight_mode)
+    work items. File-format shards expose ``num_record_batches``
+    (cheap, footer read); stream-format shards have to be walked to
+    count, which we do once here. Each shard's batches are split
+    into ``ceil(n_batches / batches_per_chunk)`` chunks."""
+    out = []
+    for path in shard_files:
+        src, reader = _open_ipc(path)
+        try:
+            n_b = _num_record_batches(reader)
+            if n_b < 0:
+                # Stream — count by walking (cheap-ish; metadata only).
+                n_b = sum(1 for _ in reader)
+        finally:
+            if hasattr(reader, "close"): reader.close()
+            src.close()
+        if n_b == 0:
+            continue
+        for start in range(0, n_b, batches_per_chunk):
+            stop = min(start + batches_per_chunk, n_b)
+            out.append((path, start, stop, weight_mode))
+    return out
+
+
+def _compute_stats_robust(
+    shard_files: Sequence[str],
+    sample_rows: int,
+    weight_mode: str,
+    progress: bool,
+):
+    """Sample-based robust location + scale: ``median`` for the
+    location, ``1.4826 * MAD`` for the scale. Reads up to
+    ``sample_rows`` filtered rows sequentially across the shard list
+    (the sharder has already globally shuffled the rows, so the
+    first ``sample_rows`` across shards is a random sample of the
+    full dataset). 1 M rows is plenty for stable median + MAD on the
+    schema we use.
+    """
+    from train_muon_response_flow import PreprocStats
+
+    if progress:
+        print(
+            f"computing robust preproc stats: median + 1.4826·MAD from "
+            f"a {sample_rows:,}-row sample, weight_mode={weight_mode!r}"
+        )
+
+    t_chunks: List[np.ndarray] = []
+    c_chunks: List[np.ndarray] = []
+    w_chunks: List[np.ndarray] = []
+    n_total = 0
+    n_filt = 0
+    for path in shard_files:
+        if n_total >= sample_rows:
+            break
+        src, reader = _open_ipc(path)
+        try:
+            for batch in _iter_record_batches(reader):
+                if n_total >= sample_rows:
+                    break
+                cols = _read_raw_columns(batch)
+                target, cond, w = _per_batch_target_cond(cols)
+                target_finite = (
+                    np.isfinite(target).all(axis=1)
+                    & np.isfinite(cond).all(axis=1)
+                )
+                w_out, w_keep = _apply_weight_mode(w, weight_mode)
+                keep = target_finite & w_keep
+                if not keep.all():
+                    target = target[keep]
+                    cond = cond[keep]
+                    w_out = w_out[keep]
+                    n_filt += int(np.size(keep) - keep.sum())
+                if target.shape[0] == 0:
+                    continue
+                if n_total + target.shape[0] > sample_rows:
+                    take = sample_rows - n_total
+                    target = target[:take]
+                    cond = cond[:take]
+                    w_out = w_out[:take]
+                t_chunks.append(target)
+                c_chunks.append(cond)
+                w_chunks.append(w_out)
+                n_total += target.shape[0]
+        finally:
+            if hasattr(reader, "close"):
+                reader.close()
+            src.close()
+
+    if n_total == 0:
+        raise RuntimeError("compute_stats_streaming(robust): zero rows survived filters")
+
+    target_arr = np.concatenate(t_chunks, axis=0)
+    cond_arr = np.concatenate(c_chunks, axis=0)
+    w_arr = np.concatenate(w_chunks, axis=0)
+
+    # Median + 1.4826·MAD per column. fp64 for the median computation
+    # — np.median internally does a partition over fp64 if input is
+    # fp64; cast once to avoid repeating it per axis.
+    t_arr64 = target_arr.astype(np.float64, copy=False)
+    t_median = np.median(t_arr64, axis=0)
+    t_mad = np.median(np.fabs(t_arr64 - t_median), axis=0)
+    t_std = 1.4826 * t_mad
+    t_std = np.where(t_std > 1e-6, t_std, 1.0)
+
+    c_arr64 = cond_arr.astype(np.float64, copy=False)
+    c_median = np.median(c_arr64, axis=0)
+    c_mad = np.median(np.fabs(c_arr64 - c_median), axis=0)
+    c_std = 1.4826 * c_mad
+    c_std = np.where(c_std > 1e-6, c_std, 1.0)
+
+    abs_w_mean = float(np.fabs(w_arr.astype(np.float64, copy=False)).mean())
+
+    if progress:
+        print(
+            f"  sampled {n_total:,} rows"
+            + (f" (dropped {n_filt:,} non-finite or filtered)" if n_filt else "")
+            + f"; |weight| mean = {abs_w_mean:.4g}"
+        )
+        print(f"  target median: {t_median.tolist()}")
+        print(f"  target 1.4826·MAD: {t_std.tolist()}")
+        print(f"  cond median: {c_median.tolist()}")
+        print(f"  cond 1.4826·MAD: {c_std.tolist()}")
+
+    return (
+        PreprocStats(
+            target_names=list(_TARGET_NAMES),
+            target_mean=t_median.tolist(),
+            target_std=t_std.tolist(),
+            cond_names=list(_COND_NAMES),
+            cond_mean=c_median.tolist(),
+            cond_std=c_std.tolist(),
+        ),
+        abs_w_mean,
+    )
+
+
+def compute_stats_streaming(
+    shard_files: Sequence[str],
+    max_rows: int = -1,
+    n_workers: int = 0,
+    batches_per_chunk: int = 32,
+    progress: bool = True,
+    weight_mode: str = "abs",
+    robust: bool = True,
+    robust_sample_rows: int = 20_000_000,
+):
+    """One pass over the shards; returns ``(PreprocStats, weight_mean)``.
+
+    Accumulates per-column ``sum`` and ``sum_of_squares`` in float64
+    so a few billion fp32 rows stay numerically clean.
+
+    Parallelism: when ``n_workers > 1`` (default: ``os.cpu_count()``)
+    record-batch chunks are dispatched to a ``ProcessPoolExecutor``.
+    Threads were tried first but pyarrow IPC read + ``to_numpy()`` hold
+    the GIL through more of the hot path than the docs suggest, so
+    threaded scaling tops out around 5-6 cores even on a 192-thread
+    box; separate Python interpreters sidestep the GIL entirely.
+    ``batches_per_chunk`` controls the granularity (more chunks =
+    better load balance, slightly more pickling overhead).
+
+    ``max_rows > 0`` caps the scan to roughly that many rows total
+    (across all workers); the precise cap is checked per-chunk so a
+    bit of overshoot is possible.
+    """
+    # ``PreprocStats`` lives in the sibling trainer script.
+    from train_muon_response_flow import PreprocStats
+    from concurrent.futures import ProcessPoolExecutor
+    import multiprocessing as mp
+
+    if weight_mode not in _WEIGHT_MODES:
+        raise ValueError(
+            f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
+        )
+    if robust:
+        # Dispatch to the sample-based median + 1.4826·MAD path.
+        # Tail mass (e.g. r_kappa charge-mismeasurement peak) doesn't
+        # move the median, so the resulting scale reflects the bulk
+        # width — what you actually want when the trainer's δ=1
+        # perturbation is meant to span ~1 typical-event width.
+        return _compute_stats_robust(
+            shard_files, int(robust_sample_rows), weight_mode, progress,
+        )
+    if n_workers <= 0:
+        n_workers = max(1, (os.cpu_count() or 1))
+
+    if progress:
+        print(
+            f"computing preproc stats: {len(shard_files)} shard(s), "
+            f"{n_workers} process(es), batches_per_chunk={batches_per_chunk}, "
+            f"weight_mode={weight_mode!r}"
+            + (f", capped at {max_rows:,} rows" if max_rows > 0 else "")
+        )
+
+    tasks = _enumerate_chunks(shard_files, batches_per_chunk, weight_mode)
+    if not tasks:
+        raise RuntimeError("compute_stats_streaming: no record batches found")
+
+    n_target = len(_TARGET_NAMES)
+    n_cond = len(_COND_NAMES)
+    t_sum = np.zeros(n_target, dtype=np.float64)
+    t_sq = np.zeros(n_target, dtype=np.float64)
+    c_sum = np.zeros(n_cond, dtype=np.float64)
+    c_sq = np.zeros(n_cond, dtype=np.float64)
+    w_sum = 0.0
+    abs_w_sum = 0.0
+    n_total = 0
+    n_filt = 0
+
+    # ``fork`` is cheaper than ``spawn`` and safe here: the trainer
+    # entry point doesn't import ROOT (or any other library that
+    # dislikes being forked through), so the worker's address space
+    # only needs numpy / pyarrow which fork cleanly. Each worker
+    # returns a tiny (sums + scalar) payload, so the per-chunk
+    # pickle round-trip is negligible.
+    ctx = mp.get_context("fork")
+    with ProcessPoolExecutor(max_workers=n_workers, mp_context=ctx) as ex:
+        for partial in ex.map(_stats_chunk, tasks):
+            (p_n, p_ts, p_tsq, p_cs, p_csq, p_ws, p_abs_ws, p_filt) = partial
+            t_sum += p_ts
+            t_sq += p_tsq
+            c_sum += p_cs
+            c_sq += p_csq
+            w_sum += p_ws
+            abs_w_sum += p_abs_ws
+            n_total += p_n
+            n_filt += p_filt
+            if max_rows > 0 and n_total >= max_rows:
+                # Best-effort early stop: cancel remaining chunks by
+                # exiting the with-block (in-flight workers finish,
+                # we just stop accumulating).
+                break
+
+    if n_total == 0:
+        raise RuntimeError("compute_stats_streaming: zero rows survived filters")
+
+    t_mean = t_sum / n_total
+    t_var = np.maximum(t_sq / n_total - t_mean * t_mean, 0.0)
+    t_std = np.sqrt(t_var)
+    # Guard against perfectly-constant columns (var=0) so apply_preproc
+    # doesn't divide by zero.
+    t_std = np.where(t_std > 1e-6, t_std, 1.0)
+
+    c_mean = c_sum / n_total
+    c_var = np.maximum(c_sq / n_total - c_mean * c_mean, 0.0)
+    c_std = np.sqrt(c_var)
+    c_std = np.where(c_std > 1e-6, c_std, 1.0)
+
+    # Normalisation scale: mean(|w|). Robust to MC@NLO-style signed
+    # weights (where mean(w) can be near zero from cancellation) while
+    # equivalent to mean(w) for ``mode=abs`` (where w is already
+    # non-negative).
+    weight_mean = abs_w_sum / n_total
+
+    if progress:
+        drop_label = {
+            "abs":  "w==0 or non-finite",
+            "keep": "non-finite",
+            "drop": "w<=0 or non-finite",
+        }[weight_mode]
+        print(
+            f"  scanned {n_total:,} rows"
+            + (f" (dropped {n_filt:,} {drop_label})" if n_filt else "")
+            + f"; |weight| mean = {weight_mean:.4g}"
+            + (f", signed weight mean = {w_sum/n_total:.4g}"
+               if weight_mode == "keep" else "")
+        )
+
+    return (
+        PreprocStats(
+            target_names=list(_TARGET_NAMES),
+            target_mean=t_mean.tolist(),
+            target_std=t_std.tolist(),
+            cond_names=list(_COND_NAMES),
+            cond_mean=c_mean.tolist(),
+            cond_std=c_std.tolist(),
+        ),
+        float(weight_mean),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming loader
+# ---------------------------------------------------------------------------
+
+
+class ArrowShardLoader(torch_data.IterableDataset):
+    """Per-epoch streaming iterator over Arrow IPC shards.
+
+    Yields ``(x, c, w)`` torch tensors per training batch. Matches the
+    ``InMemoryLoader`` API (``__len__``, ``__iter__``, ``pin_memory``)
+    so the trainer's epoch loop can switch from in-RAM to streaming
+    by swapping the loader object. Also inherits
+    :class:`torch.utils.data.IterableDataset`, so the same instance
+    can be wrapped in a ``DataLoader`` with ``num_workers > 0``: each
+    worker process gets its own shard subset (via ``get_worker_info``),
+    bypasses the GIL bottleneck of the in-process producer thread,
+    and shared-memory delivers tensors to the consumer.
+
+    * **Per-rank partition**: shards are dealt out round-robin to
+      ranks via ``shard_files[rank::world_size]``.
+    * **Train/val split**: each record batch is sliced contiguously
+      — first ``val_fraction`` of rows go to val, rest to train. The
+      shards are already globally shuffled by the bucket-shuffle
+      pass, so this is unbiased.
+    * **Per-epoch shuffle**: shard read-order is permuted; within
+      each emitted training batch (accumulated from many record
+      batches) rows are permuted again before yielding. Strong
+      enough that the trainer doesn't need to do additional
+      shuffling.
+    * **Preproc on-the-fly**: ``compute_targets_and_conditioning``
+      + ``apply_preproc`` are applied per record batch.
+      ``nominal_weight`` is divided by the global ``weight_mean`` so
+      the mean-normalised weights match the in-RAM trainer's
+      behaviour.
+    * **Prefetch thread**: a single background thread runs the
+      decompress + numpy preproc + pin-memory chain for the next
+      ``prefetch`` batches while the trainer is busy on the current
+      one (``prefetch=0`` disables and falls back to fully
+      sequential iteration). pyarrow + numpy + ``Tensor.pin_memory``
+      all release the GIL, so the prefetch overlaps cleanly with
+      GPU compute.
+    """
+
+    def __init__(
+        self,
+        shard_files: Sequence[str],
+        stats,                                 # PreprocStats
+        weight_mean: float,
+        *,
+        world_size: int,
+        rank: int,
+        batch_size: int,
+        split: str = "train",                  # "train" | "val" | "all"
+        val_fraction: float = 0.1,
+        shuffle: bool = True,
+        pin_memory: bool = True,
+        drop_last: bool = True,
+        seed: int = 0,
+        prefetch: int = 2,
+        weight_mode: str = "abs",
+        shard_row_counts: Sequence[int] | None = None,
+        num_workers_hint: int = 1,
+    ):
+        if split not in ("train", "val", "all"):
+            raise ValueError(f"split must be train|val|all, got {split!r}")
+        if weight_mode not in _WEIGHT_MODES:
+            raise ValueError(
+                f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
+            )
+        self.shard_files = list(shard_files)
+        self.my_shards = self.shard_files[rank::world_size]
+        if shard_row_counts is not None:
+            shard_row_counts = list(shard_row_counts)
+            if len(shard_row_counts) != len(self.shard_files):
+                raise ValueError(
+                    f"shard_row_counts has {len(shard_row_counts)} entries "
+                    f"but {len(self.shard_files)} shards were given"
+                )
+            self._my_row_counts = shard_row_counts[rank::world_size]
+        else:
+            self._my_row_counts = None
+        self.world_size = int(world_size)
+        self.rank = int(rank)
+        self.batch_size = int(batch_size)
+        self.split = split
+        self.val_fraction = float(val_fraction)
+        self.shuffle = bool(shuffle)
+        self.pin_memory = bool(pin_memory) and torch.cuda.is_available()
+        self.drop_last = bool(drop_last)
+        self.seed = int(seed)
+        self.prefetch = max(0, int(prefetch))
+        self.weight_mode = weight_mode
+        self.num_workers_hint = max(1, int(num_workers_hint))
+        self._epoch = 0
+        # Per-record-batch layout. Lazily filled on the first
+        # DataLoader-worker iteration (or anywhere that calls
+        # ``_ensure_layout``); not needed for the standalone path.
+        self._layout = None
+
+        self._tmean = np.asarray(stats.target_mean, dtype=np.float32)
+        self._tstd = np.asarray(stats.target_std, dtype=np.float32)
+        self._cmean = np.asarray(stats.cond_mean, dtype=np.float32)
+        self._cstd = np.asarray(stats.cond_std, dtype=np.float32)
+        self._weight_mean = float(weight_mean)
+
+        # Estimate length from the per-shard row counts. Used only by
+        # the tqdm progress bar; correctness doesn't depend on it.
+        # When caller passed ``shard_row_counts`` (e.g. populated
+        # from manifest.json), use those directly — otherwise we'd
+        # walk every record batch of every shard just to count rows,
+        # which can take tens of seconds at scale.
+        if self._my_row_counts is not None:
+            per_shard_rows = self._my_row_counts
+        else:
+            per_shard_rows = (
+                count_rows(self.my_shards) if self.my_shards else []
+            )
+        my_rows = sum(per_shard_rows)
+        frac = (
+            1.0 - self.val_fraction
+            if split == "train"
+            else self.val_fraction
+            if split == "val"
+            else 1.0
+        )
+        my_rows_split = int(my_rows * frac)
+        # Always round up: with multiple DataLoader workers the
+        # actual yielded count can EXCEED a floor-divided estimate,
+        # which triggers PyTorch's "Length of IterableDataset was X
+        # but Y samples have been fetched" warning. Also add a
+        # ``+num_workers_hint`` cushion because each worker emits
+        # its own tail partial batch when ``drop_last=False`` (and a
+        # nearly-full one when ``drop_last=True``), so the
+        # multi-worker total can exceed the single-process estimate
+        # by up to ``num_workers``. tqdm reaches 100 % a handful of
+        # iterations before the epoch finishes — fine.
+        ceil_len = (
+            (my_rows_split + self.batch_size - 1) // self.batch_size
+        )
+        self._approx_len = max(
+            ceil_len + self.num_workers_hint,
+            1,
+        )
+
+    def __len__(self):
+        return self._approx_len
+
+    def _pin(self, t: torch.Tensor) -> torch.Tensor:
+        return t.pin_memory() if self.pin_memory else t
+
+    def _yield(self, target, cond, w):
+        x_t = self._pin(torch.from_numpy(np.ascontiguousarray(target)))
+        c_t = self._pin(torch.from_numpy(np.ascontiguousarray(cond)))
+        w_t = self._pin(torch.from_numpy(np.ascontiguousarray(w)))
+        return x_t, c_t, w_t
+
+    def _ensure_layout(self):
+        """Populate ``self._layout`` (list of ``(shard_idx, batch_idx)``
+        pairs across this rank's shards). Reads only IPC footers /
+        message counts — no record-batch decompression. Cached after
+        the first call; cheap to compute even at 32 shards × 4 500
+        batches each (~ms)."""
+        if self._layout is not None:
+            return
+        layout = []
+        for s_idx, path in enumerate(self.my_shards):
+            src, reader = _open_ipc(path)
+            try:
+                n_b = _num_record_batches(reader)
+                if n_b < 0:
+                    # Stream format — count by walking metadata.
+                    n_b = sum(1 for _ in reader)
+            finally:
+                if hasattr(reader, "close"):
+                    reader.close()
+                src.close()
+            for b in range(n_b):
+                layout.append((s_idx, b))
+        self._layout = layout
+
+    def _partition_for_worker(self, worker_id: int, num_workers: int):
+        """Return ``[(shard_idx, [batch_idx, ...]), ...]`` for this
+        worker. Contiguous partition of the full record-batch layout
+        across ``num_workers`` workers, then grouped by shard so each
+        chunk only opens its shard once."""
+        self._ensure_layout()
+        total = len(self._layout)
+        start = (total * worker_id) // num_workers
+        stop = (total * (worker_id + 1)) // num_workers
+        my_layout = self._layout[start:stop]
+        chunks = []
+        cur_shard = None
+        cur_batches = None
+        for s_idx, b_idx in my_layout:
+            if s_idx != cur_shard:
+                if cur_batches:
+                    chunks.append((cur_shard, cur_batches))
+                cur_shard = s_idx
+                cur_batches = [b_idx]
+            else:
+                cur_batches.append(b_idx)
+        if cur_batches:
+            chunks.append((cur_shard, cur_batches))
+        return chunks
+
+    def __iter__(self):
+        # Detect being called inside a ``DataLoader`` worker process
+        # (``num_workers > 0``). When inside one we partition the
+        # rank's shard slice further across workers, reseed the
+        # per-epoch RNG so each worker gets independent shuffles,
+        # and skip the internal pin_memory + prefetch — DataLoader
+        # does both at the worker output stage. Outside a DataLoader
+        # (or with ``num_workers == 0``) the original single-producer
+        # path is used.
+        wi = torch_data.get_worker_info()
+        if wi is not None:
+            # Partition at the record-batch level so DataLoader can
+            # scale past ``n_shards`` workers. Each worker gets a
+            # contiguous slice of the rank's full (shard_idx, batch_idx)
+            # layout, grouped back into per-shard chunks so we only
+            # open each shard once per worker per epoch. Requires
+            # file-format shards for efficient random-access; for
+            # stream-format the loop walks the whole stream and skips
+            # batches not in the assigned set, which is wasteful but
+            # functional.
+            chunks = self._partition_for_worker(wi.id, wi.num_workers)
+            orig_seed = self.seed
+            orig_pin = self.pin_memory
+            try:
+                self.seed = (orig_seed * 1_000_003) ^ (wi.id + 1)
+                self.pin_memory = False
+                yield from self._iter_sync(chunks=chunks)
+                return
+            finally:
+                self.seed = orig_seed
+                self.pin_memory = orig_pin
+
+        if self.prefetch <= 0:
+            yield from self._iter_sync()
+            return
+
+        # Background-thread prefetch. The producer runs the same
+        # body as ``_iter_sync`` and pushes ready tensors onto a
+        # bounded queue; the trainer's epoch loop consumes them via
+        # the yields below. With ``maxsize = prefetch`` the producer
+        # stays at most ``prefetch`` batches ahead — enough to hide
+        # CPU decompress + numpy preproc behind the previous step's
+        # GPU compute, without runaway memory growth.
+        import queue
+        import threading
+
+        q: "queue.Queue" = queue.Queue(maxsize=self.prefetch)
+        sentinel = object()
+        producer_exc: list = [None]
+        stop_event = threading.Event()
+
+        def _producer():
+            try:
+                for batch in self._iter_sync():
+                    if stop_event.is_set():
+                        return
+                    # ``put`` blocks once the queue hits its cap —
+                    # that's the backpressure.
+                    q.put(batch)
+            except BaseException as e:
+                producer_exc[0] = e
+            finally:
+                q.put(sentinel)
+
+        t = threading.Thread(
+            target=_producer,
+            name=f"ArrowShardLoader-prefetch-r{self.rank}",
+            daemon=True,
+        )
+        t.start()
+        try:
+            while True:
+                item = q.get()
+                if item is sentinel:
+                    break
+                yield item
+            if producer_exc[0] is not None:
+                raise producer_exc[0]
+        finally:
+            # Make sure the producer wakes up if the consumer
+            # abandoned the iterator early (e.g. break).
+            stop_event.set()
+            try:
+                while True:
+                    q.get_nowait()
+            except queue.Empty:
+                pass
+            t.join(timeout=5.0)
+
+    def _iter_sync(self, chunks=None):
+        """Iterate one epoch's worth of training batches.
+
+        ``chunks`` is a list of ``(shard_idx, batch_indices_or_None)``
+        pairs. ``None`` means "process every record batch in this
+        shard" (the standalone path). When provided (DataLoader
+        worker path), only the listed record batches are fetched —
+        random-access for file-format shards, walk-and-skip for
+        stream-format.
+        """
+        epoch = self._epoch
+        self._epoch += 1
+        # Distinct RNG per (rank, epoch) — independent shuffles across
+        # workers but reproducible per (seed, rank, epoch).
+        rng = np.random.default_rng(
+            (self.seed * 1_000_003)
+            ^ (self.rank * 7919 + 1)
+            ^ (epoch * 2_654_435_761)
+        )
+
+        if chunks is None:
+            chunks = [(i, None) for i in range(len(self.my_shards))]
+        else:
+            # Defensive copy — we shuffle this list in place below.
+            chunks = list(chunks)
+        if self.shuffle:
+            rng.shuffle(chunks)
+
+        # Accumulator: list of arrays per column-group; merged when
+        # we have enough rows to emit one training batch.
+        buf_t: List[np.ndarray] = []
+        buf_c: List[np.ndarray] = []
+        buf_w: List[np.ndarray] = []
+        buf_n = 0
+        bs = self.batch_size
+
+        def _flush_one():
+            """Concatenate the accumulator, take ``bs`` rows (shuffled),
+            stash the remainder, yield."""
+            nonlocal buf_t, buf_c, buf_w, buf_n
+            target_cat = np.concatenate(buf_t, axis=0)
+            cond_cat = np.concatenate(buf_c, axis=0)
+            w_cat = np.concatenate(buf_w, axis=0)
+            if self.shuffle:
+                perm = rng.permutation(target_cat.shape[0])
+                target_cat = target_cat[perm]
+                cond_cat = cond_cat[perm]
+                w_cat = w_cat[perm]
+            x = target_cat[:bs]
+            c = cond_cat[:bs]
+            ww = w_cat[:bs]
+            rem_t = target_cat[bs:]
+            rem_c = cond_cat[bs:]
+            rem_w = w_cat[bs:]
+            buf_t = [rem_t] if rem_t.shape[0] else []
+            buf_c = [rem_c] if rem_c.shape[0] else []
+            buf_w = [rem_w] if rem_w.shape[0] else []
+            buf_n = rem_t.shape[0]
+            return self._yield(x, c, ww)
+
+        for shard_idx, batch_indices in chunks:
+            path = self.my_shards[shard_idx]
+            src, reader = _open_ipc(path)
+            try:
+                if batch_indices is None:
+                    batches_iter = _iter_record_batches(reader)
+                elif isinstance(reader, ipc.RecordBatchFileReader):
+                    # Random-access by index. Sort to keep the on-disk
+                    # read pattern sequential.
+                    batches_iter = (
+                        reader.get_batch(bi) for bi in sorted(batch_indices)
+                    )
+                else:
+                    # Stream format — walk the whole stream and pick
+                    # only the assigned indices. Wasteful (each worker
+                    # re-decompresses earlier batches just to skip
+                    # them), but functional.
+                    idx_set = set(batch_indices)
+                    batches_iter = (
+                        b for i, b in enumerate(reader) if i in idx_set
+                    )
+                for batch in batches_iter:
+                    cols = _read_raw_columns(batch)
+                    target, cond, w = _per_batch_target_cond(cols)
+                    n = target.shape[0]
+                    if n == 0:
+                        continue
+
+                    # Train/val split (contiguous per record batch).
+                    n_val = int(n * self.val_fraction)
+                    if self.split == "train":
+                        target = target[n_val:]
+                        cond = cond[n_val:]
+                        w = w[n_val:]
+                    elif self.split == "val":
+                        target = target[:n_val]
+                        cond = cond[:n_val]
+                        w = w[:n_val]
+                    n = target.shape[0]
+                    if n == 0:
+                        continue
+
+                    # Filter rows: target/cond must be finite, weight
+                    # mode applies its own keep mask (abs: drop w==0
+                    # & non-finite; keep: drop only non-finite; drop:
+                    # drop w<=0 & non-finite).
+                    target_finite = (
+                        np.isfinite(target).all(axis=1)
+                        & np.isfinite(cond).all(axis=1)
+                    )
+                    w_out, w_keep = _apply_weight_mode(w, self.weight_mode)
+                    keep = target_finite & w_keep
+                    if not keep.all():
+                        target = target[keep]
+                        cond = cond[keep]
+                        w_out = w_out[keep]
+
+                    if target.shape[0] == 0:
+                        continue
+
+                    # Standardise target + cond; normalise weight by
+                    # global mean(|w|).
+                    target = (target - self._tmean) / self._tstd
+                    cond = (cond - self._cmean) / self._cstd
+                    w = w_out / self._weight_mean
+
+                    buf_t.append(target)
+                    buf_c.append(cond)
+                    buf_w.append(w)
+                    buf_n += target.shape[0]
+
+                    while buf_n >= bs:
+                        yield _flush_one()
+            finally:
+                if hasattr(reader, "close"): reader.close()
+                src.close()
+
+        if buf_n > 0 and not self.drop_last:
+            target_cat = np.concatenate(buf_t, axis=0)
+            cond_cat = np.concatenate(buf_c, axis=0)
+            w_cat = np.concatenate(buf_w, axis=0)
+            if self.shuffle:
+                perm = rng.permutation(target_cat.shape[0])
+                target_cat = target_cat[perm]
+                cond_cat = cond_cat[perm]
+                w_cat = w_cat[perm]
+            yield self._yield(target_cat, cond_cat, w_cat)

--- a/scripts/corrections/muon_calibration/arrow_shard_loader.py
+++ b/scripts/corrections/muon_calibration/arrow_shard_loader.py
@@ -42,16 +42,108 @@ import torch.utils.data as torch_data
 _RAW_FEATURE_COLUMNS = (
     "eta_reco", "phi_reco", "eta_gen", "phi_gen",
     "kappa_reco", "kappa_gen", "nominal_weight",
+    # ``muon_source`` is an int32 column on the shards (1, 15 or 443)
+    # but enters the loader as a float feature in the cond vector.
+    "muon_source",
 )
 
 
 _TARGET_NAMES = ("r_kappa", "dlambda", "dphi")
 _COND_NAMES = (
     "log_pt_gen", "charge", "lambda_gen", "sin_phi_gen", "cos_phi_gen",
+    "muon_source",
 )
 
 
 _WEIGHT_MODES = ("abs", "keep", "drop")
+
+
+# Per-class mapping for the per-muon ``muon_source`` integer (mirrors
+# ``train_muon_response_flow._MUON_SOURCE_CODES``):
+#   1   -> -1   (W/Z prompt)
+#   15  ->  0   (W/Z τ-decay)
+#   443 -> +1   (J/ψ sentinel)
+_MUON_SOURCE_CODES = {1: -1.0, 15: 0.0, 443: 1.0}
+
+
+def _muon_source_to_compact(ms: np.ndarray) -> np.ndarray:
+    """Map raw ``muon_source`` int codes to ``float32`` values in
+    ``{-1, 0, +1}``. Unknown values map to NaN."""
+    ms_arr = np.asarray(ms)
+    out = np.full(ms_arr.shape, np.nan, dtype=np.float32)
+    for raw, code in _MUON_SOURCE_CODES.items():
+        out[ms_arr == raw] = code
+    return out
+
+
+# Cond features whose ``(x-μ)/σ`` standardisation we force to be a
+# no-op via mean=0, std=1 in the PreprocStats: ``charge`` is already a
+# clean ±1 binary and ``muon_source`` was just remapped to {-1, 0, +1}.
+_PASSTHROUGH_COND_FEATURES = ("charge", "muon_source")
+
+
+# ---------------------------------------------------------------------------
+# Train / val / holdout split derived from contiguous ranges of record
+# batches inside each shard. The sharder has already globally shuffled
+# rows so a per-shard contiguous range is statistically uniform across
+# splits.
+#
+#   batches [0,                  n_train_rb)            -> train
+#   batches [n_train_rb,         n_train_rb + n_val_rb) -> val
+#   batches [n_train_rb + n_val_rb, n_total_rb)         -> holdout
+#
+# The trainer reads only its split's record batches (random-access via
+# the Arrow IPC file footer), so the val / holdout passes pay roughly
+# their split's fraction of the per-shard I/O cost — *not* a full
+# shard scan. The diagnostic script applies the same per-shard slice
+# (with split="holdout") so the model is evaluated on record batches
+# never touched at training time.
+# ---------------------------------------------------------------------------
+_SPLIT_NAMES = ("train", "val", "holdout", "all")
+DEFAULT_VAL_FRACTION = 0.1
+DEFAULT_HOLDOUT_FRACTION = 0.1
+
+
+def split_batch_range(
+    n_record_batches: int,
+    split: str,
+    val_fraction: float = DEFAULT_VAL_FRACTION,
+    holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
+) -> tuple[int, int]:
+    """Return ``(start, stop)`` record-batch indices in
+    ``[0, n_record_batches)`` for the requested split. Splits are
+    contiguous, disjoint, and cover the full range — train / val /
+    holdout sizes round down, holdout absorbs any rounding remainder
+    so the three together always sum to ``n_record_batches``.
+
+    ``split="all"`` returns the full range. Any other value raises."""
+    if split == "all":
+        return 0, int(n_record_batches)
+    if split not in _SPLIT_NAMES:
+        raise ValueError(
+            f"split must be one of {_SPLIT_NAMES}, got {split!r}"
+        )
+    if not (0.0 <= val_fraction < 1.0):
+        raise ValueError(
+            f"val_fraction must be in [0, 1), got {val_fraction!r}"
+        )
+    if not (0.0 <= holdout_fraction < 1.0):
+        raise ValueError(
+            f"holdout_fraction must be in [0, 1), got {holdout_fraction!r}"
+        )
+    if val_fraction + holdout_fraction >= 1.0:
+        raise ValueError(
+            f"val_fraction + holdout_fraction must be < 1.0, "
+            f"got {val_fraction} + {holdout_fraction}"
+        )
+    n_val = int(n_record_batches * val_fraction)
+    n_holdout = int(n_record_batches * holdout_fraction)
+    n_train = n_record_batches - n_val - n_holdout
+    if split == "train":
+        return 0, n_train
+    if split == "val":
+        return n_train, n_train + n_val
+    return n_train + n_val, n_record_batches  # "holdout"
 
 
 class TimedLoader:
@@ -363,16 +455,18 @@ def count_rows(shard_files: Sequence[str]) -> List[int]:
 
 
 def _per_batch_target_cond(cols: dict):
-    """Return (target [N, 3], cond [N, 5], weight [N]) in fp32 from
-    the raw fp32 columns of one Arrow record batch.
+    """Return (target [N, 3], cond [N, n_cond], weight [N]) in fp32
+    from the raw columns of one Arrow record batch.
 
     Mirrors :func:`compute_targets_and_conditioning` exactly:
 
     * ``r_kappa = kappa_reco / kappa_gen - 1``
     * ``dlambda = arctan(sinh(eta_reco)) - arctan(sinh(eta_gen))``
     * ``dphi = atan2(sin(phi_r - phi_g), cos(phi_r - phi_g))``
-    * conditioning: log_pt_gen (from kappa_gen+eta_gen),
-      sign(kappa_gen), lambda_gen, sin/cos(phi_gen).
+    * conditioning (in :data:`_COND_NAMES` order):
+      ``log_pt_gen, charge, lambda_gen, sin_phi_gen, cos_phi_gen,
+      muon_source`` -- the last is the per-muon class tag (1, 15 or
+      443) cast to float32 before standardisation downstream.
     """
     eta_r = cols["eta_reco"]
     phi_r = cols["phi_reco"]
@@ -380,6 +474,7 @@ def _per_batch_target_cond(cols: dict):
     phi_g = cols["phi_gen"]
     kappa_r = cols["kappa_reco"]
     kappa_g = cols["kappa_gen"]
+    muon_source = cols["muon_source"]
 
     lam_r = np.arctan(np.sinh(eta_r))
     lam_g = np.arctan(np.sinh(eta_g))
@@ -396,10 +491,17 @@ def _per_batch_target_cond(cols: dict):
     cond = np.stack(
         [
             log_pt_gen,
+            # ``charge`` stays ±1 and is left un-standardised
+            # downstream (see _PASSTHROUGH_COND_FEATURES).
             np.sign(kappa_g),
             lam_g,
             np.sin(phi_g),
             np.cos(phi_g),
+            # ``muon_source``: compact {-1, 0, +1} code rather than the
+            # raw {1, 15, 443} integers; the linear standardisation
+            # would otherwise collapse prompt/τ together and stretch
+            # J/ψ far out.
+            _muon_source_to_compact(muon_source),
         ],
         axis=1,
     ).astype(np.float32)
@@ -484,12 +586,19 @@ def _stats_chunk(arg):
     return n_kept, t_sum, t_sq, c_sum, c_sq, w_sum, abs_w_sum, n_filt
 
 
-def _enumerate_chunks(shard_files, batches_per_chunk: int, weight_mode: str):
-    """Build a list of (shard, batch_start, batch_stop, weight_mode)
-    work items. File-format shards expose ``num_record_batches``
-    (cheap, footer read); stream-format shards have to be walked to
-    count, which we do once here. Each shard's batches are split
-    into ``ceil(n_batches / batches_per_chunk)`` chunks."""
+def _enumerate_chunks(
+    shard_files, batches_per_chunk: int, weight_mode: str,
+    split: str = "train",
+    val_fraction: float = DEFAULT_VAL_FRACTION,
+    holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
+):
+    """Build a list of ``(shard, batch_start, batch_stop, weight_mode)``
+    work items, restricted to the requested split's contiguous
+    record-batch range inside each shard. File-format shards expose
+    ``num_record_batches`` (cheap, footer read); stream-format shards
+    have to be walked to count, which we do once here. Each shard's
+    split-range is then split into ``ceil(n_split_batches /
+    batches_per_chunk)`` chunks."""
     out = []
     for path in shard_files:
         src, reader = _open_ipc(path)
@@ -503,8 +612,13 @@ def _enumerate_chunks(shard_files, batches_per_chunk: int, weight_mode: str):
             src.close()
         if n_b == 0:
             continue
-        for start in range(0, n_b, batches_per_chunk):
-            stop = min(start + batches_per_chunk, n_b)
+        lo, hi = split_batch_range(
+            n_b, split, val_fraction, holdout_fraction,
+        )
+        if hi <= lo:
+            continue
+        for start in range(lo, hi, batches_per_chunk):
+            stop = min(start + batches_per_chunk, hi)
             out.append((path, start, stop, weight_mode))
     return out
 
@@ -514,6 +628,9 @@ def _compute_stats_robust(
     sample_rows: int,
     weight_mode: str,
     progress: bool,
+    split: str = "train",
+    val_fraction: float = DEFAULT_VAL_FRACTION,
+    holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
 ):
     """Sample-based robust location + scale: ``median`` for the
     location, ``1.4826 * MAD`` for the scale. Reads up to
@@ -541,7 +658,20 @@ def _compute_stats_robust(
             break
         src, reader = _open_ipc(path)
         try:
-            for batch in _iter_record_batches(reader):
+            # Restrict to the split's record-batch range. File-format
+            # shards expose ``num_record_batches`` via the footer
+            # (cheap); stream-format shards have to be walked, which
+            # forces a fall-back to "all" since we can't randomly
+            # skip ahead in a stream.
+            if isinstance(reader, ipc.RecordBatchFileReader):
+                n_b = reader.num_record_batches
+                lo, hi = split_batch_range(
+                    n_b, split, val_fraction, holdout_fraction,
+                )
+                batches_iter = (reader.get_batch(i) for i in range(lo, hi))
+            else:
+                batches_iter = _iter_record_batches(reader)
+            for batch in batches_iter:
                 if n_total >= sample_rows:
                     break
                 cols = _read_raw_columns(batch)
@@ -594,6 +724,12 @@ def _compute_stats_robust(
     c_mad = np.median(np.fabs(c_arr64 - c_median), axis=0)
     c_std = 1.4826 * c_mad
     c_std = np.where(c_std > 1e-6, c_std, 1.0)
+    # Force pass-through (no standardisation) on the categorical cond
+    # features -- see _PASSTHROUGH_COND_FEATURES.
+    for i, name in enumerate(_COND_NAMES):
+        if name in _PASSTHROUGH_COND_FEATURES:
+            c_median[i] = 0.0
+            c_std[i] = 1.0
 
     abs_w_mean = float(np.fabs(w_arr.astype(np.float64, copy=False)).mean())
 
@@ -623,6 +759,10 @@ def _compute_stats_robust(
 
 def compute_stats_streaming(
     shard_files: Sequence[str],
+    *,
+    split: str = "train",
+    val_fraction: float = DEFAULT_VAL_FRACTION,
+    holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
     max_rows: int = -1,
     n_workers: int = 0,
     batches_per_chunk: int = 32,
@@ -658,6 +798,10 @@ def compute_stats_streaming(
         raise ValueError(
             f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
         )
+    if split not in _SPLIT_NAMES:
+        raise ValueError(
+            f"split must be one of {_SPLIT_NAMES}, got {split!r}"
+        )
     if robust:
         # Dispatch to the sample-based median + 1.4826·MAD path.
         # Tail mass (e.g. r_kappa charge-mismeasurement peak) doesn't
@@ -666,6 +810,9 @@ def compute_stats_streaming(
         # perturbation is meant to span ~1 typical-event width.
         return _compute_stats_robust(
             shard_files, int(robust_sample_rows), weight_mode, progress,
+            split=split,
+            val_fraction=val_fraction,
+            holdout_fraction=holdout_fraction,
         )
     if n_workers <= 0:
         n_workers = max(1, (os.cpu_count() or 1))
@@ -678,7 +825,12 @@ def compute_stats_streaming(
             + (f", capped at {max_rows:,} rows" if max_rows > 0 else "")
         )
 
-    tasks = _enumerate_chunks(shard_files, batches_per_chunk, weight_mode)
+    tasks = _enumerate_chunks(
+        shard_files, batches_per_chunk, weight_mode,
+        split=split,
+        val_fraction=val_fraction,
+        holdout_fraction=holdout_fraction,
+    )
     if not tasks:
         raise RuntimeError("compute_stats_streaming: no record batches found")
 
@@ -731,6 +883,12 @@ def compute_stats_streaming(
     c_var = np.maximum(c_sq / n_total - c_mean * c_mean, 0.0)
     c_std = np.sqrt(c_var)
     c_std = np.where(c_std > 1e-6, c_std, 1.0)
+    # Force pass-through (no standardisation) on the categorical cond
+    # features -- see _PASSTHROUGH_COND_FEATURES.
+    for i, name in enumerate(_COND_NAMES):
+        if name in _PASSTHROUGH_COND_FEATURES:
+            c_mean[i] = 0.0
+            c_std[i] = 1.0
 
     # Normalisation scale: mean(|w|). Robust to MC@NLO-style signed
     # weights (where mean(w) can be near zero from cancellation) while
@@ -785,10 +943,14 @@ class ArrowShardLoader(torch_data.IterableDataset):
 
     * **Per-rank partition**: shards are dealt out round-robin to
       ranks via ``shard_files[rank::world_size]``.
-    * **Train/val split**: each record batch is sliced contiguously
-      — first ``val_fraction`` of rows go to val, rest to train. The
-      shards are already globally shuffled by the bucket-shuffle
-      pass, so this is unbiased.
+    * **Train/val/holdout split**: each split occupies a contiguous
+      range of record-batch indices within every shard (driven by
+      :func:`split_batch_range`). Train iterates the first ~80 % of
+      record batches per shard, val the next ~10 %, holdout the
+      last ~10 %. The sharder has already globally shuffled rows so
+      a per-shard range is statistically uniform across splits —
+      and each split's loader pays only its fraction of the
+      per-shard I/O and decompression cost.
     * **Per-epoch shuffle**: shard read-order is permuted; within
       each emitted training batch (accumulated from many record
       batches) rows are permuted again before yielding. Strong
@@ -817,8 +979,9 @@ class ArrowShardLoader(torch_data.IterableDataset):
         world_size: int,
         rank: int,
         batch_size: int,
-        split: str = "train",                  # "train" | "val" | "all"
-        val_fraction: float = 0.1,
+        split: str = "train",                  # "train" | "val" | "holdout" | "all"
+        val_fraction: float = DEFAULT_VAL_FRACTION,
+        holdout_fraction: float = DEFAULT_HOLDOUT_FRACTION,
         shuffle: bool = True,
         pin_memory: bool = True,
         drop_last: bool = True,
@@ -828,8 +991,10 @@ class ArrowShardLoader(torch_data.IterableDataset):
         shard_row_counts: Sequence[int] | None = None,
         num_workers_hint: int = 1,
     ):
-        if split not in ("train", "val", "all"):
-            raise ValueError(f"split must be train|val|all, got {split!r}")
+        if split not in _SPLIT_NAMES:
+            raise ValueError(
+                f"split must be one of {_SPLIT_NAMES}, got {split!r}"
+            )
         if weight_mode not in _WEIGHT_MODES:
             raise ValueError(
                 f"weight_mode must be one of {_WEIGHT_MODES}, got {weight_mode!r}"
@@ -851,6 +1016,7 @@ class ArrowShardLoader(torch_data.IterableDataset):
         self.batch_size = int(batch_size)
         self.split = split
         self.val_fraction = float(val_fraction)
+        self.holdout_fraction = float(holdout_fraction)
         self.shuffle = bool(shuffle)
         self.pin_memory = bool(pin_memory) and torch.cuda.is_available()
         self.drop_last = bool(drop_last)
@@ -883,13 +1049,18 @@ class ArrowShardLoader(torch_data.IterableDataset):
                 count_rows(self.my_shards) if self.my_shards else []
             )
         my_rows = sum(per_shard_rows)
-        frac = (
-            1.0 - self.val_fraction
-            if split == "train"
-            else self.val_fraction
-            if split == "val"
-            else 1.0
-        )
+        # Row-count estimate matches the per-shard contiguous record-
+        # batch range each split actually iterates. Train rounds up
+        # (its range absorbs the int-rounding remainder); val and
+        # holdout floor at their respective fractions.
+        if split == "train":
+            frac = 1.0 - self.val_fraction - self.holdout_fraction
+        elif split == "val":
+            frac = self.val_fraction
+        elif split == "holdout":
+            frac = self.holdout_fraction
+        else:  # "all"
+            frac = 1.0
         my_rows_split = int(my_rows * frac)
         # Always round up: with multiple DataLoader workers the
         # actual yielded count can EXCEED a floor-divided estimate,
@@ -922,11 +1093,15 @@ class ArrowShardLoader(torch_data.IterableDataset):
         return x_t, c_t, w_t
 
     def _ensure_layout(self):
-        """Populate ``self._layout`` (list of ``(shard_idx, batch_idx)``
-        pairs across this rank's shards). Reads only IPC footers /
-        message counts — no record-batch decompression. Cached after
-        the first call; cheap to compute even at 32 shards × 4 500
-        batches each (~ms)."""
+        """Populate ``self._layout`` — the list of
+        ``(shard_idx, batch_idx)`` pairs this loader's split occupies
+        across this rank's shards. Each shard's record-batch range
+        is restricted to the contiguous slice corresponding to
+        ``self.split`` (via :func:`split_batch_range`), so the
+        DataLoader-worker partition and the standalone iteration
+        path both touch *only* the split's record batches. Reads
+        only IPC footers / message counts — no record-batch
+        decompression. Cached after the first call."""
         if self._layout is not None:
             return
         layout = []
@@ -941,7 +1116,11 @@ class ArrowShardLoader(torch_data.IterableDataset):
                 if hasattr(reader, "close"):
                     reader.close()
                 src.close()
-            for b in range(n_b):
+            lo, hi = split_batch_range(
+                n_b, self.split,
+                self.val_fraction, self.holdout_fraction,
+            )
+            for b in range(lo, hi):
                 layout.append((s_idx, b))
         self._layout = layout
 
@@ -1080,7 +1259,29 @@ class ArrowShardLoader(torch_data.IterableDataset):
         )
 
         if chunks is None:
-            chunks = [(i, None) for i in range(len(self.my_shards))]
+            # Standalone path (no DataLoader workers): build the
+            # split's per-shard contiguous batch-index range up
+            # front. Mirrors what ``_partition_for_worker`` /
+            # ``_ensure_layout`` would do, but keeps the chunk list
+            # tied to *each* shard's full split range (not subdivided
+            # across DataLoader workers).
+            chunks = []
+            for s_idx, path in enumerate(self.my_shards):
+                src, reader = _open_ipc(path)
+                try:
+                    n_b = _num_record_batches(reader)
+                    if n_b < 0:
+                        n_b = sum(1 for _ in reader)
+                finally:
+                    if hasattr(reader, "close"):
+                        reader.close()
+                    src.close()
+                lo, hi = split_batch_range(
+                    n_b, self.split,
+                    self.val_fraction, self.holdout_fraction,
+                )
+                if hi > lo:
+                    chunks.append((s_idx, list(range(lo, hi))))
         else:
             # Defensive copy — we shuffle this list in place below.
             chunks = list(chunks)
@@ -1147,24 +1348,11 @@ class ArrowShardLoader(torch_data.IterableDataset):
                     if n == 0:
                         continue
 
-                    # Train/val split (contiguous per record batch).
-                    n_val = int(n * self.val_fraction)
-                    if self.split == "train":
-                        target = target[n_val:]
-                        cond = cond[n_val:]
-                        w = w[n_val:]
-                    elif self.split == "val":
-                        target = target[:n_val]
-                        cond = cond[:n_val]
-                        w = w[:n_val]
-                    n = target.shape[0]
-                    if n == 0:
-                        continue
-
-                    # Filter rows: target/cond must be finite, weight
-                    # mode applies its own keep mask (abs: drop w==0
-                    # & non-finite; keep: drop only non-finite; drop:
-                    # drop w<=0 & non-finite).
+                    # Only finite-ness + weight policy filters here;
+                    # the train / val / holdout split is already
+                    # applied at the record-batch level upstream (the
+                    # caller hands us exactly the batches assigned to
+                    # ``self.split``).
                     target_finite = (
                         np.isfinite(target).all(axis=1)
                         & np.isfinite(cond).all(axis=1)

--- a/scripts/corrections/muon_calibration/flow_training_snapshot.py
+++ b/scripts/corrections/muon_calibration/flow_training_snapshot.py
@@ -1,0 +1,1068 @@
+"""Produce a flat per-muon snapshot of MC for normalizing-flow training.
+
+Two source modes share a single output schema; running both modes
+yields snapshots that can be merged and shuffled together by the
+sharding step.
+
+  --source jpsi  Custom J/psi ideal-geometry ntuples (default). The
+                 LBL muon calibration is applied to obtain post-
+                 correction Mu{plus,minus}cor_{pt,eta,phi}; each event
+                 row carries an RVec of length 2, one per muon.
+
+  --source wz    Standard NanoAOD W/Z MC, enumerated via
+                 ``wremnants.production.datasets.dataset_tools.getDatasets``
+                 (filtered to processes in
+                 ``wremnants.utilities.samples.wprocs + zprocs``). The
+                 ``vetoMuonsPre && genMatchedMuons`` selection is
+                 applied (gen-matched, loose veto preselection — same
+                 mask used by w_z_muonresponse.py for its response
+                 histograms). Each event row carries an RVec of the N
+                 selected muons.
+
+Both modes write the same unified per-event RVec schema (one row per
+event; the sharder flattens to per-muon rows):
+
+  eta_reco[N]     ROOT::RVec<float>   post-correction reco eta
+  phi_reco[N]     ROOT::RVec<float>   post-correction reco phi
+  eta_gen[N]      ROOT::RVec<float>   matched gen eta
+  phi_gen[N]      ROOT::RVec<float>   matched gen phi
+  kappa_reco[N]   ROOT::RVec<float>   q_reco / (pt_reco * cosh(eta_reco))
+  kappa_gen[N]    ROOT::RVec<float>   q_gen  / (pt_gen  * cosh(eta_gen))
+  nominal_weight[N] ROOT::RVec<float> event weight, replicated per muon
+  source_id[N]    ROOT::RVec<int>     dataset tag (--source-id base; W/Z
+                                      auto-increments per dataset)
+
+``kappa = q / |p|`` is the signed inverse momentum (``q`` the muon
+charge, ``|p| = pt * cosh(eta)``); it factors charge and ``|p|`` into
+the single per-muon scalar the flow's ``r_kappa = kappa_reco/kappa_gen
+- 1`` target consumes directly. ``sign(kappa)`` recovers the muon
+charge when needed; ``pt = 1 / (|kappa| * cosh(eta))`` recovers pt.
+
+For J/psi: N == 2, the RVec is built explicitly from the per-event
+Mu{plus,minus}{cor,gen}_{pt,eta,phi} columns; kappa_reco / kappa_gen
+have signs ``{+, -}`` by construction (sign-labelled muon legs).
+
+For W/Z: N == popcount(selMuons), variable per event; the signs are
+``Muon_correctedCharge[selMuons]`` and the sign of
+``GenPart_pdgId[Muon_genPartIdx[selMuons]]`` respectively. They may
+differ when reco mismeasures the curvature; the resulting sign flip
+in ``kappa_reco`` makes ``r_kappa = -2`` and lets the flow learn the
+charge-mismeasurement mode explicitly.
+
+Outputs
+-------
+  --source jpsi  --output FILE                Single .root file.
+  --source wz    --output-dir DIR             One .root per W/Z dataset
+                                              (dir/<dataset>.root).
+
+The sharding pass is not invoked from this script when running in
+either snapshot mode. After producing one or more snapshots, invoke
+``--shard-only --inputs file1.root [file2.root ...]`` to run the
+bucket-shuffle + Arrow IPC sharding pipeline from
+:mod:`wremnants.production.arrow_shard_export` over the union of
+inputs. Bucket assignment is computed at shard time from
+``(source_id, entry, muon_idx_in_event)``, so reproducibility depends
+on the ordering of ``--inputs``.
+
+Bare invocation (no mode flag) runs the full pipeline end-to-end:
+``--source jpsi`` -> ``--source wz`` -> ``--shard-only`` using the
+default output locations.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import List
+
+
+def _source_meta_path(snapshot_path: str) -> str:
+    """Return the path to the ``<basename>.source_meta.json`` side-car
+    next to a snapshot file. Sits beside the snapshot so the sharder
+    can find it without an out-of-band registry; if absent, the
+    sharder simply skips that source in the manifest's label map."""
+    root, _ = os.path.splitext(snapshot_path)
+    return root + ".source_meta.json"
+
+
+def _write_source_meta(snapshot_path: str, entries: List[dict]) -> None:
+    """Write ``{"entries": [{"source_id": int, "sample_name": str}, ...]}``
+    next to ``snapshot_path``. The sharder picks these up to build
+    ``manifest.json``'s ``source_labels`` map, which downstream tools
+    (e.g. ``shift_smear_reweight_diagnostics``) use to display readable
+    legend labels in per-source plots."""
+    meta_path = _source_meta_path(snapshot_path)
+    payload = {"entries": list(entries)}
+    with open(meta_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"  wrote source-id label side-car: {meta_path}")
+
+# Heavy imports (ROOT, wremnants, narf, pyxrootd, …) are deferred to
+# inside the ``run_jpsi_snapshot`` / ``run_wz_snapshot`` /
+# ``run_shard_only`` functions. The orchestrator path (bare
+# invocation, no mode flag) never touches them.
+#
+# **Import order matters** inside each run_* function:
+#   1. ``import XRootD.client`` first — pins pyxrootd's bundled
+#      libssl-1.1 + libcrypto-1.1 in the global symbol table so that
+#      pyarrow (transitively pulled in by wremnants via hist /
+#      uproot) can't later shadow ``CRYPTO_THREAD_*`` with its
+#      OpenSSL-3 libcrypto and crash the xrootd TLS handshake in
+#      ``OPENSSL_init_ssl``.
+#   2. ``import ROOT`` second — fine because the installed pyxrootd
+#      is pinned to ``xrootd<6`` (v5), so its ``libXrdCl.so.3``
+#      matches the one ROOT bundles. With xrootd v6 the SONAMEs
+#      diverged (pyxrootd shipped ``libXrdCl.so.6``) and ROOT's
+#      ``TNetXNGFile::Open`` cross-dispatched into pyxrootd's
+#      vtables and segfaulted — that's why the xrootd downgrade
+#      matters and the ``XRootD.client``-first rule below is now
+#      safe.
+
+
+DEFAULT_JPSI_INPUT_PATHS = [
+    # Pt8toInf samples -> source_id = base (e.g. 0).
+    "root://eoscms.cern.ch//store/group/phys_smp/ec/bendavid/muoncal/"
+    "JPsiToMuMu_Pt8toInf-pythia8/MuonGunUL2016_v722_"
+    "RecJpsiPythiaPhotosPt8toInf_quality_novtx_noconstraint_idealgeom/",
+    "root://eoscms.cern.ch//store/group/phys_smp/ec/bendavid/muoncal/"
+    "JPsiToMuMu_Pt8toInf-pythia8/MuonGunUL2016_v722_"
+    "RecJpsiPythiaPhotosPt8toInfExt1_quality_novtx_noconstraint_idealgeom/",
+    # Pt0to8 samples -> source_id = base + 1.
+    "root://eoscms.cern.ch//store/group/phys_smp/ec/bendavid/muoncal/"
+    "JPsiToMuMu_Pt0to8-pythia8/MuonGunUL2016_v722_"
+    "RecJpsiPythiaPhotosPt0to8_quality_novtx_noconstraint_idealgeom/",
+    "root://eoscms.cern.ch//store/group/phys_smp/ec/bendavid/muoncal/"
+    "JPsiToMuMu_Pt0to8-pythia8/MuonGunUL2016_v722_"
+    "RecJpsiPythiaPhotosPt0to8Ext1_quality_novtx_noconstraint_idealgeom/",
+]
+
+
+def _jpsi_sample_source_offset(path: str) -> int:
+    """Per-sample offset added to ``--source-id`` for J/psi.
+
+    The two 8toInf samples share offset 0 (the historical default
+    behaviour). The two 0to8 samples get offset 1 so they remain
+    distinguishable in the ``source_id`` column. Anything else falls
+    back to 0 — safer than failing on an unrecognised path. Mirrors
+    the C++ matcher used by ``DefinePerSample`` at snapshot time.
+    """
+    return 1 if "Pt0to8" in path else 0
+
+
+# Per-event RVec columns written for both --source modes. Trainer
+# consumes the flattened (per-muon) rows after the sharding pass.
+OUTPUT_BRANCHES = [
+    "eta_reco",
+    "phi_reco",
+    "eta_gen",
+    "phi_gen",
+    "kappa_reco",
+    "kappa_gen",
+    "nominal_weight",
+    "source_id",
+]
+
+# Columns written as int32 (everything else is fp32). Carried through
+# the sharder so downstream code can filter/split rows by source.
+INT_BRANCHES = ("source_id",)
+
+
+class _HelpFmt(
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    """Keep the module docstring's raw newlines, and append "(default:
+    ...)" to every option's help line automatically.
+    """
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=_HelpFmt,
+    )
+    mode = p.add_mutually_exclusive_group(required=False)
+    mode.add_argument(
+        "--source",
+        choices=["jpsi", "wz"],
+        help="Snapshot mode: 'jpsi' reads custom J/psi ideal-geometry "
+        "ntuples (--input-paths); 'wz' enumerates W/Z MC datasets via "
+        "wremnants getDatasets() (--data-path, --era). If neither this "
+        "nor --shard-only is given, the script runs the full pipeline "
+        "end-to-end (jpsi snapshot, wz snapshot, then shard) by "
+        "re-invoking itself once per step in a subprocess (avoids the "
+        "pyarrow + pyxrootd OpenSSL ABI clash that segfaults when "
+        "both libraries coexist in one process).",
+    )
+    mode.add_argument(
+        "--shard-only",
+        action="store_true",
+        help="Skip snapshot creation; run only the bucket-shuffle + "
+        "Arrow IPC sharding pass over --inputs (one or more snapshot "
+        "files produced by previous --source invocations).",
+    )
+
+    # ---- J/psi-source inputs ----------------------------------------
+    p.add_argument(
+        "--input-paths",
+        nargs="+",
+        default=DEFAULT_JPSI_INPUT_PATHS,
+        metavar="PATH",
+        help="(--source jpsi only) Top-level xrootd/posix paths or "
+        "explicit .root files. Each entry is resolved via "
+        "wremnants.production.datasets.dataset_tools.buildFileList. "
+        "The built-in default is the two ideal-geometry J/psi MC "
+        "samples used by jpsi_module_corrections.py.",
+    )
+    p.add_argument(
+        "--input-tree",
+        default="tree",
+        help="(--source jpsi only) TTree name inside the J/psi input "
+        "files.",
+    )
+    p.add_argument(
+        "--max-files",
+        type=int,
+        default=-1,
+        help="(--source jpsi only) Cap on number of input .root files "
+        "after resolution. -1 uses all.",
+    )
+
+    # ---- W/Z-source inputs ------------------------------------------
+    p.add_argument(
+        "--data-path",
+        default=None,
+        help="(--source wz only) Base path passed to getDatasets() for "
+        "NanoAOD discovery. None lets wremnants pick the default.",
+    )
+    p.add_argument(
+        "--era",
+        default="2016PostVFP",
+        help="Era label. Used by pileup/vertex helpers (both modes) "
+        "and for W/Z dataset selection.",
+    )
+    p.add_argument(
+        "--nano-version",
+        default="v9",
+        help="(--source wz only) nanoVersion passed to getDatasets().",
+    )
+    p.add_argument(
+        "--wz-max-files",
+        type=int,
+        default=-1,
+        help="(--source wz only) Cap on input files per dataset (via "
+        "getDatasets(maxFiles=)). -1 uses all.",
+    )
+    p.add_argument(
+        "--filter-procs",
+        nargs="*",
+        default=None,
+        help="(--source wz only) Optional list of dataset name "
+        "substrings to KEEP in addition to the default W/Z filter. "
+        "If unset, all samples.wprocs + samples.zprocs are kept "
+        "(modulo --include-tau-procs).",
+    )
+    p.add_argument(
+        "--include-tau-procs",
+        action="store_true",
+        help="(--source wz only) Include Wτν / Z→ττ samples in the W/Z "
+        "snapshot. They are excluded by default because the muon "
+        "selection requires Muon_genPartFlav == 1 (prompt-only), and "
+        "these samples otherwise contribute only secondary muons from "
+        "τ decays.",
+    )
+
+    # ---- W/Z calibration knobs (forwarded to define_corrected_muons) -
+    p.add_argument(
+        "--muonCorrMC",
+        default="idealMC_lbltruth",
+        help="(--source wz only) MC muon correction type. Default "
+        "matches w_z_muonresponse.py.",
+    )
+    p.add_argument(
+        "--muonCorrData",
+        default="massfit",
+        help="(--source wz only) Data muon correction type. Unused on "
+        "MC-only snapshots; kept for define_corrected_muons API.",
+    )
+    p.add_argument(
+        "--muonScaleVariation",
+        default="smearingWeightsGaus",
+        help="(--source wz only) Scale variation method (forwarded).",
+    )
+    p.add_argument(
+        "--biasCalibration",
+        default=None,
+        help="(--source wz only) bias calibration mode. None disables "
+        "the bias-helper branch in define_corrected_muons.",
+    )
+    p.add_argument(
+        "--noSmearing",
+        action="store_true",
+        help="(--source wz only) Disable the resolution smearing "
+        "applied during define_corrected_muons.",
+    )
+
+    # ---- source_id stamp ------------------------------------------
+    p.add_argument(
+        "--source-id",
+        type=int,
+        default=None,
+        help="Integer stamped into the ``source_id`` column. "
+        "--source jpsi: stamps every row with this value. "
+        "--source wz: this is the base; dataset i (in getDatasets() "
+        "order) gets ``source_id = base + i``. None auto-selects: 0 "
+        "for --source jpsi, 100 for --source wz (avoids the default "
+        "J/psi vs W/Z collision in an end-to-end run).",
+    )
+
+    # ---- Output ------------------------------------------------------
+    p.add_argument(
+        "--output",
+        default=None,
+        help="(--source jpsi only) Output .root file path. None falls "
+        "back to flow_training_snapshot_jpsi.root in the cwd.",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="(--source wz only) Output directory; one "
+        "<dataset_name>.root is written per dataset. None falls back "
+        "to ./flow_training_snapshot_wz/.",
+    )
+    p.add_argument(
+        "--output-tree",
+        default="tree",
+        help="RNTuple name inside each output file.",
+    )
+    p.add_argument(
+        "--snapshot-format",
+        choices=["rntuple", "ttree"],
+        default="rntuple",
+        help="Output snapshot format. The sharding step requires "
+        "RNTuple; TTree kept as a legacy path.",
+    )
+
+    # ---- Runtime knobs ----------------------------------------------
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=0,
+        help="Number of threads for ImplicitMT. 0 leaves ROOT to choose.",
+    )
+    p.add_argument(
+        "--pt-min",
+        type=float,
+        default=2.0,
+        help="(--source jpsi only) Reject events where either gen pt "
+        "is below this (GeV).",
+    )
+    p.add_argument(
+        "--eta-max",
+        type=float,
+        default=2.5,
+        help="(--source jpsi only) |gen eta| cut, applied to both "
+        "muons.",
+    )
+    p.add_argument(
+        "--no-progress",
+        dest="progress",
+        action="store_false",
+        default=True,
+        help="Disable the RDF progress bar (jpsi mode only).",
+    )
+
+    # ---- Sharding (--shard-only mode + post-snapshot shortcut) -----
+    p.add_argument(
+        "--inputs",
+        nargs="+",
+        default=None,
+        help="(--shard-only only) One or more snapshot .root files "
+        "to merge + shard. None auto-detects "
+        "./flow_training_snapshot_jpsi.root + "
+        "./flow_training_snapshot_wz/*.root produced by the default "
+        "--source jpsi / --source wz invocations.",
+    )
+    p.add_argument(
+        "--n-buckets",
+        type=int,
+        default=1024,
+        help="Bucket count for the shard pass. Per-bucket RAM during "
+        "phase 2 is ~ total_rows / n_buckets.",
+    )
+    p.add_argument(
+        "--shard-workers",
+        type=int,
+        default=os.cpu_count() or 8,
+        help="Phase-1 parallel readers for the shard pass (xrootd / "
+        "disk read + decompression). Default: ``os.cpu_count()``. "
+        "Phase 2 is separately capped at ``--shard-count`` writers "
+        "(Arrow IPC files can't be concurrently appended to).",
+    )
+    p.add_argument(
+        "--shard-count",
+        type=int,
+        default=32,
+        help="Number of output Arrow IPC shard files. Each is "
+        "written by one phase-2 worker; intra-shard parallelism "
+        "comes from phase 1's larger pool.",
+    )
+    p.add_argument(
+        "--shard-output-dir",
+        default=None,
+        help="(--shard-only only) Directory for Arrow IPC shards + "
+        "manifest.json. None falls back to <inputs[0] dir>/shards.",
+    )
+    p.add_argument(
+        "--shard-rows-per-batch",
+        type=int,
+        default=16384,
+        help="Rows per Arrow record batch in each shard.",
+    )
+    p.add_argument(
+        "--shard-seed",
+        type=int,
+        default=42,
+        help="Seed for the SplitMix64 bucket hash (applied to "
+        "(source_id, entry, muon_idx)) and the in-bucket shuffle "
+        "permutations.",
+    )
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# J/psi: explicit two-muon RVec build from the side-by-side per-event columns
+# ---------------------------------------------------------------------------
+
+
+def _declare_jpsi_sample_helper():
+    """JIT-declare the per-sample source_id matcher used by
+    ``DefinePerSample`` in J/psi mode. The matcher inspects the chain
+    link string (which embeds the input file URL) and returns
+    ``base + 1`` for Pt0to8 samples and ``base`` for everything else
+    (Pt8toInf or unrecognised). Idempotent — repeated declarations
+    are no-ops in cling.
+    """
+    import ROOT
+    ROOT.gInterpreter.Declare(
+        """
+        #ifndef _FLOW_JPSI_SAMPLE_HELPER_DECLARED
+        #define _FLOW_JPSI_SAMPLE_HELPER_DECLARED
+        namespace _flow_jpsi {
+            inline int sample_source_id(
+                const ROOT::RDF::RSampleInfo& info, int base
+            ) {
+                const std::string s = info.AsString();
+                if (s.find("Pt0to8") != std::string::npos) return base + 1;
+                return base;
+            }
+        }
+        #endif
+        """
+    )
+
+
+def _define_jpsi_rvecs(df, source_id_base: int):
+    """Define the unified per-muon RVec schema on a J/psi RDataFrame.
+
+    Each event becomes a 2-element RVec (mu+ first, mu- second).
+    The kappa pair has signs ``{+, -}`` by construction (sign-labelled
+    legs); the trainer recovers gen charge as ``sign(kappa_gen)`` and
+    pt as ``1 / (|kappa| * cosh(eta))``. ``source_id`` is assigned
+    per-sample via ``DefinePerSample`` from the chain link path:
+    Pt0to8 samples get ``source_id_base + 1``, everything else
+    (Pt8toInf or unrecognised) gets ``source_id_base``.
+    """
+    _declare_jpsi_sample_helper()
+    df = df.DefinePerSample(
+        "sample_source_id",
+        f"_flow_jpsi::sample_source_id(rdfsampleinfo_, {int(source_id_base)})",
+    )
+    df = df.Define(
+        "eta_reco",
+        "ROOT::VecOps::RVec<float>{"
+        " static_cast<float>(Mupluscor_eta),"
+        " static_cast<float>(Muminuscor_eta)}",
+    )
+    df = df.Define(
+        "phi_reco",
+        "ROOT::VecOps::RVec<float>{"
+        " static_cast<float>(Mupluscor_phi),"
+        " static_cast<float>(Muminuscor_phi)}",
+    )
+    df = df.Define(
+        "eta_gen",
+        "ROOT::VecOps::RVec<float>{"
+        " static_cast<float>(Muplusgen_eta),"
+        " static_cast<float>(Muminusgen_eta)}",
+    )
+    df = df.Define(
+        "phi_gen",
+        "ROOT::VecOps::RVec<float>{"
+        " static_cast<float>(Muplusgen_phi),"
+        " static_cast<float>(Muminusgen_phi)}",
+    )
+    # kappa = q / |p| = q / (pt * cosh(eta)). Sign-labelled legs give
+    # the {+1, -1} signs; |p| reuses the same pt/eta we just defined.
+    df = df.Define(
+        "kappa_reco",
+        "ROOT::VecOps::RVec<float>{"
+        " +1.0f / (static_cast<float>(Mupluscor_pt) "
+        "          * std::cosh(static_cast<float>(Mupluscor_eta))),"
+        " -1.0f / (static_cast<float>(Muminuscor_pt) "
+        "          * std::cosh(static_cast<float>(Muminuscor_eta)))}",
+    )
+    df = df.Define(
+        "kappa_gen",
+        "ROOT::VecOps::RVec<float>{"
+        " +1.0f / (static_cast<float>(Muplusgen_pt) "
+        "          * std::cosh(static_cast<float>(Muplusgen_eta))),"
+        " -1.0f / (static_cast<float>(Muminusgen_pt) "
+        "          * std::cosh(static_cast<float>(Muminusgen_eta)))}",
+    )
+    df = df.Define(
+        "nominal_weight",
+        "ROOT::VecOps::RVec<float>{"
+        " static_cast<float>(nominal_weight_event),"
+        " static_cast<float>(nominal_weight_event)}",
+    )
+    df = df.Define(
+        "source_id",
+        "ROOT::VecOps::RVec<int>{sample_source_id, sample_source_id}",
+    )
+    return df
+
+
+def resolve_jpsi_input_paths(paths: List[str]) -> List[str]:
+    # Caller (run_jpsi_snapshot) has already imported ROOT, so
+    # pyxrootd loaded here through dataset_tools comes second and
+    # ROOT's libXrdCl wins the symbol resolution.
+    from wremnants.production.datasets import dataset_tools
+    out: List[str] = []
+    for p in paths:
+        if p.lower().endswith(".root"):
+            out.append(p)
+            continue
+        found = dataset_tools.buildFileList(p)
+        if not found:
+            print(
+                f"warning: no .root files found under {p}", file=sys.stderr
+            )
+        out.extend(found)
+    return out
+
+
+def run_jpsi_snapshot(args) -> str:
+    # ``XRootD.client`` first: pins pyxrootd's bundled libssl-1.1 +
+    # libcrypto-1.1 in the global symbol table before pyarrow's
+    # libcrypto-3 (pulled in via ``wremnants.production.muon_calibration``
+    # -> hist / uproot) can shadow them. Requires xrootd pip package
+    # < 6 so that pyxrootd's libXrdCl matches ROOT's (both v5).
+    import XRootD.client  # noqa: F401
+    import ROOT
+    import wremnants
+    import wremnants.production.muon_calibration
+    import wremnants.production.pileup
+    import wremnants.production.vertex
+
+    out = args.output or "flow_training_snapshot_jpsi.root"
+    out_dir = os.path.dirname(os.path.abspath(out))
+    if out_dir and not os.path.isdir(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
+
+    print("resolving J/psi input paths")
+    files = resolve_jpsi_input_paths(args.input_paths)
+    if not files:
+        print("error: no input files resolved", file=sys.stderr)
+        return ""
+    if args.max_files > 0 and len(files) > args.max_files:
+        print(f"  capping from {len(files)} to {args.max_files} files")
+        files = files[: args.max_files]
+    print(f"  {len(files)} file(s) to read")
+
+    # IMT is process-global; skip re-enabling if a previous step
+    # already turned it on (bare-invocation pipeline runs all three
+    # run_* in one process).
+    if not ROOT.ROOT.IsImplicitMTEnabled():
+        if args.threads == 0:
+            ROOT.ROOT.EnableImplicitMT()
+        elif args.threads > 1:
+            ROOT.ROOT.EnableImplicitMT(args.threads)
+
+    print("building RDF and applying LBL corrections")
+    t0 = time.time()
+    df = ROOT.ROOT.RDataFrame(args.input_tree, files)
+    if args.progress:
+        ROOT.ROOT.RDF.Experimental.AddProgressBar(df)
+
+    helper = (
+        wremnants.production.muon_calibration.make_muon_calibration_helper_single()
+    )
+    df = (
+        wremnants.production.muon_calibration
+        .define_lbl_corrections_jpsi_calibration_ntuples(df, helper)
+    )
+
+    pileup_helper = wremnants.production.pileup.make_pileup_helper(era=args.era)
+    vertex_helper = wremnants.production.vertex.make_vertex_helper(era=args.era)
+    df = df.DefinePerSample("weight", "1.0")
+    df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
+    df = df.Define("weight_vtx", vertex_helper, ["Jpsigen_z", "Pileup_nTrueInt"])
+    df = df.Define("nominal_weight_event", "weight*weight_pu*weight_vtx")
+
+    df = df.Filter(
+        f"std::fabs(Muplusgen_eta) < {args.eta_max} && "
+        f"std::fabs(Muminusgen_eta) < {args.eta_max}",
+        "eta_acceptance",
+    )
+    df = df.Filter(
+        f"Muplusgen_pt > {args.pt_min} && Muminusgen_pt > {args.pt_min} && "
+        f"Mupluscor_pt > 0. && Muminuscor_pt > 0.",
+        "pt_positivity_and_gen_minimum",
+    )
+
+    source_id_base = 0 if args.source_id is None else int(args.source_id)
+    df = _define_jpsi_rvecs(df, source_id_base=source_id_base)
+    # Print the planned per-sample assignment so the user can verify
+    # the input files matched the expected Pt0to8 / Pt8toInf buckets.
+    n_0to8 = sum("Pt0to8" in p for p in files)
+    n_other = len(files) - n_0to8
+    print(
+        f"  source_id assignments (DefinePerSample):\n"
+        f"    Pt8toInf / other -> {source_id_base}   ({n_other} file(s))\n"
+        f"    Pt0to8           -> {source_id_base + 1}   ({n_0to8} file(s))"
+    )
+
+    snapshot_options = ROOT.RDF.RSnapshotOptions()
+    if args.snapshot_format == "rntuple":
+        snapshot_options.fOutputFormat = (
+            ROOT.RDF.ESnapshotOutputFormat.kRNTuple
+        )
+        snapshot_options.fCompressionAlgorithm = (
+            ROOT.RCompressionSetting.EAlgorithm.kLZ4
+        )
+        snapshot_options.fCompressionLevel = 1
+        print(f"snapshotting to RNTuple LZ4 -> {out}")
+    else:
+        snapshot_options.fCompressionAlgorithm = (
+            ROOT.RCompressionSetting.EAlgorithm.kZSTD
+        )
+        snapshot_options.fCompressionLevel = 5
+        print(f"snapshotting to TTree ZSTD -> {out}")
+
+    cols_vec = ROOT.std.vector("string")()
+    for c in OUTPUT_BRANCHES:
+        cols_vec.push_back(c)
+    df.Snapshot(args.output_tree, out, cols_vec, snapshot_options)
+
+    # Persist the source_id -> sample mapping next to the snapshot so
+    # the sharder can merge it into manifest.json. The matcher tags
+    # ``Pt0to8`` files with ``base+1`` and everything else with ``base``;
+    # skip the +1 entry when no Pt0to8 files were used.
+    jpsi_entries = [
+        {"source_id": source_id_base, "sample_name": "J/psi (pT>8 GeV)"},
+    ]
+    if n_0to8 > 0:
+        jpsi_entries.append(
+            {"source_id": source_id_base + 1,
+             "sample_name": "J/psi (pT<8 GeV)"}
+        )
+    _write_source_meta(out, jpsi_entries)
+
+    dt = time.time() - t0
+    print(f"snapshot done in {dt:.1f}s")
+    print(f"output file size: {os.path.getsize(out) / 1e6:.1f} MB")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# W/Z: gen-matched vetoMuonsPre selection on standard NanoAOD MC
+# ---------------------------------------------------------------------------
+
+
+def _define_wz_rvecs(df, dataset, args, calib_helpers, source_id: int):
+    import wremnants.production.muon_calibration
+    import wremnants.production.muon_selections
+    """Define the unified per-muon RVec schema on a W/Z RDataFrame.
+
+    Applies the same selMuons mask as ``w_z_muonresponse.py``
+    (vetoMuonsPre && genMatchedMuons) and projects per-muon RVecs from
+    Muon_corrected* and the matched GenPart_* arrays.
+    """
+    pileup_helper, vertex_helper, mc_calibration_helper, mc_jpsi_crctn_helper, \
+        smearing_helper, bias_helper = calib_helpers
+
+    df = df.Define("weight", "std::copysign(1.0, genWeight)")
+    df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
+    df = df.Define("weight_vtx", vertex_helper, ["GenVtx_z", "Pileup_nTrueInt"])
+    df = df.Define("nominal_weight_event", "weight*weight_pu*weight_vtx")
+
+    df = wremnants.production.muon_calibration.define_corrected_muons(
+        df,
+        mc_calibration_helper,
+        mc_jpsi_crctn_helper,
+        args,
+        dataset,
+        smearing_helper,
+        bias_helper,
+    )
+    df = wremnants.production.muon_selections.select_veto_muons(df, nMuons=-1)
+    # genPartFlav == 1: prompt muon (direct W/Z decay product).
+    # genPartFlav == 15: secondary muon from a τ decay -- these enter
+    # the calibration sample with a softer pT spectrum and biased gen-
+    # matching geometry, so we drop them here.
+    df = df.Define("genMatchedMuons", "Muon_genPartFlav == 1")
+    df = df.Define("selMuons", "vetoMuonsPre && genMatchedMuons")
+
+    df = df.Define("selMuons_genPartIdx", "Muon_genPartIdx[selMuons]")
+    df = df.Define(
+        "selMuons_genPdgId",
+        "Take(GenPart_pdgId, selMuons_genPartIdx)",
+    )
+
+    df = df.Define(
+        "eta_reco",
+        "ROOT::VecOps::RVec<float>(Muon_correctedEta[selMuons])",
+    )
+    df = df.Define(
+        "phi_reco",
+        "ROOT::VecOps::RVec<float>(Muon_correctedPhi[selMuons])",
+    )
+    df = df.Define(
+        "eta_gen",
+        "ROOT::VecOps::RVec<float>(Take(GenPart_eta, selMuons_genPartIdx))",
+    )
+    df = df.Define(
+        "phi_gen",
+        "ROOT::VecOps::RVec<float>(Take(GenPart_phi, selMuons_genPartIdx))",
+    )
+
+    # kappa = q / |p| = q / (pt * cosh(eta)). Reco uses
+    # Muon_correctedCharge (which may mismeasure); gen uses the sign
+    # of the matched GenPart_pdgId. For mismeasured muons,
+    # sign(kappa_reco) != sign(kappa_gen), which the trainer's
+    # r_kappa = kappa_reco/kappa_gen - 1 sees as a ~-2 mode.
+    df = df.Define(
+        "kappa_reco",
+        "ROOT::VecOps::RVec<float>("
+        "  ROOT::VecOps::RVec<float>(Muon_correctedCharge[selMuons])"
+        "  / (ROOT::VecOps::RVec<float>(Muon_correctedPt[selMuons])"
+        "     * cosh(eta_reco))"
+        ")",
+    )
+    df = df.Define(
+        "kappa_gen",
+        "ROOT::VecOps::RVec<float>("
+        "  (-1.0f*(selMuons_genPdgId > 0) + 1.0f*(selMuons_genPdgId < 0))"
+        "  / (ROOT::VecOps::RVec<float>(Take(GenPart_pt, selMuons_genPartIdx))"
+        "     * cosh(eta_gen))"
+        ")",
+    )
+
+    df = df.Define(
+        "nominal_weight",
+        "ROOT::VecOps::RVec<float>(eta_reco.size(), "
+        " static_cast<float>(nominal_weight_event))",
+    )
+    df = df.Define(
+        "source_id",
+        f"ROOT::VecOps::RVec<int>(eta_reco.size(), {int(source_id)})",
+    )
+
+    return df
+
+
+def run_wz_snapshot(args) -> List[str]:
+    # ``XRootD.client`` first — see run_jpsi_snapshot for rationale.
+    import XRootD.client  # noqa: F401
+    import ROOT
+    import wremnants
+    import wremnants.production.muon_calibration
+    import wremnants.production.pileup
+    import wremnants.production.vertex
+    from wremnants.production.datasets.dataset_tools import getDatasets
+    from wremnants.utilities import common, samples
+
+    out_dir = args.output_dir or "flow_training_snapshot_wz"
+    os.makedirs(out_dir, exist_ok=True)
+
+    # IMT is process-global; skip re-enabling if a previous step
+    # already turned it on (bare-invocation pipeline runs all three
+    # run_* in one process).
+    if not ROOT.ROOT.IsImplicitMTEnabled():
+        if args.threads == 0:
+            ROOT.ROOT.EnableImplicitMT()
+        elif args.threads > 1:
+            ROOT.ROOT.EnableImplicitMT(args.threads)
+
+    # Filter: keep only W/Z MC. --filter-procs (if set) is an additional
+    # name-substring whitelist on top of samples.wprocs + samples.zprocs.
+    # Tau-decay V samples (Wτν, Z→ττ) are excluded by default since the
+    # muon selection now requires Muon_genPartFlav == 1 (prompt only),
+    # which would leave these datasets with near-zero acceptance and
+    # only contributes a softer secondary-muon spectrum if kept.
+    # --include-tau-procs adds them back in.
+    wz_names = set(samples.wprocs) | set(samples.zprocs)
+    if not args.include_tau_procs:
+        tau_names = set(samples.wprocs_tau_minnlo) | set(
+            samples.zprocs_tau_minnlo
+        ) | set(samples.wprocs_tau_minnlo_2017G) | set(
+            samples.zprocs_tau_minnlo_2017G
+        )
+        wz_names -= tau_names
+    datasets = getDatasets(
+        maxFiles=args.wz_max_files,
+        filt=args.filter_procs,
+        excl=None,
+        extended=True,
+        nanoVersion=args.nano_version,
+        base_path=args.data_path,
+    )
+    datasets = [
+        d for d in datasets
+        if d.name in wz_names and not d.is_data
+    ]
+    if not datasets:
+        print("error: no W/Z MC datasets matched", file=sys.stderr)
+        return []
+    print(f"selected {len(datasets)} W/Z MC dataset(s):")
+    for d in datasets:
+        print(f"  {d.name}  ({len(d.filepaths)} file(s))")
+
+    # Calibration / smearing / bias helpers (W/Z analysis path).
+    calib_filepaths = common.calib_filepaths
+    # ``make_jpsi_crctn_helpers`` returns 2 values when
+    # ``make_uncertainty_helper=False`` and 4 when ``True``.
+    (
+        mc_jpsi_crctn_helper,
+        _,
+    ) = wremnants.production.muon_calibration.make_jpsi_crctn_helpers(
+        calib_filepaths,
+        muon_corr_mc=args.muonCorrMC,
+        muon_corr_data=args.muonCorrData,
+        scale_var_method=args.muonScaleVariation,
+        scale_A=0.0,
+        scale_e=0.0,
+        scale_M=0.0,
+        make_uncertainty_helper=False,
+    )
+    (
+        mc_calibration_helper,
+        _,
+        _,
+    ) = wremnants.production.muon_calibration.make_muon_calibration_helpers(args)
+    if args.noSmearing:
+        smearing_helper = None
+    else:
+        smearing_helper, _ = (
+            wremnants.production.muon_calibration.make_muon_smearing_helpers()
+        )
+    bias_helper = None  # --biasCalibration off by default
+
+    pileup_helper = wremnants.production.pileup.make_pileup_helper(era=args.era)
+    vertex_helper = wremnants.production.vertex.make_vertex_helper(era=args.era)
+    calib_helpers = (
+        pileup_helper, vertex_helper, mc_calibration_helper,
+        mc_jpsi_crctn_helper, smearing_helper, bias_helper,
+    )
+
+    # Build all per-dataset graphs first, hold a TChain + RDF +
+    # Snapshot result per dataset, then run all event loops in one
+    # narf pass.
+    chains = []
+    dfs = []
+    snapshot_handles = []
+    output_paths = []
+
+    snapshot_options = ROOT.RDF.RSnapshotOptions()
+    if args.snapshot_format == "rntuple":
+        snapshot_options.fOutputFormat = (
+            ROOT.RDF.ESnapshotOutputFormat.kRNTuple
+        )
+        snapshot_options.fCompressionAlgorithm = (
+            ROOT.RCompressionSetting.EAlgorithm.kLZ4
+        )
+        snapshot_options.fCompressionLevel = 1
+    else:
+        snapshot_options.fCompressionAlgorithm = (
+            ROOT.RCompressionSetting.EAlgorithm.kZSTD
+        )
+        snapshot_options.fCompressionLevel = 5
+    snapshot_options.fLazy = True
+
+    cols_vec = ROOT.std.vector("string")()
+    for c in OUTPUT_BRANCHES:
+        cols_vec.push_back(c)
+
+    # End-to-end-friendly default: jpsi mode stamps source_id=0,
+    # wz mode bases at 100 so they don't collide.
+    base_source_id = 100 if args.source_id is None else int(args.source_id)
+    for i, dataset in enumerate(datasets):
+        chain = ROOT.TChain("Events")
+        for fpath in dataset.filepaths:
+            chain.Add(fpath)
+        chains.append(chain)
+        df = ROOT.ROOT.RDataFrame(chain)
+        sid = base_source_id + i
+        df = _define_wz_rvecs(
+            df, dataset, args, calib_helpers, source_id=sid,
+        )
+        out_path = os.path.join(out_dir, f"{dataset.name}.root")
+        snap = df.Snapshot(args.output_tree, out_path, cols_vec, snapshot_options)
+        dfs.append(df)
+        snapshot_handles.append(snap)
+        output_paths.append(out_path)
+        # Persist source_id -> dataset.name next to each W/Z snapshot.
+        # Safe to write up-front (before the event loop) since the
+        # side-car carries metadata only — no event counts.
+        _write_source_meta(
+            out_path,
+            [{"source_id": int(sid), "sample_name": str(dataset.name)}],
+        )
+        print(
+            f"queued snapshot graph: {dataset.name} "
+            f"(source_id={sid}) -> {out_path}"
+        )
+
+    print(f"\nrunning event loops across {len(dfs)} dataset(s)")
+    t0 = time.time()
+    # Deferred narf import: keeps pandas/pyarrow (pulled in by narf)
+    # out of the process until *after* getDatasets()'s pyxrootd
+    # handshake has succeeded. From here on, file I/O goes through
+    # ROOT's xrootd plugin during the event loop, which doesn't share
+    # symbol state with pyxrootd's libssl.
+    import narf  # noqa: F401  (side effect: registers narf:: with cling)
+    interval = 1 if sys.stdout.isatty() else 5 * 60
+    # PyROOT won't auto-convert a Python list of post-Define
+    # ``RInterface<...>`` nodes into the C++ ``vector<RNode>``
+    # overload — build it explicitly with ``AsRNode``.
+    rnode_vec = ROOT.std.vector("ROOT::RDF::RNode")()
+    for df in dfs:
+        rnode_vec.push_back(ROOT.RDF.AsRNode(df))
+    ROOT.narf.RunGraphsWithProgressBar(rnode_vec, 1000, interval)
+    # Touch each Snapshot handle so any lazy book-keeping is flushed.
+    for h in snapshot_handles:
+        h.GetValue()
+    dt = time.time() - t0
+    print(f"all snapshots done in {dt:.1f}s")
+    for p in output_paths:
+        if os.path.exists(p):
+            print(f"  {p}  ({os.path.getsize(p) / 1e6:.1f} MB)")
+        else:
+            print(f"  {p}  (MISSING)")
+    return output_paths
+
+
+# ---------------------------------------------------------------------------
+# Shard-only mode
+# ---------------------------------------------------------------------------
+
+
+def _autodetect_shard_inputs() -> List[str]:
+    """Pick up the J/psi snapshot file + every W/Z snapshot in the
+    default output locations used by --source jpsi / --source wz.
+    Empty list if nothing's present.
+    """
+    found: List[str] = []
+    jpsi_default = "flow_training_snapshot_jpsi.root"
+    if os.path.isfile(jpsi_default):
+        found.append(jpsi_default)
+    wz_default_dir = "flow_training_snapshot_wz"
+    if os.path.isdir(wz_default_dir):
+        for fname in sorted(os.listdir(wz_default_dir)):
+            if fname.endswith(".root"):
+                found.append(os.path.join(wz_default_dir, fname))
+    return found
+
+
+def run_shard_only(args) -> int:
+    inputs = list(args.inputs) if args.inputs else _autodetect_shard_inputs()
+    if not inputs:
+        print(
+            "error: --shard-only requires --inputs (no default "
+            "snapshots found in cwd: looked for "
+            "./flow_training_snapshot_jpsi.root and "
+            "./flow_training_snapshot_wz/*.root)",
+            file=sys.stderr,
+        )
+        return 1
+    if not args.inputs:
+        print(f"auto-detected {len(inputs)} snapshot input(s):")
+        for p in inputs:
+            print(f"  {p}")
+    args.inputs = inputs
+    missing = [p for p in args.inputs if not os.path.exists(p)]
+    if missing:
+        for p in missing:
+            print(f"error: input not found: {p}", file=sys.stderr)
+        return 1
+
+    shard_dir = args.shard_output_dir
+    if shard_dir is None:
+        shard_dir = os.path.join(
+            os.path.dirname(os.path.abspath(args.inputs[0])) or ".",
+            "shards",
+        )
+
+    from wremnants.production.arrow_shard_export import run_sharding_pass
+
+    run_sharding_pass(
+        snapshot_paths=list(args.inputs),
+        tree_name=args.output_tree,
+        branches=list(OUTPUT_BRANCHES),
+        int_columns=list(INT_BRANCHES),
+        n_buckets=int(args.n_buckets),
+        n_workers=int(args.shard_workers),
+        n_shards=int(args.shard_count),
+        shard_dir=shard_dir,
+        batch_rows=int(args.shard_rows_per_batch),
+        seed=int(args.shard_seed),
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    args = parse_args()
+    if args.shard_only:
+        return run_shard_only(args)
+    if args.source == "jpsi":
+        ok = run_jpsi_snapshot(args)
+        return 0 if ok else 1
+    if args.source == "wz":
+        paths = run_wz_snapshot(args)
+        return 0 if paths else 1
+    # Bare invocation: run all three steps sequentially in this
+    # process. Each ``run_*`` function imports ``XRootD.client``
+    # first to pin pyxrootd's libssl-1.1 before pyarrow loads
+    # libcrypto-3, so the OpenSSL clash doesn't fire. With xrootd
+    # pinned to v5 (pip ``xrootd<6``), the libXrdCl conflict that
+    # previously forced subprocess isolation is gone too.
+    print("=" * 70)
+    print("end-to-end pipeline (no mode flag given):")
+    print("  step 1: J/psi snapshot     -> flow_training_snapshot_jpsi.root")
+    print("  step 2: W/Z snapshot       -> flow_training_snapshot_wz/*.root")
+    print("  step 3: Arrow IPC sharding -> shards/")
+    print("=" * 70)
+
+    print("\n[step 1/3] J/psi snapshot")
+    if not run_jpsi_snapshot(args):
+        print("error: J/psi snapshot failed", file=sys.stderr)
+        return 1
+
+    print("\n[step 2/3] W/Z snapshot")
+    if not run_wz_snapshot(args):
+        print("error: W/Z snapshot failed", file=sys.stderr)
+        return 1
+
+    print("\n[step 3/3] Arrow IPC sharding")
+    return run_shard_only(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corrections/muon_calibration/flow_training_snapshot.py
+++ b/scripts/corrections/muon_calibration/flow_training_snapshot.py
@@ -161,11 +161,18 @@ OUTPUT_BRANCHES = [
     "kappa_gen",
     "nominal_weight",
     "source_id",
+    # Per-muon "muon source" -- ``Muon_genPartFlav`` (1 = prompt W/Z,
+    # 15 = secondary from a τ decay) on the W/Z branch, hardcoded to
+    # 443 (J/ψ PDG id) on the J/ψ branch. Used as a conditioning input
+    # in the flow and shift+smear reweight training so the model can
+    # learn class-dependent response shapes (e.g. the slightly biased
+    # gen-matching geometry of τ-decay muons).
+    "muon_source",
 ]
 
 # Columns written as int32 (everything else is fp32). Carried through
 # the sharder so downstream code can filter/split rows by source.
-INT_BRANCHES = ("source_id",)
+INT_BRANCHES = ("source_id", "muon_source")
 
 
 class _HelpFmt(
@@ -175,6 +182,36 @@ class _HelpFmt(
     """Keep the module docstring's raw newlines, and append "(default:
     ...)" to every option's help line automatically.
     """
+
+
+def _default_shard_workers(hard_cap: int = 32):
+    """Choose a phase-1 worker count that's unlikely to exceed the
+    cgroup ``pids.max`` budget on a shared host.
+
+    ``os.cpu_count()`` returns the *machine-wide* core count (256+ on
+    a typical box) but the per-cgroup PID limit is usually 2048 with a
+    few hundred PIDs already in flight from the user's session.
+    Spawning ``cpu_count`` workers -- each its own process plus a few
+    helper threads -- routinely hits ``EAGAIN`` on ``os.fork()`` at
+    ``mp.Pool.__init__``. Cap the default to ``hard_cap=32`` (proven
+    to fit under the typical 2048-PID budget) while still allowing
+    bigger pools via ``--shard-workers N`` on hosts with a larger
+    budget.
+    """
+    cpu = os.cpu_count() or 8
+    # Best-effort cgroup pids.max read (returns "max" or an integer).
+    pids_max = None
+    for path in ("/sys/fs/cgroup/pids.max", "/sys/fs/cgroup/pids/pids.max"):
+        try:
+            with open(path) as f:
+                raw = f.read().strip()
+            if raw and raw != "max":
+                pids_max = int(raw)
+                break
+        except (FileNotFoundError, ValueError, OSError):
+            continue
+    cgroup_cap = max(1, (pids_max // 8) if pids_max else hard_cap)
+    return max(1, min(cpu, hard_cap, cgroup_cap))
 
 
 def parse_args():
@@ -261,16 +298,17 @@ def parse_args():
         help="(--source wz only) Optional list of dataset name "
         "substrings to KEEP in addition to the default W/Z filter. "
         "If unset, all samples.wprocs + samples.zprocs are kept "
-        "(modulo --include-tau-procs).",
+        "(modulo --exclude-tau-procs).",
     )
     p.add_argument(
-        "--include-tau-procs",
+        "--exclude-tau-procs",
         action="store_true",
-        help="(--source wz only) Include Wτν / Z→ττ samples in the W/Z "
-        "snapshot. They are excluded by default because the muon "
-        "selection requires Muon_genPartFlav == 1 (prompt-only), and "
-        "these samples otherwise contribute only secondary muons from "
-        "τ decays.",
+        help="(--source wz only) Drop the Wτν / Z→ττ samples from the "
+        "W/Z snapshot. By default they are *kept*: the per-muon "
+        "selection ``Muon_genPartFlav == 1 || == 15`` accepts both "
+        "prompt and τ-decay muons, and the ``muon_source`` column "
+        "records which one each muon is so the trainer can condition "
+        "on it.",
     )
 
     # ---- W/Z calibration knobs (forwarded to define_corrected_muons) -
@@ -298,10 +336,15 @@ def parse_args():
         "the bias-helper branch in define_corrected_muons.",
     )
     p.add_argument(
-        "--noSmearing",
-        action="store_true",
-        help="(--source wz only) Disable the resolution smearing "
-        "applied during define_corrected_muons.",
+        "--smearing",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Apply the data/MC resolution-matching smearing helper "
+        "to the reco muons of *both* the J/ψ and W/Z snapshots. On by "
+        "default so the two samples are directly comparable in the "
+        "target distributions (same LBL + cvhideal calibration chain, "
+        "same smearing). Pass --no-smearing to drop the smearing on "
+        "both paths.",
     )
 
     # ---- source_id stamp ------------------------------------------
@@ -394,11 +437,16 @@ def parse_args():
     p.add_argument(
         "--shard-workers",
         type=int,
-        default=os.cpu_count() or 8,
+        default=_default_shard_workers(),
         help="Phase-1 parallel readers for the shard pass (xrootd / "
-        "disk read + decompression). Default: ``os.cpu_count()``. "
-        "Phase 2 is separately capped at ``--shard-count`` writers "
-        "(Arrow IPC files can't be concurrently appended to).",
+        "disk read + decompression). Default: an auto-selected value "
+        "capped against the cgroup ``pids.max`` budget so the worker "
+        "pool can actually be forked (each worker is a separate "
+        "process plus a couple of threads; high values like "
+        "``os.cpu_count() == 256`` typically exceed the per-cgroup "
+        "PID limit on a shared host). Phase 2 is separately capped at "
+        "``--shard-count`` writers (Arrow IPC files can't be "
+        "concurrently appended to).",
     )
     p.add_argument(
         "--shard-count",
@@ -463,7 +511,7 @@ def _declare_jpsi_sample_helper():
     )
 
 
-def _define_jpsi_rvecs(df, source_id_base: int):
+def _define_jpsi_rvecs(df, source_id_base: int, smearing_helper=None):
     """Define the unified per-muon RVec schema on a J/psi RDataFrame.
 
     Each event becomes a 2-element RVec (mu+ first, mu- second).
@@ -473,6 +521,15 @@ def _define_jpsi_rvecs(df, source_id_base: int):
     per-sample via ``DefinePerSample`` from the chain link path:
     Pt0to8 samples get ``source_id_base + 1``, everything else
     (Pt8toInf or unrecognised) gets ``source_id_base``.
+
+    When ``smearing_helper`` is provided the reco pt is smeared with
+    the same per-(η, pt) resolution-matching helper used on the W/Z
+    branch so the two snapshots are directly comparable. The smear
+    affects only pt; (η, φ) and the gen leg are untouched. The seed
+    triplet is the J/ψ ntuple's own ``(run, lumi, event)`` branches
+    (note ``lumi``, not the NanoAOD ``luminosityBlock`` -- the J/ψ
+    calibration ntuples use the shorter name) so the same physical
+    event always gets the same smear across re-runs.
     """
     _declare_jpsi_sample_helper()
     df = df.DefinePerSample(
@@ -505,14 +562,42 @@ def _define_jpsi_rvecs(df, source_id_base: int):
     )
     # kappa = q / |p| = q / (pt * cosh(eta)). Sign-labelled legs give
     # the {+1, -1} signs; |p| reuses the same pt/eta we just defined.
-    df = df.Define(
-        "kappa_reco",
-        "ROOT::VecOps::RVec<float>{"
-        " +1.0f / (static_cast<float>(Mupluscor_pt) "
-        "          * std::cosh(static_cast<float>(Mupluscor_eta))),"
-        " -1.0f / (static_cast<float>(Muminuscor_pt) "
-        "          * std::cosh(static_cast<float>(Muminuscor_eta)))}",
-    )
+    # When the smearing helper is requested, smear the LBL-corrected
+    # pt RVec with the same data/MC resolution-matching helper used on
+    # the W/Z branch (only pt is smeared; (η, φ) are unchanged).
+    if smearing_helper is not None:
+        df = df.Define(
+            "_jpsi_recopt_pre_smear",
+            "ROOT::VecOps::RVec<float>{"
+            " static_cast<float>(Mupluscor_pt),"
+            " static_cast<float>(Muminuscor_pt)}",
+        )
+        df = df.Define(
+            "_jpsi_recopt_smeared",
+            smearing_helper,
+            [
+                # The J/ψ calibration ntuples expose ``lumi`` (not the
+                # NanoAOD ``luminosityBlock``); ``run`` and ``event``
+                # match the standard names.
+                "run", "lumi", "event",
+                "_jpsi_recopt_pre_smear", "eta_reco",
+            ],
+        )
+        df = df.Define(
+            "kappa_reco",
+            "ROOT::VecOps::RVec<float>{"
+            " +1.0f / (_jpsi_recopt_smeared[0] * std::cosh(eta_reco[0])),"
+            " -1.0f / (_jpsi_recopt_smeared[1] * std::cosh(eta_reco[1]))}",
+        )
+    else:
+        df = df.Define(
+            "kappa_reco",
+            "ROOT::VecOps::RVec<float>{"
+            " +1.0f / (static_cast<float>(Mupluscor_pt) "
+            "          * std::cosh(static_cast<float>(Mupluscor_eta))),"
+            " -1.0f / (static_cast<float>(Muminuscor_pt) "
+            "          * std::cosh(static_cast<float>(Muminuscor_eta)))}",
+        )
     df = df.Define(
         "kappa_gen",
         "ROOT::VecOps::RVec<float>{"
@@ -530,6 +615,14 @@ def _define_jpsi_rvecs(df, source_id_base: int):
     df = df.Define(
         "source_id",
         "ROOT::VecOps::RVec<int>{sample_source_id, sample_source_id}",
+    )
+    # Hardcode the J/ψ PDG id (443) as the per-muon ``muon_source``;
+    # there is no ``Muon_genPartFlav`` equivalent on the calibration
+    # ntuples, and a sentinel value distinguishes J/ψ from the
+    # ``Muon_genPartFlav`` values (1 / 15) written on the W/Z branch.
+    df = df.Define(
+        "muon_source",
+        "ROOT::VecOps::RVec<int>{443, 443}",
     )
     return df
 
@@ -623,7 +716,18 @@ def run_jpsi_snapshot(args) -> str:
     )
 
     source_id_base = 0 if args.source_id is None else int(args.source_id)
-    df = _define_jpsi_rvecs(df, source_id_base=source_id_base)
+    if args.smearing:
+        smearing_helper, _ = (
+            wremnants.production.muon_calibration.make_muon_smearing_helpers()
+        )
+        print("  applying resolution smearing helper to J/ψ reco pt")
+    else:
+        smearing_helper = None
+    df = _define_jpsi_rvecs(
+        df,
+        source_id_base=source_id_base,
+        smearing_helper=smearing_helper,
+    )
     # Print the planned per-sample assignment so the user can verify
     # the input files matched the expected Pt0to8 / Pt8toInf buckets.
     n_0to8 = sum("Pt0to8" in p for p in files)
@@ -708,11 +812,15 @@ def _define_wz_rvecs(df, dataset, args, calib_helpers, source_id: int):
         bias_helper,
     )
     df = wremnants.production.muon_selections.select_veto_muons(df, nMuons=-1)
-    # genPartFlav == 1: prompt muon (direct W/Z decay product).
-    # genPartFlav == 15: secondary muon from a τ decay -- these enter
-    # the calibration sample with a softer pT spectrum and biased gen-
-    # matching geometry, so we drop them here.
-    df = df.Define("genMatchedMuons", "Muon_genPartFlav == 1")
+    # Keep both prompt (genPartFlav == 1) and τ-decay (== 15) muons.
+    # The per-muon ``Muon_genPartFlav`` is carried through as the
+    # ``muon_source`` column so the trainer can condition on the class
+    # (and the model can learn the slightly different gen-matching
+    # geometry / softer pT spectrum of τ-decay muons).
+    df = df.Define(
+        "genMatchedMuons",
+        "Muon_genPartFlav == 1 || Muon_genPartFlav == 15",
+    )
     df = df.Define("selMuons", "vetoMuonsPre && genMatchedMuons")
 
     df = df.Define("selMuons_genPartIdx", "Muon_genPartIdx[selMuons]")
@@ -769,6 +877,13 @@ def _define_wz_rvecs(df, dataset, args, calib_helpers, source_id: int):
         "source_id",
         f"ROOT::VecOps::RVec<int>(eta_reco.size(), {int(source_id)})",
     )
+    # Per-muon ``muon_source`` = ``Muon_genPartFlav`` for the selected
+    # rows (1 = prompt, 15 = from a τ decay), cast to int. Mirrors the
+    # J/ψ branch which writes 443 (J/ψ PDG id) instead.
+    df = df.Define(
+        "muon_source",
+        "ROOT::VecOps::RVec<int>(Muon_genPartFlav[selMuons])",
+    )
 
     return df
 
@@ -798,13 +913,13 @@ def run_wz_snapshot(args) -> List[str]:
 
     # Filter: keep only W/Z MC. --filter-procs (if set) is an additional
     # name-substring whitelist on top of samples.wprocs + samples.zprocs.
-    # Tau-decay V samples (Wτν, Z→ττ) are excluded by default since the
-    # muon selection now requires Muon_genPartFlav == 1 (prompt only),
-    # which would leave these datasets with near-zero acceptance and
-    # only contributes a softer secondary-muon spectrum if kept.
-    # --include-tau-procs adds them back in.
+    # Tau-decay V samples (Wτν, Z→ττ) are now included by default; the
+    # muon selection (``Muon_genPartFlav == 1 || == 15``) accepts both
+    # prompt and τ-decay muons, and the per-muon ``muon_source`` column
+    # records which one each muon is. ``--exclude-tau-procs`` drops the
+    # τ samples if that's what you want.
     wz_names = set(samples.wprocs) | set(samples.zprocs)
-    if not args.include_tau_procs:
+    if args.exclude_tau_procs:
         tau_names = set(samples.wprocs_tau_minnlo) | set(
             samples.zprocs_tau_minnlo
         ) | set(samples.wprocs_tau_minnlo_2017G) | set(
@@ -852,12 +967,12 @@ def run_wz_snapshot(args) -> List[str]:
         _,
         _,
     ) = wremnants.production.muon_calibration.make_muon_calibration_helpers(args)
-    if args.noSmearing:
-        smearing_helper = None
-    else:
+    if args.smearing:
         smearing_helper, _ = (
             wremnants.production.muon_calibration.make_muon_smearing_helpers()
         )
+    else:
+        smearing_helper = None
     bias_helper = None  # --biasCalibration off by default
 
     pileup_helper = wremnants.production.pileup.make_pileup_helper(era=args.era)

--- a/scripts/corrections/muon_calibration/flow_training_snapshot.py
+++ b/scripts/corrections/muon_calibration/flow_training_snapshot.py
@@ -98,6 +98,7 @@ def _write_source_meta(snapshot_path: str, entries: List[dict]) -> None:
         json.dump(payload, f, indent=2)
     print(f"  wrote source-id label side-car: {meta_path}")
 
+
 # Heavy imports (ROOT, wremnants, narf, pyxrootd, …) are deferred to
 # inside the ``run_jpsi_snapshot`` / ``run_wz_snapshot`` /
 # ``run_shard_only`` functions. The orchestrator path (bare
@@ -255,8 +256,7 @@ def parse_args():
     p.add_argument(
         "--input-tree",
         default="tree",
-        help="(--source jpsi only) TTree name inside the J/psi input "
-        "files.",
+        help="(--source jpsi only) TTree name inside the J/psi input " "files.",
     )
     p.add_argument(
         "--max-files",
@@ -405,8 +405,7 @@ def parse_args():
         "--eta-max",
         type=float,
         default=2.5,
-        help="(--source jpsi only) |gen eta| cut, applied to both "
-        "muons.",
+        help="(--source jpsi only) |gen eta| cut, applied to both " "muons.",
     )
     p.add_argument(
         "--no-progress",
@@ -493,8 +492,8 @@ def _declare_jpsi_sample_helper():
     are no-ops in cling.
     """
     import ROOT
-    ROOT.gInterpreter.Declare(
-        """
+
+    ROOT.gInterpreter.Declare("""
         #ifndef _FLOW_JPSI_SAMPLE_HELPER_DECLARED
         #define _FLOW_JPSI_SAMPLE_HELPER_DECLARED
         namespace _flow_jpsi {
@@ -507,8 +506,7 @@ def _declare_jpsi_sample_helper():
             }
         }
         #endif
-        """
-    )
+        """)
 
 
 def _define_jpsi_rvecs(df, source_id_base: int, smearing_helper=None):
@@ -579,8 +577,11 @@ def _define_jpsi_rvecs(df, source_id_base: int, smearing_helper=None):
                 # The J/ψ calibration ntuples expose ``lumi`` (not the
                 # NanoAOD ``luminosityBlock``); ``run`` and ``event``
                 # match the standard names.
-                "run", "lumi", "event",
-                "_jpsi_recopt_pre_smear", "eta_reco",
+                "run",
+                "lumi",
+                "event",
+                "_jpsi_recopt_pre_smear",
+                "eta_reco",
             ],
         )
         df = df.Define(
@@ -632,6 +633,7 @@ def resolve_jpsi_input_paths(paths: List[str]) -> List[str]:
     # pyxrootd loaded here through dataset_tools comes second and
     # ROOT's libXrdCl wins the symbol resolution.
     from wremnants.production.datasets import dataset_tools
+
     out: List[str] = []
     for p in paths:
         if p.lower().endswith(".root"):
@@ -639,9 +641,7 @@ def resolve_jpsi_input_paths(paths: List[str]) -> List[str]:
             continue
         found = dataset_tools.buildFileList(p)
         if not found:
-            print(
-                f"warning: no .root files found under {p}", file=sys.stderr
-            )
+            print(f"warning: no .root files found under {p}", file=sys.stderr)
         out.extend(found)
     return out
 
@@ -652,8 +652,9 @@ def run_jpsi_snapshot(args) -> str:
     # libcrypto-3 (pulled in via ``wremnants.production.muon_calibration``
     # -> hist / uproot) can shadow them. Requires xrootd pip package
     # < 6 so that pyxrootd's libXrdCl matches ROOT's (both v5).
-    import XRootD.client  # noqa: F401
     import ROOT
+    import XRootD.client  # noqa: F401
+
     import wremnants
     import wremnants.production.muon_calibration
     import wremnants.production.pileup
@@ -689,12 +690,9 @@ def run_jpsi_snapshot(args) -> str:
     if args.progress:
         ROOT.ROOT.RDF.Experimental.AddProgressBar(df)
 
-    helper = (
-        wremnants.production.muon_calibration.make_muon_calibration_helper_single()
-    )
-    df = (
-        wremnants.production.muon_calibration
-        .define_lbl_corrections_jpsi_calibration_ntuples(df, helper)
+    helper = wremnants.production.muon_calibration.make_muon_calibration_helper_single()
+    df = wremnants.production.muon_calibration.define_lbl_corrections_jpsi_calibration_ntuples(
+        df, helper
     )
 
     pileup_helper = wremnants.production.pileup.make_pileup_helper(era=args.era)
@@ -740,9 +738,7 @@ def run_jpsi_snapshot(args) -> str:
 
     snapshot_options = ROOT.RDF.RSnapshotOptions()
     if args.snapshot_format == "rntuple":
-        snapshot_options.fOutputFormat = (
-            ROOT.RDF.ESnapshotOutputFormat.kRNTuple
-        )
+        snapshot_options.fOutputFormat = ROOT.RDF.ESnapshotOutputFormat.kRNTuple
         snapshot_options.fCompressionAlgorithm = (
             ROOT.RCompressionSetting.EAlgorithm.kLZ4
         )
@@ -769,8 +765,7 @@ def run_jpsi_snapshot(args) -> str:
     ]
     if n_0to8 > 0:
         jpsi_entries.append(
-            {"source_id": source_id_base + 1,
-             "sample_name": "J/psi (pT<8 GeV)"}
+            {"source_id": source_id_base + 1, "sample_name": "J/psi (pT<8 GeV)"}
         )
     _write_source_meta(out, jpsi_entries)
 
@@ -788,14 +783,21 @@ def run_jpsi_snapshot(args) -> str:
 def _define_wz_rvecs(df, dataset, args, calib_helpers, source_id: int):
     import wremnants.production.muon_calibration
     import wremnants.production.muon_selections
+
     """Define the unified per-muon RVec schema on a W/Z RDataFrame.
 
     Applies the same selMuons mask as ``w_z_muonresponse.py``
     (vetoMuonsPre && genMatchedMuons) and projects per-muon RVecs from
     Muon_corrected* and the matched GenPart_* arrays.
     """
-    pileup_helper, vertex_helper, mc_calibration_helper, mc_jpsi_crctn_helper, \
-        smearing_helper, bias_helper = calib_helpers
+    (
+        pileup_helper,
+        vertex_helper,
+        mc_calibration_helper,
+        mc_jpsi_crctn_helper,
+        smearing_helper,
+        bias_helper,
+    ) = calib_helpers
 
     df = df.Define("weight", "std::copysign(1.0, genWeight)")
     df = df.Define("weight_pu", pileup_helper, ["Pileup_nTrueInt"])
@@ -890,8 +892,9 @@ def _define_wz_rvecs(df, dataset, args, calib_helpers, source_id: int):
 
 def run_wz_snapshot(args) -> List[str]:
     # ``XRootD.client`` first — see run_jpsi_snapshot for rationale.
-    import XRootD.client  # noqa: F401
     import ROOT
+    import XRootD.client  # noqa: F401
+
     import wremnants
     import wremnants.production.muon_calibration
     import wremnants.production.pileup
@@ -920,10 +923,11 @@ def run_wz_snapshot(args) -> List[str]:
     # τ samples if that's what you want.
     wz_names = set(samples.wprocs) | set(samples.zprocs)
     if args.exclude_tau_procs:
-        tau_names = set(samples.wprocs_tau_minnlo) | set(
-            samples.zprocs_tau_minnlo
-        ) | set(samples.wprocs_tau_minnlo_2017G) | set(
-            samples.zprocs_tau_minnlo_2017G
+        tau_names = (
+            set(samples.wprocs_tau_minnlo)
+            | set(samples.zprocs_tau_minnlo)
+            | set(samples.wprocs_tau_minnlo_2017G)
+            | set(samples.zprocs_tau_minnlo_2017G)
         )
         wz_names -= tau_names
     datasets = getDatasets(
@@ -934,10 +938,7 @@ def run_wz_snapshot(args) -> List[str]:
         nanoVersion=args.nano_version,
         base_path=args.data_path,
     )
-    datasets = [
-        d for d in datasets
-        if d.name in wz_names and not d.is_data
-    ]
+    datasets = [d for d in datasets if d.name in wz_names and not d.is_data]
     if not datasets:
         print("error: no W/Z MC datasets matched", file=sys.stderr)
         return []
@@ -978,8 +979,12 @@ def run_wz_snapshot(args) -> List[str]:
     pileup_helper = wremnants.production.pileup.make_pileup_helper(era=args.era)
     vertex_helper = wremnants.production.vertex.make_vertex_helper(era=args.era)
     calib_helpers = (
-        pileup_helper, vertex_helper, mc_calibration_helper,
-        mc_jpsi_crctn_helper, smearing_helper, bias_helper,
+        pileup_helper,
+        vertex_helper,
+        mc_calibration_helper,
+        mc_jpsi_crctn_helper,
+        smearing_helper,
+        bias_helper,
     )
 
     # Build all per-dataset graphs first, hold a TChain + RDF +
@@ -992,9 +997,7 @@ def run_wz_snapshot(args) -> List[str]:
 
     snapshot_options = ROOT.RDF.RSnapshotOptions()
     if args.snapshot_format == "rntuple":
-        snapshot_options.fOutputFormat = (
-            ROOT.RDF.ESnapshotOutputFormat.kRNTuple
-        )
+        snapshot_options.fOutputFormat = ROOT.RDF.ESnapshotOutputFormat.kRNTuple
         snapshot_options.fCompressionAlgorithm = (
             ROOT.RCompressionSetting.EAlgorithm.kLZ4
         )
@@ -1021,7 +1024,11 @@ def run_wz_snapshot(args) -> List[str]:
         df = ROOT.ROOT.RDataFrame(chain)
         sid = base_source_id + i
         df = _define_wz_rvecs(
-            df, dataset, args, calib_helpers, source_id=sid,
+            df,
+            dataset,
+            args,
+            calib_helpers,
+            source_id=sid,
         )
         out_path = os.path.join(out_dir, f"{dataset.name}.root")
         snap = df.Snapshot(args.output_tree, out_path, cols_vec, snapshot_options)
@@ -1036,8 +1043,7 @@ def run_wz_snapshot(args) -> List[str]:
             [{"source_id": int(sid), "sample_name": str(dataset.name)}],
         )
         print(
-            f"queued snapshot graph: {dataset.name} "
-            f"(source_id={sid}) -> {out_path}"
+            f"queued snapshot graph: {dataset.name} " f"(source_id={sid}) -> {out_path}"
         )
 
     print(f"\nrunning event loops across {len(dfs)} dataset(s)")
@@ -1048,6 +1054,7 @@ def run_wz_snapshot(args) -> List[str]:
     # ROOT's xrootd plugin during the event loop, which doesn't share
     # symbol state with pyxrootd's libssl.
     import narf  # noqa: F401  (side effect: registers narf:: with cling)
+
     interval = 1 if sys.stdout.isatty() else 5 * 60
     # PyROOT won't auto-convert a Python list of post-Define
     # ``RInterface<...>`` nodes into the C++ ``vector<RNode>``

--- a/scripts/corrections/muon_calibration/plot_muonresponse_reweight_closure.py
+++ b/scripts/corrections/muon_calibration/plot_muonresponse_reweight_closure.py
@@ -25,7 +25,6 @@ import sys
 import warnings
 
 import h5py
-import hist
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -35,7 +34,6 @@ sys.path.insert(
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")),
 )
 from wremnants.utilities.io_tools import base_io  # noqa: E402
-
 
 SMEAR_PLOT = {
     "title": "Smear closure (qop_reco / qop_gen)",
@@ -83,9 +81,7 @@ def load_aggregated_hists(path, process=None):
         if process is not None:
             procs = [p for p in procs if process in p]
         if not procs:
-            raise SystemExit(
-                f"No MC processes found in {path} (filter={process!r})."
-            )
+            raise SystemExit(f"No MC processes found in {path} (filter={process!r}).")
 
         summed = {}
         for proc in procs:
@@ -127,10 +123,12 @@ def _auto_ratio_ylim(ratios_in_view, pad=1.3, floor=0.005, ceiling=0.5):
     return (1.0 - half, 1.0 + half)
 
 
-def plot_one(summed, plot_spec, output_prefix, yscale="log",
-             xlim=(0.95, 1.05), ratio_ylim=None):
+def plot_one(
+    summed, plot_spec, output_prefix, yscale="log", xlim=(0.95, 1.05), ratio_ylim=None
+):
     fig, (ax_top, ax_bot) = plt.subplots(
-        2, 1,
+        2,
+        1,
         figsize=(7.5, 6.0),
         sharex=True,
         gridspec_kw={"height_ratios": [3.0, 1.0], "hspace": 0.05},
@@ -156,9 +154,7 @@ def plot_one(summed, plot_spec, output_prefix, yscale="log",
     nominal_int = nominal.values().sum()
     truth_v_raw = truth.values()
     truth_int = truth_v_raw.sum()
-    truth_scale = (
-        nominal_int / truth_int if truth_int > 0.0 else 1.0
-    )
+    truth_scale = nominal_int / truth_int if truth_int > 0.0 else 1.0
     if not np.isclose(truth_scale, 1.0, atol=1e-3):
         print(
             f"  [{plot_spec['title']}] scaling truth hist"
@@ -169,8 +165,15 @@ def plot_one(summed, plot_spec, output_prefix, yscale="log",
     edges = nominal.axes["qopr"].edges
 
     def step_arr(ax, v, label, color, ls="-"):
-        ax.step(edges, np.concatenate([[v[0]], v]), where="pre",
-                label=label, color=color, linestyle=ls, linewidth=1.4)
+        ax.step(
+            edges,
+            np.concatenate([[v[0]], v]),
+            where="pre",
+            label=label,
+            color=color,
+            linestyle=ls,
+            linewidth=1.4,
+        )
 
     def step(ax, h, label, color, ls="-"):
         v, _ = _values_with_err(h)
@@ -200,8 +203,13 @@ def plot_one(summed, plot_spec, output_prefix, yscale="log",
         step(ax_top, h, label, color)
         v, _ = _values_with_err(h)
         ratio = v / truth_safe
-        ax_bot.step(edges, np.concatenate([[ratio[0]], ratio]),
-                    where="pre", color=color, linewidth=1.2)
+        ax_bot.step(
+            edges,
+            np.concatenate([[ratio[0]], ratio]),
+            where="pre",
+            color=color,
+            linewidth=1.2,
+        )
         ratios_in_view.append(ratio[in_view & well_populated])
 
     ax_top.set_yscale(yscale)
@@ -236,22 +244,31 @@ def plot_one(summed, plot_spec, output_prefix, yscale="log",
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
-        "--input", "-i", required=True,
+        "--input",
+        "-i",
+        required=True,
         help="HDF5 from w_z_muonresponse.py --testHelpers",
     )
     p.add_argument(
-        "--output", "-o", default="muonresponse_closure",
+        "--output",
+        "-o",
+        default="muonresponse_closure",
         help="Output filename prefix (default: %(default)s)",
     )
     p.add_argument(
-        "--process", default=None,
+        "--process",
+        default=None,
         help="Only aggregate over processes whose name contains this string.",
     )
     p.add_argument(
-        "--ratio-ylim", type=float, nargs=2, default=None, metavar=("LO", "HI"),
+        "--ratio-ylim",
+        type=float,
+        nargs=2,
+        default=None,
+        metavar=("LO", "HI"),
         help="Override the ratio panel y-limits (default: auto-zoomed to "
-             "max |ratio-1| over well-populated bins in the visible x-range, "
-             "clamped to ±[0.5%%, 50%%]).",
+        "max |ratio-1| over well-populated bins in the visible x-range, "
+        "clamped to ±[0.5%%, 50%%]).",
     )
     args = p.parse_args()
 
@@ -260,10 +277,20 @@ def main():
 
     for ys in ("log", "lin"):
         ys_mpl = "log" if ys == "log" else "linear"
-        plot_one(summed, SMEAR_PLOT, f"{args.output}_smear_{ys}",
-                 yscale=ys_mpl, ratio_ylim=args.ratio_ylim)
-        plot_one(summed, SCALE_PLOT, f"{args.output}_scale_{ys}",
-                 yscale=ys_mpl, ratio_ylim=args.ratio_ylim)
+        plot_one(
+            summed,
+            SMEAR_PLOT,
+            f"{args.output}_smear_{ys}",
+            yscale=ys_mpl,
+            ratio_ylim=args.ratio_ylim,
+        )
+        plot_one(
+            summed,
+            SCALE_PLOT,
+            f"{args.output}_scale_{ys}",
+            yscale=ys_mpl,
+            ratio_ylim=args.ratio_ylim,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/corrections/muon_calibration/plot_muonresponse_reweight_closure.py
+++ b/scripts/corrections/muon_calibration/plot_muonresponse_reweight_closure.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+"""Plot the qop_reco/qop_gen distribution from the MC-shifted/smeared
+reference and the analytic-splines / ONNX reweight tests written by
+``scripts/histmakers/w_z_muonresponse.py --testHelpers``.
+
+Two figures are produced:
+
+* ``<out>_smear.{pdf,png}`` overlays nominal, MC-smeared (truth),
+  splines-reweight and ONNX-reweight; ratio panel against MC truth.
+* ``<out>_scale.{pdf,png}`` same layout for the scale shift.
+
+The input is the HDF5 produced by the histmaker. By default it
+aggregates over all MC processes in the file (skipping data). A
+specific process group can be selected with ``--process``.
+
+Usage:
+    python plot_muonresponse_reweight_closure.py \\
+        --input w_z_muonresponse_..._maxFiles_*.hdf5 \\
+        --output muonresponse_closure
+"""
+
+import argparse
+import os
+import sys
+import warnings
+
+import h5py
+import hist
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Repo root, so the wremnants/wums imports work without an env setup.
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")),
+)
+from wremnants.utilities.io_tools import base_io  # noqa: E402
+
+
+SMEAR_PLOT = {
+    "title": "Smear closure (qop_reco / qop_gen)",
+    "nominal": "hist_qopr",
+    "truth": "hist_qopr_smearedmulti",
+    "truth_label": "MC smeared (sample, multi)",
+    "variants": [
+        ("hist_qopr_smeared_weight", "splines reweight"),
+        ("hist_qopr_smeared_weight_onnx", "ONNX reweight"),
+        ("hist_qopr_transformed", "splines transform"),
+    ],
+}
+
+SCALE_PLOT = {
+    "title": "Scale closure (qop_reco / qop_gen)",
+    "nominal": "hist_qopr",
+    "truth": "hist_qopr_shifted",
+    "truth_label": "MC shifted",
+    "variants": [
+        ("hist_qopr_scaled_weight", "splines reweight"),
+        ("hist_qopr_scaled_weight_onnx", "ONNX reweight"),
+    ],
+}
+
+
+def load_aggregated_hists(path, process=None):
+    """Return a dict {hist_name: 1D-projected-on-qopr ``hist.Hist``},
+    summed over the requested MC processes."""
+    # Pre-discover every histogram the plots care about.
+    wanted = set()
+    for plot in (SMEAR_PLOT, SCALE_PLOT):
+        wanted.add(plot["nominal"])
+        wanted.add(plot["truth"])
+        for h, _ in plot["variants"]:
+            wanted.add(h)
+
+    # Keep the HDF5 open while resolving the lazy H5PickleProxy entries.
+    with h5py.File(path, "r") as f:
+        results = base_io.load_results_h5py(f)
+        procs = [
+            p
+            for p in results
+            if isinstance(results[p], dict) and "output" in results[p]
+        ]
+        if process is not None:
+            procs = [p for p in procs if process in p]
+        if not procs:
+            raise SystemExit(
+                f"No MC processes found in {path} (filter={process!r})."
+            )
+
+        summed = {}
+        for proc in procs:
+            out = results[proc]["output"]
+            for name in wanted:
+                if name not in out:
+                    continue
+                h = out[name].get() if hasattr(out[name], "get") else out[name]
+                # Project on qopr axis only.
+                h1 = h.project("qopr")
+                summed[name] = h1 if name not in summed else summed[name] + h1
+
+    missing = wanted - summed.keys()
+    if missing:
+        warnings.warn(f"missing histograms (will be skipped): {sorted(missing)}")
+    return summed, procs
+
+
+def _values_with_err(h):
+    vals = h.values()
+    var = h.variances() if h.variances() is not None else np.zeros_like(vals)
+    err = np.sqrt(np.clip(var, 0.0, None))
+    return vals, err
+
+
+def _auto_ratio_ylim(ratios_in_view, pad=1.3, floor=0.005, ceiling=0.5):
+    """Pick a symmetric y-range around 1 that contains every ratio
+    value in ``ratios_in_view`` (a list of 1-D numpy arrays already
+    restricted to the visible x-range and statistically-populated
+    bins).  Padded by ``pad`` and clamped to [floor, ceiling]."""
+    devs = []
+    for r in ratios_in_view:
+        r = r[np.isfinite(r)]
+        if r.size:
+            devs.append(np.max(np.abs(r - 1.0)))
+    if not devs:
+        return (1.0 - ceiling, 1.0 + ceiling)
+    half = float(np.clip(pad * max(devs), floor, ceiling))
+    return (1.0 - half, 1.0 + half)
+
+
+def plot_one(summed, plot_spec, output_prefix, yscale="log",
+             xlim=(0.95, 1.05), ratio_ylim=None):
+    fig, (ax_top, ax_bot) = plt.subplots(
+        2, 1,
+        figsize=(7.5, 6.0),
+        sharex=True,
+        gridspec_kw={"height_ratios": [3.0, 1.0], "hspace": 0.05},
+    )
+
+    nominal = summed.get(plot_spec["nominal"])
+    truth = summed.get(plot_spec["truth"])
+    if nominal is None or truth is None:
+        warnings.warn(
+            f"Skipping {plot_spec['title']!r}: missing"
+            f" nominal={plot_spec['nominal']} or truth={plot_spec['truth']}"
+        )
+        plt.close(fig)
+        return
+
+    # The MC-smeared reference (``hist_qopr_smearedmulti``) is filled
+    # with multiple smear replicas per muon (``SmearingHelperSimpleMulti``
+    # at ``nreps=100`` in the histmaker), so its integral is N_reps ×
+    # the nominal integral. Rescale to match the nominal integral so
+    # the shape and the ratio-to-truth panel are comparable across
+    # variants. For single-sample reference hists this is a no-op
+    # (ratio ≈ 1).
+    nominal_int = nominal.values().sum()
+    truth_v_raw = truth.values()
+    truth_int = truth_v_raw.sum()
+    truth_scale = (
+        nominal_int / truth_int if truth_int > 0.0 else 1.0
+    )
+    if not np.isclose(truth_scale, 1.0, atol=1e-3):
+        print(
+            f"  [{plot_spec['title']}] scaling truth hist"
+            f" {plot_spec['truth']!r} by {truth_scale:.6g}"
+            f" (integral {truth_int:.4g} -> {truth_int * truth_scale:.4g})"
+        )
+
+    edges = nominal.axes["qopr"].edges
+
+    def step_arr(ax, v, label, color, ls="-"):
+        ax.step(edges, np.concatenate([[v[0]], v]), where="pre",
+                label=label, color=color, linestyle=ls, linewidth=1.4)
+
+    def step(ax, h, label, color, ls="-"):
+        v, _ = _values_with_err(h)
+        step_arr(ax, v, label, color, ls=ls)
+
+    step(ax_top, nominal, "nominal", "black", ls=":")
+    truth_v = truth_v_raw * truth_scale
+    step_arr(ax_top, truth_v, plot_spec["truth_label"], "black")
+
+    truth_safe = np.where(truth_v > 0.0, truth_v, np.nan)
+
+    # Bin-center mask for "what is in the visible x-range" + a soft
+    # statistical mask (only bins where the truth bulk is well-populated
+    # contribute to the auto y-range -- avoids the ratio fitting to
+    # noise in the far tails).
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    in_view = (centers >= xlim[0]) & (centers <= xlim[1])
+    truth_max = float(np.nanmax(truth_v)) if truth_v.size else 0.0
+    well_populated = truth_v >= 0.01 * truth_max  # >= 1% of peak
+
+    palette = ["tab:red", "tab:blue", "tab:green", "tab:purple"]
+    ratios_in_view = []
+    for (name, label), color in zip(plot_spec["variants"], palette):
+        h = summed.get(name)
+        if h is None:
+            continue
+        step(ax_top, h, label, color)
+        v, _ = _values_with_err(h)
+        ratio = v / truth_safe
+        ax_bot.step(edges, np.concatenate([[ratio[0]], ratio]),
+                    where="pre", color=color, linewidth=1.2)
+        ratios_in_view.append(ratio[in_view & well_populated])
+
+    ax_top.set_yscale(yscale)
+    ax_top.set_ylabel("entries / bin")
+    ax_top.set_title(plot_spec["title"])
+    ax_top.legend(loc="upper right", fontsize=9)
+    ax_top.grid(alpha=0.3)
+    # Focus on the closure-relevant region around 1.0.
+    ax_top.set_xlim(*xlim)
+    if yscale == "log":
+        ax_top.set_ylim(bottom=max(1e-3, nominal.values().max() * 1e-5))
+    else:
+        ax_top.set_ylim(bottom=0.0)
+
+    ax_bot.axhline(1.0, color="black", linewidth=0.8, alpha=0.5)
+    ax_bot.set_ylabel("variant / truth")
+    ax_bot.set_xlabel("qop_reco / qop_gen")
+    if ratio_ylim is None:
+        rlo, rhi = _auto_ratio_ylim(ratios_in_view)
+    else:
+        rlo, rhi = ratio_ylim
+    ax_bot.set_ylim(rlo, rhi)
+    ax_bot.grid(alpha=0.3)
+
+    for ext in ("pdf", "png"):
+        out = f"{output_prefix}.{ext}"
+        fig.savefig(out, bbox_inches="tight", dpi=150)
+        print(f"wrote {out}")
+    plt.close(fig)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--input", "-i", required=True,
+        help="HDF5 from w_z_muonresponse.py --testHelpers",
+    )
+    p.add_argument(
+        "--output", "-o", default="muonresponse_closure",
+        help="Output filename prefix (default: %(default)s)",
+    )
+    p.add_argument(
+        "--process", default=None,
+        help="Only aggregate over processes whose name contains this string.",
+    )
+    p.add_argument(
+        "--ratio-ylim", type=float, nargs=2, default=None, metavar=("LO", "HI"),
+        help="Override the ratio panel y-limits (default: auto-zoomed to "
+             "max |ratio-1| over well-populated bins in the visible x-range, "
+             "clamped to ±[0.5%%, 50%%]).",
+    )
+    args = p.parse_args()
+
+    summed, procs = load_aggregated_hists(args.input, process=args.process)
+    print(f"aggregated over {len(procs)} process(es): {procs}")
+
+    for ys in ("log", "lin"):
+        ys_mpl = "log" if ys == "log" else "linear"
+        plot_one(summed, SMEAR_PLOT, f"{args.output}_smear_{ys}",
+                 yscale=ys_mpl, ratio_ylim=args.ratio_ylim)
+        plot_one(summed, SCALE_PLOT, f"{args.output}_scale_{ys}",
+                 yscale=ys_mpl, ratio_ylim=args.ratio_ylim)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
@@ -1,0 +1,2297 @@
+"""Diagnostic plots for a shift+smear reweight model.
+
+Loads a checkpoint produced by ``train_shift_smear_reweight.py`` (either
+``--arch mlp`` or ``--arch polyhead``) and produces:
+
+  * **Shift closure** — per target component (r_κ, dλ, dφ) and shift
+    magnitude, histograms of (raw MC, shifted MC, MLP-pred-W reweight)
+    with ratios divided by the explicitly-shifted MC. The shifted-MC
+    curve is the literal closure target.
+
+  * **Smear closure** — per target component and smear magnitude,
+    histograms of (raw MC, smeared MC, MLP-pred-W reweight). The
+    smeared-MC curve has each event drawn from
+    ``y_smeared = y + ε · σ · e_tcol`` with one ε ~ N(0, 1) per event,
+    matching the rank-1 Gaussian smear our model is trained on.
+
+  * **log r distribution** — across events, separately for shift and
+    smear axes, one curve per magnitude. Shows the spread of per-event
+    reweighting factors.
+
+  * **log r magnitude scan** — weighted mean and ±1σ band of predicted
+    log r vs. perturbation magnitude, separately for shift and smear,
+    per axis. For small perturbations should grow linearly (score) for
+    shifts and quadratically (Hessian) for smears.
+
+The structural priors ``r(y, c, 0, 0) = 1`` (by construction) and
+``r`` even in σ_vec (by Σ-input symmetry / polynomial parity) are not
+plotted — they hold structurally and don't need empirical verification.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from typing import List
+
+import matplotlib
+matplotlib.use("Agg")  # noqa: E402  — non-interactive backend; must precede pyplot
+import matplotlib.pyplot as plt  # noqa: E402
+
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+import torch.nn.functional as F  # noqa: E402
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from train_muon_response_flow import (  # noqa: E402
+    PreprocStats,
+    apply_preproc,
+    compute_targets_and_conditioning,
+    evaluate_joint,
+    load_ntuples,
+)
+from train_shift_smear_reweight import (  # noqa: E402
+    _ACTIVATIONS,
+    _LOG_LOG2,
+    _LOG_W_CLAMP,
+    _sigma_pack_indices,
+    GaussBaseline,
+    ReweightMLP_B,
+    ReweightMLPFactored,
+    ReweightPolyhead,
+    gauss_baseline_log_r,
+)
+
+
+TARGET_NAMES = ["r_kappa", "dlambda", "dphi"]
+
+
+# Default mapping from snapshot ``source_id`` integers to display labels.
+# The snapshot script assigns:
+#   J/ψ:  base = 0  (Pt8toInf), base+1 = 1 (Pt0to8)
+#   W/Z:  base = 100, then incremented by getDatasets() ordering.
+# Z→μμ is conventionally the first W/Z entry, hence source_id = 100.
+# Anything else falls back to ``source <id>``; the user can override or
+# extend via ``--cmp-source-labels``.
+DEFAULT_SOURCE_LABELS = {
+    0: r"J/$\psi$ (p$_T$>8 GeV)",
+    1: r"J/$\psi$ (p$_T$<8 GeV)",
+    100: r"Z$\to\mu\mu$",
+}
+ZMUMU_SOURCE_ID = 100
+
+
+def _tic():
+    return time.perf_counter()
+
+
+def _toc(label, t0):
+    dt = time.perf_counter() - t0
+    print(f"  [time] {label}: {dt:.2f}s")
+    return time.perf_counter()
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Diagnostic plots for a shift+smear reweight "
+        "model (mlp / polyhead).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--checkpoint", required=True, default=argparse.SUPPRESS,
+        help="(required) Path to a shift_smear_reweight_{mlp,polyhead}.pt "
+        "or checkpoint.pt produced by train_shift_smear_reweight.py.",
+    )
+    p.add_argument(
+        "--input-files", nargs="+", required=True,
+        default=argparse.SUPPRESS,
+        help="(required) Input ROOT file(s) with the J/psi snapshot tree.",
+    )
+    p.add_argument(
+        "--tree", default="tree",
+        help="ROOT TTree name to read from --input-files.",
+    )
+    p.add_argument(
+        "--output", default=None,
+        help="Output dir for plots. None = directory containing "
+        "--checkpoint.",
+    )
+    p.add_argument(
+        "--device", default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Torch device for model evaluation.",
+    )
+    p.add_argument(
+        "--n-events", type=int, default=500_000,
+        help="Number of muon rows to use for plotting. Subsampled "
+        "post-quality-cut. -1 = use all surviving rows.",
+    )
+    p.add_argument(
+        "--max-events", type=int, default=1_000_000,
+        help="Cap on raw J/psi events kept via RDataFrame Filter("
+        "rdfentry_<N). 1M events comfortably covers --n-events at "
+        "~2 muons/event. -1 = load all.",
+    )
+    p.add_argument(
+        "--max-muons", type=int, default=-1,
+        help="Cap on muon rows after the event filter. -1 = no cap.",
+    )
+    p.add_argument(
+        "--threads", type=int, default=0,
+        help="RDataFrame ImplicitMT threads. 0 = ROOT auto.",
+    )
+    p.add_argument(
+        "--pt-min", type=float, default=2.0,
+        help="Min gen pt (GeV); matches snapshot script default.",
+    )
+    p.add_argument(
+        "--pt-max", type=float, default=200.0,
+        help="Max gen pt (GeV).",
+    )
+    p.add_argument(
+        "--eta-max", type=float, default=2.4,
+        help="Max |gen eta|.",
+    )
+    p.add_argument(
+        "--shift-factors", nargs="+", type=float,
+        default=[0.1, 0.3, 0.5, 1.0],
+        help="Shift magnitudes (in standardized-target σ units).",
+    )
+    p.add_argument(
+        "--smear-factors", nargs="+", type=float,
+        default=[0.1, 0.3, 0.5, 1.0],
+        help="Smear magnitudes (in standardized-target σ units).",
+    )
+    p.add_argument(
+        "--smear-gh-K", type=int, default=0,
+        help="Gauss-Hermite order K for an extra smear-closure curve "
+        "computed from the *shift* component of the polyhead via "
+        "r_smear(σ·ê) ≈ Σ_k w_k · r_shift(ε_k·σ·ê) with probabilists' "
+        "K-point Hermite nodes/weights for ε ~ N(0, 1). Tests "
+        "self-consistency between the pure-σ and pure-u parts of the "
+        "polyhead. 0 disables the curve (default); 3 is a reasonable "
+        "starting value.",
+    )
+    p.add_argument(
+        "--n-bins", type=int, default=80,
+        help="Histogram bin count for closure plots.",
+    )
+    p.add_argument(
+        "--range-percentile", type=float, default=0.5,
+        help="Percentile (each side) trimmed when setting histogram "
+        "x-range from raw target distribution.",
+    )
+    p.add_argument(
+        "--scan-magnitudes", type=int, default=11,
+        help="Number of magnitudes per axis in the log-r scan plot.",
+    )
+    p.add_argument(
+        "--batch-size", type=int, default=8192,
+        help="Batch size for model evaluation.",
+    )
+    p.add_argument(
+        "--seed", type=int, default=0,
+        help="Seed for the per-event ε draw used to form the "
+        "smeared-MC histogram (literal closure target).",
+    )
+    p.add_argument(
+        "--flow-checkpoint", default=None,
+        help="Optional path to a flow checkpoint produced by "
+        "train_muon_response_flow.py. When provided, an additional "
+        "diagnostic plot ``polyhead_pred_vs_flow.{png,pdf}`` is "
+        "generated comparing this BCE-polyhead's predicted log W to "
+        "the flow's analytic log W on a common (y, c, u, σ) grid — "
+        "the analog of flow_training_diagnostics.py's "
+        "``polyhead_pred_vs_true`` for direct-trained heads. "
+        "Skipped if not provided. Assumes the flow's preproc is "
+        "compatible with this checkpoint's preproc (i.e. trained on "
+        "the same MC sample).",
+    )
+    p.add_argument(
+        "--flow-validate-n", type=int, default=10000,
+        help="Number of events to use for the optional "
+        "polyhead_pred_vs_flow plot. Smaller = faster.",
+    )
+    # ------------------------------------------------------------------
+    # Per-source target-distribution comparison window.
+    # Datasets with different kinematics can't be compared at the
+    # marginal level, so restrict the comparison to a phase-space cell
+    # in (pt_gen, eta_gen, charge_gen); phi_gen is integrated.
+    # ------------------------------------------------------------------
+    p.add_argument(
+        "--cmp-pt-min", type=float, default=25.0,
+        help="Lower gen-pT (GeV) edge of the (deliberately narrow) "
+        "phase-space window used for the per-source target-distribution "
+        "comparison plot.",
+    )
+    p.add_argument(
+        "--cmp-pt-max", type=float, default=30.0,
+        help="Upper gen-pT (GeV) edge of the cmp window.",
+    )
+    p.add_argument(
+        "--cmp-eta-min", type=float, default=0.0,
+        help="Lower gen-η edge of the cmp window.",
+    )
+    p.add_argument(
+        "--cmp-eta-max", type=float, default=0.4,
+        help="Upper gen-η edge of the cmp window.",
+    )
+    p.add_argument(
+        "--cmp-charge", choices=["pos", "neg", "both", "each"],
+        default="each",
+        help="Charge selection in the cmp window. ``each`` (default) "
+        "produces a separate plot for q>0 and q<0; ``both`` integrates "
+        "over charge; ``pos`` / ``neg`` produce one plot for the chosen "
+        "charge only.",
+    )
+    p.add_argument(
+        "--cmp-source-labels", nargs="+", default=None,
+        help="Optional per-source labels of the form ``id:label`` "
+        "(e.g. ``0:J/psi 100:Zmumu``). Sources without a mapping use "
+        "their integer id.",
+    )
+    p.add_argument(
+        "--cmp-ref-source", type=int, default=ZMUMU_SOURCE_ID,
+        help="Reference source_id for the ratio panel of the per-source "
+        "comparison plot. Defaults to the Z→μμ convention (100); falls "
+        "back to the smallest source_id present if absent in the window.",
+    )
+    p.add_argument(
+        "--cmp-max-events", type=int, default=-1,
+        help="Cap on raw muon rows *read* for the per-source target-"
+        "distribution plots only. -1 (default) = all available rows. "
+        "These plots stream shards in parallel and apply the (pt, eta) "
+        "window per-shard, so peak memory is bounded by the kept-row "
+        "count, not the full dataset — typically far smaller than the "
+        "inference-side caps (--n-events / --max-events).",
+    )
+    p.add_argument(
+        "--cmp-workers", type=int, default=8,
+        help="Parallel shard readers (thread pool) for the per-source "
+        "comparison loader.",
+    )
+    return p.parse_args()
+
+
+# ============================================================================
+# Checkpoint loader — dispatches on arch
+# ============================================================================
+
+def load_model_from_checkpoint(checkpoint_path: str, device):
+    """Load model + stats + train_config. Builds ``ReweightMLP_B`` or
+    ``ReweightPolyhead`` based on ``model_config['arch']``."""
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    cfg = ckpt["model_config"]
+    train_cfg = ckpt.get("train_config", {})
+    activation_name = str(cfg.get("activation", "gelu")).lower()
+    activation_cls = _ACTIVATIONS.get(activation_name, torch.nn.GELU)
+    arch = cfg.get("arch", "mlp")
+
+    # Optional analytic Gaussian baseline. Older checkpoints predate
+    # this and don't carry the ``gauss_baseline`` key — treat None /
+    # missing as "no baseline".
+    gb_cfg = cfg.get("gauss_baseline", None)
+    gauss_baseline = (
+        GaussBaseline(
+            n_features=int(cfg["n_features"]),
+            n_cond=int(cfg["n_cond"]),
+            hidden=int(gb_cfg.get("hidden", 64)),
+            n_layers=int(gb_cfg.get("n_layers", 2)),
+            activation=activation_cls,
+        )
+        if gb_cfg is not None else None
+    )
+
+    if arch == "mlp":
+        # ``shift_only`` was introduced with the --include-smear flag
+        # (default False = shift-only). Older mlp checkpoints that
+        # predate it do not carry the key; default to False so the
+        # full-Σ_pack head is rebuilt for them.
+        shift_only = bool(cfg.get("shift_only", False))
+        model = ReweightMLP_B(
+            n_features=int(cfg["n_features"]),
+            n_cond=int(cfg["n_cond"]),
+            d_emb=int(cfg.get("d_emb", 32)),
+            trunk_hidden=int(cfg.get("trunk_hidden", 64)),
+            trunk_layers=int(cfg.get("trunk_layers", 2)),
+            head_hidden=int(cfg.get("head_hidden", 32)),
+            head_layers=int(cfg.get("head_layers", 2)),
+            activation=activation_cls,
+            shift_only=shift_only,
+            gauss_baseline=gauss_baseline,
+        )
+    elif arch == "mlp-factored":
+        # Structurally factored MLP head. ``detach_pure_{shift,smear}_in_joint``
+        # affect the factorisation form (whether A depends on σ_pack,
+        # whether B depends on u, whether a separate cross head C
+        # exists), so they must be threaded through at construction so
+        # the state_dict shapes match.
+        model = ReweightMLPFactored(
+            n_features=int(cfg["n_features"]),
+            n_cond=int(cfg["n_cond"]),
+            d_emb=int(cfg.get("d_emb", 32)),
+            trunk_hidden=int(cfg.get("trunk_hidden", 64)),
+            trunk_layers=int(cfg.get("trunk_layers", 2)),
+            head_hidden=int(cfg.get("head_hidden", 32)),
+            head_layers=int(cfg.get("head_layers", 2)),
+            activation=activation_cls,
+            shift_only=bool(cfg.get("shift_only", False)),
+            detach_pure_shift_in_joint=bool(
+                cfg.get("detach_pure_shift_in_joint", False)
+            ),
+            detach_pure_smear_in_joint=bool(
+                cfg.get("detach_pure_smear_in_joint", False)
+            ),
+            gauss_baseline=gauss_baseline,
+        )
+    elif arch == "polyhead":
+        # Older checkpoints stored these as ``hidden_features`` /
+        # ``n_hidden_layers``; new ones use ``trunk_hidden`` /
+        # ``trunk_layers`` (shared with the mlp arch).
+        trunk_hidden = int(cfg.get(
+            "trunk_hidden", cfg.get("hidden_features", 64),
+        ))
+        trunk_layers = int(cfg.get(
+            "trunk_layers", cfg.get("n_hidden_layers", 2),
+        ))
+        model = ReweightPolyhead(
+            n_features=int(cfg["n_features"]),
+            n_cond=int(cfg["n_cond"]),
+            trunk_hidden=trunk_hidden,
+            trunk_layers=trunk_layers,
+            max_deg_u=int(cfg.get("max_deg_u", 3)),
+            max_deg_sigma=int(cfg.get("max_deg_sigma", 4)),
+            max_cross_deg=int(cfg.get("max_cross_deg", 3)),
+            activation=activation_cls,
+            basis=str(cfg.get("basis", "monomial")),
+            basis_scale_u=float(cfg.get("basis_scale_u", 1.0)),
+            basis_scale_sigma=float(cfg.get("basis_scale_sigma", 1.0)),
+            gauss_baseline=gauss_baseline,
+        )
+    else:
+        raise ValueError(f"unknown arch in checkpoint: {arch!r}")
+
+    model.load_state_dict(ckpt["state_dict"])
+    model.to(device).eval()
+
+    stats_dict = ckpt.get("stats")
+    stats = PreprocStats(**stats_dict) if stats_dict is not None else None
+    return model, arch, stats, train_cfg
+
+
+# ============================================================================
+# Unified per-axis log r prediction
+# ============================================================================
+
+def _apply_positivity(d, positivity):
+    if positivity == "exp":
+        return d.clamp(min=-_LOG_W_CLAMP, max=_LOG_W_CLAMP)
+    if positivity == "softplus":
+        # Mirror the trainer: no input clamp; output clamp_min sized
+        # to the dtype's smallest normal so the same wrap is safe
+        # under fp32 / bf16 / fp16.
+        tiny = torch.finfo(d.dtype).tiny
+        return torch.log(F.softplus(d).clamp_min(tiny)) - _LOG_LOG2
+    if positivity == "asinh":
+        return torch.asinh(d)
+    raise ValueError(f"unknown positivity {positivity!r}")
+
+
+@torch.no_grad()
+def predict_log_r_axis(
+    model, arch, y_dev, c_dev, u_axis_value, sigma_axis_value, tcol,
+    n_features, batch_size, positivity,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Per-event log r prediction with an axis-aligned perturbation.
+
+    ``u = u_axis_value · e_tcol``, ``σ_vec = sigma_axis_value · e_tcol``.
+
+    Both ``y_dev`` and ``c_dev`` should already be on the target device.
+    Reuses small per-batch buffers for ``u``, ``σ_vec``, and (for the
+    MLP arch) ``Σ_pack`` so there's no per-call CPU-side allocation
+    proportional to the dataset size.
+    """
+    device = y_dev.device
+    N = y_dev.shape[0]
+    out = np.empty(N, dtype=np.float32)
+
+    # Pre-allocate per-batch buffers on device.
+    u_buf = torch.zeros(batch_size, n_features, device=device)
+    sigma_vec_buf = torch.zeros(batch_size, n_features, device=device)
+    u_buf[:, tcol] = float(u_axis_value)
+    sigma_vec_buf[:, tcol] = float(sigma_axis_value)
+
+    if arch in ("mlp", "mlp-factored"):
+        # Σ_pack for u-axis-aligned σ is zero except for the (tcol,tcol)
+        # entry = sigma_axis_value². Compute via the standard helper so
+        # the indexing matches the model's expectations.
+        n_sigma_pack = sigma_pack_iu.shape[0]
+        sigma_pack_buf = torch.zeros(
+            batch_size, n_sigma_pack, device=device,
+        )
+        for k in range(n_sigma_pack):
+            i, j = int(sigma_pack_iu[k]), int(sigma_pack_ju[k])
+            if i == tcol and j == tcol:
+                sigma_pack_buf[:, k] = float(sigma_axis_value) ** 2
+
+    for s in range(0, N, batch_size):
+        e = min(s + batch_size, N)
+        bsz = e - s
+        y = y_dev[s:e]
+        c = c_dev[s:e]
+        u = u_buf[:bsz]
+        sigma_vec = sigma_vec_buf[:bsz]
+
+        if arch in ("mlp", "mlp-factored"):
+            sigma_pack = sigma_pack_buf[:bsz]
+            u_zero = torch.zeros_like(u)
+            sp_zero = torch.zeros_like(sigma_pack)
+            # 2B head batching: f at (e_y, u, σ) and (e_y, 0, 0).
+            ev = model.trunk_forward(y, c)             # [bsz, d_emb]
+            ev2 = torch.cat([ev, ev], dim=0)
+            u2 = torch.cat([u, u_zero], dim=0)
+            sp2 = torch.cat([sigma_pack, sp_zero], dim=0)
+            f = model.head_forward(ev2, u2, sp2)
+            d = f[:bsz] - f[bsz:]
+        elif arch == "polyhead":
+            coefs = model(y, c)                         # [bsz, n_basis]
+            d = evaluate_joint(
+                coefs, u, sigma_vec, model.joint_indices,
+                basis=getattr(model, "basis", "monomial"),
+                scale_u=float(getattr(model, "basis_scale_u", 1.0)),
+                scale_sigma=float(getattr(model, "basis_scale_sigma", 1.0)),
+            )
+        else:
+            raise ValueError(f"unknown arch {arch!r}")
+
+        # Add the analytic Gaussian baseline (additive log-r term)
+        # if the model carries one. Mirror the trainer's
+        # compute_d_quadrature so closure plots match training-time
+        # log r̂ exactly.
+        gb = getattr(model, "gauss_baseline", None)
+        if gb is not None:
+            mu_g, L_g = gb(c)
+            d = d + gauss_baseline_log_r(y, mu_g, L_g, u, sigma_vec)
+
+        log_r = _apply_positivity(d, positivity)
+        out[s:e] = log_r.detach().cpu().numpy().astype(np.float32)
+    return out
+
+
+def predict_log_r_perevent(
+    model, arch, y_dev, c_dev, u_dev, sigma_dev,
+    batch_size, positivity,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Per-event log r prediction with **arbitrary** per-event
+    ``(u, σ_vec)`` (not axis-aligned). All four input tensors are on
+    the model's device with shape ``[N, *]``. Used by the optional
+    flow-comparison diagnostic.
+    """
+    device = y_dev.device
+    N = y_dev.shape[0]
+    n_features = y_dev.shape[1]
+    out = np.empty(N, dtype=np.float32)
+
+    if arch in ("mlp", "mlp-factored"):
+        # Build Σ_pack from per-event σ_vec via the standard outer-
+        # product packing. Done per-batch to bound memory.
+        n_sigma_pack = sigma_pack_iu.shape[0]
+
+    for s in range(0, N, batch_size):
+        e = min(s + batch_size, N)
+        bsz = e - s
+        y = y_dev[s:e]
+        c = c_dev[s:e]
+        u = u_dev[s:e]
+        sigma_vec = sigma_dev[s:e]
+
+        if arch in ("mlp", "mlp-factored"):
+            sigma_pack = torch.zeros(
+                bsz, n_sigma_pack, device=device, dtype=y.dtype,
+            )
+            for k in range(n_sigma_pack):
+                i, j = int(sigma_pack_iu[k]), int(sigma_pack_ju[k])
+                sigma_pack[:, k] = sigma_vec[:, i] * sigma_vec[:, j]
+            u_zero = torch.zeros_like(u)
+            sp_zero = torch.zeros_like(sigma_pack)
+            ev = model.trunk_forward(y, c)
+            ev2 = torch.cat([ev, ev], dim=0)
+            u2 = torch.cat([u, u_zero], dim=0)
+            sp2 = torch.cat([sigma_pack, sp_zero], dim=0)
+            f = model.head_forward(ev2, u2, sp2)
+            d = f[:bsz] - f[bsz:]
+        elif arch == "polyhead":
+            coefs = model(y, c)
+            d = evaluate_joint(
+                coefs, u, sigma_vec, model.joint_indices,
+                basis=getattr(model, "basis", "monomial"),
+                scale_u=float(getattr(model, "basis_scale_u", 1.0)),
+                scale_sigma=float(getattr(model, "basis_scale_sigma", 1.0)),
+            )
+        else:
+            raise ValueError(f"unknown arch {arch!r}")
+
+        # Add the analytic Gaussian baseline (additive log-r term)
+        # if the model carries one.
+        gb = getattr(model, "gauss_baseline", None)
+        if gb is not None:
+            mu_g, L_g = gb(c)
+            d = d + gauss_baseline_log_r(y, mu_g, L_g, u, sigma_vec)
+
+        log_r = _apply_positivity(d, positivity)
+        out[s:e] = log_r.detach().cpu().numpy().astype(np.float32)
+    return out
+
+
+def _gh_nodes_weights(K):
+    """Probabilists' Gauss-Hermite nodes/weights for ε ~ N(0, 1).
+
+    Returns ``(eps_k, w_k_norm)`` with ``Σ_k w_k_norm · f(eps_k) ≈
+    E_{ε~N(0,1)}[f(ε)]``. The 1/√(2π) Gaussian density is folded
+    into the weights.
+    """
+    eps_k, w_k = np.polynomial.hermite_e.hermegauss(int(K))
+    w_norm = w_k / np.sqrt(2.0 * np.pi)
+    return eps_k.astype(np.float64), w_norm.astype(np.float64)
+
+
+def predict_smear_via_gh_shift(
+    model, arch, y_dev, c_dev, factor, tcol, K,
+    n_features, batch_size, positivity,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Estimate per-event log r for an axis-aligned smear from the
+    *shift* component of the polyhead via Gauss-Hermite integration:
+
+        r_smear(y, c, factor·ê_tcol)
+            ≈ E_{ε~N(0,1)}[ r_shift(y, c, ε·factor·ê_tcol) ]
+            ≈ Σ_k (w_k / √(2π)) · r_shift(y, c, ε_k·factor·ê_tcol)
+
+    with K probabilists' Hermite nodes ε_k and weights w_k. Each
+    GH-node call evaluates the polyhead with σ_vec = 0 (so only the
+    pure-u / shift basis is exercised), giving a self-consistency
+    check between the model's shift and smear branches. Returns
+    ``log r_smear_gh`` of shape ``[N]``, computed with log-sum-exp.
+    """
+    eps_k, w_norm = _gh_nodes_weights(K)
+    log_w = np.log(np.maximum(w_norm, 1e-300))
+
+    N = y_dev.shape[0]
+    stack = np.empty((int(K), N), dtype=np.float64)
+    for k in range(int(K)):
+        u_val = float(eps_k[k]) * float(factor)
+        log_r_k = predict_log_r_axis(
+            model, arch, y_dev, c_dev,
+            u_axis_value=u_val, sigma_axis_value=0.0, tcol=tcol,
+            n_features=n_features, batch_size=batch_size,
+            positivity=positivity,
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        )
+        stack[k] = log_r_k.astype(np.float64) + float(log_w[k])
+
+    M = stack.max(axis=0)
+    M_safe = np.where(np.isfinite(M), M, 0.0)
+    log_sum = M_safe + np.log(np.exp(stack - M_safe).sum(axis=0))
+    return log_sum.astype(np.float32)
+
+
+# ============================================================================
+# Plot helpers
+# ============================================================================
+
+def _save(fig, path):
+    fig.savefig(path, dpi=120, bbox_inches="tight")
+    pdf = path.rsplit(".", 1)[0] + ".pdf"
+    fig.savefig(pdf, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _weighted_hist_err(values, bins, weights):
+    """Weighted histogram with per-bin sqrt(sum w^2) statistical
+    uncertainty. ``weights`` is the per-event weight array; the bin
+    content is ``Σ w_i`` and the bin error is ``√Σ w_i²``.
+
+    Returns ``(h, sigma)``, both shape ``(n_bins,)``.
+    """
+    w = np.asarray(weights, dtype=np.float64)
+    h, _ = np.histogram(values, bins=bins, weights=w)
+    h2, _ = np.histogram(values, bins=bins, weights=w * w)
+    sigma = np.sqrt(np.maximum(h2, 0.0))
+    return h, sigma
+
+
+def _ratio_with_err(h_num, sigma_num, h_den, sigma_den):
+    """Bin-wise ratio h_num/h_den with propagated uncertainty assuming
+    the two histograms are *uncorrelated* per bin. In the closure
+    plots this holds because ``h_pred`` and ``h_shifted`` (or
+    ``h_smeared``) are filled in different bins for any given event:
+    h_pred at ``y_orig`` with weight ``w·r_pred``, h_shifted at
+    ``y_orig + dy``. So while the two histograms come from the same
+    event sample, per-bin counts are statistically independent (modulo
+    bin-edge effects, which we neglect).
+
+    Returns ``(ratio, sigma_ratio)`` with NaN where ``h_den ≤ 0``.
+    """
+    h_num = np.asarray(h_num, dtype=np.float64)
+    h_den = np.asarray(h_den, dtype=np.float64)
+    den_safe = np.where(h_den > 0, h_den, np.nan)
+    num_safe = np.where(h_num > 0, h_num, np.nan)
+    ratio = h_num / den_safe
+    rel = np.sqrt(
+        (sigma_num / num_safe) ** 2 + (sigma_den / den_safe) ** 2
+    )
+    return ratio, ratio * rel
+
+
+def _stepped_errorbar(ax, centers, h, sigma, color, **kwargs):
+    """Draw vertical sqrt(Σw²) error bars at each bin center, matched
+    visually to a step histogram. ``kwargs`` are forwarded to errorbar
+    (e.g. label, lw)."""
+    ax.errorbar(
+        centers, h, yerr=sigma, fmt="none", ecolor=color,
+        elinewidth=0.7, capsize=0, alpha=0.6, **kwargs,
+    )
+
+
+def _common_predict_call(
+    model, arch, y_dev, c_dev, factor, tcol, mode, n_features,
+    batch_size, positivity, sigma_pack_iu, sigma_pack_ju,
+):
+    """Thin wrapper that maps mode={shift,smear} → axis values."""
+    if mode == "shift":
+        return predict_log_r_axis(
+            model, arch, y_dev, c_dev,
+            u_axis_value=float(factor), sigma_axis_value=0.0, tcol=tcol,
+            n_features=n_features, batch_size=batch_size,
+            positivity=positivity,
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        )
+    if mode == "smear":
+        return predict_log_r_axis(
+            model, arch, y_dev, c_dev,
+            u_axis_value=0.0, sigma_axis_value=float(factor), tcol=tcol,
+            n_features=n_features, batch_size=batch_size,
+            positivity=positivity,
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        )
+    raise ValueError(f"unknown mode {mode!r}")
+
+
+# ============================================================================
+# 1) Per-axis 1D shift closure
+# ============================================================================
+
+def plot_shift_closure(
+    target, w_event, args, out_dir, log_r_grid_shift, target_std_per_dim,
+):
+    """Per-axis shift-closure plots from a precomputed log r grid."""
+    n_features = target.shape[1]
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    factors = args.shift_factors
+
+    n_rows = len(factors)
+    n_cols = len(target_components)
+    fig, axes = plt.subplots(
+        2 * n_rows, n_cols,
+        figsize=(4.0 * n_cols, 3.5 * n_rows),
+        sharex="col",
+        gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
+        squeeze=False,
+        layout="constrained",
+    )
+
+    for r, factor in enumerate(factors):
+        for cidx, tcol in enumerate(target_components):
+            log_r = log_r_grid_shift[(float(factor), int(tcol))]
+            r_pred = np.exp(log_r)
+
+            lo, hi = np.percentile(
+                target[:, tcol],
+                [args.range_percentile, 100 - args.range_percentile],
+            )
+            bins = np.linspace(lo, hi, args.n_bins + 1)
+            centers = 0.5 * (bins[:-1] + bins[1:])
+
+            dy = float(factor) * float(target_std_per_dim[tcol])
+            y_shifted = target[:, tcol] + dy
+
+            h_raw, e_raw = _weighted_hist_err(
+                target[:, tcol], bins, w_event,
+            )
+            h_shifted, e_shifted = _weighted_hist_err(
+                y_shifted, bins, w_event,
+            )
+            h_pred, e_pred = _weighted_hist_err(
+                target[:, tcol], bins,
+                (w_event * r_pred).astype(np.float64),
+            )
+
+            ax_main = axes[2 * r][cidx]
+            ax_main.step(
+                centers, h_raw, where="mid", color="0.4",
+                linestyle=":", lw=1.0, label="raw MC",
+            )
+            ax_main.step(
+                centers, h_shifted, where="mid", color="k", lw=1.0,
+                label=f"shifted MC ({factor:g}·σ_y)",
+            )
+            _stepped_errorbar(ax_main, centers, h_shifted, e_shifted, "k")
+            ax_main.step(
+                centers, h_pred, where="mid", color="C0",
+                linestyle="--", lw=1.0, label="MLP pred W reweight",
+            )
+            _stepped_errorbar(ax_main, centers, h_pred, e_pred, "C0")
+            ax_main.set_ylabel("events")
+            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            ax_main.set_title(
+                f"shift |δ|={factor:g} along {tname}", fontsize=10,
+            )
+            if r == 0 and cidx == 0:
+                ax_main.legend(loc="best", fontsize=7)
+
+            ax_ratio = axes[2 * r + 1][cidx]
+            ratio, e_ratio = _ratio_with_err(
+                h_pred, e_pred, h_shifted, e_shifted,
+            )
+            ax_ratio.step(
+                centers, ratio, where="mid",
+                color="C0", linestyle="--", lw=1.0,
+            )
+            _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C0")
+            ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
+            ax_ratio.set_ylabel("/ shifted MC", fontsize=8)
+            ax_ratio.set_xlabel(tname)
+            ratios = np.atleast_1d(ratio)
+            ratios = ratios[np.isfinite(ratios)]
+            if ratios.size:
+                lo_r, hi_r = np.quantile(ratios, [0.05, 0.95])
+                pad = max(0.05, 0.5 * (hi_r - lo_r))
+                ax_ratio.set_ylim(
+                    max(0.0, min(lo_r - pad, 1.0 - pad)),
+                    max(hi_r + pad, 1.0 + pad),
+                )
+
+    fig.suptitle("MLP shift-reweight closure")
+    _save(fig, os.path.join(out_dir, "shift_closure.png"))
+
+
+# ============================================================================
+# 2) Per-axis 1D smear closure
+# ============================================================================
+
+def plot_smear_closure(
+    target, w_event, args, out_dir, log_r_grid_smear, target_std_per_dim,
+    log_r_grid_smear_via_gh=None,
+):
+    """Per-axis smear-closure plots.
+
+    For each (factor, tcol) the smeared-MC histogram is built from
+    ``y_smeared = y + ε·σ·e_tcol`` with one ε ~ N(0, 1) per event —
+    matching exactly the rank-1 smear the model was trained on. The
+    pred-W reweight uses the smear-only log r at u = 0,
+    σ_vec = factor·e_tcol.
+
+    When ``log_r_grid_smear_via_gh`` is provided, an additional
+    overlaid curve uses the *shift* component of the polyhead with
+    a K-point Gauss-Hermite expansion over the per-event ε to build
+    a second estimate of the smear weight. Discrepancy between the
+    two reweight curves is a diagnostic of polyhead self-consistency
+    between its pure-σ and pure-u parts.
+    """
+    n_features = target.shape[1]
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    factors = args.smear_factors
+    rng = np.random.default_rng(args.seed)
+
+    n_rows = len(factors)
+    n_cols = len(target_components)
+    fig, axes = plt.subplots(
+        2 * n_rows, n_cols,
+        figsize=(4.0 * n_cols, 3.5 * n_rows),
+        sharex="col",
+        gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
+        squeeze=False,
+        layout="constrained",
+    )
+
+    for r, factor in enumerate(factors):
+        for cidx, tcol in enumerate(target_components):
+            log_r = log_r_grid_smear[(float(factor), int(tcol))]
+            r_pred = np.exp(log_r)
+
+            lo, hi = np.percentile(
+                target[:, tcol],
+                [args.range_percentile, 100 - args.range_percentile],
+            )
+            bins = np.linspace(lo, hi, args.n_bins + 1)
+            centers = 0.5 * (bins[:-1] + bins[1:])
+
+            dy = float(factor) * float(target_std_per_dim[tcol])
+            # Per-event ε draw — one draw per event, axis-aligned smear
+            # along tcol. Same ε shared across factors here for cleaner
+            # visual comparison row-to-row; switch to per-(factor, tcol)
+            # seed if you want truly independent draws.
+            eps = rng.standard_normal(target.shape[0])
+            y_smeared = target[:, tcol] + dy * eps
+
+            h_raw, e_raw = _weighted_hist_err(
+                target[:, tcol], bins, w_event,
+            )
+            h_smeared, e_smeared = _weighted_hist_err(
+                y_smeared, bins, w_event,
+            )
+            h_pred, e_pred = _weighted_hist_err(
+                target[:, tcol], bins,
+                (w_event * r_pred).astype(np.float64),
+            )
+
+            ax_main = axes[2 * r][cidx]
+            ax_main.step(
+                centers, h_raw, where="mid", color="0.4",
+                linestyle=":", lw=1.0, label="raw MC",
+            )
+            ax_main.step(
+                centers, h_smeared, where="mid", color="k", lw=1.0,
+                label=f"smeared MC ({factor:g}·σ_y, K=1)",
+            )
+            _stepped_errorbar(ax_main, centers, h_smeared, e_smeared, "k")
+            ax_main.step(
+                centers, h_pred, where="mid", color="C2",
+                linestyle="--", lw=1.0, label="MLP pred W reweight",
+            )
+            _stepped_errorbar(ax_main, centers, h_pred, e_pred, "C2")
+
+            # Optional: GH-on-shift smear estimate.
+            h_pred_gh = e_pred_gh = None
+            if log_r_grid_smear_via_gh is not None:
+                log_r_gh = log_r_grid_smear_via_gh[
+                    (float(factor), int(tcol))
+                ]
+                r_pred_gh = np.exp(log_r_gh)
+                h_pred_gh, e_pred_gh = _weighted_hist_err(
+                    target[:, tcol], bins,
+                    (w_event * r_pred_gh).astype(np.float64),
+                )
+                ax_main.step(
+                    centers, h_pred_gh, where="mid", color="C1",
+                    linestyle="-.", lw=1.0,
+                    label=f"GH(K={int(args.smear_gh_K)}) on shift",
+                )
+                _stepped_errorbar(
+                    ax_main, centers, h_pred_gh, e_pred_gh, "C1",
+                )
+
+            ax_main.set_ylabel("events")
+            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            ax_main.set_title(
+                f"smear |σ|={factor:g} along {tname}", fontsize=10,
+            )
+            if r == 0 and cidx == 0:
+                ax_main.legend(loc="best", fontsize=7)
+
+            ax_ratio = axes[2 * r + 1][cidx]
+            ratio, e_ratio = _ratio_with_err(
+                h_pred, e_pred, h_smeared, e_smeared,
+            )
+            ax_ratio.step(
+                centers, ratio, where="mid",
+                color="C2", linestyle="--", lw=1.0,
+            )
+            _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C2")
+            ratios_for_ylim = [ratio]
+            if h_pred_gh is not None:
+                ratio_gh, e_ratio_gh = _ratio_with_err(
+                    h_pred_gh, e_pred_gh, h_smeared, e_smeared,
+                )
+                ax_ratio.step(
+                    centers, ratio_gh, where="mid",
+                    color="C1", linestyle="-.", lw=1.0,
+                )
+                _stepped_errorbar(
+                    ax_ratio, centers, ratio_gh, e_ratio_gh, "C1",
+                )
+                ratios_for_ylim.append(ratio_gh)
+            ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
+            ax_ratio.set_ylabel("/ smeared MC", fontsize=8)
+            ax_ratio.set_xlabel(tname)
+            ratios = np.concatenate([
+                np.atleast_1d(rr)[np.isfinite(np.atleast_1d(rr))]
+                for rr in ratios_for_ylim
+            ]) if ratios_for_ylim else np.empty(0)
+            if ratios.size:
+                lo_r, hi_r = np.quantile(ratios, [0.05, 0.95])
+                pad = max(0.05, 0.5 * (hi_r - lo_r))
+                ax_ratio.set_ylim(
+                    max(0.0, min(lo_r - pad, 1.0 - pad)),
+                    max(hi_r + pad, 1.0 + pad),
+                )
+
+    fig.suptitle(
+        "MLP smear-reweight closure (rank-1 K=1 smeared MC; ratios "
+        "carry K=1 sampling noise)"
+    )
+    _save(fig, os.path.join(out_dir, "smear_closure.png"))
+
+
+# ============================================================================
+# 2.5) Per-bin error comparison: polyhead-reweight vs literal shifted/
+#      smeared MC. The per-bin σ = √Σwᵢ² is a direct measure of
+#      effective sample size; the ratio σ_pred / σ_ref tells you the
+#      statistical-inefficiency cost of using the reweight in place
+#      of a literal sample. Ratio = 1 is optimal; ratio > 1 means the
+#      reweight inflates the error vs a fresh sample.
+# ============================================================================
+
+def plot_closure_error_ratio(
+    target, w_event, args, out_dir, log_r_grid, target_std_per_dim,
+    mode,
+):
+    """Per-bin √Σw² error comparison: polyhead reweight vs literal
+    shifted/smeared MC, with the variance-optimal constant-per-bin
+    reweight as the achievable floor.
+
+    Per (factor, axis) cell, two stacked panels:
+      * Top: three overlaid step histograms (log y):
+          - σ_ref = √Σ wᵢ² at perturbed y (literal shifted/smeared
+            MC).
+          - σ_pred = √Σ (wᵢ · r̂)² at unperturbed y (polyhead
+            reweight).
+          - σ_optimal = (h_ref / h_raw) · σ_raw — the variance-
+            minimal per-bin error achievable by **any** reweight
+            that matches the perturbed-MC bin totals (constant per-
+            bin reweight). Lower bound on what the polyhead can
+            possibly reach.
+      * Bottom: σ_pred / σ_optimal and σ_ref / σ_optimal per bin
+        (linear y). σ_pred / σ_optimal is bounded below by 1
+        (variance-minimality of the optimal reweight subject to
+        matching bin totals); σ_ref / σ_optimal is the
+        reference-vs-floor benchmark.
+
+    The polyhead's per-bin σ_pred can never be lower than σ_optimal,
+    so σ_pred / σ_optimal ≥ 1 everywhere; values close to 1 mean
+    the polyhead is achieving near-uniform per-bin reweight (the
+    intra-bin reweight values vary little). Values ≫ 1 mean the
+    polyhead is assigning highly variable weights within bin —
+    visible signal of intra-bin reweight roughness.
+
+    σ_ref / σ_optimal tells you how the literal sample compares to
+    the achievable floor: > 1 in regions where the reference is
+    statistically inferior to a perfectly-uniform reweight (i.e.
+    where reweighting *can* beat a fresh sample if done right);
+    < 1 where the reference is intrinsically more efficient than
+    any reweight could be (e.g., perturbation moving events into
+    sparse origin bins).
+
+    ``mode = 'shift'`` uses the shifted-MC reference (deterministic
+    shift along the tcol axis); ``mode = 'smear'`` uses the K=1
+    stochastic smeared-MC reference. Layouts and binning match
+    ``plot_shift_closure`` / ``plot_smear_closure``.
+    """
+    assert mode in ("shift", "smear")
+    n_features = target.shape[1]
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    factors = (
+        args.shift_factors if mode == "shift" else args.smear_factors
+    )
+    rng = (
+        np.random.default_rng(args.seed) if mode == "smear" else None
+    )
+
+    n_rows = len(factors)
+    n_cols = len(target_components)
+    fig, axes = plt.subplots(
+        2 * n_rows, n_cols,
+        figsize=(4.0 * n_cols, 3.5 * n_rows),
+        sharex="col",
+        gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
+        squeeze=False,
+        layout="constrained",
+    )
+
+    for r, factor in enumerate(factors):
+        for cidx, tcol in enumerate(target_components):
+            log_r = log_r_grid[(float(factor), int(tcol))]
+            r_pred = np.exp(log_r)
+
+            lo, hi = np.percentile(
+                target[:, tcol],
+                [args.range_percentile, 100 - args.range_percentile],
+            )
+            bins = np.linspace(lo, hi, args.n_bins + 1)
+            centers = 0.5 * (bins[:-1] + bins[1:])
+
+            dy = float(factor) * float(target_std_per_dim[tcol])
+            if mode == "shift":
+                y_ref = target[:, tcol] + dy
+                ref_label = f"shifted MC ({factor:g}·σ_y)"
+            else:
+                eps = rng.standard_normal(target.shape[0])
+                y_ref = target[:, tcol] + dy * eps
+                ref_label = (
+                    f"smeared MC ({factor:g}·σ_y, K=1 stochastic)"
+                )
+
+            # Three histograms / sigma vectors:
+            #   raw      — unperturbed MC at original y (bin-fill).
+            #   ref      — perturbed MC at shifted/smeared y.
+            #   pred     — polyhead-reweighted MC at original y.
+            h_raw, e_raw = _weighted_hist_err(
+                target[:, tcol], bins, w_event,
+            )
+            h_ref, e_ref = _weighted_hist_err(y_ref, bins, w_event)
+            _, e_pred = _weighted_hist_err(
+                target[:, tcol], bins,
+                (w_event * r_pred).astype(np.float64),
+            )
+            # Optimal: constant-per-bin reweight = h_ref / h_raw.
+            # σ_opt = (h_ref / h_raw) · σ_raw. NaN where h_raw == 0
+            # (no events to reweight) so the line drops out cleanly
+            # in those bins.
+            scale = h_ref / np.where(h_raw > 0, h_raw, np.nan)
+            e_optimal = scale * e_raw
+
+            ax_main = axes[2 * r][cidx]
+            ax_main.step(
+                centers, e_ref, where="mid",
+                color="k", lw=1.0, label=ref_label,
+            )
+            ax_main.step(
+                centers, e_pred, where="mid",
+                color="C0", linestyle="--", lw=1.0,
+                label=r"polyhead reweight: $\sqrt{\sum (w \hat r)^2}$",
+            )
+            ax_main.step(
+                centers, e_optimal, where="mid",
+                color="C2", linestyle=":", lw=1.0,
+                label=(
+                    r"optimal reweight: $(h_{\rm ref}/h_{\rm raw})"
+                    r" \sqrt{\sum w^2}$"
+                ),
+            )
+            ax_main.set_yscale("log")
+            ax_main.set_ylabel(r"$\sigma$ per bin")
+            tname = (
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES)
+                else f"target[{tcol}]"
+            )
+            ax_main.set_title(
+                f"{mode}: |{'δ' if mode == 'shift' else 'σ'}|="
+                f"{factor:g} along {tname}",
+                fontsize=10,
+            )
+            if r == 0 and cidx == 0:
+                ax_main.legend(loc="best", fontsize=7)
+
+            # Ratio panel — two step lines vs the σ_optimal floor.
+            # Bins with h_raw == 0 (no events to reweight) make
+            # σ_optimal NaN and drop both lines cleanly.
+            denom = np.where(e_optimal > 0, e_optimal, np.nan)
+            ratio_pred = e_pred / denom
+            ratio_ref = e_ref / denom
+            ax_ratio = axes[2 * r + 1][cidx]
+            ax_ratio.step(
+                centers, ratio_pred, where="mid",
+                color="C0", lw=1.0,
+                label=r"$\hat r$ / optimal",
+            )
+            ax_ratio.step(
+                centers, ratio_ref, where="mid",
+                color="k", lw=1.0,
+                label="ref / optimal",
+            )
+            ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
+            ax_ratio.set_ylabel(
+                r"$\sigma / \sigma_{\rm optimal}$", fontsize=8,
+            )
+            ax_ratio.set_xlabel(tname)
+            if r == 0 and cidx == 0:
+                ax_ratio.legend(loc="best", fontsize=7)
+            ratios_all = np.concatenate([
+                ratio_pred[np.isfinite(ratio_pred)],
+                ratio_ref[np.isfinite(ratio_ref)],
+            ])
+            if ratios_all.size:
+                lo_r, hi_r = np.quantile(ratios_all, [0.05, 0.95])
+                pad = max(0.05, 0.5 * (hi_r - lo_r))
+                ax_ratio.set_ylim(
+                    max(0.0, min(lo_r - pad, 0.9)),
+                    max(hi_r + pad, 1.1),
+                )
+
+    fig.suptitle(
+        f"Polyhead reweight per-bin error vs {mode} MC: "
+        r"ratio relative to the optimal-reweight floor"
+    )
+    _save(
+        fig,
+        os.path.join(out_dir, f"{mode}_closure_error_ratio.png"),
+    )
+
+
+# ============================================================================
+# 3) log r distribution (per axis × magnitude × mode)
+# ============================================================================
+
+def plot_log_r_distribution(
+    n_features, w_event, args, out_dir,
+    log_r_grid_shift, log_r_grid_smear,
+):
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+
+    fig, axes = plt.subplots(
+        2, len(target_components),
+        figsize=(4.5 * len(target_components), 7.0),
+        squeeze=False,
+        layout="constrained",
+    )
+
+    for row, (mode, grid, factors) in enumerate([
+        ("shift", log_r_grid_shift, args.shift_factors),
+        ("smear", log_r_grid_smear, args.smear_factors),
+    ]):
+        for cidx, tcol in enumerate(target_components):
+            ax = axes[row][cidx]
+            all_log_r = []
+            labels = []
+            for factor in factors:
+                all_log_r.append(grid[(float(factor), int(tcol))])
+                tag = "δ" if mode == "shift" else "σ"
+                labels.append(f"|{tag}|={factor:g}·σ_y")
+
+            concat = np.concatenate(all_log_r)
+            finite = concat[np.isfinite(concat)]
+            if finite.size == 0:
+                continue
+            lo, hi = np.percentile(finite, [0.5, 99.5])
+            m = max(abs(lo), abs(hi), 0.05)
+            bins = np.linspace(-m, m, 80)
+
+            centers = 0.5 * (bins[:-1] + bins[1:])
+            for i, (log_r, lbl) in enumerate(zip(all_log_r, labels)):
+                color = f"C{i}"
+                h, sigma = _weighted_hist_err(log_r, bins, w_event)
+                ax.step(
+                    centers, h, where="mid", color=color, lw=1.2,
+                    label=lbl,
+                )
+                _stepped_errorbar(ax, centers, h, sigma, color)
+            ax.axvline(0.0, color="k", lw=0.5, alpha=0.5)
+            ax.set_xlabel("log r")
+            ax.set_ylabel("events (weighted)")
+            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            ax.set_title(f"{mode}: log r along {tname}", fontsize=10)
+            ax.legend(fontsize=7)
+            ax.set_yscale("log")
+
+    fig.suptitle("MLP predicted log r — distribution across events")
+    _save(fig, os.path.join(out_dir, "log_r_distribution.png"))
+
+
+# ============================================================================
+# 4) log r vs |perturbation| scan (shift and smear)
+# ============================================================================
+
+def plot_log_r_scan(
+    model, arch, y_dev, c_dev, n_features, w_event, args, positivity,
+    out_dir, sigma_pack_iu, sigma_pack_ju,
+):
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    u_max = float(max(args.shift_factors))
+    sigma_max = float(max(args.smear_factors))
+    u_grid = np.linspace(-u_max, u_max, args.scan_magnitudes)
+    # Smear is even in σ so the negative-σ side is redundant; use a
+    # one-sided scan from 0 to σ_max to keep the panel readable.
+    sigma_grid = np.linspace(0.0, sigma_max, args.scan_magnitudes)
+
+    w64 = w_event.astype(np.float64)
+    wsum = float(w64.sum())
+
+    fig, axes = plt.subplots(
+        2, len(target_components),
+        figsize=(4.5 * len(target_components), 7.0),
+        squeeze=False, layout="constrained",
+    )
+
+    for row, (mode, grid, label_x) in enumerate([
+        ("shift", u_grid, "u (in σ_y units)"),
+        ("smear", sigma_grid, "|σ_vec| (in σ_y units)"),
+    ]):
+        for cidx, tcol in enumerate(target_components):
+            ax = axes[row][cidx]
+            means = []
+            stds = []
+            sigma_means = []
+            for v in grid:
+                log_r = _common_predict_call(
+                    model, arch, y_dev, c_dev, float(v), int(tcol),
+                    mode, n_features, args.batch_size, positivity,
+                    sigma_pack_iu, sigma_pack_ju,
+                ).astype(np.float64)
+                mean = (w64 * log_r).sum() / max(wsum, 1e-30)
+                var = (w64 * (log_r - mean) ** 2).sum() / max(wsum, 1e-30)
+                # Statistical uncertainty on the weighted mean:
+                #   σ²<x> = Σ wᵢ² (xᵢ − <x>)² / (Σ wᵢ)²
+                # = (effective-N) variance with Σw² in the numerator.
+                sigma_mean_sq = (
+                    (w64 * w64 * (log_r - mean) ** 2).sum()
+                    / max(wsum * wsum, 1e-60)
+                )
+                means.append(mean)
+                stds.append(math.sqrt(max(var, 0.0)))
+                sigma_means.append(math.sqrt(max(sigma_mean_sq, 0.0)))
+            means = np.asarray(means)
+            stds = np.asarray(stds)
+            sigma_means = np.asarray(sigma_means)
+            color = "C0" if mode == "shift" else "C2"
+            ax.errorbar(
+                grid, means, yerr=sigma_means,
+                fmt="o-", color=color, lw=1.2, capsize=2,
+                label="⟨log r⟩  ± stat (√Σw²/Σw)",
+            )
+            ax.fill_between(
+                grid, means - stds, means + stds,
+                alpha=0.25, color=color, label="±1σ across events",
+            )
+            ax.axhline(0.0, color="k", lw=0.5, alpha=0.5)
+            ax.axvline(0.0, color="k", lw=0.5, alpha=0.5)
+            ax.set_xlabel(label_x)
+            ax.set_ylabel("log r")
+            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            ax.set_title(
+                f"{mode}: ⟨log r⟩ along {tname}", fontsize=10,
+            )
+            ax.legend(fontsize=7)
+
+    fig.suptitle(
+        "MLP predicted log r — magnitude scan (top: shift / "
+        "bottom: smear)"
+    )
+    _save(fig, os.path.join(out_dir, "log_r_scan.png"))
+
+
+# ============================================================================
+# Optional: BCE-polyhead vs flow-truth scatter
+# ============================================================================
+
+def plot_polyhead_pred_vs_flow(
+    model, arch, flow, flow_stats, polyhead_stats,
+    target_std, cond, n_features, w_event,
+    args, out_dir,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Scatter / 2D-density of this script's polyhead-predicted W vs.
+    a flow's analytic W on a common ``(y, c, u, σ)`` grid. Mirrors
+    flow_training_diagnostics.py's ``plot_polyhead_pred_vs_true`` so
+    the two estimators are comparable on the same metric.
+
+    Three panels: SHIFT (σ=0), SMEAR (u=0), JOINT (both nonzero).
+    Reports ``log_W rms`` and ``bias`` per panel, computed
+    weighted-by-``w_event``. The diagonal indicates a perfect
+    polyhead-vs-flow agreement; the BCE polyhead's training target
+    *is* the same density ratio the flow estimates analytically, so
+    in the population limit both should sit on the diagonal.
+
+    Assumes ``flow_stats`` and ``polyhead_stats`` are compatible
+    (i.e. both trained on the same MC sample with the same
+    standardization). Only checks for shape compatibility — caller
+    is expected to verify upstream.
+    """
+    device = args.device
+    n_use = min(args.flow_validate_n, target_std.shape[0])
+    rng = np.random.default_rng(0)
+    idx = rng.choice(target_std.shape[0], size=n_use, replace=False)
+
+    # Use the polyhead's stats to standardize. If flow's stats differ
+    # we issue a warning — exact agreement requires aligned preproc.
+    if not np.allclose(
+        np.asarray(flow_stats.target_mean),
+        np.asarray(polyhead_stats.target_mean),
+        atol=1e-4,
+    ) or not np.allclose(
+        np.asarray(flow_stats.target_std),
+        np.asarray(polyhead_stats.target_std),
+        atol=1e-4,
+    ):
+        print(
+            "  warning: flow preproc differs from polyhead preproc "
+            "— pred-vs-flow plot will be approximate."
+        )
+
+    y_std_t = torch.from_numpy(target_std[idx]).to(device)
+    c_std_t = torch.from_numpy(cond[idx]).to(device)
+    w_sub = w_event[idx].astype(np.float32)
+
+    # Sample perturbations in standardized target space, matching the
+    # training-time sampler: |δ| uniform on [0, 1.3 · delta_max], v on
+    # the unit sphere. Read magnitudes from the polyhead's training
+    # config when available; fall back to the conventional 1.3.
+    train_cfg = getattr(args, "_polyhead_train_cfg", {}) or {}
+    delta_max_train = float(train_cfg.get("delta_max", 1.0))
+    sigma_max_train = float(train_cfg.get("sigma_max", 1.0)) or 1.0
+    oversample = 1.3
+    half = oversample * delta_max_train
+    half_sig = oversample * sigma_max_train
+
+    g = torch.Generator().manual_seed(0)
+    delta_shift = (
+        torch.rand(n_use, generator=g) * 2.0 - 1.0
+    ) * half
+    v_shift = torch.randn(n_use, n_features, generator=g)
+    v_shift = v_shift / v_shift.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+    sigma_smear = torch.rand(n_use, generator=g) * half_sig
+    v_smear = torch.randn(n_use, n_features, generator=g)
+    v_smear = v_smear / v_smear.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+    delta_smear = sigma_smear * torch.randn(n_use, generator=g)
+    u_shift_full = (delta_shift.unsqueeze(-1) * v_shift).to(device)
+    sigma_vec_full = (sigma_smear.unsqueeze(-1) * v_smear).to(device)
+    delta_smear = delta_smear.to(device)
+    v_smear = v_smear.to(device)
+
+    # Local flow log-W computation — mirrors
+    # flow_training_diagnostics._flow_log_w_at without taking a
+    # cross-script dependency.
+    def flow_log_w_at(u_eval):
+        N = y_std_t.shape[0]
+        out = np.empty(N, dtype=np.float32)
+        flow.eval()
+        with torch.no_grad():
+            for s in range(0, N, args.batch_size):
+                e = min(s + args.batch_size, N)
+                y = y_std_t[s:e]
+                c = c_std_t[s:e]
+                u = u_eval[s:e]
+                z, ladj = flow(c).transform.call_and_ladj(y)
+                z_p, ladj_p = flow(c).transform.call_and_ladj(y - u)
+                lw = -0.5 * (
+                    (z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)
+                ) + (ladj_p - ladj)
+                out[s:e] = lw.cpu().numpy().astype(np.float32)
+        return out
+
+    titles = ("SHIFT (σ=0)", "SMEAR (u=0)", "JOINT (both)")
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4.7), sharey=False)
+    for col, title in enumerate(titles):
+        if col == 0:
+            u_eval = u_shift_full.clone()
+            u_in = u_shift_full.clone()
+            sigma_in = torch.zeros_like(sigma_vec_full)
+        elif col == 1:
+            u_eval = delta_smear.unsqueeze(-1) * v_smear
+            u_in = torch.zeros_like(u_shift_full)
+            sigma_in = sigma_vec_full.clone()
+        else:
+            u_eval = u_shift_full + delta_smear.unsqueeze(-1) * v_smear
+            u_in = u_shift_full.clone()
+            sigma_in = sigma_vec_full.clone()
+
+        true_lw = flow_log_w_at(u_eval)
+        pred_lw = predict_log_r_perevent(
+            model, arch, y_std_t, c_std_t, u_in, sigma_in,
+            args.batch_size, getattr(args, "_positivity", "exp"),
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        )
+
+        # Weighted RMS / bias of pred − true.
+        err = pred_lw - true_lw
+        finite = np.isfinite(err)
+        e_f = err[finite]
+        w_f = w_sub[finite]
+        wsum = float(w_f.sum())
+        if wsum <= 0.0:
+            rms = bias = float("nan")
+        else:
+            bias = float((w_f * e_f).sum() / wsum)
+            rms = float(np.sqrt((w_f * e_f * e_f).sum() / wsum))
+
+        ax = axes[col]
+        # 2D log-density scatter (mirrors flow+polyhead diagnostic).
+        x = true_lw[finite] / np.log(10.0)
+        y = pred_lw[finite] / np.log(10.0)
+        lo = float(min(x.min(), y.min()))
+        hi = float(max(x.max(), y.max()))
+        bins = np.linspace(lo, hi, 80)
+        h, xe, ye = np.histogram2d(x, y, bins=[bins, bins], weights=w_f)
+        from matplotlib.colors import LogNorm
+        ax.pcolormesh(
+            xe, ye, h.T,
+            norm=LogNorm(vmin=max(1.0, h.max() * 1e-4), vmax=h.max()),
+            cmap="viridis",
+        )
+        ax.plot([lo, hi], [lo, hi], "r-", lw=1.0, label="diagonal")
+        ax.set_xlim(lo, hi)
+        ax.set_ylim(lo, hi)
+        ax.set_xlabel("log10  flow log-W")
+        ax.set_ylabel("log10  BCE-polyhead log-W")
+        ax.set_title(
+            f"{title}\nlog-W rms={rms:.3f}  bias={bias:+.3f}",
+        )
+        ax.legend(loc="upper left", fontsize=8)
+
+    fig.suptitle("BCE polyhead pred  vs  flow log-W (analytic)")
+    fig.tight_layout()
+    _save(fig, os.path.join(out_dir, "polyhead_pred_vs_flow.png"))
+
+
+def plot_polyhead_axis_logw_error_vs_flow(
+    model, arch, flow, flow_stats, polyhead_stats,
+    target_std, cond, n_features, w_event,
+    args, out_dir,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Per-axis polyhead-vs-flow log-W error histograms at the
+    closure shift magnitudes. Mirror of
+    flow_training_diagnostics.py's
+    ``plot_polyhead_axis_logw_error`` for the direct-BCE polyhead.
+
+    Lays out a grid of ``log(pred_W) − log(W_flow)`` histograms with
+    rows = ``args.shift_factors`` and cols = target axes
+    (r_kappa, dlambda, dphi). Each panel evaluates axis-aligned
+    shifts ``u = δ · ê_axis`` for every event, with the flow's
+    analytic log W as the reference, and reports weighted RMS and
+    bias. Useful for direct comparison against the flow+polyhead's
+    per-axis numbers — same metric, same shifts, same axes.
+
+    Saves four files:
+      * ``polyhead_axis_logw_error_vs_flow.{png,pdf}`` (linear y)
+      * ``polyhead_axis_logw_error_vs_flow_log.{png,pdf}`` (log y)
+    """
+    device = args.device
+    n_use = min(args.flow_validate_n, target_std.shape[0])
+    rng = np.random.default_rng(2)
+    idx = rng.choice(target_std.shape[0], size=n_use, replace=False)
+    y_std_t = torch.from_numpy(target_std[idx]).to(device)
+    c_std_t = torch.from_numpy(cond[idx]).to(device)
+    w_sub = w_event[idx].astype(np.float32)
+
+    deltas = list(args.shift_factors)
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    target_names = TARGET_NAMES[: len(target_components)]
+
+    n_rows = len(deltas)
+    n_cols = len(target_components)
+
+    # Local flow log-W at axis-aligned u (broadcast scalar mag * ê).
+    def flow_log_w_axis(factor, axis):
+        N = y_std_t.shape[0]
+        out = np.empty(N, dtype=np.float32)
+        u_buf = torch.zeros(args.batch_size, n_features, device=device)
+        u_buf[:, axis] = float(factor)
+        flow.eval()
+        with torch.no_grad():
+            for s in range(0, N, args.batch_size):
+                e = min(s + args.batch_size, N)
+                bsz = e - s
+                u = u_buf[:bsz]
+                y = y_std_t[s:e]
+                c = c_std_t[s:e]
+                z, ladj = flow(c).transform.call_and_ladj(y)
+                z_p, ladj_p = flow(c).transform.call_and_ladj(y - u)
+                lw = -0.5 * (
+                    (z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)
+                ) + (ladj_p - ladj)
+                out[s:e] = lw.cpu().numpy().astype(np.float32)
+        return out
+
+    panel_data = [[None] * n_cols for _ in range(n_rows)]
+    for r, factor in enumerate(deltas):
+        for c, axis in enumerate(target_components):
+            true_lw = flow_log_w_axis(float(factor), int(axis))
+            pred_lw = predict_log_r_axis(
+                model, arch, y_std_t, c_std_t,
+                u_axis_value=float(factor), sigma_axis_value=0.0,
+                tcol=int(axis), n_features=n_features,
+                batch_size=args.batch_size,
+                positivity=getattr(args, "_positivity", "exp"),
+                sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            )
+            log_err = pred_lw - true_lw
+            finite = np.isfinite(log_err)
+            le = log_err[finite]
+            wle = w_sub[finite]
+            wsum = float(wle.sum())
+            if wsum <= 0.0:
+                rms = bias = float("nan")
+            else:
+                rms = float(np.sqrt(np.average(le ** 2, weights=wle)))
+                bias = float(np.average(le, weights=wle))
+            panel_data[r][c] = (le, wle, rms, bias)
+
+    for yscale, suffix in (("linear", ""), ("log", "_log")):
+        fig, axes = plt.subplots(
+            n_rows, n_cols,
+            figsize=(4.0 * n_cols, 3.0 * n_rows),
+            sharex="row", sharey="row", squeeze=False,
+        )
+        for r, factor in enumerate(deltas):
+            spreads = []
+            for c in range(n_cols):
+                le, *_ = panel_data[r][c]
+                lo, hi = np.quantile(le, [0.005, 0.995])
+                spreads.append(max(abs(lo), abs(hi)))
+            spread = max(spreads) if spreads else 1.0
+            bins = np.linspace(-spread, spread, 81)
+            for c, name in enumerate(target_names):
+                ax = axes[r][c]
+                le, wle, rms, bias = panel_data[r][c]
+                ax.hist(
+                    le, bins=bins, weights=wle, histtype="step",
+                    color="C0", lw=1.5,
+                )
+                ax.axvline(0.0, color="k", lw=0.8, alpha=0.5)
+                ax.set_title(
+                    f"|δ|={factor:g} along {name}: "
+                    f"rms={rms:.4f} bias={bias:+.4f}"
+                )
+                ax.set_yscale(yscale)
+                if r == n_rows - 1:
+                    ax.set_xlabel(
+                        r"$\log(\hat W) - \log W_{\rm flow}$"
+                    )
+                if c == 0:
+                    ax.set_ylabel("weighted events")
+        fig.suptitle(
+            "BCE polyhead reconstruction error vs flow, "
+            "axis-aligned shifts"
+        )
+        fig.tight_layout()
+        _save(
+            fig,
+            os.path.join(
+                out_dir,
+                f"polyhead_axis_logw_error_vs_flow{suffix}.png",
+            ),
+        )
+
+
+# ============================================================================
+# Per-source target-distribution comparison
+# ============================================================================
+
+def _parse_source_labels(spec):
+    """Parse ``["0:Jpsi", "100:Zmumu"]`` into ``{0: "Jpsi", 100: "Zmumu"}``."""
+    if spec is None:
+        return {}
+    out = {}
+    for entry in spec:
+        if ":" not in entry:
+            raise ValueError(
+                f"--cmp-source-labels entry {entry!r} missing ':' "
+                "separator; expected ``id:label``"
+            )
+        sid_str, lbl = entry.split(":", 1)
+        out[int(sid_str)] = lbl
+    return out
+
+
+def _read_manifest_source_labels(paths):
+    """Locate the shard ``manifest.json`` reachable from ``paths`` and
+    return its ``source_labels`` map as ``{int: str}``.
+
+    Recognises three forms of input path:
+      * a directory containing ``manifest.json`` (the standard shard dir);
+      * an explicit ``manifest.json`` file;
+      * a shard file -- in which case the sibling ``manifest.json`` in
+        the containing directory is used.
+
+    Last-write-wins across multiple inputs; missing files are skipped
+    silently so older shards without the labels block still work.
+    """
+    labels: dict[int, str] = {}
+    seen: set[str] = set()
+    for p in paths:
+        mfp = None
+        if os.path.isdir(p):
+            cand = os.path.join(p, "manifest.json")
+            if os.path.exists(cand):
+                mfp = cand
+        elif os.path.isfile(p):
+            if os.path.basename(p) == "manifest.json":
+                mfp = p
+            else:
+                cand = os.path.join(
+                    os.path.dirname(os.path.abspath(p)), "manifest.json",
+                )
+                if os.path.exists(cand):
+                    mfp = cand
+        if mfp is None or mfp in seen:
+            continue
+        seen.add(mfp)
+        try:
+            with open(mfp) as f:
+                manifest = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"  warning: failed to read {mfp}: {exc!r}")
+            continue
+        for k, v in (manifest.get("source_labels") or {}).items():
+            try:
+                labels[int(k)] = str(v)
+            except (ValueError, TypeError):
+                continue
+    return labels
+
+
+def _load_per_source_window(
+    paths, *, pt_min, pt_max, eta_min, eta_max,
+    max_events=-1, n_workers=8,
+):
+    """Parallel streaming loader specialised for the per-source target-
+    distribution plots.
+
+    Reads Arrow IPC shards via a thread pool (pyarrow IO and numpy
+    vector ops release the GIL during the heavy work), applies the
+    ``(pt_gen, eta_gen)`` window per shard, and computes the three
+    target columns inline. Peak memory is bounded by the *kept* rows
+    across all shards, not the full dataset — so a narrow window over
+    the full statistics is cheap. Charge is not filtered here: the
+    caller may split by charge in the rendering pass without reloading.
+
+    Returns ``(data, rows_read, rows_kept)`` where ``data`` is either
+    ``None`` (no kept rows) or a 5-tuple of arrays
+    ``(target [N,3], weight [N], source_id [N], kappa_gen [N],
+    eta_gen [N])``. ``rows_read`` is the total raw rows pulled off
+    disk (after any ``max_events`` truncation); ``rows_kept`` counts
+    those that passed the (pt, eta, finite, w>0) mask.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+
+    # Reuse the shard-directory expansion already used by load_ntuples.
+    from train_muon_response_flow import _expand_input_paths
+
+    paths = _expand_input_paths(paths)
+    if not paths:
+        raise ValueError(
+            "_load_per_source_window: no input paths after expansion"
+        )
+    if not all(p.endswith(".arrow") for p in paths):
+        raise ValueError(
+            "_load_per_source_window: only Arrow IPC shards (.arrow) "
+            "or a shard directory with manifest.json are supported"
+        )
+
+    _MAGIC = b"ARROW1"
+
+    def _read_one(p):
+        with pa.memory_map(p, "r") as f:
+            head = f.read(len(_MAGIC))
+            f.seek(0)
+            if head == _MAGIC:
+                t = ipc.open_file(f).read_all()
+            else:
+                t = ipc.open_stream(f).read_all()
+        eta_r = t["eta_reco"].to_numpy().astype(np.float64)
+        phi_r = t["phi_reco"].to_numpy().astype(np.float64)
+        eta_g = t["eta_gen"].to_numpy().astype(np.float64)
+        phi_g = t["phi_gen"].to_numpy().astype(np.float64)
+        kappa_r = t["kappa_reco"].to_numpy().astype(np.float64)
+        kappa_g = t["kappa_gen"].to_numpy().astype(np.float64)
+        w_raw = t["nominal_weight"].to_numpy().astype(np.float64)
+        sid = t["source_id"].to_numpy().astype(np.int32, copy=False)
+        n_block = eta_r.shape[0]
+
+        abs_k = np.fabs(kappa_g)
+        safe_k = np.where(abs_k > 0, abs_k, np.nan)
+        pt_g = 1.0 / (safe_k * np.cosh(eta_g))
+        mask = (
+            np.isfinite(pt_g)
+            & (pt_g >= pt_min) & (pt_g <= pt_max)
+            & (eta_g >= eta_min) & (eta_g <= eta_max)
+            & np.isfinite(kappa_r) & np.isfinite(kappa_g)
+            & (w_raw > 0.0)
+        )
+        if not mask.any():
+            return None, n_block
+        eta_r = eta_r[mask]; phi_r = phi_r[mask]
+        eta_g = eta_g[mask]; phi_g = phi_g[mask]
+        kappa_r = kappa_r[mask]; kappa_g = kappa_g[mask]
+        w = w_raw[mask]; sid = sid[mask]
+
+        # Inline target columns from compute_targets_and_conditioning,
+        # restricted to the masked rows so we never form full-shard
+        # target arrays.
+        lam_r = np.arctan(np.sinh(eta_r))
+        lam_g = np.arctan(np.sinh(eta_g))
+        r_kappa = kappa_r / kappa_g - 1.0
+        dphi = np.arctan2(
+            np.sin(phi_r - phi_g), np.cos(phi_r - phi_g),
+        )
+        dlambda = lam_r - lam_g
+        target = np.stack([r_kappa, dlambda, dphi], axis=1)
+
+        return (
+            (target, w.astype(np.float32), sid, kappa_g, eta_g),
+            n_block,
+        )
+
+    blocks = []
+    rows_read = 0
+    rows_kept = 0
+    with ThreadPoolExecutor(max_workers=max(1, int(n_workers))) as ex:
+        futures = {ex.submit(_read_one, p): p for p in paths}
+        for fut in as_completed(futures):
+            try:
+                res, n_block = fut.result()
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[per-source loader] shard {futures[fut]} failed: "
+                    f"{exc!r}"
+                )
+                continue
+            rows_read += n_block
+            if res is not None:
+                blocks.append(res)
+                rows_kept += res[0].shape[0]
+            if max_events > 0 and rows_read >= max_events:
+                for f in futures:
+                    f.cancel()
+                break
+
+    if not blocks:
+        return None, rows_read, 0
+
+    target = np.concatenate([b[0] for b in blocks], axis=0)
+    w = np.concatenate([b[1] for b in blocks])
+    sid = np.concatenate([b[2] for b in blocks])
+    kappa_g = np.concatenate([b[3] for b in blocks])
+    eta_g = np.concatenate([b[4] for b in blocks])
+    return (target, w, sid, kappa_g, eta_g), rows_read, rows_kept
+
+
+def plot_per_source_target_distributions(
+    target, w_event, source_id, kappa_g, eta_g, args, out_dir,
+):
+    """Compare the marginal target distributions across datasets
+    (distinct ``source_id`` values) inside a phase-space window in
+    (pt_gen, eta_gen, charge_gen). phi_gen is integrated.
+
+    Per target component the top row shows weighted, area-normalised
+    histograms (one curve per source); the bottom row is the bin-wise
+    ratio to a reference source. Bin edges are taken from the
+    pooled-sample quantiles inside the window so all sources share the
+    same binning.
+    """
+    target = np.asarray(target)
+    n_features = target.shape[1]
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+
+    # Reconstruct pt_gen, charge_gen from kappa_gen + eta_gen.
+    kappa_g = np.asarray(kappa_g, dtype=np.float64)
+    eta_g = np.asarray(eta_g, dtype=np.float64)
+    abs_k = np.fabs(kappa_g)
+    safe_k = np.where(abs_k > 0, abs_k, np.nan)
+    pt_g = 1.0 / (safe_k * np.cosh(eta_g))
+    charge_g = np.sign(kappa_g).astype(np.int8)
+
+    # Phase-space window (pt, eta) — shared across charge modes.
+    pt_min = float(args.cmp_pt_min)
+    pt_max = float(args.cmp_pt_max)
+    eta_min = float(args.cmp_eta_min)
+    eta_max = float(args.cmp_eta_max)
+    base_mask = (
+        np.isfinite(pt_g)
+        & (pt_g >= pt_min) & (pt_g <= pt_max)
+        & (eta_g >= eta_min) & (eta_g <= eta_max)
+    )
+
+    # Charge modes: ``each`` runs pos and neg in separate plots.
+    if args.cmp_charge == "each":
+        charge_modes = ["pos", "neg"]
+    else:
+        charge_modes = [args.cmp_charge]
+
+    # Label precedence (lowest -> highest):
+    #   1. hard-coded DEFAULT_SOURCE_LABELS    -- last-resort fallback
+    #   2. manifest.json's ``source_labels``   -- the authoritative
+    #      id-to-sample mapping written by the snapshot/sharder pipeline
+    #   3. ``--cmp-source-labels`` CLI args    -- user override
+    label_map = dict(DEFAULT_SOURCE_LABELS)
+    label_map.update(_read_manifest_source_labels(args.input_files))
+    label_map.update(_parse_source_labels(args.cmp_source_labels))
+    def _source_label(sid):
+        return label_map.get(int(sid), f"source {int(sid)}")
+
+    w_event = np.asarray(w_event, dtype=np.float64)
+    source_id = np.asarray(source_id)
+
+    n_cols = len(target_components)
+
+    for charge_mode in charge_modes:
+        if charge_mode == "pos":
+            mask = base_mask & (charge_g > 0)
+        elif charge_mode == "neg":
+            mask = base_mask & (charge_g < 0)
+        else:
+            mask = base_mask
+
+        n_in = int(mask.sum())
+        if n_in == 0:
+            print(
+                "[per-source target distributions] window is empty "
+                f"(pt∈[{pt_min},{pt_max}], η∈[{eta_min},{eta_max}], "
+                f"charge={charge_mode}); skipping"
+            )
+            continue
+
+        target_w = target[mask]
+        w_w = w_event[mask]
+        src_w = source_id[mask]
+
+        unique_sources = np.unique(src_w).tolist()
+        if len(unique_sources) < 2:
+            print(
+                "[per-source target distributions] only "
+                f"{len(unique_sources)} source(s) in {charge_mode} window "
+                f"{unique_sources}; comparison needs ≥2 sources — skipping"
+            )
+            continue
+
+        if args.cmp_ref_source is not None:
+            ref_source = int(args.cmp_ref_source)
+            if ref_source not in unique_sources:
+                print(
+                    f"[per-source target distributions] --cmp-ref-source="
+                    f"{ref_source} not present in {charge_mode} window; "
+                    f"falling back to {unique_sources[0]}"
+                )
+                ref_source = int(unique_sources[0])
+        else:
+            ref_source = int(unique_sources[0])
+
+        print(
+            f"[per-source target distributions] window: "
+            f"pt∈[{pt_min:g},{pt_max:g}] GeV, "
+            f"η∈[{eta_min:g},{eta_max:g}], charge={charge_mode}; "
+            f"{n_in:,} muons; sources={unique_sources}; ref={ref_source}"
+        )
+
+        # Precompute per-column binned data so we can render the same
+        # plot twice (linear + log y-axis) without redoing the
+        # histogramming.
+        per_col = {}
+        for tcol in target_components:
+            y = target_w[:, tcol]
+            finite = np.isfinite(y)
+            if not finite.all():
+                y = y[finite]
+                w_col = w_w[finite]
+                s_col = src_w[finite]
+            else:
+                w_col = w_w
+                s_col = src_w
+            if y.size == 0:
+                continue
+
+            pct = float(args.range_percentile)
+            lo, hi = np.percentile(y, [pct, 100.0 - pct])
+            if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
+                lo, hi = float(np.min(y)), float(np.max(y))
+                if hi <= lo:
+                    hi = lo + 1.0
+            bins = np.linspace(lo, hi, args.n_bins + 1)
+            centers = 0.5 * (bins[:-1] + bins[1:])
+            bw = bins[1] - bins[0]
+
+            ref_mask = (s_col == ref_source)
+            h_ref, e_ref = _weighted_hist_err(
+                y[ref_mask], bins, w_col[ref_mask],
+            )
+            norm_ref = h_ref.sum()
+            if norm_ref <= 0:
+                print(
+                    "[per-source target distributions] ref source "
+                    f"{ref_source} has zero weight in column "
+                    f"{TARGET_NAMES[tcol]} (charge={charge_mode}); skipping"
+                )
+                continue
+            h_ref_n = h_ref / (norm_ref * bw)
+            e_ref_n = e_ref / (norm_ref * bw)
+
+            per_source = []
+            for i, sid in enumerate(unique_sources):
+                sm = (s_col == sid)
+                if sm.sum() == 0:
+                    continue
+                h, e = _weighted_hist_err(y[sm], bins, w_col[sm])
+                tot = h.sum()
+                if tot <= 0:
+                    continue
+                h_n = h / (tot * bw)
+                e_n = e / (tot * bw)
+                per_source.append({
+                    "sid": int(sid),
+                    "n": int(sm.sum()),
+                    "color": f"C{i}",
+                    "h": h_n,
+                    "e": e_n,
+                })
+
+            per_col[tcol] = {
+                "centers": centers,
+                "per_source": per_source,
+                "h_ref": h_ref_n,
+                "e_ref": e_ref_n,
+            }
+
+        if not per_col:
+            continue
+
+        ch_tag = {"pos": "q>0", "neg": "q<0", "both": "both q"}[charge_mode]
+        ch_suffix = {"pos": "_qpos", "neg": "_qneg", "both": "_qboth"}[
+            charge_mode
+        ]
+
+        for yscale, ysuffix in (("linear", ""), ("log", "_log")):
+            fig, axes = plt.subplots(
+                2, n_cols,
+                figsize=(4.5 * n_cols, 6.5),
+                sharex="col", squeeze=False,
+                gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
+                layout="constrained",
+            )
+
+            for cidx, tcol in enumerate(target_components):
+                ax_main = axes[0][cidx]
+                ax_ratio = axes[1][cidx]
+
+                data = per_col.get(tcol)
+                if data is None:
+                    continue
+                centers = data["centers"]
+                h_ref_n = data["h_ref"]
+                e_ref_n = data["e_ref"]
+
+                for entry in data["per_source"]:
+                    sid = entry["sid"]
+                    color = entry["color"]
+                    lbl = f"{_source_label(sid)}  (N={entry['n']})"
+                    ax_main.step(
+                        centers, entry["h"], where="mid",
+                        color=color, lw=1.2, label=lbl,
+                    )
+                    _stepped_errorbar(
+                        ax_main, centers, entry["h"], entry["e"], color,
+                    )
+
+                    if sid == ref_source:
+                        ax_ratio.axhline(1.0, color=color, lw=0.8)
+                        continue
+                    ratio, e_ratio = _ratio_with_err(
+                        entry["h"], entry["e"], h_ref_n, e_ref_n,
+                    )
+                    ax_ratio.step(
+                        centers, ratio, where="mid", color=color, lw=1.0,
+                    )
+                    _stepped_errorbar(
+                        ax_ratio, centers, ratio, e_ratio, color,
+                    )
+
+                ax_main.set_yscale(yscale)
+                ax_main.set_ylabel("p.d.f. (weighted, unit area)")
+                ax_main.set_title(
+                    f"{TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f'target[{tcol}]'}",
+                    fontsize=10,
+                )
+                ax_main.legend(fontsize=7)
+                ax_main.axvline(0.0, color="k", lw=0.4, alpha=0.4)
+
+                ax_ratio.axhline(1.0, color="k", lw=0.4, alpha=0.4)
+                ax_ratio.set_ylabel(
+                    f"ratio /\n{_source_label(ref_source)}", fontsize=8,
+                )
+                ax_ratio.set_xlabel(
+                    TARGET_NAMES[tcol]
+                    if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+                )
+                ax_ratio.set_ylim(0.5, 1.5)
+
+            fig.suptitle(
+                f"Per-source target distributions  ·  "
+                f"pt∈[{pt_min:g},{pt_max:g}] GeV, "
+                f"η∈[{eta_min:g},{eta_max:g}], {ch_tag} (φ integrated)"
+            )
+            _save(
+                fig,
+                os.path.join(
+                    out_dir,
+                    f"per_source_target_distributions{ch_suffix}{ysuffix}.png",
+                ),
+            )
+
+
+# ============================================================================
+# main
+# ============================================================================
+
+def main():
+    args = parse_args()
+    if args.output is None:
+        args.output = os.path.dirname(os.path.abspath(args.checkpoint))
+    os.makedirs(args.output, exist_ok=True)
+
+    if args.device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.set_device(0)
+        device = "cuda:0"
+    else:
+        device = "cpu"
+    args.device = device
+
+    print(f"loading checkpoint {args.checkpoint}")
+    model, arch, stats, train_cfg = load_model_from_checkpoint(
+        args.checkpoint, device,
+    )
+    if stats is None:
+        # Older / per-epoch checkpoints didn't bundle PreprocStats.
+        ckpt_dir = os.path.dirname(os.path.abspath(args.checkpoint))
+        preproc_path = os.path.join(ckpt_dir, "preproc.json")
+        if not os.path.exists(preproc_path):
+            raise SystemExit(
+                f"Checkpoint has no PreprocStats and no preproc.json "
+                f"at {preproc_path}."
+            )
+        with open(preproc_path) as f:
+            stats = PreprocStats(**json.load(f))
+        print(f"  loaded preproc stats from {preproc_path}")
+    positivity = str(train_cfg.get("positivity", "softplus"))
+    loss_fn = str(train_cfg.get("loss_fn", "?"))
+    delta_max = train_cfg.get("delta_max", "?")
+    sigma_max_train = train_cfg.get("sigma_max", "?")
+    print(
+        f"  arch={arch} loss={loss_fn} positivity={positivity} "
+        f"delta_max={delta_max} sigma_max={sigma_max_train}"
+    )
+
+    print(f"loading ntuples from {len(args.input_files)} file(s)")
+    t0 = _tic()
+    (
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, source_id,
+    ) = load_ntuples(
+        args.input_files, args.tree, args.max_muons,
+        args.pt_min, args.pt_max, args.eta_max,
+        threads=args.threads, max_events=args.max_events,
+    )
+    t0 = _toc("load_ntuples", t0)
+
+    # Subsample at raw-array stage (cheap rng.integers with sorted
+    # gather, no O(N) np.random.choice permutation).
+    N_raw = eta_r.shape[0]
+    if args.n_events > 0 and N_raw > args.n_events:
+        rng = np.random.default_rng(0)
+        sel = np.sort(rng.integers(0, N_raw, args.n_events))
+        eta_r, phi_r = eta_r[sel], phi_r[sel]
+        eta_g, phi_g = eta_g[sel], phi_g[sel]
+        kappa_r, kappa_g, w = kappa_r[sel], kappa_g[sel], w[sel]
+        source_id = source_id[sel]
+        print(
+            f"  loaded {N_raw} muon rows; subsampled to "
+            f"{eta_r.shape[0]} for plotting"
+        )
+    else:
+        print(f"  loaded {N_raw} muon rows")
+    t0 = _toc("subsample raw arrays", t0)
+
+    target, cond_raw = compute_targets_and_conditioning(
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+    )
+    t0 = _toc("compute_targets_and_conditioning", t0)
+
+    w = (w / w.mean()).astype(np.float32)
+    target_std, cond = apply_preproc(target, cond_raw, stats)
+    t0 = _toc("apply_preproc + weight norm", t0)
+
+    y_dev = torch.from_numpy(target_std).to(device, non_blocking=False)
+    c_dev = torch.from_numpy(cond).to(device, non_blocking=False)
+    n_features = target_std.shape[1]
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    t0 = _toc("data H2D to device", t0)
+
+    target_std_per_dim = np.asarray(stats.target_std, dtype=np.float64)
+
+    # Σ_pack indices for the MLP arch.
+    sigma_pack_iu = sigma_pack_ju = None
+    if arch in ("mlp", "mlp-factored"):
+        iu, ju = _sigma_pack_indices(n_features)
+        sigma_pack_iu, sigma_pack_ju = iu.to(device), ju.to(device)
+
+    # Precompute the (factor × tcol × mode) log r grid. Both the
+    # closure and the distribution plots iterate the same grid, so
+    # caching halves the inference work for those.
+    target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
+    print(
+        f"  predicting log r grid: shift={len(args.shift_factors)} × "
+        f"smear={len(args.smear_factors)} × "
+        f"axes={len(target_components)} ..."
+    )
+    log_r_grid_shift = {}
+    log_r_grid_smear = {}
+    for factor in args.shift_factors:
+        for tcol in target_components:
+            log_r_grid_shift[(float(factor), int(tcol))] = (
+                _common_predict_call(
+                    model, arch, y_dev, c_dev, float(factor), int(tcol),
+                    "shift", n_features, args.batch_size, positivity,
+                    sigma_pack_iu, sigma_pack_ju,
+                )
+            )
+    for factor in args.smear_factors:
+        for tcol in target_components:
+            log_r_grid_smear[(float(factor), int(tcol))] = (
+                _common_predict_call(
+                    model, arch, y_dev, c_dev, float(factor), int(tcol),
+                    "smear", n_features, args.batch_size, positivity,
+                    sigma_pack_iu, sigma_pack_ju,
+                )
+            )
+    t0 = _toc("grid prediction (shift + smear)", t0)
+
+    # GH-on-shift smear-closure curve (self-consistency between the
+    # polyhead's pure-σ and pure-u parts). Skip when --smear-gh-K=0.
+    log_r_grid_smear_via_gh = None
+    if int(args.smear_gh_K) > 0:
+        K = int(args.smear_gh_K)
+        print(
+            f"  predicting GH(K={K}) smear-via-shift grid: "
+            f"{len(args.smear_factors)} × {len(target_components)} "
+            f"× {K} shift evals ..."
+        )
+        log_r_grid_smear_via_gh = {}
+        for factor in args.smear_factors:
+            for tcol in target_components:
+                log_r_grid_smear_via_gh[(float(factor), int(tcol))] = (
+                    predict_smear_via_gh_shift(
+                        model, arch, y_dev, c_dev,
+                        float(factor), int(tcol), K,
+                        n_features, args.batch_size, positivity,
+                        sigma_pack_iu=sigma_pack_iu,
+                        sigma_pack_ju=sigma_pack_ju,
+                    )
+                )
+        t0 = _toc(f"GH(K={K}) smear-via-shift grid prediction", t0)
+
+    plot_shift_closure(
+        target, w, args, args.output,
+        log_r_grid_shift, target_std_per_dim,
+    )
+    t0 = _toc("plot_shift_closure", t0)
+
+    plot_closure_error_ratio(
+        target, w, args, args.output,
+        log_r_grid_shift, target_std_per_dim, mode="shift",
+    )
+    t0 = _toc("plot_shift_closure_error_ratio", t0)
+
+    plot_smear_closure(
+        target, w, args, args.output,
+        log_r_grid_smear, target_std_per_dim,
+        log_r_grid_smear_via_gh=log_r_grid_smear_via_gh,
+    )
+    t0 = _toc("plot_smear_closure", t0)
+
+    plot_closure_error_ratio(
+        target, w, args, args.output,
+        log_r_grid_smear, target_std_per_dim, mode="smear",
+    )
+    t0 = _toc("plot_smear_closure_error_ratio", t0)
+
+    plot_log_r_distribution(
+        n_features, w, args, args.output,
+        log_r_grid_shift, log_r_grid_smear,
+    )
+    t0 = _toc("plot_log_r_distribution", t0)
+
+    plot_log_r_scan(
+        model, arch, y_dev, c_dev, n_features, w, args,
+        positivity, args.output, sigma_pack_iu, sigma_pack_ju,
+    )
+    t0 = _toc("plot_log_r_scan", t0)
+
+    # Per-source comparison uses its own streaming, parallel loader so
+    # it can run over the full statistics (much larger than the
+    # subsampled in-memory arrays the inference plots use). The (pt,
+    # eta) window is applied per shard so peak memory stays bounded.
+    print(
+        "loading per-source comparison window via streaming loader: "
+        f"pt∈[{args.cmp_pt_min:g},{args.cmp_pt_max:g}] GeV, "
+        f"η∈[{args.cmp_eta_min:g},{args.cmp_eta_max:g}], "
+        f"max_events={args.cmp_max_events}, workers={args.cmp_workers}"
+    )
+    cmp_data, cmp_read, cmp_kept = _load_per_source_window(
+        args.input_files,
+        pt_min=float(args.cmp_pt_min), pt_max=float(args.cmp_pt_max),
+        eta_min=float(args.cmp_eta_min), eta_max=float(args.cmp_eta_max),
+        max_events=int(args.cmp_max_events),
+        n_workers=int(args.cmp_workers),
+    )
+    t0 = _toc("load per-source window (streaming)", t0)
+    if cmp_data is None:
+        print(
+            f"[per-source target distributions] no rows passed the "
+            f"window ({cmp_read} read); skipping plot"
+        )
+    else:
+        target_cmp, w_cmp, sid_cmp, kg_cmp, eg_cmp = cmp_data
+        # Normalise weights the same way the standard plots do (mean=1)
+        # so legend yields and ratio axes are comparable.
+        w_cmp = (w_cmp / w_cmp.mean()).astype(np.float32)
+        print(
+            f"  read {cmp_read:,} raw rows; kept {cmp_kept:,} after the "
+            f"window cut (={100 * cmp_kept / max(cmp_read, 1):.2f}%)"
+        )
+        plot_per_source_target_distributions(
+            target_cmp, w_cmp, sid_cmp, kg_cmp, eg_cmp,
+            args, args.output,
+        )
+        t0 = _toc("plot_per_source_target_distributions", t0)
+
+    if args.flow_checkpoint:
+        print(f"loading flow checkpoint {args.flow_checkpoint}")
+        # Lazy import: only needed when flow comparison is requested,
+        # and avoids the cost of importing the heavier flow-diag module
+        # for the standard diagnostic path.
+        from flow_training_diagnostics import (
+            load_flow_from_checkpoint,
+        )
+        flow, flow_stats, _flow_ckpt = load_flow_from_checkpoint(
+            args.flow_checkpoint, device,
+        )
+        flow.eval()
+        # Stash these on args so plot_polyhead_pred_vs_flow can reach
+        # the polyhead's training config + positivity without a wider
+        # signature change.
+        args._polyhead_train_cfg = train_cfg
+        args._positivity = positivity
+        plot_polyhead_pred_vs_flow(
+            model, arch, flow, flow_stats, stats,
+            target_std, cond, n_features, w,
+            args, args.output,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
+        )
+        t0 = _toc("plot_polyhead_pred_vs_flow", t0)
+
+        plot_polyhead_axis_logw_error_vs_flow(
+            model, arch, flow, flow_stats, stats,
+            target_std, cond, n_features, w,
+            args, args.output,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
+        )
+        t0 = _toc("plot_polyhead_axis_logw_error_vs_flow", t0)
+
+    print(f"wrote diagnostic plots to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
@@ -79,6 +79,28 @@ TARGET_NAMES = ["r_kappa", "dlambda", "dphi"]
 # Z→μμ is conventionally the first W/Z entry, hence source_id = 100.
 # Anything else falls back to ``source <id>``; the user can override or
 # extend via ``--cmp-source-labels``.
+def _apply_weight_mode(w, mode):
+    """Return ``(w_out, keep_mask)`` after applying the diagnostic's
+    ``--weight-handling`` policy. Mirrors
+    ``arrow_shard_loader._apply_weight_mode`` so the trainer and the
+    diagnostic agree on what they consider a "kept" row.
+
+    * ``abs``: ``|w|``, drop ``w == 0`` or non-finite.
+    * ``keep``: pass through unchanged, drop only non-finite.
+    * ``drop``: drop ``w <= 0`` or non-finite (legacy diagnostic).
+    """
+    finite = np.isfinite(w)
+    if mode == "abs":
+        return np.fabs(w), finite & (w != 0.0)
+    if mode == "keep":
+        return w, finite
+    if mode == "drop":
+        return w, finite & (w > 0.0)
+    raise ValueError(
+        f"--weight-handling must be one of {{abs, keep, drop}}, got {mode!r}"
+    )
+
+
 DEFAULT_SOURCE_LABELS = {
     0: r"J/$\psi$ (p$_T$>8 GeV)",
     1: r"J/$\psi$ (p$_T$<8 GeV)",
@@ -228,13 +250,13 @@ def parse_args():
     # in (pt_gen, eta_gen, charge_gen); phi_gen is integrated.
     # ------------------------------------------------------------------
     p.add_argument(
-        "--cmp-pt-min", type=float, default=25.0,
+        "--cmp-pt-min", type=float, default=12.0,
         help="Lower gen-pT (GeV) edge of the (deliberately narrow) "
         "phase-space window used for the per-source target-distribution "
         "comparison plot.",
     )
     p.add_argument(
-        "--cmp-pt-max", type=float, default=30.0,
+        "--cmp-pt-max", type=float, default=13.0,
         help="Upper gen-pT (GeV) edge of the cmp window.",
     )
     p.add_argument(
@@ -266,6 +288,11 @@ def parse_args():
         "back to the smallest source_id present if absent in the window.",
     )
     p.add_argument(
+        "--cmp-source-min-events", type=int, default=10000,
+        help="Drop sources contributing fewer than this many rows within "
+        "the per-source comparison window. Set to 0 to disable.",
+    )
+    p.add_argument(
         "--cmp-max-events", type=int, default=-1,
         help="Cap on raw muon rows *read* for the per-source target-"
         "distribution plots only. -1 (default) = all available rows. "
@@ -278,6 +305,84 @@ def parse_args():
         "--cmp-workers", type=int, default=8,
         help="Parallel shard readers (thread pool) for the per-source "
         "comparison loader.",
+    )
+    # ------------------------------------------------------------------
+    # Aggregated J/ψ vs W/Z comparison.  Two-pass streaming: pass 1
+    # builds 3D (pt_gen, eta_gen, charge_gen) histograms per group and
+    # forms a per-cell W/Z -> J/ψ reweight; pass 2 fills the target-
+    # distribution histograms for each group with the reweight applied
+    # to W/Z. Validates that the two physically-distinct calibration
+    # samples produce statistically-equivalent shapes in (r_κ, δλ, δφ)
+    # once their kinematics are matched.
+    # ------------------------------------------------------------------
+    p.add_argument(
+        "--cmp-agg-pt-min", type=float, default=10.0,
+        help="Lower gen-pT (GeV) edge of the window for the aggregated "
+        "J/ψ-vs-W/Z target-distribution plot.",
+    )
+    p.add_argument(
+        "--cmp-agg-pt-max", type=float, default=16.0,
+        help="Upper gen-pT (GeV) edge of the aggregated window.",
+    )
+    p.add_argument(
+        "--cmp-agg-eta-min", type=float, default=-2.4,
+        help="Lower gen-η edge of the aggregated window.",
+    )
+    p.add_argument(
+        "--cmp-agg-eta-max", type=float, default=2.4,
+        help="Upper gen-η edge of the aggregated window.",
+    )
+    p.add_argument(
+        "--cmp-agg-rew-eta-bins", type=int, default=24,
+        help="Number of η bins in the 3D (pt, η, charge) reweighting "
+        "histogram. The window above is split uniformly.",
+    )
+    p.add_argument(
+        "--cmp-agg-rew-pt-bins", type=int, default=12,
+        help="Number of pT bins in the reweighting histogram (default "
+        "12 → 0.5 GeV bins across the default [10, 16] GeV window).",
+    )
+    p.add_argument(
+        "--cmp-agg-range-sigma", type=float, default=5.0,
+        help="Target-distribution histogram half-range, in units of "
+        "stats.target_std around stats.target_mean (per axis).",
+    )
+    p.add_argument(
+        "--cmp-agg-n-bins", type=int, default=80,
+        help="Number of bins in each 1D target-distribution histogram.",
+    )
+    p.add_argument(
+        "--weight-handling", choices=["abs", "keep", "drop"],
+        default="abs",
+        help="How to treat MC@NLO signed event weights in every plot "
+        "and loader: ``abs`` (default; |w|, drops zero/non-finite) "
+        "matches the trainer's --weight-handling=abs and keeps every "
+        "row's magnitude; ``keep`` passes the signed weight through; "
+        "``drop`` rejects rows with w<=0 -- the historical diagnostic "
+        "behaviour, which silently removes the ~5-20%% negative-weight "
+        "fraction in MC@NLO W/Z samples and makes diagnostic plots "
+        "see a different effective sample than the trainer.",
+    )
+    p.add_argument(
+        "--split", choices=["train", "val", "holdout", "all"],
+        default="holdout",
+        help="Which contiguous per-shard record-batch slice to load "
+        "(see ``arrow_shard_loader.split_batch_range``). Default "
+        "``holdout`` — the 10%% slice never seen during training, so "
+        "the model is evaluated on novel rows. ``train`` / ``val`` "
+        "match the trainer's splits; ``all`` loads everything.",
+    )
+    p.add_argument(
+        "--split-val-fraction", type=float, default=0.1,
+        help="Fraction of each shard's record batches assigned to "
+        "the val split. Must match the trainer's --val-fraction so "
+        "the train / val / holdout slices line up.",
+    )
+    p.add_argument(
+        "--split-holdout-fraction", type=float, default=0.1,
+        help="Fraction of each shard's record batches assigned to "
+        "the holdout split. Must match the trainer's "
+        "--holdout-fraction.",
     )
     return p.parse_args()
 
@@ -694,8 +799,28 @@ def _common_predict_call(
 
 def plot_shift_closure(
     target, w_event, args, out_dir, log_r_grid_shift, target_std_per_dim,
+    *, group_mask=None, group_label=None,
 ):
-    """Per-axis shift-closure plots from a precomputed log r grid."""
+    """Per-axis shift-closure plots from a precomputed log r grid.
+
+    When ``group_mask`` is provided every per-event input (``target``,
+    ``w_event``, every entry of ``log_r_grid_shift``) is sliced to the
+    subset of events for which the mask is True, ``group_label`` is
+    appended to the figure title, and the output filename is suffixed
+    by ``"_" + group_label``. Used to test the closure separately on
+    the J/ψ and W/Z aggregated subsamples without re-running model
+    inference."""
+    if group_mask is not None:
+        m = np.asarray(group_mask, dtype=bool)
+        target = target[m]
+        w_event = np.asarray(w_event)[m]
+        log_r_grid_shift = {k: v[m] for k, v in log_r_grid_shift.items()}
+        if target.shape[0] == 0:
+            print(
+                f"  [shift_closure] group {group_label!r} empty — "
+                "skipping"
+            )
+            return
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
     factors = args.shift_factors
@@ -782,8 +907,10 @@ def plot_shift_closure(
                     max(hi_r + pad, 1.0 + pad),
                 )
 
-    fig.suptitle("MLP shift-reweight closure")
-    _save(fig, os.path.join(out_dir, "shift_closure.png"))
+    suffix = f"_{group_label}" if group_label else ""
+    label_blurb = f" ({group_label})" if group_label else ""
+    fig.suptitle(f"MLP shift-reweight closure{label_blurb}")
+    _save(fig, os.path.join(out_dir, f"shift_closure{suffix}.png"))
 
 
 # ============================================================================
@@ -793,6 +920,7 @@ def plot_shift_closure(
 def plot_smear_closure(
     target, w_event, args, out_dir, log_r_grid_smear, target_std_per_dim,
     log_r_grid_smear_via_gh=None,
+    *, group_mask=None, group_label=None,
 ):
     """Per-axis smear-closure plots.
 
@@ -809,6 +937,21 @@ def plot_smear_closure(
     two reweight curves is a diagnostic of polyhead self-consistency
     between its pure-σ and pure-u parts.
     """
+    if group_mask is not None:
+        m = np.asarray(group_mask, dtype=bool)
+        target = target[m]
+        w_event = np.asarray(w_event)[m]
+        log_r_grid_smear = {k: v[m] for k, v in log_r_grid_smear.items()}
+        if log_r_grid_smear_via_gh is not None:
+            log_r_grid_smear_via_gh = {
+                k: v[m] for k, v in log_r_grid_smear_via_gh.items()
+            }
+        if target.shape[0] == 0:
+            print(
+                f"  [smear_closure] group {group_label!r} empty — "
+                "skipping"
+            )
+            return
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
     factors = args.smear_factors
@@ -937,11 +1080,13 @@ def plot_smear_closure(
                     max(hi_r + pad, 1.0 + pad),
                 )
 
+    suffix = f"_{group_label}" if group_label else ""
+    label_blurb = f" ({group_label})" if group_label else ""
     fig.suptitle(
-        "MLP smear-reweight closure (rank-1 K=1 smeared MC; ratios "
-        "carry K=1 sampling noise)"
+        f"MLP smear-reweight closure{label_blurb} "
+        "(rank-1 K=1 smeared MC; ratios carry K=1 sampling noise)"
     )
-    _save(fig, os.path.join(out_dir, "smear_closure.png"))
+    _save(fig, os.path.join(out_dir, f"smear_closure{suffix}.png"))
 
 
 # ============================================================================
@@ -1643,7 +1788,8 @@ def _read_manifest_source_labels(paths):
 
 def _load_per_source_window(
     paths, *, pt_min, pt_max, eta_min, eta_max,
-    max_events=-1, n_workers=8,
+    max_events=-1, n_workers=8, weight_mode="abs",
+    split="all", val_fraction=0.1, holdout_fraction=0.1,
 ):
     """Parallel streaming loader specialised for the per-source target-
     distribution plots.
@@ -1682,13 +1828,23 @@ def _load_per_source_window(
         )
 
     _MAGIC = b"ARROW1"
+    from arrow_shard_loader import split_batch_range
 
     def _read_one(p):
         with pa.memory_map(p, "r") as f:
             head = f.read(len(_MAGIC))
             f.seek(0)
             if head == _MAGIC:
-                t = ipc.open_file(f).read_all()
+                reader = ipc.open_file(f)
+                lo, hi = split_batch_range(
+                    reader.num_record_batches, split,
+                    val_fraction, holdout_fraction,
+                )
+                if hi <= lo:
+                    return None, 0
+                t = pa.Table.from_batches(
+                    [reader.get_batch(i) for i in range(lo, hi)]
+                )
             else:
                 t = ipc.open_stream(f).read_all()
         eta_r = t["eta_reco"].to_numpy().astype(np.float64)
@@ -1701,6 +1857,7 @@ def _load_per_source_window(
         sid = t["source_id"].to_numpy().astype(np.int32, copy=False)
         n_block = eta_r.shape[0]
 
+        w_handled, w_mask = _apply_weight_mode(w_raw, weight_mode)
         abs_k = np.fabs(kappa_g)
         safe_k = np.where(abs_k > 0, abs_k, np.nan)
         pt_g = 1.0 / (safe_k * np.cosh(eta_g))
@@ -1709,14 +1866,14 @@ def _load_per_source_window(
             & (pt_g >= pt_min) & (pt_g <= pt_max)
             & (eta_g >= eta_min) & (eta_g <= eta_max)
             & np.isfinite(kappa_r) & np.isfinite(kappa_g)
-            & (w_raw > 0.0)
+            & w_mask
         )
         if not mask.any():
             return None, n_block
         eta_r = eta_r[mask]; phi_r = phi_r[mask]
         eta_g = eta_g[mask]; phi_g = phi_g[mask]
         kappa_r = kappa_r[mask]; kappa_g = kappa_g[mask]
-        w = w_raw[mask]; sid = sid[mask]
+        w = w_handled[mask]; sid = sid[mask]
 
         # Inline target columns from compute_targets_and_conditioning,
         # restricted to the masked rows so we never form full-shard
@@ -1856,6 +2013,35 @@ def plot_per_source_target_distributions(
                 f"{unique_sources}; comparison needs ≥2 sources — skipping"
             )
             continue
+
+        min_n = int(getattr(args, "cmp_source_min_events", 0))
+        if min_n > 0:
+            src_counts = {
+                int(s): int((src_w == s).sum()) for s in unique_sources
+            }
+            kept = [s for s in unique_sources if src_counts[int(s)] >= min_n]
+            dropped = [
+                (int(s), src_counts[int(s)])
+                for s in unique_sources if src_counts[int(s)] < min_n
+            ]
+            if dropped:
+                print(
+                    "[per-source target distributions] dropped sources "
+                    f"with <{min_n} events in {charge_mode} window: "
+                    + ", ".join(
+                        f"{_source_label(sid)} (id={sid}, N={n})"
+                        for sid, n in dropped
+                    )
+                )
+            unique_sources = kept
+            if len(unique_sources) < 2:
+                print(
+                    "[per-source target distributions] only "
+                    f"{len(unique_sources)} source(s) remaining in "
+                    f"{charge_mode} window after the "
+                    f"--cmp-source-min-events={min_n} cut; skipping"
+                )
+                continue
 
         if args.cmp_ref_source is not None:
             ref_source = int(args.cmp_ref_source)
@@ -2031,6 +2217,838 @@ def plot_per_source_target_distributions(
 
 
 # ============================================================================
+# Aggregated J/ψ vs prompt vs τ-decay target-distribution comparison
+# ============================================================================
+#
+# Two-pass streaming over the shards, classifying events by the per-
+# muon ``muon_source`` integer the snapshot writes:
+#   muon_source == 443 -> J/ψ (calibration-clean reference)
+#   muon_source == 1   -> W/Z prompt
+#   muon_source == 15  -> W/Z secondary muon from τ decay
+# Pass 1 builds weighted 3D histograms over (pt_gen, η_gen, charge_gen)
+# per group; pass 2 fills 1D target-distribution histograms with the
+# non-reference groups reweighted to J/ψ kinematics. Streaming
+# per-shard chunks keep peak memory bounded by the per-shard masked-
+# row count, not the full dataset.
+
+# Plot ordering. ``ref`` flags the kinematic reference for reweighting
+# (must be the first entry). Colours: ``main_color`` is used for the
+# group's reweighted curve and ratio; ``raw_color`` for the raw curve
+# in the kinematic-validation plot.
+_AGG_GROUPS = (
+    {"raw":  443, "name": "jpsi",   "label": r"J/$\psi$",
+     "main_color": "C0", "raw_color": "C0", "ref": True},
+    {"raw":  1,   "name": "prompt", "label": "W/Z prompt",
+     "main_color": "C1", "raw_color": "C3", "ref": False},
+    {"raw":  15,  "name": "tau",    "label": r"W/Z $\tau$-decay",
+     "main_color": "C2", "raw_color": "C4", "ref": False},
+)
+_AGG_REF_NAME = "jpsi"
+_AGG_NAMES = tuple(g["name"] for g in _AGG_GROUPS)
+_AGG_NONREF_NAMES = tuple(
+    g["name"] for g in _AGG_GROUPS if not g["ref"]
+)
+
+
+def _agg_group_masks(muon_source):
+    """Return ``{name: bool_mask}`` for the three aggregated groups,
+    classifying each row by the integer ``muon_source`` column written
+    by the snapshot."""
+    ms = np.asarray(muon_source)
+    return {g["name"]: (ms == g["raw"]) for g in _AGG_GROUPS}
+
+
+def _stream_pteta_charge_3d(
+    paths, *, pt_min, pt_max, eta_min, eta_max,
+    pt_edges, eta_edges, charge_edges,
+    n_workers=8, weight_mode="abs",
+    split="all", val_fraction=0.1, holdout_fraction=0.1,
+):
+    """Pass 1: stream shards and fill weighted 3D ``(pt, η, charge)``
+    histograms per ``muon_source`` group (J/ψ, prompt, τ).
+
+    Returns ``(H, H_w2, rows_read, n_kept)`` where:
+      * ``H``      -- ``{group_name: ndarray(n_pt, n_eta, n_ch)}``
+      * ``H_w2``   -- same shape, accumulates ``Σw²``
+      * ``rows_read``  -- total raw rows pulled off disk
+      * ``n_kept``     -- ``{group_name: int}`` count of windowed rows
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+    from train_muon_response_flow import _expand_input_paths
+    from arrow_shard_loader import split_batch_range
+
+    paths = _expand_input_paths(paths)
+    _MAGIC = b"ARROW1"
+    n_pt = len(pt_edges) - 1
+    n_eta = len(eta_edges) - 1
+    n_ch = len(charge_edges) - 1
+    shape = (n_pt, n_eta, n_ch)
+    bins = (pt_edges, eta_edges, charge_edges)
+
+    def _read_one(p):
+        with pa.memory_map(p, "r") as f:
+            head = f.read(len(_MAGIC))
+            f.seek(0)
+            if head == _MAGIC:
+                reader = ipc.open_file(f)
+                lo, hi = split_batch_range(
+                    reader.num_record_batches, split,
+                    val_fraction, holdout_fraction,
+                )
+                if hi <= lo:
+                    empty_H = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
+                    return empty_H, dict(empty_H), 0, {n: 0 for n in _AGG_NAMES}
+                t = pa.Table.from_batches(
+                    [reader.get_batch(i) for i in range(lo, hi)]
+                )
+            else:
+                t = ipc.open_stream(f).read_all()
+        eta_g = t["eta_gen"].to_numpy().astype(np.float64)
+        kappa_g = t["kappa_gen"].to_numpy().astype(np.float64)
+        w_raw = t["nominal_weight"].to_numpy().astype(np.float64)
+        ms = t["muon_source"].to_numpy().astype(np.int32, copy=False)
+        n_block = eta_g.shape[0]
+
+        w_handled, w_mask = _apply_weight_mode(w_raw, weight_mode)
+        abs_k = np.fabs(kappa_g)
+        safe_k = np.where(abs_k > 0, abs_k, np.nan)
+        pt_g = 1.0 / (safe_k * np.cosh(eta_g))
+        mask = (
+            np.isfinite(pt_g)
+            & (pt_g >= pt_min) & (pt_g <= pt_max)
+            & (eta_g >= eta_min) & (eta_g <= eta_max)
+            & np.isfinite(kappa_g) & w_mask
+        )
+        partial_H = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
+        partial_H2 = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
+        partial_kept = {n: 0 for n in _AGG_NAMES}
+        if not mask.any():
+            return partial_H, partial_H2, n_block, partial_kept
+
+        eta_g = eta_g[mask]; kappa_g = kappa_g[mask]
+        pt_g = pt_g[mask]; w = w_handled[mask]; ms = ms[mask]
+        charge_g = np.where(kappa_g >= 0, 1.0, -1.0)
+        group_masks = _agg_group_masks(ms)
+
+        for name in _AGG_NAMES:
+            gm = group_masks[name]
+            if not gm.any():
+                continue
+            coords = np.stack(
+                [pt_g[gm], eta_g[gm], charge_g[gm]], axis=1,
+            )
+            ww = w[gm]
+            partial_H[name] = np.histogramdd(coords, bins=bins, weights=ww)[0]
+            partial_H2[name] = np.histogramdd(
+                coords, bins=bins, weights=ww * ww,
+            )[0]
+            partial_kept[name] = int(gm.sum())
+        return partial_H, partial_H2, n_block, partial_kept
+
+    H = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
+    H_w2 = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
+    rows_read = 0
+    n_kept = {n: 0 for n in _AGG_NAMES}
+    with ThreadPoolExecutor(max_workers=max(1, int(n_workers))) as ex:
+        futures = {ex.submit(_read_one, p): p for p in paths}
+        for fut in as_completed(futures):
+            try:
+                pH, pH2, n_b, pk = fut.result()
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[agg pass-1] shard {futures[fut]} failed: {exc!r}"
+                )
+                continue
+            rows_read += n_b
+            for name in _AGG_NAMES:
+                H[name] += pH[name]
+                H_w2[name] += pH2[name]
+                n_kept[name] += pk[name]
+    return H, H_w2, rows_read, n_kept
+
+
+def _stream_aggregated_targets(
+    paths, *, pt_min, pt_max, eta_min, eta_max,
+    pt_edges, eta_edges, charge_edges,
+    weight_grids, target_axes_edges,
+    n_workers=8, weight_mode="abs", charge_filter=None,
+    split="all", val_fraction=0.1, holdout_fraction=0.1,
+):
+    """Pass 2: stream shards and accumulate 1D target-distribution
+    histograms per (axis × group × {raw, reweighted}). The reference
+    group (J/ψ) is filled raw only; non-reference groups (prompt, τ)
+    are filled both raw and after multiplying by their per-cell
+    reweight grid that targets the J/ψ kinematic distribution.
+
+    ``weight_grids`` is a ``{group_name: 3D ndarray}`` for the non-ref
+    groups; the ref group has no entry (its reweight is trivially 1).
+
+    Returns ``per_axis`` -- a list of length ``F`` where each element
+    is a dict keyed by ``f"{group}_h"`` / ``f"{group}_h2"`` for the
+    reweighted curves and ``f"{group}_raw_h"`` / ``f"{group}_raw_h2"``
+    for the raw curves (only the ref group skips the ``_raw_`` pair
+    since its "raw" and "reweighted" are identical)."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+    from train_muon_response_flow import _expand_input_paths
+    from arrow_shard_loader import split_batch_range
+
+    paths = _expand_input_paths(paths)
+    _MAGIC = b"ARROW1"
+    F = len(target_axes_edges)
+    n_pt = len(pt_edges) - 1
+    n_eta = len(eta_edges) - 1
+    n_ch = len(charge_edges) - 1
+
+    def _empty_partial():
+        # One entry per axis: per-group raw + (for non-ref groups)
+        # reweighted histograms with their Σw² companions.
+        out = []
+        for e in target_axes_edges:
+            n = len(e) - 1
+            d = {}
+            for name in _AGG_NAMES:
+                d[f"{name}_raw_h"] = np.zeros(n, dtype=np.float64)
+                d[f"{name}_raw_h2"] = np.zeros(n, dtype=np.float64)
+                if name != _AGG_REF_NAME:
+                    d[f"{name}_h"] = np.zeros(n, dtype=np.float64)
+                    d[f"{name}_h2"] = np.zeros(n, dtype=np.float64)
+            out.append(d)
+        return out
+
+    def _read_one(p):
+        with pa.memory_map(p, "r") as f:
+            head = f.read(len(_MAGIC))
+            f.seek(0)
+            if head == _MAGIC:
+                reader = ipc.open_file(f)
+                lo, hi = split_batch_range(
+                    reader.num_record_batches, split,
+                    val_fraction, holdout_fraction,
+                )
+                if hi <= lo:
+                    return _empty_partial()
+                t = pa.Table.from_batches(
+                    [reader.get_batch(i) for i in range(lo, hi)]
+                )
+            else:
+                t = ipc.open_stream(f).read_all()
+        eta_r = t["eta_reco"].to_numpy().astype(np.float64)
+        phi_r = t["phi_reco"].to_numpy().astype(np.float64)
+        eta_g = t["eta_gen"].to_numpy().astype(np.float64)
+        phi_g = t["phi_gen"].to_numpy().astype(np.float64)
+        kappa_r = t["kappa_reco"].to_numpy().astype(np.float64)
+        kappa_g = t["kappa_gen"].to_numpy().astype(np.float64)
+        w_raw = t["nominal_weight"].to_numpy().astype(np.float64)
+        ms = t["muon_source"].to_numpy().astype(np.int32, copy=False)
+
+        w_handled, w_mask = _apply_weight_mode(w_raw, weight_mode)
+        abs_k = np.fabs(kappa_g)
+        safe_k = np.where(abs_k > 0, abs_k, np.nan)
+        pt_g = 1.0 / (safe_k * np.cosh(eta_g))
+        mask = (
+            np.isfinite(pt_g)
+            & (pt_g >= pt_min) & (pt_g <= pt_max)
+            & (eta_g >= eta_min) & (eta_g <= eta_max)
+            & np.isfinite(kappa_r) & np.isfinite(kappa_g)
+            & w_mask
+        )
+        if charge_filter is not None:
+            if charge_filter > 0:
+                mask &= (kappa_g >= 0)
+            else:
+                mask &= (kappa_g < 0)
+        partial = _empty_partial()
+        if not mask.any():
+            return partial
+
+        eta_r = eta_r[mask]; phi_r = phi_r[mask]
+        eta_g = eta_g[mask]; phi_g = phi_g[mask]
+        kappa_r = kappa_r[mask]; kappa_g = kappa_g[mask]
+        pt_g = pt_g[mask]; w = w_handled[mask]; ms = ms[mask]
+
+        # Targets inline.
+        lam_r = np.arctan(np.sinh(eta_r))
+        lam_g = np.arctan(np.sinh(eta_g))
+        r_kappa = kappa_r / kappa_g - 1.0
+        dphi = np.arctan2(
+            np.sin(phi_r - phi_g), np.cos(phi_r - phi_g),
+        )
+        dlambda = lam_r - lam_g
+        target_cols = (r_kappa, dlambda, dphi)
+
+        # Per-cell reweight lookup, shared across the non-ref groups
+        # (each group's weight_grid is a different array of identical
+        # shape).
+        charge_g = np.where(kappa_g >= 0, 1.0, -1.0)
+        pt_idx = np.clip(np.digitize(pt_g, pt_edges) - 1, 0, n_pt - 1)
+        eta_idx = np.clip(np.digitize(eta_g, eta_edges) - 1, 0, n_eta - 1)
+        ch_idx = np.clip(np.digitize(charge_g, charge_edges) - 1, 0, n_ch - 1)
+
+        group_masks = _agg_group_masks(ms)
+        for k in range(F):
+            y = target_cols[k]
+            edges = target_axes_edges[k]
+            for name in _AGG_NAMES:
+                gm = group_masks[name]
+                if not gm.any():
+                    continue
+                y_g = y[gm]
+                w_raw_g = w[gm]
+                h, _ = np.histogram(y_g, bins=edges, weights=w_raw_g)
+                h2, _ = np.histogram(
+                    y_g, bins=edges, weights=w_raw_g * w_raw_g,
+                )
+                partial[k][f"{name}_raw_h"] = h
+                partial[k][f"{name}_raw_h2"] = h2
+                if name == _AGG_REF_NAME:
+                    continue
+                rew_g = weight_grids[name][
+                    pt_idx[gm], eta_idx[gm], ch_idx[gm]
+                ]
+                w_rew = w_raw_g * rew_g
+                h_rw, _ = np.histogram(y_g, bins=edges, weights=w_rew)
+                h_rw2, _ = np.histogram(
+                    y_g, bins=edges, weights=w_rew * w_rew,
+                )
+                partial[k][f"{name}_h"] = h_rw
+                partial[k][f"{name}_h2"] = h_rw2
+        return partial
+
+    totals = _empty_partial()
+    with ThreadPoolExecutor(max_workers=max(1, int(n_workers))) as ex:
+        futures = {ex.submit(_read_one, p): p for p in paths}
+        for fut in as_completed(futures):
+            try:
+                partial = fut.result()
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[agg pass-2] shard {futures[fut]} failed: {exc!r}"
+                )
+                continue
+            for k in range(F):
+                for key in totals[k]:
+                    totals[k][key] += partial[k][key]
+    return totals
+
+
+def _plot_agg_kinematic_validation_2d(
+    H, weight_grids, pt_edges, eta_edges, charge_edges, out_dir,
+    *, charge_filter=None, ch_suffix="", ch_tag="charge integrated",
+):
+    """2D ``(pt_gen, η_gen)`` heatmaps for each ``muon_source`` group
+    summed over the (possibly filtered) charge axis. Panels: J/ψ
+    reference, then per non-ref group the (raw, reweighted) pair. All
+    panels share a single ``LogNorm`` so absolute densities are
+    directly comparable; by construction the reweighted panel of any
+    non-ref group matches the J/ψ one in every cell with non-zero
+    support."""
+    from matplotlib.colors import LogNorm
+
+    centers_ch = 0.5 * (charge_edges[:-1] + charge_edges[1:])
+    if charge_filter is None:
+        ch_keep_idx = np.arange(len(centers_ch))
+    elif charge_filter > 0:
+        ch_keep_idx = np.where(centers_ch > 0)[0]
+    else:
+        ch_keep_idx = np.where(centers_ch < 0)[0]
+
+    def _sum_ch(H3d):
+        return H3d[:, :, ch_keep_idx].sum(axis=2)
+
+    panels = []  # (title, H_2d)
+    for g in _AGG_GROUPS:
+        H2d = _sum_ch(H[g["name"]])
+        if g["ref"]:
+            panels.append((g["label"], H2d))
+            continue
+        panels.append((f"{g['label']} (raw)", H2d))
+        H_rew = _sum_ch(H[g["name"]] * weight_grids[g["name"]])
+        panels.append((f"{g['label']} (reweighted)", H_rew))
+
+    pooled = np.concatenate([p[1].ravel() for p in panels])
+    finite_pos = pooled[(pooled > 0) & np.isfinite(pooled)]
+    if finite_pos.size == 0:
+        return
+    vmax = float(finite_pos.max())
+    vmin = float(finite_pos.min())
+    norm = LogNorm(vmin=max(vmin, 1e-6 * vmax), vmax=vmax)
+
+    fig, axes = plt.subplots(
+        1, len(panels), figsize=(3.8 * len(panels), 4.2),
+        sharey=True, layout="constrained",
+    )
+    pt_edges_arr = np.asarray(pt_edges, dtype=np.float64)
+    eta_edges_arr = np.asarray(eta_edges, dtype=np.float64)
+    for ax, (title, Hp) in zip(axes, panels):
+        mesh = ax.pcolormesh(
+            eta_edges_arr, pt_edges_arr, Hp, norm=norm,
+            cmap="viridis", shading="flat",
+        )
+        ax.set_title(title, fontsize=9)
+        ax.set_xlabel("eta_gen")
+    axes[0].set_ylabel("pt_gen [GeV]")
+    fig.colorbar(
+        mesh, ax=axes, shrink=0.85, label=f"Σ w ({ch_tag})",
+    )
+    fig.suptitle(
+        "Aggregated J/$\\psi$ vs prompt vs τ 2D kinematic validation  "
+        f"·  reweighted panels match J/$\\psi$ by construction  ·  {ch_tag}"
+    )
+    _save(
+        fig,
+        os.path.join(
+            out_dir,
+            f"aggregated_jpsi_vs_wz_kinematic_validation_2d{ch_suffix}.png",
+        ),
+    )
+
+
+def _plot_agg_kinematic_validation(
+    H, H_w2, weight_grids,
+    pt_edges, eta_edges, charge_edges, args, out_dir,
+    *, charge_filter=None, ch_suffix="", ch_tag="charge integrated",
+):
+    """Plot the (pt_gen, η_gen, charge_gen) marginals for J/ψ vs the
+    prompt and τ-decay raw + reweighted distributions, with the bottom
+    panel showing the per-group raw and reweighted ratios to J/ψ. By
+    construction the reweighted marginal of any non-ref group matches
+    J/ψ in every cell where that group had support; mismatches at the
+    marginal level expose cells the reweight had to discard.
+    """
+    centers_ch = 0.5 * (charge_edges[:-1] + charge_edges[1:])
+    if charge_filter is None:
+        ch_keep_idx = np.arange(len(centers_ch))
+    elif charge_filter > 0:
+        ch_keep_idx = np.where(centers_ch > 0)[0]
+    else:
+        ch_keep_idx = np.where(centers_ch < 0)[0]
+
+    def _restrict_charge(H_3d):
+        # Zero-out the dropped charge bins (keepdims so axis indices
+        # remain valid for the marginal sums below).
+        if charge_filter is None:
+            return H_3d
+        out = np.zeros_like(H_3d)
+        out[:, :, ch_keep_idx] = H_3d[:, :, ch_keep_idx]
+        return out
+
+    H_sel = {n: _restrict_charge(H[n]) for n in _AGG_NAMES}
+    H_w2_sel = {n: _restrict_charge(H_w2[n]) for n in _AGG_NAMES}
+
+    def _marg(H_3d, axis_keep):
+        other = tuple(a for a in (0, 1, 2) if a != axis_keep)
+        return H_3d.sum(axis=other)
+
+    # Pre-compute reweighted 3D content + Σw² per non-ref group.
+    H_rew = {}
+    H_rew_w2 = {}
+    for name in _AGG_NONREF_NAMES:
+        wg = weight_grids[name]
+        H_rew[name] = H_sel[name] * wg
+        H_rew_w2[name] = H_w2_sel[name] * (wg * wg)
+
+    panel_axes_all = (
+        (0, "pt_gen [GeV]", pt_edges),
+        (1, "eta_gen", eta_edges),
+        (2, "charge_gen", charge_edges),
+    )
+    # Drop the (degenerate) charge_gen panel when restricted to a
+    # single charge slice.
+    if charge_filter is None:
+        panel_axes = panel_axes_all
+    else:
+        panel_axes = panel_axes_all[:2]
+    n_cols = len(panel_axes)
+    fig, axes = plt.subplots(
+        2, n_cols, figsize=(4.8 * n_cols, 6.5),
+        sharex="col", squeeze=False,
+        gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
+        layout="constrained",
+    )
+
+    for k, (axis_keep, axis_label, edges) in enumerate(panel_axes):
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        bw = edges[1:] - edges[:-1]
+
+        def _norm(h_arr, h2_arr):
+            tot = h_arr.sum()
+            if tot <= 0:
+                return np.zeros_like(h_arr), np.zeros_like(h_arr)
+            return (
+                h_arr / (tot * bw),
+                np.sqrt(np.maximum(h2_arr, 0.0)) / (tot * bw),
+            )
+
+        ax_main = axes[0][k]
+        ax_ratio = axes[1][k]
+
+        # Reference (J/ψ).
+        ref_g = _AGG_GROUPS[0]
+        h_ref_n, s_ref_n = _norm(
+            _marg(H_sel[ref_g["name"]], axis_keep),
+            _marg(H_w2_sel[ref_g["name"]], axis_keep),
+        )
+        ax_main.step(
+            centers, h_ref_n, where="mid",
+            color=ref_g["main_color"], lw=1.4, label=ref_g["label"],
+        )
+        _stepped_errorbar(
+            ax_main, centers, h_ref_n, s_ref_n, ref_g["main_color"],
+        )
+
+        # Non-reference groups: raw + reweighted.
+        for g in _AGG_GROUPS[1:]:
+            name = g["name"]
+            h_raw_n, s_raw_n = _norm(
+                _marg(H_sel[name], axis_keep),
+                _marg(H_w2_sel[name], axis_keep),
+            )
+            h_rew_n, s_rew_n = _norm(
+                _marg(H_rew[name], axis_keep),
+                _marg(H_rew_w2[name], axis_keep),
+            )
+            ax_main.step(
+                centers, h_raw_n, where="mid",
+                color=g["raw_color"], lw=1.0, linestyle=":",
+                label=f"{g['label']} (raw)",
+            )
+            _stepped_errorbar(
+                ax_main, centers, h_raw_n, s_raw_n, g["raw_color"],
+            )
+            ax_main.step(
+                centers, h_rew_n, where="mid",
+                color=g["main_color"], lw=1.2,
+                label=f"{g['label']} (rew)",
+            )
+            _stepped_errorbar(
+                ax_main, centers, h_rew_n, s_rew_n, g["main_color"],
+            )
+
+            # Bottom-panel ratios to J/ψ.
+            r_raw, e_raw = _ratio_with_err(
+                h_raw_n, s_raw_n, h_ref_n, s_ref_n,
+            )
+            r_rew, e_rew = _ratio_with_err(
+                h_rew_n, s_rew_n, h_ref_n, s_ref_n,
+            )
+            ax_ratio.step(
+                centers, r_raw, where="mid",
+                color=g["raw_color"], lw=0.9, linestyle=":",
+            )
+            _stepped_errorbar(
+                ax_ratio, centers, r_raw, e_raw, g["raw_color"],
+            )
+            ax_ratio.step(
+                centers, r_rew, where="mid",
+                color=g["main_color"], lw=1.0,
+            )
+            _stepped_errorbar(
+                ax_ratio, centers, r_rew, e_rew, g["main_color"],
+            )
+
+        ax_main.set_ylabel("p.d.f.")
+        ax_main.set_title(axis_label, fontsize=10)
+        ax_main.legend(fontsize=7)
+
+        ax_ratio.axhline(1.0, color="k", lw=0.4, alpha=0.4)
+        ax_ratio.set_ylabel(r"$/$ J/$\psi$", fontsize=8)
+        ax_ratio.set_xlabel(axis_label)
+        ax_ratio.set_ylim(0.0, 2.0)
+
+    fig.suptitle(
+        "Aggregated J/$\\psi$ vs prompt vs τ kinematic validation  ·  "
+        "reweighted marginals should match J/$\\psi$ "
+        f"(modulo J/$\\psi$-only cells)  ·  {ch_tag}"
+    )
+    _save(
+        fig,
+        os.path.join(
+            out_dir,
+            f"aggregated_jpsi_vs_wz_kinematic_validation{ch_suffix}.png",
+        ),
+    )
+
+
+def plot_aggregated_target_distributions(stats, paths, args, out_dir):
+    """Aggregate the per-muon ``muon_source`` groups (J/ψ, prompt,
+    τ-decay) and overlay the target-distribution shapes after
+    reweighting the two non-reference groups to the J/ψ
+    ``(pt_gen, η_gen, charge_gen)`` distribution.
+    """
+    # Window + reweight binning.
+    pt_min = float(args.cmp_agg_pt_min)
+    pt_max = float(args.cmp_agg_pt_max)
+    eta_min = float(args.cmp_agg_eta_min)
+    eta_max = float(args.cmp_agg_eta_max)
+    n_eta = int(args.cmp_agg_rew_eta_bins)
+    n_pt = max(1, int(args.cmp_agg_rew_pt_bins))
+    pt_edges = np.linspace(pt_min, pt_max, n_pt + 1)
+    eta_edges = np.linspace(eta_min, eta_max, n_eta + 1)
+    charge_edges = np.array([-2.0, 0.0, 2.0])
+
+    print(
+        f"[agg] window: pt∈[{pt_min:g},{pt_max:g}] GeV  "
+        f"η∈[{eta_min:g},{eta_max:g}]; reweight grid "
+        f"({n_pt} × {n_eta} × 2)"
+    )
+
+    # Pass 1: per-group 3D histograms.
+    t0 = _tic()
+    H, H_w2, rows_read, n_kept = _stream_pteta_charge_3d(
+        paths,
+        pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
+        pt_edges=pt_edges, eta_edges=eta_edges, charge_edges=charge_edges,
+        n_workers=int(args.cmp_workers),
+        weight_mode=str(args.weight_handling),
+        split=str(args.split),
+        val_fraction=float(args.split_val_fraction),
+        holdout_fraction=float(args.split_holdout_fraction),
+    )
+    t0 = _toc("agg pass-1 (pt-η-charge 3D)", t0)
+    sums = {n: float(H[n].sum()) for n in _AGG_NAMES}
+    counts_str = "  ".join(
+        f"{n}: {n_kept[n]:,} (Σw={sums[n]:.3g})" for n in _AGG_NAMES
+    )
+    print(f"[agg]   read {rows_read:,} rows; per-group kept: {counts_str}")
+    if sums[_AGG_REF_NAME] <= 0:
+        print(
+            "[agg] reference group (J/ψ) is empty in this window — "
+            "skipping aggregated plot"
+        )
+        return
+
+    # Per-cell reweight: target -> J/ψ. One grid per non-ref group.
+    H_ref = H[_AGG_REF_NAME]
+    weight_grids = {}
+    for name in _AGG_NONREF_NAMES:
+        H_g = H[name]
+        if H_g.sum() <= 0:
+            print(
+                f"[agg]   group {name!r} empty in window — its reweight "
+                "grid is identically zero"
+            )
+            weight_grids[name] = np.zeros_like(H_g)
+            continue
+        safe = np.where(H_g > 0, H_g, np.nan)
+        wg = np.where(H_g > 0, H_ref / safe, 0.0)
+        n_zero = int((H_g == 0).sum())
+        if n_zero:
+            print(
+                f"[agg]   {name}: {n_zero}/{wg.size} reweight cells "
+                "have zero support (weight set to 0)"
+            )
+        weight_grids[name] = wg
+
+    # Charge modes for the aggregated plots. ``each`` → produce a
+    # separate set for q>0 and q<0; ``both`` → integrate over charge;
+    # ``pos`` / ``neg`` → single plot for the chosen charge.
+    if args.cmp_charge == "each":
+        charge_modes = ["pos", "neg"]
+    else:
+        charge_modes = [args.cmp_charge]
+
+    _CHARGE_FILTER = {"pos": +1, "neg": -1, "both": None}
+    _CHARGE_SUFFIX = {"pos": "_qpos", "neg": "_qneg", "both": "_qboth"}
+    _CHARGE_TAG = {"pos": "q>0", "neg": "q<0", "both": "charge integrated"}
+
+    # Bin edges for the per-axis target histograms (shared across
+    # charge modes — only the fill differs).
+    means = np.asarray(stats.target_mean, dtype=np.float64)
+    stds = np.asarray(stats.target_std, dtype=np.float64)
+    nsig = float(args.cmp_agg_range_sigma)
+    n_bins = int(args.cmp_agg_n_bins)
+    target_axes_edges = [
+        np.linspace(means[k] - nsig * stds[k], means[k] + nsig * stds[k],
+                    n_bins + 1)
+        for k in range(min(3, len(means)))
+    ]
+
+    for ch_mode in charge_modes:
+        cf = _CHARGE_FILTER[ch_mode]
+        ch_suffix = _CHARGE_SUFFIX[ch_mode]
+        ch_tag = _CHARGE_TAG[ch_mode]
+        print(f"[agg] charge mode = {ch_mode} ({ch_tag})")
+
+        _plot_agg_kinematic_validation(
+            H, H_w2, weight_grids,
+            pt_edges, eta_edges, charge_edges, args, out_dir,
+            charge_filter=cf, ch_suffix=ch_suffix, ch_tag=ch_tag,
+        )
+        _plot_agg_kinematic_validation_2d(
+            H, weight_grids, pt_edges, eta_edges, charge_edges, out_dir,
+            charge_filter=cf, ch_suffix=ch_suffix, ch_tag=ch_tag,
+        )
+
+        # Pass 2 (charge-filtered).
+        t0 = _tic()
+        totals = _stream_aggregated_targets(
+            paths,
+            pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
+            pt_edges=pt_edges, eta_edges=eta_edges,
+            charge_edges=charge_edges,
+            weight_grids=weight_grids, target_axes_edges=target_axes_edges,
+            n_workers=int(args.cmp_workers),
+            weight_mode=str(args.weight_handling),
+            charge_filter=cf,
+            split=str(args.split),
+            val_fraction=float(args.split_val_fraction),
+            holdout_fraction=float(args.split_holdout_fraction),
+        )
+        _toc(f"agg pass-2 (target hists, {ch_mode})", t0)
+
+        _plot_aggregated_target_distributions_one(
+            totals, target_axes_edges, args, out_dir,
+            pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
+            n_pt=n_pt, n_eta=n_eta,
+            ch_suffix=ch_suffix, ch_tag=ch_tag,
+        )
+
+
+def _plot_aggregated_target_distributions_one(
+    totals, target_axes_edges, args, out_dir,
+    *, pt_min, pt_max, eta_min, eta_max, n_pt, n_eta,
+    ch_suffix, ch_tag,
+):
+    """Render the per-axis target-distribution plot for a single
+    charge selection. Extracted from ``plot_aggregated_target_distributions``
+    so the charge-mode loop can call it once per slice."""
+    n_cols = len(target_axes_edges)
+    for yscale, ysuffix in (("linear", ""), ("log", "_log")):
+        fig, axes = plt.subplots(
+            2, n_cols, figsize=(5.0 * n_cols, 6.8),
+            sharex="col", squeeze=False,
+            gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
+            layout="constrained",
+        )
+        for k in range(n_cols):
+            edges = target_axes_edges[k]
+            centers = 0.5 * (edges[:-1] + edges[1:])
+            bw = edges[1] - edges[0]
+
+            def _norm(h, h2):
+                tot = h.sum()
+                if tot <= 0:
+                    return np.zeros_like(h), np.zeros_like(h)
+                return h / (tot * bw), np.sqrt(np.maximum(h2, 0.0)) / (tot * bw)
+
+            ax_main = axes[0][k]
+            ax_ratio = axes[1][k]
+
+            # Reference.
+            ref_g = _AGG_GROUPS[0]
+            h_ref = totals[k][f"{ref_g['name']}_raw_h"]
+            h_ref2 = totals[k][f"{ref_g['name']}_raw_h2"]
+            h_ref_n, s_ref_n = _norm(h_ref, h_ref2)
+            if h_ref.sum() <= 0:
+                continue
+            ax_main.step(
+                centers, h_ref_n, where="mid",
+                color=ref_g["main_color"], lw=1.3,
+                label=ref_g["label"],
+            )
+            _stepped_errorbar(
+                ax_main, centers, h_ref_n, s_ref_n,
+                ref_g["main_color"],
+            )
+
+            for g in _AGG_GROUPS[1:]:
+                name = g["name"]
+                h_raw = totals[k][f"{name}_raw_h"]
+                h_raw2 = totals[k][f"{name}_raw_h2"]
+                h_rew = totals[k][f"{name}_h"]
+                h_rew2 = totals[k][f"{name}_h2"]
+                tot_raw = h_raw.sum()
+                tot_rew = h_rew.sum()
+                if tot_rew <= 0 and tot_raw <= 0:
+                    continue
+                h_raw_n, s_raw_n = _norm(h_raw, h_raw2)
+                h_rew_n, s_rew_n = _norm(h_rew, h_rew2)
+
+                if tot_raw > 0:
+                    ax_main.step(
+                        centers, h_raw_n, where="mid",
+                        color=g["raw_color"], lw=0.9, linestyle=":",
+                        label=f"{g['label']} (raw)",
+                    )
+                    _stepped_errorbar(
+                        ax_main, centers, h_raw_n, s_raw_n,
+                        g["raw_color"],
+                    )
+                if tot_rew > 0:
+                    ax_main.step(
+                        centers, h_rew_n, where="mid",
+                        color=g["main_color"], lw=1.2,
+                        label=f"{g['label']} (rew → J/$\\psi$ kin.)",
+                    )
+                    _stepped_errorbar(
+                        ax_main, centers, h_rew_n, s_rew_n,
+                        g["main_color"],
+                    )
+
+                # Ratios to J/ψ.
+                if tot_raw > 0:
+                    r_raw, e_raw = _ratio_with_err(
+                        h_raw_n, s_raw_n, h_ref_n, s_ref_n,
+                    )
+                    ax_ratio.step(
+                        centers, r_raw, where="mid",
+                        color=g["raw_color"], lw=0.9, linestyle=":",
+                    )
+                    _stepped_errorbar(
+                        ax_ratio, centers, r_raw, e_raw, g["raw_color"],
+                    )
+                if tot_rew > 0:
+                    r_rew, e_rew = _ratio_with_err(
+                        h_rew_n, s_rew_n, h_ref_n, s_ref_n,
+                    )
+                    ax_ratio.step(
+                        centers, r_rew, where="mid",
+                        color=g["main_color"], lw=1.0,
+                    )
+                    _stepped_errorbar(
+                        ax_ratio, centers, r_rew, e_rew,
+                        g["main_color"],
+                    )
+
+            ax_main.set_yscale(yscale)
+            ax_main.set_ylabel("p.d.f. (weighted, unit area)")
+            ax_main.set_title(
+                TARGET_NAMES[k] if k < len(TARGET_NAMES)
+                else f"target[{k}]",
+                fontsize=10,
+            )
+            ax_main.legend(fontsize=7)
+            ax_main.axvline(0.0, color="k", lw=0.4, alpha=0.4)
+
+            ax_ratio.axhline(1.0, color="k", lw=0.4, alpha=0.4)
+            ax_ratio.set_ylabel(r"$/$ J/$\psi$", fontsize=8)
+            ax_ratio.set_xlabel(
+                TARGET_NAMES[k] if k < len(TARGET_NAMES)
+                else f"target[{k}]"
+            )
+            ax_ratio.set_ylim(0.5, 1.5)
+
+        fig.suptitle(
+            f"Aggregated J/$\\psi$ vs prompt vs τ target distributions  ·  "
+            f"pt∈[{pt_min:g},{pt_max:g}] GeV, "
+            f"η∈[{eta_min:g},{eta_max:g}], {ch_tag}; non-ref groups "
+            f"reweighted to J/$\\psi$ kinematics ({n_pt}·{n_eta}·2 grid)"
+        )
+        _save(
+            fig,
+            os.path.join(
+                out_dir,
+                f"aggregated_jpsi_vs_wz_target_distributions"
+                f"{ch_suffix}{ysuffix}.png",
+            ),
+        )
+
+
+# ============================================================================
 # main
 # ============================================================================
 
@@ -2075,11 +3093,16 @@ def main():
     print(f"loading ntuples from {len(args.input_files)} file(s)")
     t0 = _tic()
     (
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, source_id,
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
+        source_id, muon_source,
     ) = load_ntuples(
         args.input_files, args.tree, args.max_muons,
         args.pt_min, args.pt_max, args.eta_max,
         threads=args.threads, max_events=args.max_events,
+        weight_mode=args.weight_handling,
+        split=args.split,
+        val_fraction=args.split_val_fraction,
+        holdout_fraction=args.split_holdout_fraction,
     )
     t0 = _toc("load_ntuples", t0)
 
@@ -2093,6 +3116,7 @@ def main():
         eta_g, phi_g = eta_g[sel], phi_g[sel]
         kappa_r, kappa_g, w = kappa_r[sel], kappa_g[sel], w[sel]
         source_id = source_id[sel]
+        muon_source = muon_source[sel]
         print(
             f"  loaded {N_raw} muon rows; subsampled to "
             f"{eta_r.shape[0]} for plotting"
@@ -2101,8 +3125,13 @@ def main():
         print(f"  loaded {N_raw} muon rows")
     t0 = _toc("subsample raw arrays", t0)
 
+    # Only feed ``muon_source`` to the conditioning if the loaded
+    # checkpoint was trained with it; older 5-cond checkpoints would
+    # mismatch in apply_preproc/n_cond otherwise.
+    use_muon_source_cond = "muon_source" in (stats.cond_names or [])
     target, cond_raw = compute_targets_and_conditioning(
         eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+        muon_source=muon_source if use_muon_source_cond else None,
     )
     t0 = _toc("compute_targets_and_conditioning", t0)
 
@@ -2199,6 +3228,30 @@ def main():
     )
     t0 = _toc("plot_smear_closure", t0)
 
+    # Per-group closure plots: same model output, restricted to each
+    # ``muon_source`` aggregate (J/ψ, W/Z prompt, W/Z τ-decay)
+    # separately. All span the full loaded phase space; the split is
+    # the muon_source integer the snapshot writes (443, 1, 15).
+    group_masks = _agg_group_masks(muon_source)
+    for g in _AGG_GROUPS:
+        mask = group_masks[g["name"]]
+        if not mask.any():
+            print(f"  [closure] group {g['name']!r} empty — skipping")
+            continue
+        plot_shift_closure(
+            target, w, args, args.output,
+            log_r_grid_shift, target_std_per_dim,
+            group_mask=mask, group_label=g["name"],
+        )
+        t0 = _toc(f"plot_shift_closure[{g['name']}]", t0)
+        plot_smear_closure(
+            target, w, args, args.output,
+            log_r_grid_smear, target_std_per_dim,
+            log_r_grid_smear_via_gh=log_r_grid_smear_via_gh,
+            group_mask=mask, group_label=g["name"],
+        )
+        t0 = _toc(f"plot_smear_closure[{g['name']}]", t0)
+
     plot_closure_error_ratio(
         target, w, args, args.output,
         log_r_grid_smear, target_std_per_dim, mode="smear",
@@ -2233,6 +3286,10 @@ def main():
         eta_min=float(args.cmp_eta_min), eta_max=float(args.cmp_eta_max),
         max_events=int(args.cmp_max_events),
         n_workers=int(args.cmp_workers),
+        weight_mode=str(args.weight_handling),
+        split=str(args.split),
+        val_fraction=float(args.split_val_fraction),
+        holdout_fraction=float(args.split_holdout_fraction),
     )
     t0 = _toc("load per-source window (streaming)", t0)
     if cmp_data is None:
@@ -2254,6 +3311,15 @@ def main():
             args, args.output,
         )
         t0 = _toc("plot_per_source_target_distributions", t0)
+
+    # Aggregated J/ψ vs W/Z comparison with kinematic reweighting.
+    # Two-pass streaming over the same shards; doesn't reuse the
+    # in-memory arrays from the per-source loader because the agg
+    # window is intentionally wider.
+    plot_aggregated_target_distributions(
+        stats, args.input_files, args, args.output,
+    )
+    t0 = _toc("plot_aggregated_target_distributions", t0)
 
     if args.flow_checkpoint:
         print(f"loading flow checkpoint {args.flow_checkpoint}")

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
@@ -27,6 +27,7 @@ The structural priors ``r(y, c, 0, 0) = 1`` (by construction) and
 ``r`` even in σ_vec (by Σ-input symmetry / polynomial parity) are not
 plotted — they hold structurally and don't need empirical verification.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -35,12 +36,11 @@ import math
 import os
 import sys
 import time
-from typing import List
 
 import matplotlib
+
 matplotlib.use("Agg")  # noqa: E402  — non-interactive backend; must precede pyplot
 import matplotlib.pyplot as plt  # noqa: E402
-
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
 import torch.nn.functional as F  # noqa: E402
@@ -60,14 +60,13 @@ from train_shift_smear_reweight import (  # noqa: E402
     _ACTIVATIONS,
     _LOG_LOG2,
     _LOG_W_CLAMP,
-    _sigma_pack_indices,
     GaussBaseline,
     ReweightMLP_B,
     ReweightMLPFactored,
     ReweightPolyhead,
+    _sigma_pack_indices,
     gauss_baseline_log_r,
 )
-
 
 TARGET_NAMES = ["r_kappa", "dlambda", "dphi"]
 
@@ -123,6 +122,7 @@ def _toc(label, t0):
 # CLI
 # ============================================================================
 
+
 def parse_args():
     p = argparse.ArgumentParser(
         description="Diagnostic plots for a shift+smear reweight "
@@ -130,71 +130,97 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument(
-        "--checkpoint", required=True, default=argparse.SUPPRESS,
+        "--checkpoint",
+        required=True,
+        default=argparse.SUPPRESS,
         help="(required) Path to a shift_smear_reweight_{mlp,polyhead}.pt "
         "or checkpoint.pt produced by train_shift_smear_reweight.py.",
     )
     p.add_argument(
-        "--input-files", nargs="+", required=True,
+        "--input-files",
+        nargs="+",
+        required=True,
         default=argparse.SUPPRESS,
         help="(required) Input ROOT file(s) with the J/psi snapshot tree.",
     )
     p.add_argument(
-        "--tree", default="tree",
+        "--tree",
+        default="tree",
         help="ROOT TTree name to read from --input-files.",
     )
     p.add_argument(
-        "--output", default=None,
-        help="Output dir for plots. None = directory containing "
-        "--checkpoint.",
+        "--output",
+        default=None,
+        help="Output dir for plots. None = directory containing " "--checkpoint.",
     )
     p.add_argument(
-        "--device", default="cuda" if torch.cuda.is_available() else "cpu",
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Torch device for model evaluation.",
     )
     p.add_argument(
-        "--n-events", type=int, default=500_000,
+        "--n-events",
+        type=int,
+        default=500_000,
         help="Number of muon rows to use for plotting. Subsampled "
         "post-quality-cut. -1 = use all surviving rows.",
     )
     p.add_argument(
-        "--max-events", type=int, default=1_000_000,
+        "--max-events",
+        type=int,
+        default=1_000_000,
         help="Cap on raw J/psi events kept via RDataFrame Filter("
         "rdfentry_<N). 1M events comfortably covers --n-events at "
         "~2 muons/event. -1 = load all.",
     )
     p.add_argument(
-        "--max-muons", type=int, default=-1,
+        "--max-muons",
+        type=int,
+        default=-1,
         help="Cap on muon rows after the event filter. -1 = no cap.",
     )
     p.add_argument(
-        "--threads", type=int, default=0,
+        "--threads",
+        type=int,
+        default=0,
         help="RDataFrame ImplicitMT threads. 0 = ROOT auto.",
     )
     p.add_argument(
-        "--pt-min", type=float, default=2.0,
+        "--pt-min",
+        type=float,
+        default=2.0,
         help="Min gen pt (GeV); matches snapshot script default.",
     )
     p.add_argument(
-        "--pt-max", type=float, default=200.0,
+        "--pt-max",
+        type=float,
+        default=200.0,
         help="Max gen pt (GeV).",
     )
     p.add_argument(
-        "--eta-max", type=float, default=2.4,
+        "--eta-max",
+        type=float,
+        default=2.4,
         help="Max |gen eta|.",
     )
     p.add_argument(
-        "--shift-factors", nargs="+", type=float,
+        "--shift-factors",
+        nargs="+",
+        type=float,
         default=[0.1, 0.3, 0.5, 1.0],
         help="Shift magnitudes (in standardized-target σ units).",
     )
     p.add_argument(
-        "--smear-factors", nargs="+", type=float,
+        "--smear-factors",
+        nargs="+",
+        type=float,
         default=[0.1, 0.3, 0.5, 1.0],
         help="Smear magnitudes (in standardized-target σ units).",
     )
     p.add_argument(
-        "--smear-gh-K", type=int, default=0,
+        "--smear-gh-K",
+        type=int,
+        default=0,
         help="Gauss-Hermite order K for an extra smear-closure curve "
         "computed from the *shift* component of the polyhead via "
         "r_smear(σ·ê) ≈ Σ_k w_k · r_shift(ε_k·σ·ê) with probabilists' "
@@ -204,29 +230,40 @@ def parse_args():
         "starting value.",
     )
     p.add_argument(
-        "--n-bins", type=int, default=80,
+        "--n-bins",
+        type=int,
+        default=80,
         help="Histogram bin count for closure plots.",
     )
     p.add_argument(
-        "--range-percentile", type=float, default=0.5,
+        "--range-percentile",
+        type=float,
+        default=0.5,
         help="Percentile (each side) trimmed when setting histogram "
         "x-range from raw target distribution.",
     )
     p.add_argument(
-        "--scan-magnitudes", type=int, default=11,
+        "--scan-magnitudes",
+        type=int,
+        default=11,
         help="Number of magnitudes per axis in the log-r scan plot.",
     )
     p.add_argument(
-        "--batch-size", type=int, default=8192,
+        "--batch-size",
+        type=int,
+        default=8192,
         help="Batch size for model evaluation.",
     )
     p.add_argument(
-        "--seed", type=int, default=0,
+        "--seed",
+        type=int,
+        default=0,
         help="Seed for the per-event ε draw used to form the "
         "smeared-MC histogram (literal closure target).",
     )
     p.add_argument(
-        "--flow-checkpoint", default=None,
+        "--flow-checkpoint",
+        default=None,
         help="Optional path to a flow checkpoint produced by "
         "train_muon_response_flow.py. When provided, an additional "
         "diagnostic plot ``polyhead_pred_vs_flow.{png,pdf}`` is "
@@ -239,7 +276,9 @@ def parse_args():
         "the same MC sample).",
     )
     p.add_argument(
-        "--flow-validate-n", type=int, default=10000,
+        "--flow-validate-n",
+        type=int,
+        default=10000,
         help="Number of events to use for the optional "
         "polyhead_pred_vs_flow plot. Smaller = faster.",
     )
@@ -250,25 +289,34 @@ def parse_args():
     # in (pt_gen, eta_gen, charge_gen); phi_gen is integrated.
     # ------------------------------------------------------------------
     p.add_argument(
-        "--cmp-pt-min", type=float, default=12.0,
+        "--cmp-pt-min",
+        type=float,
+        default=12.0,
         help="Lower gen-pT (GeV) edge of the (deliberately narrow) "
         "phase-space window used for the per-source target-distribution "
         "comparison plot.",
     )
     p.add_argument(
-        "--cmp-pt-max", type=float, default=13.0,
+        "--cmp-pt-max",
+        type=float,
+        default=13.0,
         help="Upper gen-pT (GeV) edge of the cmp window.",
     )
     p.add_argument(
-        "--cmp-eta-min", type=float, default=0.0,
+        "--cmp-eta-min",
+        type=float,
+        default=0.0,
         help="Lower gen-η edge of the cmp window.",
     )
     p.add_argument(
-        "--cmp-eta-max", type=float, default=0.4,
+        "--cmp-eta-max",
+        type=float,
+        default=0.4,
         help="Upper gen-η edge of the cmp window.",
     )
     p.add_argument(
-        "--cmp-charge", choices=["pos", "neg", "both", "each"],
+        "--cmp-charge",
+        choices=["pos", "neg", "both", "each"],
         default="each",
         help="Charge selection in the cmp window. ``each`` (default) "
         "produces a separate plot for q>0 and q<0; ``both`` integrates "
@@ -276,24 +324,32 @@ def parse_args():
         "charge only.",
     )
     p.add_argument(
-        "--cmp-source-labels", nargs="+", default=None,
+        "--cmp-source-labels",
+        nargs="+",
+        default=None,
         help="Optional per-source labels of the form ``id:label`` "
         "(e.g. ``0:J/psi 100:Zmumu``). Sources without a mapping use "
         "their integer id.",
     )
     p.add_argument(
-        "--cmp-ref-source", type=int, default=ZMUMU_SOURCE_ID,
+        "--cmp-ref-source",
+        type=int,
+        default=ZMUMU_SOURCE_ID,
         help="Reference source_id for the ratio panel of the per-source "
         "comparison plot. Defaults to the Z→μμ convention (100); falls "
         "back to the smallest source_id present if absent in the window.",
     )
     p.add_argument(
-        "--cmp-source-min-events", type=int, default=10000,
+        "--cmp-source-min-events",
+        type=int,
+        default=10000,
         help="Drop sources contributing fewer than this many rows within "
         "the per-source comparison window. Set to 0 to disable.",
     )
     p.add_argument(
-        "--cmp-max-events", type=int, default=-1,
+        "--cmp-max-events",
+        type=int,
+        default=-1,
         help="Cap on raw muon rows *read* for the per-source target-"
         "distribution plots only. -1 (default) = all available rows. "
         "These plots stream shards in parallel and apply the (pt, eta) "
@@ -302,7 +358,9 @@ def parse_args():
         "inference-side caps (--n-events / --max-events).",
     )
     p.add_argument(
-        "--cmp-workers", type=int, default=8,
+        "--cmp-workers",
+        type=int,
+        default=8,
         help="Parallel shard readers (thread pool) for the per-source "
         "comparison loader.",
     )
@@ -316,43 +374,60 @@ def parse_args():
     # once their kinematics are matched.
     # ------------------------------------------------------------------
     p.add_argument(
-        "--cmp-agg-pt-min", type=float, default=10.0,
+        "--cmp-agg-pt-min",
+        type=float,
+        default=10.0,
         help="Lower gen-pT (GeV) edge of the window for the aggregated "
         "J/ψ-vs-W/Z target-distribution plot.",
     )
     p.add_argument(
-        "--cmp-agg-pt-max", type=float, default=16.0,
+        "--cmp-agg-pt-max",
+        type=float,
+        default=16.0,
         help="Upper gen-pT (GeV) edge of the aggregated window.",
     )
     p.add_argument(
-        "--cmp-agg-eta-min", type=float, default=-2.4,
+        "--cmp-agg-eta-min",
+        type=float,
+        default=-2.4,
         help="Lower gen-η edge of the aggregated window.",
     )
     p.add_argument(
-        "--cmp-agg-eta-max", type=float, default=2.4,
+        "--cmp-agg-eta-max",
+        type=float,
+        default=2.4,
         help="Upper gen-η edge of the aggregated window.",
     )
     p.add_argument(
-        "--cmp-agg-rew-eta-bins", type=int, default=24,
+        "--cmp-agg-rew-eta-bins",
+        type=int,
+        default=24,
         help="Number of η bins in the 3D (pt, η, charge) reweighting "
         "histogram. The window above is split uniformly.",
     )
     p.add_argument(
-        "--cmp-agg-rew-pt-bins", type=int, default=12,
+        "--cmp-agg-rew-pt-bins",
+        type=int,
+        default=12,
         help="Number of pT bins in the reweighting histogram (default "
         "12 → 0.5 GeV bins across the default [10, 16] GeV window).",
     )
     p.add_argument(
-        "--cmp-agg-range-sigma", type=float, default=5.0,
+        "--cmp-agg-range-sigma",
+        type=float,
+        default=5.0,
         help="Target-distribution histogram half-range, in units of "
         "stats.target_std around stats.target_mean (per axis).",
     )
     p.add_argument(
-        "--cmp-agg-n-bins", type=int, default=80,
+        "--cmp-agg-n-bins",
+        type=int,
+        default=80,
         help="Number of bins in each 1D target-distribution histogram.",
     )
     p.add_argument(
-        "--weight-handling", choices=["abs", "keep", "drop"],
+        "--weight-handling",
+        choices=["abs", "keep", "drop"],
         default="abs",
         help="How to treat MC@NLO signed event weights in every plot "
         "and loader: ``abs`` (default; |w|, drops zero/non-finite) "
@@ -364,7 +439,8 @@ def parse_args():
         "see a different effective sample than the trainer.",
     )
     p.add_argument(
-        "--split", choices=["train", "val", "holdout", "all"],
+        "--split",
+        choices=["train", "val", "holdout", "all"],
         default="holdout",
         help="Which contiguous per-shard record-batch slice to load "
         "(see ``arrow_shard_loader.split_batch_range``). Default "
@@ -373,13 +449,17 @@ def parse_args():
         "match the trainer's splits; ``all`` loads everything.",
     )
     p.add_argument(
-        "--split-val-fraction", type=float, default=0.1,
+        "--split-val-fraction",
+        type=float,
+        default=0.1,
         help="Fraction of each shard's record batches assigned to "
         "the val split. Must match the trainer's --val-fraction so "
         "the train / val / holdout slices line up.",
     )
     p.add_argument(
-        "--split-holdout-fraction", type=float, default=0.1,
+        "--split-holdout-fraction",
+        type=float,
+        default=0.1,
         help="Fraction of each shard's record batches assigned to "
         "the holdout split. Must match the trainer's "
         "--holdout-fraction.",
@@ -390,6 +470,7 @@ def parse_args():
 # ============================================================================
 # Checkpoint loader — dispatches on arch
 # ============================================================================
+
 
 def load_model_from_checkpoint(checkpoint_path: str, device):
     """Load model + stats + train_config. Builds ``ReweightMLP_B`` or
@@ -413,7 +494,8 @@ def load_model_from_checkpoint(checkpoint_path: str, device):
             n_layers=int(gb_cfg.get("n_layers", 2)),
             activation=activation_cls,
         )
-        if gb_cfg is not None else None
+        if gb_cfg is not None
+        else None
     )
 
     if arch == "mlp":
@@ -462,12 +544,18 @@ def load_model_from_checkpoint(checkpoint_path: str, device):
         # Older checkpoints stored these as ``hidden_features`` /
         # ``n_hidden_layers``; new ones use ``trunk_hidden`` /
         # ``trunk_layers`` (shared with the mlp arch).
-        trunk_hidden = int(cfg.get(
-            "trunk_hidden", cfg.get("hidden_features", 64),
-        ))
-        trunk_layers = int(cfg.get(
-            "trunk_layers", cfg.get("n_hidden_layers", 2),
-        ))
+        trunk_hidden = int(
+            cfg.get(
+                "trunk_hidden",
+                cfg.get("hidden_features", 64),
+            )
+        )
+        trunk_layers = int(
+            cfg.get(
+                "trunk_layers",
+                cfg.get("n_hidden_layers", 2),
+            )
+        )
         model = ReweightPolyhead(
             n_features=int(cfg["n_features"]),
             n_cond=int(cfg["n_cond"]),
@@ -497,6 +585,7 @@ def load_model_from_checkpoint(checkpoint_path: str, device):
 # Unified per-axis log r prediction
 # ============================================================================
 
+
 def _apply_positivity(d, positivity):
     if positivity == "exp":
         return d.clamp(min=-_LOG_W_CLAMP, max=_LOG_W_CLAMP)
@@ -513,9 +602,18 @@ def _apply_positivity(d, positivity):
 
 @torch.no_grad()
 def predict_log_r_axis(
-    model, arch, y_dev, c_dev, u_axis_value, sigma_axis_value, tcol,
-    n_features, batch_size, positivity,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    model,
+    arch,
+    y_dev,
+    c_dev,
+    u_axis_value,
+    sigma_axis_value,
+    tcol,
+    n_features,
+    batch_size,
+    positivity,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Per-event log r prediction with an axis-aligned perturbation.
 
@@ -542,7 +640,9 @@ def predict_log_r_axis(
         # the indexing matches the model's expectations.
         n_sigma_pack = sigma_pack_iu.shape[0]
         sigma_pack_buf = torch.zeros(
-            batch_size, n_sigma_pack, device=device,
+            batch_size,
+            n_sigma_pack,
+            device=device,
         )
         for k in range(n_sigma_pack):
             i, j = int(sigma_pack_iu[k]), int(sigma_pack_ju[k])
@@ -562,16 +662,19 @@ def predict_log_r_axis(
             u_zero = torch.zeros_like(u)
             sp_zero = torch.zeros_like(sigma_pack)
             # 2B head batching: f at (e_y, u, σ) and (e_y, 0, 0).
-            ev = model.trunk_forward(y, c)             # [bsz, d_emb]
+            ev = model.trunk_forward(y, c)  # [bsz, d_emb]
             ev2 = torch.cat([ev, ev], dim=0)
             u2 = torch.cat([u, u_zero], dim=0)
             sp2 = torch.cat([sigma_pack, sp_zero], dim=0)
             f = model.head_forward(ev2, u2, sp2)
             d = f[:bsz] - f[bsz:]
         elif arch == "polyhead":
-            coefs = model(y, c)                         # [bsz, n_basis]
+            coefs = model(y, c)  # [bsz, n_basis]
             d = evaluate_joint(
-                coefs, u, sigma_vec, model.joint_indices,
+                coefs,
+                u,
+                sigma_vec,
+                model.joint_indices,
                 basis=getattr(model, "basis", "monomial"),
                 scale_u=float(getattr(model, "basis_scale_u", 1.0)),
                 scale_sigma=float(getattr(model, "basis_scale_sigma", 1.0)),
@@ -594,9 +697,16 @@ def predict_log_r_axis(
 
 
 def predict_log_r_perevent(
-    model, arch, y_dev, c_dev, u_dev, sigma_dev,
-    batch_size, positivity,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    model,
+    arch,
+    y_dev,
+    c_dev,
+    u_dev,
+    sigma_dev,
+    batch_size,
+    positivity,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Per-event log r prediction with **arbitrary** per-event
     ``(u, σ_vec)`` (not axis-aligned). All four input tensors are on
@@ -623,7 +733,10 @@ def predict_log_r_perevent(
 
         if arch in ("mlp", "mlp-factored"):
             sigma_pack = torch.zeros(
-                bsz, n_sigma_pack, device=device, dtype=y.dtype,
+                bsz,
+                n_sigma_pack,
+                device=device,
+                dtype=y.dtype,
             )
             for k in range(n_sigma_pack):
                 i, j = int(sigma_pack_iu[k]), int(sigma_pack_ju[k])
@@ -639,7 +752,10 @@ def predict_log_r_perevent(
         elif arch == "polyhead":
             coefs = model(y, c)
             d = evaluate_joint(
-                coefs, u, sigma_vec, model.joint_indices,
+                coefs,
+                u,
+                sigma_vec,
+                model.joint_indices,
                 basis=getattr(model, "basis", "monomial"),
                 scale_u=float(getattr(model, "basis_scale_u", 1.0)),
                 scale_sigma=float(getattr(model, "basis_scale_sigma", 1.0)),
@@ -672,9 +788,18 @@ def _gh_nodes_weights(K):
 
 
 def predict_smear_via_gh_shift(
-    model, arch, y_dev, c_dev, factor, tcol, K,
-    n_features, batch_size, positivity,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    model,
+    arch,
+    y_dev,
+    c_dev,
+    factor,
+    tcol,
+    K,
+    n_features,
+    batch_size,
+    positivity,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Estimate per-event log r for an axis-aligned smear from the
     *shift* component of the polyhead via Gauss-Hermite integration:
@@ -697,11 +822,18 @@ def predict_smear_via_gh_shift(
     for k in range(int(K)):
         u_val = float(eps_k[k]) * float(factor)
         log_r_k = predict_log_r_axis(
-            model, arch, y_dev, c_dev,
-            u_axis_value=u_val, sigma_axis_value=0.0, tcol=tcol,
-            n_features=n_features, batch_size=batch_size,
+            model,
+            arch,
+            y_dev,
+            c_dev,
+            u_axis_value=u_val,
+            sigma_axis_value=0.0,
+            tcol=tcol,
+            n_features=n_features,
+            batch_size=batch_size,
             positivity=positivity,
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
         )
         stack[k] = log_r_k.astype(np.float64) + float(log_w[k])
 
@@ -714,6 +846,7 @@ def predict_smear_via_gh_shift(
 # ============================================================================
 # Plot helpers
 # ============================================================================
+
 
 def _save(fig, path):
     fig.savefig(path, dpi=120, bbox_inches="tight")
@@ -753,9 +886,7 @@ def _ratio_with_err(h_num, sigma_num, h_den, sigma_den):
     den_safe = np.where(h_den > 0, h_den, np.nan)
     num_safe = np.where(h_num > 0, h_num, np.nan)
     ratio = h_num / den_safe
-    rel = np.sqrt(
-        (sigma_num / num_safe) ** 2 + (sigma_den / den_safe) ** 2
-    )
+    rel = np.sqrt((sigma_num / num_safe) ** 2 + (sigma_den / den_safe) ** 2)
     return ratio, ratio * rel
 
 
@@ -764,31 +895,62 @@ def _stepped_errorbar(ax, centers, h, sigma, color, **kwargs):
     visually to a step histogram. ``kwargs`` are forwarded to errorbar
     (e.g. label, lw)."""
     ax.errorbar(
-        centers, h, yerr=sigma, fmt="none", ecolor=color,
-        elinewidth=0.7, capsize=0, alpha=0.6, **kwargs,
+        centers,
+        h,
+        yerr=sigma,
+        fmt="none",
+        ecolor=color,
+        elinewidth=0.7,
+        capsize=0,
+        alpha=0.6,
+        **kwargs,
     )
 
 
 def _common_predict_call(
-    model, arch, y_dev, c_dev, factor, tcol, mode, n_features,
-    batch_size, positivity, sigma_pack_iu, sigma_pack_ju,
+    model,
+    arch,
+    y_dev,
+    c_dev,
+    factor,
+    tcol,
+    mode,
+    n_features,
+    batch_size,
+    positivity,
+    sigma_pack_iu,
+    sigma_pack_ju,
 ):
     """Thin wrapper that maps mode={shift,smear} → axis values."""
     if mode == "shift":
         return predict_log_r_axis(
-            model, arch, y_dev, c_dev,
-            u_axis_value=float(factor), sigma_axis_value=0.0, tcol=tcol,
-            n_features=n_features, batch_size=batch_size,
+            model,
+            arch,
+            y_dev,
+            c_dev,
+            u_axis_value=float(factor),
+            sigma_axis_value=0.0,
+            tcol=tcol,
+            n_features=n_features,
+            batch_size=batch_size,
             positivity=positivity,
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
         )
     if mode == "smear":
         return predict_log_r_axis(
-            model, arch, y_dev, c_dev,
-            u_axis_value=0.0, sigma_axis_value=float(factor), tcol=tcol,
-            n_features=n_features, batch_size=batch_size,
+            model,
+            arch,
+            y_dev,
+            c_dev,
+            u_axis_value=0.0,
+            sigma_axis_value=float(factor),
+            tcol=tcol,
+            n_features=n_features,
+            batch_size=batch_size,
             positivity=positivity,
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
         )
     raise ValueError(f"unknown mode {mode!r}")
 
@@ -797,9 +959,17 @@ def _common_predict_call(
 # 1) Per-axis 1D shift closure
 # ============================================================================
 
+
 def plot_shift_closure(
-    target, w_event, args, out_dir, log_r_grid_shift, target_std_per_dim,
-    *, group_mask=None, group_label=None,
+    target,
+    w_event,
+    args,
+    out_dir,
+    log_r_grid_shift,
+    target_std_per_dim,
+    *,
+    group_mask=None,
+    group_label=None,
 ):
     """Per-axis shift-closure plots from a precomputed log r grid.
 
@@ -816,10 +986,7 @@ def plot_shift_closure(
         w_event = np.asarray(w_event)[m]
         log_r_grid_shift = {k: v[m] for k, v in log_r_grid_shift.items()}
         if target.shape[0] == 0:
-            print(
-                f"  [shift_closure] group {group_label!r} empty — "
-                "skipping"
-            )
+            print(f"  [shift_closure] group {group_label!r} empty — " "skipping")
             return
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
@@ -828,7 +995,8 @@ def plot_shift_closure(
     n_rows = len(factors)
     n_cols = len(target_components)
     fig, axes = plt.subplots(
-        2 * n_rows, n_cols,
+        2 * n_rows,
+        n_cols,
         figsize=(4.0 * n_cols, 3.5 * n_rows),
         sharex="col",
         gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
@@ -852,46 +1020,75 @@ def plot_shift_closure(
             y_shifted = target[:, tcol] + dy
 
             h_raw, e_raw = _weighted_hist_err(
-                target[:, tcol], bins, w_event,
+                target[:, tcol],
+                bins,
+                w_event,
             )
             h_shifted, e_shifted = _weighted_hist_err(
-                y_shifted, bins, w_event,
+                y_shifted,
+                bins,
+                w_event,
             )
             h_pred, e_pred = _weighted_hist_err(
-                target[:, tcol], bins,
+                target[:, tcol],
+                bins,
                 (w_event * r_pred).astype(np.float64),
             )
 
             ax_main = axes[2 * r][cidx]
             ax_main.step(
-                centers, h_raw, where="mid", color="0.4",
-                linestyle=":", lw=1.0, label="raw MC",
+                centers,
+                h_raw,
+                where="mid",
+                color="0.4",
+                linestyle=":",
+                lw=1.0,
+                label="raw MC",
             )
             ax_main.step(
-                centers, h_shifted, where="mid", color="k", lw=1.0,
+                centers,
+                h_shifted,
+                where="mid",
+                color="k",
+                lw=1.0,
                 label=f"shifted MC ({factor:g}·σ_y)",
             )
             _stepped_errorbar(ax_main, centers, h_shifted, e_shifted, "k")
             ax_main.step(
-                centers, h_pred, where="mid", color="C0",
-                linestyle="--", lw=1.0, label="MLP pred W reweight",
+                centers,
+                h_pred,
+                where="mid",
+                color="C0",
+                linestyle="--",
+                lw=1.0,
+                label="MLP pred W reweight",
             )
             _stepped_errorbar(ax_main, centers, h_pred, e_pred, "C0")
             ax_main.set_ylabel("events")
-            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            tname = (
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            )
             ax_main.set_title(
-                f"shift |δ|={factor:g} along {tname}", fontsize=10,
+                f"shift |δ|={factor:g} along {tname}",
+                fontsize=10,
             )
             if r == 0 and cidx == 0:
                 ax_main.legend(loc="best", fontsize=7)
 
             ax_ratio = axes[2 * r + 1][cidx]
             ratio, e_ratio = _ratio_with_err(
-                h_pred, e_pred, h_shifted, e_shifted,
+                h_pred,
+                e_pred,
+                h_shifted,
+                e_shifted,
             )
             ax_ratio.step(
-                centers, ratio, where="mid",
-                color="C0", linestyle="--", lw=1.0,
+                centers,
+                ratio,
+                where="mid",
+                color="C0",
+                linestyle="--",
+                lw=1.0,
             )
             _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C0")
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
@@ -917,10 +1114,18 @@ def plot_shift_closure(
 # 2) Per-axis 1D smear closure
 # ============================================================================
 
+
 def plot_smear_closure(
-    target, w_event, args, out_dir, log_r_grid_smear, target_std_per_dim,
+    target,
+    w_event,
+    args,
+    out_dir,
+    log_r_grid_smear,
+    target_std_per_dim,
     log_r_grid_smear_via_gh=None,
-    *, group_mask=None, group_label=None,
+    *,
+    group_mask=None,
+    group_label=None,
 ):
     """Per-axis smear-closure plots.
 
@@ -947,10 +1152,7 @@ def plot_smear_closure(
                 k: v[m] for k, v in log_r_grid_smear_via_gh.items()
             }
         if target.shape[0] == 0:
-            print(
-                f"  [smear_closure] group {group_label!r} empty — "
-                "skipping"
-            )
+            print(f"  [smear_closure] group {group_label!r} empty — " "skipping")
             return
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
@@ -960,7 +1162,8 @@ def plot_smear_closure(
     n_rows = len(factors)
     n_cols = len(target_components)
     fig, axes = plt.subplots(
-        2 * n_rows, n_cols,
+        2 * n_rows,
+        n_cols,
         figsize=(4.0 * n_cols, 3.5 * n_rows),
         sharex="col",
         gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
@@ -989,89 +1192,142 @@ def plot_smear_closure(
             y_smeared = target[:, tcol] + dy * eps
 
             h_raw, e_raw = _weighted_hist_err(
-                target[:, tcol], bins, w_event,
+                target[:, tcol],
+                bins,
+                w_event,
             )
             h_smeared, e_smeared = _weighted_hist_err(
-                y_smeared, bins, w_event,
+                y_smeared,
+                bins,
+                w_event,
             )
             h_pred, e_pred = _weighted_hist_err(
-                target[:, tcol], bins,
+                target[:, tcol],
+                bins,
                 (w_event * r_pred).astype(np.float64),
             )
 
             ax_main = axes[2 * r][cidx]
             ax_main.step(
-                centers, h_raw, where="mid", color="0.4",
-                linestyle=":", lw=1.0, label="raw MC",
+                centers,
+                h_raw,
+                where="mid",
+                color="0.4",
+                linestyle=":",
+                lw=1.0,
+                label="raw MC",
             )
             ax_main.step(
-                centers, h_smeared, where="mid", color="k", lw=1.0,
+                centers,
+                h_smeared,
+                where="mid",
+                color="k",
+                lw=1.0,
                 label=f"smeared MC ({factor:g}·σ_y, K=1)",
             )
             _stepped_errorbar(ax_main, centers, h_smeared, e_smeared, "k")
             ax_main.step(
-                centers, h_pred, where="mid", color="C2",
-                linestyle="--", lw=1.0, label="MLP pred W reweight",
+                centers,
+                h_pred,
+                where="mid",
+                color="C2",
+                linestyle="--",
+                lw=1.0,
+                label="MLP pred W reweight",
             )
             _stepped_errorbar(ax_main, centers, h_pred, e_pred, "C2")
 
             # Optional: GH-on-shift smear estimate.
             h_pred_gh = e_pred_gh = None
             if log_r_grid_smear_via_gh is not None:
-                log_r_gh = log_r_grid_smear_via_gh[
-                    (float(factor), int(tcol))
-                ]
+                log_r_gh = log_r_grid_smear_via_gh[(float(factor), int(tcol))]
                 r_pred_gh = np.exp(log_r_gh)
                 h_pred_gh, e_pred_gh = _weighted_hist_err(
-                    target[:, tcol], bins,
+                    target[:, tcol],
+                    bins,
                     (w_event * r_pred_gh).astype(np.float64),
                 )
                 ax_main.step(
-                    centers, h_pred_gh, where="mid", color="C1",
-                    linestyle="-.", lw=1.0,
+                    centers,
+                    h_pred_gh,
+                    where="mid",
+                    color="C1",
+                    linestyle="-.",
+                    lw=1.0,
                     label=f"GH(K={int(args.smear_gh_K)}) on shift",
                 )
                 _stepped_errorbar(
-                    ax_main, centers, h_pred_gh, e_pred_gh, "C1",
+                    ax_main,
+                    centers,
+                    h_pred_gh,
+                    e_pred_gh,
+                    "C1",
                 )
 
             ax_main.set_ylabel("events")
-            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            tname = (
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            )
             ax_main.set_title(
-                f"smear |σ|={factor:g} along {tname}", fontsize=10,
+                f"smear |σ|={factor:g} along {tname}",
+                fontsize=10,
             )
             if r == 0 and cidx == 0:
                 ax_main.legend(loc="best", fontsize=7)
 
             ax_ratio = axes[2 * r + 1][cidx]
             ratio, e_ratio = _ratio_with_err(
-                h_pred, e_pred, h_smeared, e_smeared,
+                h_pred,
+                e_pred,
+                h_smeared,
+                e_smeared,
             )
             ax_ratio.step(
-                centers, ratio, where="mid",
-                color="C2", linestyle="--", lw=1.0,
+                centers,
+                ratio,
+                where="mid",
+                color="C2",
+                linestyle="--",
+                lw=1.0,
             )
             _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C2")
             ratios_for_ylim = [ratio]
             if h_pred_gh is not None:
                 ratio_gh, e_ratio_gh = _ratio_with_err(
-                    h_pred_gh, e_pred_gh, h_smeared, e_smeared,
+                    h_pred_gh,
+                    e_pred_gh,
+                    h_smeared,
+                    e_smeared,
                 )
                 ax_ratio.step(
-                    centers, ratio_gh, where="mid",
-                    color="C1", linestyle="-.", lw=1.0,
+                    centers,
+                    ratio_gh,
+                    where="mid",
+                    color="C1",
+                    linestyle="-.",
+                    lw=1.0,
                 )
                 _stepped_errorbar(
-                    ax_ratio, centers, ratio_gh, e_ratio_gh, "C1",
+                    ax_ratio,
+                    centers,
+                    ratio_gh,
+                    e_ratio_gh,
+                    "C1",
                 )
                 ratios_for_ylim.append(ratio_gh)
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
             ax_ratio.set_ylabel("/ smeared MC", fontsize=8)
             ax_ratio.set_xlabel(tname)
-            ratios = np.concatenate([
-                np.atleast_1d(rr)[np.isfinite(np.atleast_1d(rr))]
-                for rr in ratios_for_ylim
-            ]) if ratios_for_ylim else np.empty(0)
+            ratios = (
+                np.concatenate(
+                    [
+                        np.atleast_1d(rr)[np.isfinite(np.atleast_1d(rr))]
+                        for rr in ratios_for_ylim
+                    ]
+                )
+                if ratios_for_ylim
+                else np.empty(0)
+            )
             if ratios.size:
                 lo_r, hi_r = np.quantile(ratios, [0.05, 0.95])
                 pad = max(0.05, 0.5 * (hi_r - lo_r))
@@ -1098,8 +1354,14 @@ def plot_smear_closure(
 #      reweight inflates the error vs a fresh sample.
 # ============================================================================
 
+
 def plot_closure_error_ratio(
-    target, w_event, args, out_dir, log_r_grid, target_std_per_dim,
+    target,
+    w_event,
+    args,
+    out_dir,
+    log_r_grid,
+    target_std_per_dim,
     mode,
 ):
     """Per-bin √Σw² error comparison: polyhead reweight vs literal
@@ -1146,17 +1408,14 @@ def plot_closure_error_ratio(
     assert mode in ("shift", "smear")
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
-    factors = (
-        args.shift_factors if mode == "shift" else args.smear_factors
-    )
-    rng = (
-        np.random.default_rng(args.seed) if mode == "smear" else None
-    )
+    factors = args.shift_factors if mode == "shift" else args.smear_factors
+    rng = np.random.default_rng(args.seed) if mode == "smear" else None
 
     n_rows = len(factors)
     n_cols = len(target_components)
     fig, axes = plt.subplots(
-        2 * n_rows, n_cols,
+        2 * n_rows,
+        n_cols,
         figsize=(4.0 * n_cols, 3.5 * n_rows),
         sharex="col",
         gridspec_kw={"height_ratios": [3, 1] * n_rows, "hspace": 0.05},
@@ -1183,20 +1442,21 @@ def plot_closure_error_ratio(
             else:
                 eps = rng.standard_normal(target.shape[0])
                 y_ref = target[:, tcol] + dy * eps
-                ref_label = (
-                    f"smeared MC ({factor:g}·σ_y, K=1 stochastic)"
-                )
+                ref_label = f"smeared MC ({factor:g}·σ_y, K=1 stochastic)"
 
             # Three histograms / sigma vectors:
             #   raw      — unperturbed MC at original y (bin-fill).
             #   ref      — perturbed MC at shifted/smeared y.
             #   pred     — polyhead-reweighted MC at original y.
             h_raw, e_raw = _weighted_hist_err(
-                target[:, tcol], bins, w_event,
+                target[:, tcol],
+                bins,
+                w_event,
             )
             h_ref, e_ref = _weighted_hist_err(y_ref, bins, w_event)
             _, e_pred = _weighted_hist_err(
-                target[:, tcol], bins,
+                target[:, tcol],
+                bins,
                 (w_event * r_pred).astype(np.float64),
             )
             # Optimal: constant-per-bin reweight = h_ref / h_raw.
@@ -1208,27 +1468,37 @@ def plot_closure_error_ratio(
 
             ax_main = axes[2 * r][cidx]
             ax_main.step(
-                centers, e_ref, where="mid",
-                color="k", lw=1.0, label=ref_label,
+                centers,
+                e_ref,
+                where="mid",
+                color="k",
+                lw=1.0,
+                label=ref_label,
             )
             ax_main.step(
-                centers, e_pred, where="mid",
-                color="C0", linestyle="--", lw=1.0,
+                centers,
+                e_pred,
+                where="mid",
+                color="C0",
+                linestyle="--",
+                lw=1.0,
                 label=r"polyhead reweight: $\sqrt{\sum (w \hat r)^2}$",
             )
             ax_main.step(
-                centers, e_optimal, where="mid",
-                color="C2", linestyle=":", lw=1.0,
+                centers,
+                e_optimal,
+                where="mid",
+                color="C2",
+                linestyle=":",
+                lw=1.0,
                 label=(
-                    r"optimal reweight: $(h_{\rm ref}/h_{\rm raw})"
-                    r" \sqrt{\sum w^2}$"
+                    r"optimal reweight: $(h_{\rm ref}/h_{\rm raw})" r" \sqrt{\sum w^2}$"
                 ),
             )
             ax_main.set_yscale("log")
             ax_main.set_ylabel(r"$\sigma$ per bin")
             tname = (
-                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES)
-                else f"target[{tcol}]"
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
             )
             ax_main.set_title(
                 f"{mode}: |{'δ' if mode == 'shift' else 'σ'}|="
@@ -1246,26 +1516,35 @@ def plot_closure_error_ratio(
             ratio_ref = e_ref / denom
             ax_ratio = axes[2 * r + 1][cidx]
             ax_ratio.step(
-                centers, ratio_pred, where="mid",
-                color="C0", lw=1.0,
+                centers,
+                ratio_pred,
+                where="mid",
+                color="C0",
+                lw=1.0,
                 label=r"$\hat r$ / optimal",
             )
             ax_ratio.step(
-                centers, ratio_ref, where="mid",
-                color="k", lw=1.0,
+                centers,
+                ratio_ref,
+                where="mid",
+                color="k",
+                lw=1.0,
                 label="ref / optimal",
             )
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
             ax_ratio.set_ylabel(
-                r"$\sigma / \sigma_{\rm optimal}$", fontsize=8,
+                r"$\sigma / \sigma_{\rm optimal}$",
+                fontsize=8,
             )
             ax_ratio.set_xlabel(tname)
             if r == 0 and cidx == 0:
                 ax_ratio.legend(loc="best", fontsize=7)
-            ratios_all = np.concatenate([
-                ratio_pred[np.isfinite(ratio_pred)],
-                ratio_ref[np.isfinite(ratio_ref)],
-            ])
+            ratios_all = np.concatenate(
+                [
+                    ratio_pred[np.isfinite(ratio_pred)],
+                    ratio_ref[np.isfinite(ratio_ref)],
+                ]
+            )
             if ratios_all.size:
                 lo_r, hi_r = np.quantile(ratios_all, [0.05, 0.95])
                 pad = max(0.05, 0.5 * (hi_r - lo_r))
@@ -1288,23 +1567,31 @@ def plot_closure_error_ratio(
 # 3) log r distribution (per axis × magnitude × mode)
 # ============================================================================
 
+
 def plot_log_r_distribution(
-    n_features, w_event, args, out_dir,
-    log_r_grid_shift, log_r_grid_smear,
+    n_features,
+    w_event,
+    args,
+    out_dir,
+    log_r_grid_shift,
+    log_r_grid_smear,
 ):
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
 
     fig, axes = plt.subplots(
-        2, len(target_components),
+        2,
+        len(target_components),
         figsize=(4.5 * len(target_components), 7.0),
         squeeze=False,
         layout="constrained",
     )
 
-    for row, (mode, grid, factors) in enumerate([
-        ("shift", log_r_grid_shift, args.shift_factors),
-        ("smear", log_r_grid_smear, args.smear_factors),
-    ]):
+    for row, (mode, grid, factors) in enumerate(
+        [
+            ("shift", log_r_grid_shift, args.shift_factors),
+            ("smear", log_r_grid_smear, args.smear_factors),
+        ]
+    ):
         for cidx, tcol in enumerate(target_components):
             ax = axes[row][cidx]
             all_log_r = []
@@ -1327,14 +1614,20 @@ def plot_log_r_distribution(
                 color = f"C{i}"
                 h, sigma = _weighted_hist_err(log_r, bins, w_event)
                 ax.step(
-                    centers, h, where="mid", color=color, lw=1.2,
+                    centers,
+                    h,
+                    where="mid",
+                    color=color,
+                    lw=1.2,
                     label=lbl,
                 )
                 _stepped_errorbar(ax, centers, h, sigma, color)
             ax.axvline(0.0, color="k", lw=0.5, alpha=0.5)
             ax.set_xlabel("log r")
             ax.set_ylabel("events (weighted)")
-            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            tname = (
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            )
             ax.set_title(f"{mode}: log r along {tname}", fontsize=10)
             ax.legend(fontsize=7)
             ax.set_yscale("log")
@@ -1347,9 +1640,19 @@ def plot_log_r_distribution(
 # 4) log r vs |perturbation| scan (shift and smear)
 # ============================================================================
 
+
 def plot_log_r_scan(
-    model, arch, y_dev, c_dev, n_features, w_event, args, positivity,
-    out_dir, sigma_pack_iu, sigma_pack_ju,
+    model,
+    arch,
+    y_dev,
+    c_dev,
+    n_features,
+    w_event,
+    args,
+    positivity,
+    out_dir,
+    sigma_pack_iu,
+    sigma_pack_ju,
 ):
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
     u_max = float(max(args.shift_factors))
@@ -1363,15 +1666,19 @@ def plot_log_r_scan(
     wsum = float(w64.sum())
 
     fig, axes = plt.subplots(
-        2, len(target_components),
+        2,
+        len(target_components),
         figsize=(4.5 * len(target_components), 7.0),
-        squeeze=False, layout="constrained",
+        squeeze=False,
+        layout="constrained",
     )
 
-    for row, (mode, grid, label_x) in enumerate([
-        ("shift", u_grid, "u (in σ_y units)"),
-        ("smear", sigma_grid, "|σ_vec| (in σ_y units)"),
-    ]):
+    for row, (mode, grid, label_x) in enumerate(
+        [
+            ("shift", u_grid, "u (in σ_y units)"),
+            ("smear", sigma_grid, "|σ_vec| (in σ_y units)"),
+        ]
+    ):
         for cidx, tcol in enumerate(target_components):
             ax = axes[row][cidx]
             means = []
@@ -1379,18 +1686,26 @@ def plot_log_r_scan(
             sigma_means = []
             for v in grid:
                 log_r = _common_predict_call(
-                    model, arch, y_dev, c_dev, float(v), int(tcol),
-                    mode, n_features, args.batch_size, positivity,
-                    sigma_pack_iu, sigma_pack_ju,
+                    model,
+                    arch,
+                    y_dev,
+                    c_dev,
+                    float(v),
+                    int(tcol),
+                    mode,
+                    n_features,
+                    args.batch_size,
+                    positivity,
+                    sigma_pack_iu,
+                    sigma_pack_ju,
                 ).astype(np.float64)
                 mean = (w64 * log_r).sum() / max(wsum, 1e-30)
                 var = (w64 * (log_r - mean) ** 2).sum() / max(wsum, 1e-30)
                 # Statistical uncertainty on the weighted mean:
                 #   σ²<x> = Σ wᵢ² (xᵢ − <x>)² / (Σ wᵢ)²
                 # = (effective-N) variance with Σw² in the numerator.
-                sigma_mean_sq = (
-                    (w64 * w64 * (log_r - mean) ** 2).sum()
-                    / max(wsum * wsum, 1e-60)
+                sigma_mean_sq = (w64 * w64 * (log_r - mean) ** 2).sum() / max(
+                    wsum * wsum, 1e-60
                 )
                 means.append(mean)
                 stds.append(math.sqrt(max(var, 0.0)))
@@ -1400,28 +1715,37 @@ def plot_log_r_scan(
             sigma_means = np.asarray(sigma_means)
             color = "C0" if mode == "shift" else "C2"
             ax.errorbar(
-                grid, means, yerr=sigma_means,
-                fmt="o-", color=color, lw=1.2, capsize=2,
+                grid,
+                means,
+                yerr=sigma_means,
+                fmt="o-",
+                color=color,
+                lw=1.2,
+                capsize=2,
                 label="⟨log r⟩  ± stat (√Σw²/Σw)",
             )
             ax.fill_between(
-                grid, means - stds, means + stds,
-                alpha=0.25, color=color, label="±1σ across events",
+                grid,
+                means - stds,
+                means + stds,
+                alpha=0.25,
+                color=color,
+                label="±1σ across events",
             )
             ax.axhline(0.0, color="k", lw=0.5, alpha=0.5)
             ax.axvline(0.0, color="k", lw=0.5, alpha=0.5)
             ax.set_xlabel(label_x)
             ax.set_ylabel("log r")
-            tname = TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            tname = (
+                TARGET_NAMES[tcol] if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+            )
             ax.set_title(
-                f"{mode}: ⟨log r⟩ along {tname}", fontsize=10,
+                f"{mode}: ⟨log r⟩ along {tname}",
+                fontsize=10,
             )
             ax.legend(fontsize=7)
 
-    fig.suptitle(
-        "MLP predicted log r — magnitude scan (top: shift / "
-        "bottom: smear)"
-    )
+    fig.suptitle("MLP predicted log r — magnitude scan (top: shift / " "bottom: smear)")
     _save(fig, os.path.join(out_dir, "log_r_scan.png"))
 
 
@@ -1429,11 +1753,21 @@ def plot_log_r_scan(
 # Optional: BCE-polyhead vs flow-truth scatter
 # ============================================================================
 
+
 def plot_polyhead_pred_vs_flow(
-    model, arch, flow, flow_stats, polyhead_stats,
-    target_std, cond, n_features, w_event,
-    args, out_dir,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    model,
+    arch,
+    flow,
+    flow_stats,
+    polyhead_stats,
+    target_std,
+    cond,
+    n_features,
+    w_event,
+    args,
+    out_dir,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Scatter / 2D-density of this script's polyhead-predicted W vs.
     a flow's analytic W on a common ``(y, c, u, σ)`` grid. Mirrors
@@ -1489,9 +1823,7 @@ def plot_polyhead_pred_vs_flow(
     half_sig = oversample * sigma_max_train
 
     g = torch.Generator().manual_seed(0)
-    delta_shift = (
-        torch.rand(n_use, generator=g) * 2.0 - 1.0
-    ) * half
+    delta_shift = (torch.rand(n_use, generator=g) * 2.0 - 1.0) * half
     v_shift = torch.randn(n_use, n_features, generator=g)
     v_shift = v_shift / v_shift.norm(dim=-1, keepdim=True).clamp_min(1e-30)
     sigma_smear = torch.rand(n_use, generator=g) * half_sig
@@ -1518,9 +1850,9 @@ def plot_polyhead_pred_vs_flow(
                 u = u_eval[s:e]
                 z, ladj = flow(c).transform.call_and_ladj(y)
                 z_p, ladj_p = flow(c).transform.call_and_ladj(y - u)
-                lw = -0.5 * (
-                    (z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)
-                ) + (ladj_p - ladj)
+                lw = -0.5 * ((z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)) + (
+                    ladj_p - ladj
+                )
                 out[s:e] = lw.cpu().numpy().astype(np.float32)
         return out
 
@@ -1542,9 +1874,16 @@ def plot_polyhead_pred_vs_flow(
 
         true_lw = flow_log_w_at(u_eval)
         pred_lw = predict_log_r_perevent(
-            model, arch, y_std_t, c_std_t, u_in, sigma_in,
-            args.batch_size, getattr(args, "_positivity", "exp"),
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            model,
+            arch,
+            y_std_t,
+            c_std_t,
+            u_in,
+            sigma_in,
+            args.batch_size,
+            getattr(args, "_positivity", "exp"),
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
         )
 
         # Weighted RMS / bias of pred − true.
@@ -1568,8 +1907,11 @@ def plot_polyhead_pred_vs_flow(
         bins = np.linspace(lo, hi, 80)
         h, xe, ye = np.histogram2d(x, y, bins=[bins, bins], weights=w_f)
         from matplotlib.colors import LogNorm
+
         ax.pcolormesh(
-            xe, ye, h.T,
+            xe,
+            ye,
+            h.T,
             norm=LogNorm(vmin=max(1.0, h.max() * 1e-4), vmax=h.max()),
             cmap="viridis",
         )
@@ -1589,10 +1931,19 @@ def plot_polyhead_pred_vs_flow(
 
 
 def plot_polyhead_axis_logw_error_vs_flow(
-    model, arch, flow, flow_stats, polyhead_stats,
-    target_std, cond, n_features, w_event,
-    args, out_dir,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    model,
+    arch,
+    flow,
+    flow_stats,
+    polyhead_stats,
+    target_std,
+    cond,
+    n_features,
+    w_event,
+    args,
+    out_dir,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Per-axis polyhead-vs-flow log-W error histograms at the
     closure shift magnitudes. Mirror of
@@ -1642,9 +1993,9 @@ def plot_polyhead_axis_logw_error_vs_flow(
                 c = c_std_t[s:e]
                 z, ladj = flow(c).transform.call_and_ladj(y)
                 z_p, ladj_p = flow(c).transform.call_and_ladj(y - u)
-                lw = -0.5 * (
-                    (z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)
-                ) + (ladj_p - ladj)
+                lw = -0.5 * ((z_p * z_p).sum(dim=-1) - (z * z).sum(dim=-1)) + (
+                    ladj_p - ladj
+                )
                 out[s:e] = lw.cpu().numpy().astype(np.float32)
         return out
 
@@ -1653,12 +2004,18 @@ def plot_polyhead_axis_logw_error_vs_flow(
         for c, axis in enumerate(target_components):
             true_lw = flow_log_w_axis(float(factor), int(axis))
             pred_lw = predict_log_r_axis(
-                model, arch, y_std_t, c_std_t,
-                u_axis_value=float(factor), sigma_axis_value=0.0,
-                tcol=int(axis), n_features=n_features,
+                model,
+                arch,
+                y_std_t,
+                c_std_t,
+                u_axis_value=float(factor),
+                sigma_axis_value=0.0,
+                tcol=int(axis),
+                n_features=n_features,
                 batch_size=args.batch_size,
                 positivity=getattr(args, "_positivity", "exp"),
-                sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+                sigma_pack_iu=sigma_pack_iu,
+                sigma_pack_ju=sigma_pack_ju,
             )
             log_err = pred_lw - true_lw
             finite = np.isfinite(log_err)
@@ -1668,15 +2025,18 @@ def plot_polyhead_axis_logw_error_vs_flow(
             if wsum <= 0.0:
                 rms = bias = float("nan")
             else:
-                rms = float(np.sqrt(np.average(le ** 2, weights=wle)))
+                rms = float(np.sqrt(np.average(le**2, weights=wle)))
                 bias = float(np.average(le, weights=wle))
             panel_data[r][c] = (le, wle, rms, bias)
 
     for yscale, suffix in (("linear", ""), ("log", "_log")):
         fig, axes = plt.subplots(
-            n_rows, n_cols,
+            n_rows,
+            n_cols,
             figsize=(4.0 * n_cols, 3.0 * n_rows),
-            sharex="row", sharey="row", squeeze=False,
+            sharex="row",
+            sharey="row",
+            squeeze=False,
         )
         for r, factor in enumerate(deltas):
             spreads = []
@@ -1690,24 +2050,24 @@ def plot_polyhead_axis_logw_error_vs_flow(
                 ax = axes[r][c]
                 le, wle, rms, bias = panel_data[r][c]
                 ax.hist(
-                    le, bins=bins, weights=wle, histtype="step",
-                    color="C0", lw=1.5,
+                    le,
+                    bins=bins,
+                    weights=wle,
+                    histtype="step",
+                    color="C0",
+                    lw=1.5,
                 )
                 ax.axvline(0.0, color="k", lw=0.8, alpha=0.5)
                 ax.set_title(
-                    f"|δ|={factor:g} along {name}: "
-                    f"rms={rms:.4f} bias={bias:+.4f}"
+                    f"|δ|={factor:g} along {name}: " f"rms={rms:.4f} bias={bias:+.4f}"
                 )
                 ax.set_yscale(yscale)
                 if r == n_rows - 1:
-                    ax.set_xlabel(
-                        r"$\log(\hat W) - \log W_{\rm flow}$"
-                    )
+                    ax.set_xlabel(r"$\log(\hat W) - \log W_{\rm flow}$")
                 if c == 0:
                     ax.set_ylabel("weighted events")
         fig.suptitle(
-            "BCE polyhead reconstruction error vs flow, "
-            "axis-aligned shifts"
+            "BCE polyhead reconstruction error vs flow, " "axis-aligned shifts"
         )
         fig.tight_layout()
         _save(
@@ -1722,6 +2082,7 @@ def plot_polyhead_axis_logw_error_vs_flow(
 # ============================================================================
 # Per-source target-distribution comparison
 # ============================================================================
+
 
 def _parse_source_labels(spec):
     """Parse ``["0:Jpsi", "100:Zmumu"]`` into ``{0: "Jpsi", 100: "Zmumu"}``."""
@@ -1765,7 +2126,8 @@ def _read_manifest_source_labels(paths):
                 mfp = p
             else:
                 cand = os.path.join(
-                    os.path.dirname(os.path.abspath(p)), "manifest.json",
+                    os.path.dirname(os.path.abspath(p)),
+                    "manifest.json",
                 )
                 if os.path.exists(cand):
                     mfp = cand
@@ -1787,9 +2149,18 @@ def _read_manifest_source_labels(paths):
 
 
 def _load_per_source_window(
-    paths, *, pt_min, pt_max, eta_min, eta_max,
-    max_events=-1, n_workers=8, weight_mode="abs",
-    split="all", val_fraction=0.1, holdout_fraction=0.1,
+    paths,
+    *,
+    pt_min,
+    pt_max,
+    eta_min,
+    eta_max,
+    max_events=-1,
+    n_workers=8,
+    weight_mode="abs",
+    split="all",
+    val_fraction=0.1,
+    holdout_fraction=0.1,
 ):
     """Parallel streaming loader specialised for the per-source target-
     distribution plots.
@@ -1810,6 +2181,7 @@ def _load_per_source_window(
     those that passed the (pt, eta, finite, w>0) mask.
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
+
     import pyarrow as pa
     import pyarrow.ipc as ipc
 
@@ -1818,9 +2190,7 @@ def _load_per_source_window(
 
     paths = _expand_input_paths(paths)
     if not paths:
-        raise ValueError(
-            "_load_per_source_window: no input paths after expansion"
-        )
+        raise ValueError("_load_per_source_window: no input paths after expansion")
     if not all(p.endswith(".arrow") for p in paths):
         raise ValueError(
             "_load_per_source_window: only Arrow IPC shards (.arrow) "
@@ -1837,14 +2207,14 @@ def _load_per_source_window(
             if head == _MAGIC:
                 reader = ipc.open_file(f)
                 lo, hi = split_batch_range(
-                    reader.num_record_batches, split,
-                    val_fraction, holdout_fraction,
+                    reader.num_record_batches,
+                    split,
+                    val_fraction,
+                    holdout_fraction,
                 )
                 if hi <= lo:
                     return None, 0
-                t = pa.Table.from_batches(
-                    [reader.get_batch(i) for i in range(lo, hi)]
-                )
+                t = pa.Table.from_batches([reader.get_batch(i) for i in range(lo, hi)])
             else:
                 t = ipc.open_stream(f).read_all()
         eta_r = t["eta_reco"].to_numpy().astype(np.float64)
@@ -1863,17 +2233,24 @@ def _load_per_source_window(
         pt_g = 1.0 / (safe_k * np.cosh(eta_g))
         mask = (
             np.isfinite(pt_g)
-            & (pt_g >= pt_min) & (pt_g <= pt_max)
-            & (eta_g >= eta_min) & (eta_g <= eta_max)
-            & np.isfinite(kappa_r) & np.isfinite(kappa_g)
+            & (pt_g >= pt_min)
+            & (pt_g <= pt_max)
+            & (eta_g >= eta_min)
+            & (eta_g <= eta_max)
+            & np.isfinite(kappa_r)
+            & np.isfinite(kappa_g)
             & w_mask
         )
         if not mask.any():
             return None, n_block
-        eta_r = eta_r[mask]; phi_r = phi_r[mask]
-        eta_g = eta_g[mask]; phi_g = phi_g[mask]
-        kappa_r = kappa_r[mask]; kappa_g = kappa_g[mask]
-        w = w_handled[mask]; sid = sid[mask]
+        eta_r = eta_r[mask]
+        phi_r = phi_r[mask]
+        eta_g = eta_g[mask]
+        phi_g = phi_g[mask]
+        kappa_r = kappa_r[mask]
+        kappa_g = kappa_g[mask]
+        w = w_handled[mask]
+        sid = sid[mask]
 
         # Inline target columns from compute_targets_and_conditioning,
         # restricted to the masked rows so we never form full-shard
@@ -1882,7 +2259,8 @@ def _load_per_source_window(
         lam_g = np.arctan(np.sinh(eta_g))
         r_kappa = kappa_r / kappa_g - 1.0
         dphi = np.arctan2(
-            np.sin(phi_r - phi_g), np.cos(phi_r - phi_g),
+            np.sin(phi_r - phi_g),
+            np.cos(phi_r - phi_g),
         )
         dlambda = lam_r - lam_g
         target = np.stack([r_kappa, dlambda, dphi], axis=1)
@@ -1901,10 +2279,7 @@ def _load_per_source_window(
             try:
                 res, n_block = fut.result()
             except Exception as exc:  # noqa: BLE001
-                print(
-                    f"[per-source loader] shard {futures[fut]} failed: "
-                    f"{exc!r}"
-                )
+                print(f"[per-source loader] shard {futures[fut]} failed: " f"{exc!r}")
                 continue
             rows_read += n_block
             if res is not None:
@@ -1927,7 +2302,13 @@ def _load_per_source_window(
 
 
 def plot_per_source_target_distributions(
-    target, w_event, source_id, kappa_g, eta_g, args, out_dir,
+    target,
+    w_event,
+    source_id,
+    kappa_g,
+    eta_g,
+    args,
+    out_dir,
 ):
     """Compare the marginal target distributions across datasets
     (distinct ``source_id`` values) inside a phase-space window in
@@ -1958,8 +2339,10 @@ def plot_per_source_target_distributions(
     eta_max = float(args.cmp_eta_max)
     base_mask = (
         np.isfinite(pt_g)
-        & (pt_g >= pt_min) & (pt_g <= pt_max)
-        & (eta_g >= eta_min) & (eta_g <= eta_max)
+        & (pt_g >= pt_min)
+        & (pt_g <= pt_max)
+        & (eta_g >= eta_min)
+        & (eta_g <= eta_max)
     )
 
     # Charge modes: ``each`` runs pos and neg in separate plots.
@@ -1976,6 +2359,7 @@ def plot_per_source_target_distributions(
     label_map = dict(DEFAULT_SOURCE_LABELS)
     label_map.update(_read_manifest_source_labels(args.input_files))
     label_map.update(_parse_source_labels(args.cmp_source_labels))
+
     def _source_label(sid):
         return label_map.get(int(sid), f"source {int(sid)}")
 
@@ -2016,21 +2400,19 @@ def plot_per_source_target_distributions(
 
         min_n = int(getattr(args, "cmp_source_min_events", 0))
         if min_n > 0:
-            src_counts = {
-                int(s): int((src_w == s).sum()) for s in unique_sources
-            }
+            src_counts = {int(s): int((src_w == s).sum()) for s in unique_sources}
             kept = [s for s in unique_sources if src_counts[int(s)] >= min_n]
             dropped = [
                 (int(s), src_counts[int(s)])
-                for s in unique_sources if src_counts[int(s)] < min_n
+                for s in unique_sources
+                if src_counts[int(s)] < min_n
             ]
             if dropped:
                 print(
                     "[per-source target distributions] dropped sources "
                     f"with <{min_n} events in {charge_mode} window: "
                     + ", ".join(
-                        f"{_source_label(sid)} (id={sid}, N={n})"
-                        for sid, n in dropped
+                        f"{_source_label(sid)} (id={sid}, N={n})" for sid, n in dropped
                     )
                 )
             unique_sources = kept
@@ -2089,9 +2471,11 @@ def plot_per_source_target_distributions(
             centers = 0.5 * (bins[:-1] + bins[1:])
             bw = bins[1] - bins[0]
 
-            ref_mask = (s_col == ref_source)
+            ref_mask = s_col == ref_source
             h_ref, e_ref = _weighted_hist_err(
-                y[ref_mask], bins, w_col[ref_mask],
+                y[ref_mask],
+                bins,
+                w_col[ref_mask],
             )
             norm_ref = h_ref.sum()
             if norm_ref <= 0:
@@ -2106,7 +2490,7 @@ def plot_per_source_target_distributions(
 
             per_source = []
             for i, sid in enumerate(unique_sources):
-                sm = (s_col == sid)
+                sm = s_col == sid
                 if sm.sum() == 0:
                     continue
                 h, e = _weighted_hist_err(y[sm], bins, w_col[sm])
@@ -2115,13 +2499,15 @@ def plot_per_source_target_distributions(
                     continue
                 h_n = h / (tot * bw)
                 e_n = e / (tot * bw)
-                per_source.append({
-                    "sid": int(sid),
-                    "n": int(sm.sum()),
-                    "color": f"C{i}",
-                    "h": h_n,
-                    "e": e_n,
-                })
+                per_source.append(
+                    {
+                        "sid": int(sid),
+                        "n": int(sm.sum()),
+                        "color": f"C{i}",
+                        "h": h_n,
+                        "e": e_n,
+                    }
+                )
 
             per_col[tcol] = {
                 "centers": centers,
@@ -2134,15 +2520,15 @@ def plot_per_source_target_distributions(
             continue
 
         ch_tag = {"pos": "q>0", "neg": "q<0", "both": "both q"}[charge_mode]
-        ch_suffix = {"pos": "_qpos", "neg": "_qneg", "both": "_qboth"}[
-            charge_mode
-        ]
+        ch_suffix = {"pos": "_qpos", "neg": "_qneg", "both": "_qboth"}[charge_mode]
 
         for yscale, ysuffix in (("linear", ""), ("log", "_log")):
             fig, axes = plt.subplots(
-                2, n_cols,
+                2,
+                n_cols,
                 figsize=(4.5 * n_cols, 6.5),
-                sharex="col", squeeze=False,
+                sharex="col",
+                squeeze=False,
                 gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
                 layout="constrained",
             )
@@ -2163,24 +2549,43 @@ def plot_per_source_target_distributions(
                     color = entry["color"]
                     lbl = f"{_source_label(sid)}  (N={entry['n']})"
                     ax_main.step(
-                        centers, entry["h"], where="mid",
-                        color=color, lw=1.2, label=lbl,
+                        centers,
+                        entry["h"],
+                        where="mid",
+                        color=color,
+                        lw=1.2,
+                        label=lbl,
                     )
                     _stepped_errorbar(
-                        ax_main, centers, entry["h"], entry["e"], color,
+                        ax_main,
+                        centers,
+                        entry["h"],
+                        entry["e"],
+                        color,
                     )
 
                     if sid == ref_source:
                         ax_ratio.axhline(1.0, color=color, lw=0.8)
                         continue
                     ratio, e_ratio = _ratio_with_err(
-                        entry["h"], entry["e"], h_ref_n, e_ref_n,
+                        entry["h"],
+                        entry["e"],
+                        h_ref_n,
+                        e_ref_n,
                     )
                     ax_ratio.step(
-                        centers, ratio, where="mid", color=color, lw=1.0,
+                        centers,
+                        ratio,
+                        where="mid",
+                        color=color,
+                        lw=1.0,
                     )
                     _stepped_errorbar(
-                        ax_ratio, centers, ratio, e_ratio, color,
+                        ax_ratio,
+                        centers,
+                        ratio,
+                        e_ratio,
+                        color,
                     )
 
                 ax_main.set_yscale(yscale)
@@ -2194,11 +2599,13 @@ def plot_per_source_target_distributions(
 
                 ax_ratio.axhline(1.0, color="k", lw=0.4, alpha=0.4)
                 ax_ratio.set_ylabel(
-                    f"ratio /\n{_source_label(ref_source)}", fontsize=8,
+                    f"ratio /\n{_source_label(ref_source)}",
+                    fontsize=8,
                 )
                 ax_ratio.set_xlabel(
                     TARGET_NAMES[tcol]
-                    if tcol < len(TARGET_NAMES) else f"target[{tcol}]"
+                    if tcol < len(TARGET_NAMES)
+                    else f"target[{tcol}]"
                 )
                 ax_ratio.set_ylim(0.5, 1.5)
 
@@ -2236,18 +2643,34 @@ def plot_per_source_target_distributions(
 # group's reweighted curve and ratio; ``raw_color`` for the raw curve
 # in the kinematic-validation plot.
 _AGG_GROUPS = (
-    {"raw":  443, "name": "jpsi",   "label": r"J/$\psi$",
-     "main_color": "C0", "raw_color": "C0", "ref": True},
-    {"raw":  1,   "name": "prompt", "label": "W/Z prompt",
-     "main_color": "C1", "raw_color": "C3", "ref": False},
-    {"raw":  15,  "name": "tau",    "label": r"W/Z $\tau$-decay",
-     "main_color": "C2", "raw_color": "C4", "ref": False},
+    {
+        "raw": 443,
+        "name": "jpsi",
+        "label": r"J/$\psi$",
+        "main_color": "C0",
+        "raw_color": "C0",
+        "ref": True,
+    },
+    {
+        "raw": 1,
+        "name": "prompt",
+        "label": "W/Z prompt",
+        "main_color": "C1",
+        "raw_color": "C3",
+        "ref": False,
+    },
+    {
+        "raw": 15,
+        "name": "tau",
+        "label": r"W/Z $\tau$-decay",
+        "main_color": "C2",
+        "raw_color": "C4",
+        "ref": False,
+    },
 )
 _AGG_REF_NAME = "jpsi"
 _AGG_NAMES = tuple(g["name"] for g in _AGG_GROUPS)
-_AGG_NONREF_NAMES = tuple(
-    g["name"] for g in _AGG_GROUPS if not g["ref"]
-)
+_AGG_NONREF_NAMES = tuple(g["name"] for g in _AGG_GROUPS if not g["ref"])
 
 
 def _agg_group_masks(muon_source):
@@ -2259,10 +2682,20 @@ def _agg_group_masks(muon_source):
 
 
 def _stream_pteta_charge_3d(
-    paths, *, pt_min, pt_max, eta_min, eta_max,
-    pt_edges, eta_edges, charge_edges,
-    n_workers=8, weight_mode="abs",
-    split="all", val_fraction=0.1, holdout_fraction=0.1,
+    paths,
+    *,
+    pt_min,
+    pt_max,
+    eta_min,
+    eta_max,
+    pt_edges,
+    eta_edges,
+    charge_edges,
+    n_workers=8,
+    weight_mode="abs",
+    split="all",
+    val_fraction=0.1,
+    holdout_fraction=0.1,
 ):
     """Pass 1: stream shards and fill weighted 3D ``(pt, η, charge)``
     histograms per ``muon_source`` group (J/ψ, prompt, τ).
@@ -2274,10 +2707,11 @@ def _stream_pteta_charge_3d(
       * ``n_kept``     -- ``{group_name: int}`` count of windowed rows
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
+
     import pyarrow as pa
     import pyarrow.ipc as ipc
-    from train_muon_response_flow import _expand_input_paths
     from arrow_shard_loader import split_batch_range
+    from train_muon_response_flow import _expand_input_paths
 
     paths = _expand_input_paths(paths)
     _MAGIC = b"ARROW1"
@@ -2294,15 +2728,15 @@ def _stream_pteta_charge_3d(
             if head == _MAGIC:
                 reader = ipc.open_file(f)
                 lo, hi = split_batch_range(
-                    reader.num_record_batches, split,
-                    val_fraction, holdout_fraction,
+                    reader.num_record_batches,
+                    split,
+                    val_fraction,
+                    holdout_fraction,
                 )
                 if hi <= lo:
                     empty_H = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
                     return empty_H, dict(empty_H), 0, {n: 0 for n in _AGG_NAMES}
-                t = pa.Table.from_batches(
-                    [reader.get_batch(i) for i in range(lo, hi)]
-                )
+                t = pa.Table.from_batches([reader.get_batch(i) for i in range(lo, hi)])
             else:
                 t = ipc.open_stream(f).read_all()
         eta_g = t["eta_gen"].to_numpy().astype(np.float64)
@@ -2317,9 +2751,12 @@ def _stream_pteta_charge_3d(
         pt_g = 1.0 / (safe_k * np.cosh(eta_g))
         mask = (
             np.isfinite(pt_g)
-            & (pt_g >= pt_min) & (pt_g <= pt_max)
-            & (eta_g >= eta_min) & (eta_g <= eta_max)
-            & np.isfinite(kappa_g) & w_mask
+            & (pt_g >= pt_min)
+            & (pt_g <= pt_max)
+            & (eta_g >= eta_min)
+            & (eta_g <= eta_max)
+            & np.isfinite(kappa_g)
+            & w_mask
         )
         partial_H = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
         partial_H2 = {n: np.zeros(shape, dtype=np.float64) for n in _AGG_NAMES}
@@ -2327,8 +2764,11 @@ def _stream_pteta_charge_3d(
         if not mask.any():
             return partial_H, partial_H2, n_block, partial_kept
 
-        eta_g = eta_g[mask]; kappa_g = kappa_g[mask]
-        pt_g = pt_g[mask]; w = w_handled[mask]; ms = ms[mask]
+        eta_g = eta_g[mask]
+        kappa_g = kappa_g[mask]
+        pt_g = pt_g[mask]
+        w = w_handled[mask]
+        ms = ms[mask]
         charge_g = np.where(kappa_g >= 0, 1.0, -1.0)
         group_masks = _agg_group_masks(ms)
 
@@ -2337,12 +2777,15 @@ def _stream_pteta_charge_3d(
             if not gm.any():
                 continue
             coords = np.stack(
-                [pt_g[gm], eta_g[gm], charge_g[gm]], axis=1,
+                [pt_g[gm], eta_g[gm], charge_g[gm]],
+                axis=1,
             )
             ww = w[gm]
             partial_H[name] = np.histogramdd(coords, bins=bins, weights=ww)[0]
             partial_H2[name] = np.histogramdd(
-                coords, bins=bins, weights=ww * ww,
+                coords,
+                bins=bins,
+                weights=ww * ww,
             )[0]
             partial_kept[name] = int(gm.sum())
         return partial_H, partial_H2, n_block, partial_kept
@@ -2357,9 +2800,7 @@ def _stream_pteta_charge_3d(
             try:
                 pH, pH2, n_b, pk = fut.result()
             except Exception as exc:  # noqa: BLE001
-                print(
-                    f"[agg pass-1] shard {futures[fut]} failed: {exc!r}"
-                )
+                print(f"[agg pass-1] shard {futures[fut]} failed: {exc!r}")
                 continue
             rows_read += n_b
             for name in _AGG_NAMES:
@@ -2370,11 +2811,23 @@ def _stream_pteta_charge_3d(
 
 
 def _stream_aggregated_targets(
-    paths, *, pt_min, pt_max, eta_min, eta_max,
-    pt_edges, eta_edges, charge_edges,
-    weight_grids, target_axes_edges,
-    n_workers=8, weight_mode="abs", charge_filter=None,
-    split="all", val_fraction=0.1, holdout_fraction=0.1,
+    paths,
+    *,
+    pt_min,
+    pt_max,
+    eta_min,
+    eta_max,
+    pt_edges,
+    eta_edges,
+    charge_edges,
+    weight_grids,
+    target_axes_edges,
+    n_workers=8,
+    weight_mode="abs",
+    charge_filter=None,
+    split="all",
+    val_fraction=0.1,
+    holdout_fraction=0.1,
 ):
     """Pass 2: stream shards and accumulate 1D target-distribution
     histograms per (axis × group × {raw, reweighted}). The reference
@@ -2391,10 +2844,11 @@ def _stream_aggregated_targets(
     for the raw curves (only the ref group skips the ``_raw_`` pair
     since its "raw" and "reweighted" are identical)."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
+
     import pyarrow as pa
     import pyarrow.ipc as ipc
-    from train_muon_response_flow import _expand_input_paths
     from arrow_shard_loader import split_batch_range
+    from train_muon_response_flow import _expand_input_paths
 
     paths = _expand_input_paths(paths)
     _MAGIC = b"ARROW1"
@@ -2426,14 +2880,14 @@ def _stream_aggregated_targets(
             if head == _MAGIC:
                 reader = ipc.open_file(f)
                 lo, hi = split_batch_range(
-                    reader.num_record_batches, split,
-                    val_fraction, holdout_fraction,
+                    reader.num_record_batches,
+                    split,
+                    val_fraction,
+                    holdout_fraction,
                 )
                 if hi <= lo:
                     return _empty_partial()
-                t = pa.Table.from_batches(
-                    [reader.get_batch(i) for i in range(lo, hi)]
-                )
+                t = pa.Table.from_batches([reader.get_batch(i) for i in range(lo, hi)])
             else:
                 t = ipc.open_stream(f).read_all()
         eta_r = t["eta_reco"].to_numpy().astype(np.float64)
@@ -2451,31 +2905,40 @@ def _stream_aggregated_targets(
         pt_g = 1.0 / (safe_k * np.cosh(eta_g))
         mask = (
             np.isfinite(pt_g)
-            & (pt_g >= pt_min) & (pt_g <= pt_max)
-            & (eta_g >= eta_min) & (eta_g <= eta_max)
-            & np.isfinite(kappa_r) & np.isfinite(kappa_g)
+            & (pt_g >= pt_min)
+            & (pt_g <= pt_max)
+            & (eta_g >= eta_min)
+            & (eta_g <= eta_max)
+            & np.isfinite(kappa_r)
+            & np.isfinite(kappa_g)
             & w_mask
         )
         if charge_filter is not None:
             if charge_filter > 0:
-                mask &= (kappa_g >= 0)
+                mask &= kappa_g >= 0
             else:
-                mask &= (kappa_g < 0)
+                mask &= kappa_g < 0
         partial = _empty_partial()
         if not mask.any():
             return partial
 
-        eta_r = eta_r[mask]; phi_r = phi_r[mask]
-        eta_g = eta_g[mask]; phi_g = phi_g[mask]
-        kappa_r = kappa_r[mask]; kappa_g = kappa_g[mask]
-        pt_g = pt_g[mask]; w = w_handled[mask]; ms = ms[mask]
+        eta_r = eta_r[mask]
+        phi_r = phi_r[mask]
+        eta_g = eta_g[mask]
+        phi_g = phi_g[mask]
+        kappa_r = kappa_r[mask]
+        kappa_g = kappa_g[mask]
+        pt_g = pt_g[mask]
+        w = w_handled[mask]
+        ms = ms[mask]
 
         # Targets inline.
         lam_r = np.arctan(np.sinh(eta_r))
         lam_g = np.arctan(np.sinh(eta_g))
         r_kappa = kappa_r / kappa_g - 1.0
         dphi = np.arctan2(
-            np.sin(phi_r - phi_g), np.cos(phi_r - phi_g),
+            np.sin(phi_r - phi_g),
+            np.cos(phi_r - phi_g),
         )
         dlambda = lam_r - lam_g
         target_cols = (r_kappa, dlambda, dphi)
@@ -2500,19 +2963,21 @@ def _stream_aggregated_targets(
                 w_raw_g = w[gm]
                 h, _ = np.histogram(y_g, bins=edges, weights=w_raw_g)
                 h2, _ = np.histogram(
-                    y_g, bins=edges, weights=w_raw_g * w_raw_g,
+                    y_g,
+                    bins=edges,
+                    weights=w_raw_g * w_raw_g,
                 )
                 partial[k][f"{name}_raw_h"] = h
                 partial[k][f"{name}_raw_h2"] = h2
                 if name == _AGG_REF_NAME:
                     continue
-                rew_g = weight_grids[name][
-                    pt_idx[gm], eta_idx[gm], ch_idx[gm]
-                ]
+                rew_g = weight_grids[name][pt_idx[gm], eta_idx[gm], ch_idx[gm]]
                 w_rew = w_raw_g * rew_g
                 h_rw, _ = np.histogram(y_g, bins=edges, weights=w_rew)
                 h_rw2, _ = np.histogram(
-                    y_g, bins=edges, weights=w_rew * w_rew,
+                    y_g,
+                    bins=edges,
+                    weights=w_rew * w_rew,
                 )
                 partial[k][f"{name}_h"] = h_rw
                 partial[k][f"{name}_h2"] = h_rw2
@@ -2525,9 +2990,7 @@ def _stream_aggregated_targets(
             try:
                 partial = fut.result()
             except Exception as exc:  # noqa: BLE001
-                print(
-                    f"[agg pass-2] shard {futures[fut]} failed: {exc!r}"
-                )
+                print(f"[agg pass-2] shard {futures[fut]} failed: {exc!r}")
                 continue
             for k in range(F):
                 for key in totals[k]:
@@ -2536,8 +2999,16 @@ def _stream_aggregated_targets(
 
 
 def _plot_agg_kinematic_validation_2d(
-    H, weight_grids, pt_edges, eta_edges, charge_edges, out_dir,
-    *, charge_filter=None, ch_suffix="", ch_tag="charge integrated",
+    H,
+    weight_grids,
+    pt_edges,
+    eta_edges,
+    charge_edges,
+    out_dir,
+    *,
+    charge_filter=None,
+    ch_suffix="",
+    ch_tag="charge integrated",
 ):
     """2D ``(pt_gen, η_gen)`` heatmaps for each ``muon_source`` group
     summed over the (possibly filtered) charge axis. Panels: J/ψ
@@ -2578,21 +3049,31 @@ def _plot_agg_kinematic_validation_2d(
     norm = LogNorm(vmin=max(vmin, 1e-6 * vmax), vmax=vmax)
 
     fig, axes = plt.subplots(
-        1, len(panels), figsize=(3.8 * len(panels), 4.2),
-        sharey=True, layout="constrained",
+        1,
+        len(panels),
+        figsize=(3.8 * len(panels), 4.2),
+        sharey=True,
+        layout="constrained",
     )
     pt_edges_arr = np.asarray(pt_edges, dtype=np.float64)
     eta_edges_arr = np.asarray(eta_edges, dtype=np.float64)
     for ax, (title, Hp) in zip(axes, panels):
         mesh = ax.pcolormesh(
-            eta_edges_arr, pt_edges_arr, Hp, norm=norm,
-            cmap="viridis", shading="flat",
+            eta_edges_arr,
+            pt_edges_arr,
+            Hp,
+            norm=norm,
+            cmap="viridis",
+            shading="flat",
         )
         ax.set_title(title, fontsize=9)
         ax.set_xlabel("eta_gen")
     axes[0].set_ylabel("pt_gen [GeV]")
     fig.colorbar(
-        mesh, ax=axes, shrink=0.85, label=f"Σ w ({ch_tag})",
+        mesh,
+        ax=axes,
+        shrink=0.85,
+        label=f"Σ w ({ch_tag})",
     )
     fig.suptitle(
         "Aggregated J/$\\psi$ vs prompt vs τ 2D kinematic validation  "
@@ -2608,9 +3089,18 @@ def _plot_agg_kinematic_validation_2d(
 
 
 def _plot_agg_kinematic_validation(
-    H, H_w2, weight_grids,
-    pt_edges, eta_edges, charge_edges, args, out_dir,
-    *, charge_filter=None, ch_suffix="", ch_tag="charge integrated",
+    H,
+    H_w2,
+    weight_grids,
+    pt_edges,
+    eta_edges,
+    charge_edges,
+    args,
+    out_dir,
+    *,
+    charge_filter=None,
+    ch_suffix="",
+    ch_tag="charge integrated",
 ):
     """Plot the (pt_gen, η_gen, charge_gen) marginals for J/ψ vs the
     prompt and τ-decay raw + reweighted distributions, with the bottom
@@ -2664,8 +3154,11 @@ def _plot_agg_kinematic_validation(
         panel_axes = panel_axes_all[:2]
     n_cols = len(panel_axes)
     fig, axes = plt.subplots(
-        2, n_cols, figsize=(4.8 * n_cols, 6.5),
-        sharex="col", squeeze=False,
+        2,
+        n_cols,
+        figsize=(4.8 * n_cols, 6.5),
+        sharex="col",
+        squeeze=False,
         gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
         layout="constrained",
     )
@@ -2693,11 +3186,19 @@ def _plot_agg_kinematic_validation(
             _marg(H_w2_sel[ref_g["name"]], axis_keep),
         )
         ax_main.step(
-            centers, h_ref_n, where="mid",
-            color=ref_g["main_color"], lw=1.4, label=ref_g["label"],
+            centers,
+            h_ref_n,
+            where="mid",
+            color=ref_g["main_color"],
+            lw=1.4,
+            label=ref_g["label"],
         )
         _stepped_errorbar(
-            ax_main, centers, h_ref_n, s_ref_n, ref_g["main_color"],
+            ax_main,
+            centers,
+            h_ref_n,
+            s_ref_n,
+            ref_g["main_color"],
         )
 
         # Non-reference groups: raw + reweighted.
@@ -2712,42 +3213,78 @@ def _plot_agg_kinematic_validation(
                 _marg(H_rew_w2[name], axis_keep),
             )
             ax_main.step(
-                centers, h_raw_n, where="mid",
-                color=g["raw_color"], lw=1.0, linestyle=":",
+                centers,
+                h_raw_n,
+                where="mid",
+                color=g["raw_color"],
+                lw=1.0,
+                linestyle=":",
                 label=f"{g['label']} (raw)",
             )
             _stepped_errorbar(
-                ax_main, centers, h_raw_n, s_raw_n, g["raw_color"],
+                ax_main,
+                centers,
+                h_raw_n,
+                s_raw_n,
+                g["raw_color"],
             )
             ax_main.step(
-                centers, h_rew_n, where="mid",
-                color=g["main_color"], lw=1.2,
+                centers,
+                h_rew_n,
+                where="mid",
+                color=g["main_color"],
+                lw=1.2,
                 label=f"{g['label']} (rew)",
             )
             _stepped_errorbar(
-                ax_main, centers, h_rew_n, s_rew_n, g["main_color"],
+                ax_main,
+                centers,
+                h_rew_n,
+                s_rew_n,
+                g["main_color"],
             )
 
             # Bottom-panel ratios to J/ψ.
             r_raw, e_raw = _ratio_with_err(
-                h_raw_n, s_raw_n, h_ref_n, s_ref_n,
+                h_raw_n,
+                s_raw_n,
+                h_ref_n,
+                s_ref_n,
             )
             r_rew, e_rew = _ratio_with_err(
-                h_rew_n, s_rew_n, h_ref_n, s_ref_n,
+                h_rew_n,
+                s_rew_n,
+                h_ref_n,
+                s_ref_n,
             )
             ax_ratio.step(
-                centers, r_raw, where="mid",
-                color=g["raw_color"], lw=0.9, linestyle=":",
+                centers,
+                r_raw,
+                where="mid",
+                color=g["raw_color"],
+                lw=0.9,
+                linestyle=":",
             )
             _stepped_errorbar(
-                ax_ratio, centers, r_raw, e_raw, g["raw_color"],
+                ax_ratio,
+                centers,
+                r_raw,
+                e_raw,
+                g["raw_color"],
             )
             ax_ratio.step(
-                centers, r_rew, where="mid",
-                color=g["main_color"], lw=1.0,
+                centers,
+                r_rew,
+                where="mid",
+                color=g["main_color"],
+                lw=1.0,
             )
             _stepped_errorbar(
-                ax_ratio, centers, r_rew, e_rew, g["main_color"],
+                ax_ratio,
+                centers,
+                r_rew,
+                e_rew,
+                g["main_color"],
             )
 
         ax_main.set_ylabel("p.d.f.")
@@ -2800,8 +3337,13 @@ def plot_aggregated_target_distributions(stats, paths, args, out_dir):
     t0 = _tic()
     H, H_w2, rows_read, n_kept = _stream_pteta_charge_3d(
         paths,
-        pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
-        pt_edges=pt_edges, eta_edges=eta_edges, charge_edges=charge_edges,
+        pt_min=pt_min,
+        pt_max=pt_max,
+        eta_min=eta_min,
+        eta_max=eta_max,
+        pt_edges=pt_edges,
+        eta_edges=eta_edges,
+        charge_edges=charge_edges,
         n_workers=int(args.cmp_workers),
         weight_mode=str(args.weight_handling),
         split=str(args.split),
@@ -2810,9 +3352,7 @@ def plot_aggregated_target_distributions(stats, paths, args, out_dir):
     )
     t0 = _toc("agg pass-1 (pt-η-charge 3D)", t0)
     sums = {n: float(H[n].sum()) for n in _AGG_NAMES}
-    counts_str = "  ".join(
-        f"{n}: {n_kept[n]:,} (Σw={sums[n]:.3g})" for n in _AGG_NAMES
-    )
+    counts_str = "  ".join(f"{n}: {n_kept[n]:,} (Σw={sums[n]:.3g})" for n in _AGG_NAMES)
     print(f"[agg]   read {rows_read:,} rows; per-group kept: {counts_str}")
     if sums[_AGG_REF_NAME] <= 0:
         print(
@@ -2862,8 +3402,7 @@ def plot_aggregated_target_distributions(stats, paths, args, out_dir):
     nsig = float(args.cmp_agg_range_sigma)
     n_bins = int(args.cmp_agg_n_bins)
     target_axes_edges = [
-        np.linspace(means[k] - nsig * stds[k], means[k] + nsig * stds[k],
-                    n_bins + 1)
+        np.linspace(means[k] - nsig * stds[k], means[k] + nsig * stds[k], n_bins + 1)
         for k in range(min(3, len(means)))
     ]
 
@@ -2874,23 +3413,43 @@ def plot_aggregated_target_distributions(stats, paths, args, out_dir):
         print(f"[agg] charge mode = {ch_mode} ({ch_tag})")
 
         _plot_agg_kinematic_validation(
-            H, H_w2, weight_grids,
-            pt_edges, eta_edges, charge_edges, args, out_dir,
-            charge_filter=cf, ch_suffix=ch_suffix, ch_tag=ch_tag,
+            H,
+            H_w2,
+            weight_grids,
+            pt_edges,
+            eta_edges,
+            charge_edges,
+            args,
+            out_dir,
+            charge_filter=cf,
+            ch_suffix=ch_suffix,
+            ch_tag=ch_tag,
         )
         _plot_agg_kinematic_validation_2d(
-            H, weight_grids, pt_edges, eta_edges, charge_edges, out_dir,
-            charge_filter=cf, ch_suffix=ch_suffix, ch_tag=ch_tag,
+            H,
+            weight_grids,
+            pt_edges,
+            eta_edges,
+            charge_edges,
+            out_dir,
+            charge_filter=cf,
+            ch_suffix=ch_suffix,
+            ch_tag=ch_tag,
         )
 
         # Pass 2 (charge-filtered).
         t0 = _tic()
         totals = _stream_aggregated_targets(
             paths,
-            pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
-            pt_edges=pt_edges, eta_edges=eta_edges,
+            pt_min=pt_min,
+            pt_max=pt_max,
+            eta_min=eta_min,
+            eta_max=eta_max,
+            pt_edges=pt_edges,
+            eta_edges=eta_edges,
             charge_edges=charge_edges,
-            weight_grids=weight_grids, target_axes_edges=target_axes_edges,
+            weight_grids=weight_grids,
+            target_axes_edges=target_axes_edges,
             n_workers=int(args.cmp_workers),
             weight_mode=str(args.weight_handling),
             charge_filter=cf,
@@ -2901,17 +3460,35 @@ def plot_aggregated_target_distributions(stats, paths, args, out_dir):
         _toc(f"agg pass-2 (target hists, {ch_mode})", t0)
 
         _plot_aggregated_target_distributions_one(
-            totals, target_axes_edges, args, out_dir,
-            pt_min=pt_min, pt_max=pt_max, eta_min=eta_min, eta_max=eta_max,
-            n_pt=n_pt, n_eta=n_eta,
-            ch_suffix=ch_suffix, ch_tag=ch_tag,
+            totals,
+            target_axes_edges,
+            args,
+            out_dir,
+            pt_min=pt_min,
+            pt_max=pt_max,
+            eta_min=eta_min,
+            eta_max=eta_max,
+            n_pt=n_pt,
+            n_eta=n_eta,
+            ch_suffix=ch_suffix,
+            ch_tag=ch_tag,
         )
 
 
 def _plot_aggregated_target_distributions_one(
-    totals, target_axes_edges, args, out_dir,
-    *, pt_min, pt_max, eta_min, eta_max, n_pt, n_eta,
-    ch_suffix, ch_tag,
+    totals,
+    target_axes_edges,
+    args,
+    out_dir,
+    *,
+    pt_min,
+    pt_max,
+    eta_min,
+    eta_max,
+    n_pt,
+    n_eta,
+    ch_suffix,
+    ch_tag,
 ):
     """Render the per-axis target-distribution plot for a single
     charge selection. Extracted from ``plot_aggregated_target_distributions``
@@ -2919,8 +3496,11 @@ def _plot_aggregated_target_distributions_one(
     n_cols = len(target_axes_edges)
     for yscale, ysuffix in (("linear", ""), ("log", "_log")):
         fig, axes = plt.subplots(
-            2, n_cols, figsize=(5.0 * n_cols, 6.8),
-            sharex="col", squeeze=False,
+            2,
+            n_cols,
+            figsize=(5.0 * n_cols, 6.8),
+            sharex="col",
+            squeeze=False,
             gridspec_kw={"height_ratios": [3, 1], "hspace": 0.05},
             layout="constrained",
         )
@@ -2946,12 +3526,18 @@ def _plot_aggregated_target_distributions_one(
             if h_ref.sum() <= 0:
                 continue
             ax_main.step(
-                centers, h_ref_n, where="mid",
-                color=ref_g["main_color"], lw=1.3,
+                centers,
+                h_ref_n,
+                where="mid",
+                color=ref_g["main_color"],
+                lw=1.3,
                 label=ref_g["label"],
             )
             _stepped_errorbar(
-                ax_main, centers, h_ref_n, s_ref_n,
+                ax_main,
+                centers,
+                h_ref_n,
+                s_ref_n,
                 ref_g["main_color"],
             )
 
@@ -2970,55 +3556,87 @@ def _plot_aggregated_target_distributions_one(
 
                 if tot_raw > 0:
                     ax_main.step(
-                        centers, h_raw_n, where="mid",
-                        color=g["raw_color"], lw=0.9, linestyle=":",
+                        centers,
+                        h_raw_n,
+                        where="mid",
+                        color=g["raw_color"],
+                        lw=0.9,
+                        linestyle=":",
                         label=f"{g['label']} (raw)",
                     )
                     _stepped_errorbar(
-                        ax_main, centers, h_raw_n, s_raw_n,
+                        ax_main,
+                        centers,
+                        h_raw_n,
+                        s_raw_n,
                         g["raw_color"],
                     )
                 if tot_rew > 0:
                     ax_main.step(
-                        centers, h_rew_n, where="mid",
-                        color=g["main_color"], lw=1.2,
+                        centers,
+                        h_rew_n,
+                        where="mid",
+                        color=g["main_color"],
+                        lw=1.2,
                         label=f"{g['label']} (rew → J/$\\psi$ kin.)",
                     )
                     _stepped_errorbar(
-                        ax_main, centers, h_rew_n, s_rew_n,
+                        ax_main,
+                        centers,
+                        h_rew_n,
+                        s_rew_n,
                         g["main_color"],
                     )
 
                 # Ratios to J/ψ.
                 if tot_raw > 0:
                     r_raw, e_raw = _ratio_with_err(
-                        h_raw_n, s_raw_n, h_ref_n, s_ref_n,
+                        h_raw_n,
+                        s_raw_n,
+                        h_ref_n,
+                        s_ref_n,
                     )
                     ax_ratio.step(
-                        centers, r_raw, where="mid",
-                        color=g["raw_color"], lw=0.9, linestyle=":",
+                        centers,
+                        r_raw,
+                        where="mid",
+                        color=g["raw_color"],
+                        lw=0.9,
+                        linestyle=":",
                     )
                     _stepped_errorbar(
-                        ax_ratio, centers, r_raw, e_raw, g["raw_color"],
+                        ax_ratio,
+                        centers,
+                        r_raw,
+                        e_raw,
+                        g["raw_color"],
                     )
                 if tot_rew > 0:
                     r_rew, e_rew = _ratio_with_err(
-                        h_rew_n, s_rew_n, h_ref_n, s_ref_n,
+                        h_rew_n,
+                        s_rew_n,
+                        h_ref_n,
+                        s_ref_n,
                     )
                     ax_ratio.step(
-                        centers, r_rew, where="mid",
-                        color=g["main_color"], lw=1.0,
+                        centers,
+                        r_rew,
+                        where="mid",
+                        color=g["main_color"],
+                        lw=1.0,
                     )
                     _stepped_errorbar(
-                        ax_ratio, centers, r_rew, e_rew,
+                        ax_ratio,
+                        centers,
+                        r_rew,
+                        e_rew,
                         g["main_color"],
                     )
 
             ax_main.set_yscale(yscale)
             ax_main.set_ylabel("p.d.f. (weighted, unit area)")
             ax_main.set_title(
-                TARGET_NAMES[k] if k < len(TARGET_NAMES)
-                else f"target[{k}]",
+                TARGET_NAMES[k] if k < len(TARGET_NAMES) else f"target[{k}]",
                 fontsize=10,
             )
             ax_main.legend(fontsize=7)
@@ -3027,8 +3645,7 @@ def _plot_aggregated_target_distributions_one(
             ax_ratio.axhline(1.0, color="k", lw=0.4, alpha=0.4)
             ax_ratio.set_ylabel(r"$/$ J/$\psi$", fontsize=8)
             ax_ratio.set_xlabel(
-                TARGET_NAMES[k] if k < len(TARGET_NAMES)
-                else f"target[{k}]"
+                TARGET_NAMES[k] if k < len(TARGET_NAMES) else f"target[{k}]"
             )
             ax_ratio.set_ylim(0.5, 1.5)
 
@@ -3052,6 +3669,7 @@ def _plot_aggregated_target_distributions_one(
 # main
 # ============================================================================
 
+
 def main():
     args = parse_args()
     if args.output is None:
@@ -3067,7 +3685,8 @@ def main():
 
     print(f"loading checkpoint {args.checkpoint}")
     model, arch, stats, train_cfg = load_model_from_checkpoint(
-        args.checkpoint, device,
+        args.checkpoint,
+        device,
     )
     if stats is None:
         # Older / per-epoch checkpoints didn't bundle PreprocStats.
@@ -3093,12 +3712,24 @@ def main():
     print(f"loading ntuples from {len(args.input_files)} file(s)")
     t0 = _tic()
     (
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
-        source_id, muon_source,
+        eta_r,
+        phi_r,
+        eta_g,
+        phi_g,
+        kappa_r,
+        kappa_g,
+        w,
+        source_id,
+        muon_source,
     ) = load_ntuples(
-        args.input_files, args.tree, args.max_muons,
-        args.pt_min, args.pt_max, args.eta_max,
-        threads=args.threads, max_events=args.max_events,
+        args.input_files,
+        args.tree,
+        args.max_muons,
+        args.pt_min,
+        args.pt_max,
+        args.eta_max,
+        threads=args.threads,
+        max_events=args.max_events,
         weight_mode=args.weight_handling,
         split=args.split,
         val_fraction=args.split_val_fraction,
@@ -3130,7 +3761,12 @@ def main():
     # mismatch in apply_preproc/n_cond otherwise.
     use_muon_source_cond = "muon_source" in (stats.cond_names or [])
     target, cond_raw = compute_targets_and_conditioning(
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+        eta_r,
+        phi_r,
+        eta_g,
+        phi_g,
+        kappa_r,
+        kappa_g,
         muon_source=muon_source if use_muon_source_cond else None,
     )
     t0 = _toc("compute_targets_and_conditioning", t0)
@@ -3167,21 +3803,35 @@ def main():
     log_r_grid_smear = {}
     for factor in args.shift_factors:
         for tcol in target_components:
-            log_r_grid_shift[(float(factor), int(tcol))] = (
-                _common_predict_call(
-                    model, arch, y_dev, c_dev, float(factor), int(tcol),
-                    "shift", n_features, args.batch_size, positivity,
-                    sigma_pack_iu, sigma_pack_ju,
-                )
+            log_r_grid_shift[(float(factor), int(tcol))] = _common_predict_call(
+                model,
+                arch,
+                y_dev,
+                c_dev,
+                float(factor),
+                int(tcol),
+                "shift",
+                n_features,
+                args.batch_size,
+                positivity,
+                sigma_pack_iu,
+                sigma_pack_ju,
             )
     for factor in args.smear_factors:
         for tcol in target_components:
-            log_r_grid_smear[(float(factor), int(tcol))] = (
-                _common_predict_call(
-                    model, arch, y_dev, c_dev, float(factor), int(tcol),
-                    "smear", n_features, args.batch_size, positivity,
-                    sigma_pack_iu, sigma_pack_ju,
-                )
+            log_r_grid_smear[(float(factor), int(tcol))] = _common_predict_call(
+                model,
+                arch,
+                y_dev,
+                c_dev,
+                float(factor),
+                int(tcol),
+                "smear",
+                n_features,
+                args.batch_size,
+                positivity,
+                sigma_pack_iu,
+                sigma_pack_ju,
             )
     t0 = _toc("grid prediction (shift + smear)", t0)
 
@@ -3200,9 +3850,16 @@ def main():
             for tcol in target_components:
                 log_r_grid_smear_via_gh[(float(factor), int(tcol))] = (
                     predict_smear_via_gh_shift(
-                        model, arch, y_dev, c_dev,
-                        float(factor), int(tcol), K,
-                        n_features, args.batch_size, positivity,
+                        model,
+                        arch,
+                        y_dev,
+                        c_dev,
+                        float(factor),
+                        int(tcol),
+                        K,
+                        n_features,
+                        args.batch_size,
+                        positivity,
                         sigma_pack_iu=sigma_pack_iu,
                         sigma_pack_ju=sigma_pack_ju,
                     )
@@ -3210,20 +3867,33 @@ def main():
         t0 = _toc(f"GH(K={K}) smear-via-shift grid prediction", t0)
 
     plot_shift_closure(
-        target, w, args, args.output,
-        log_r_grid_shift, target_std_per_dim,
+        target,
+        w,
+        args,
+        args.output,
+        log_r_grid_shift,
+        target_std_per_dim,
     )
     t0 = _toc("plot_shift_closure", t0)
 
     plot_closure_error_ratio(
-        target, w, args, args.output,
-        log_r_grid_shift, target_std_per_dim, mode="shift",
+        target,
+        w,
+        args,
+        args.output,
+        log_r_grid_shift,
+        target_std_per_dim,
+        mode="shift",
     )
     t0 = _toc("plot_shift_closure_error_ratio", t0)
 
     plot_smear_closure(
-        target, w, args, args.output,
-        log_r_grid_smear, target_std_per_dim,
+        target,
+        w,
+        args,
+        args.output,
+        log_r_grid_smear,
+        target_std_per_dim,
         log_r_grid_smear_via_gh=log_r_grid_smear_via_gh,
     )
     t0 = _toc("plot_smear_closure", t0)
@@ -3239,34 +3909,62 @@ def main():
             print(f"  [closure] group {g['name']!r} empty — skipping")
             continue
         plot_shift_closure(
-            target, w, args, args.output,
-            log_r_grid_shift, target_std_per_dim,
-            group_mask=mask, group_label=g["name"],
+            target,
+            w,
+            args,
+            args.output,
+            log_r_grid_shift,
+            target_std_per_dim,
+            group_mask=mask,
+            group_label=g["name"],
         )
         t0 = _toc(f"plot_shift_closure[{g['name']}]", t0)
         plot_smear_closure(
-            target, w, args, args.output,
-            log_r_grid_smear, target_std_per_dim,
+            target,
+            w,
+            args,
+            args.output,
+            log_r_grid_smear,
+            target_std_per_dim,
             log_r_grid_smear_via_gh=log_r_grid_smear_via_gh,
-            group_mask=mask, group_label=g["name"],
+            group_mask=mask,
+            group_label=g["name"],
         )
         t0 = _toc(f"plot_smear_closure[{g['name']}]", t0)
 
     plot_closure_error_ratio(
-        target, w, args, args.output,
-        log_r_grid_smear, target_std_per_dim, mode="smear",
+        target,
+        w,
+        args,
+        args.output,
+        log_r_grid_smear,
+        target_std_per_dim,
+        mode="smear",
     )
     t0 = _toc("plot_smear_closure_error_ratio", t0)
 
     plot_log_r_distribution(
-        n_features, w, args, args.output,
-        log_r_grid_shift, log_r_grid_smear,
+        n_features,
+        w,
+        args,
+        args.output,
+        log_r_grid_shift,
+        log_r_grid_smear,
     )
     t0 = _toc("plot_log_r_distribution", t0)
 
     plot_log_r_scan(
-        model, arch, y_dev, c_dev, n_features, w, args,
-        positivity, args.output, sigma_pack_iu, sigma_pack_ju,
+        model,
+        arch,
+        y_dev,
+        c_dev,
+        n_features,
+        w,
+        args,
+        positivity,
+        args.output,
+        sigma_pack_iu,
+        sigma_pack_ju,
     )
     t0 = _toc("plot_log_r_scan", t0)
 
@@ -3282,8 +3980,10 @@ def main():
     )
     cmp_data, cmp_read, cmp_kept = _load_per_source_window(
         args.input_files,
-        pt_min=float(args.cmp_pt_min), pt_max=float(args.cmp_pt_max),
-        eta_min=float(args.cmp_eta_min), eta_max=float(args.cmp_eta_max),
+        pt_min=float(args.cmp_pt_min),
+        pt_max=float(args.cmp_pt_max),
+        eta_min=float(args.cmp_eta_min),
+        eta_max=float(args.cmp_eta_max),
         max_events=int(args.cmp_max_events),
         n_workers=int(args.cmp_workers),
         weight_mode=str(args.weight_handling),
@@ -3307,8 +4007,13 @@ def main():
             f"window cut (={100 * cmp_kept / max(cmp_read, 1):.2f}%)"
         )
         plot_per_source_target_distributions(
-            target_cmp, w_cmp, sid_cmp, kg_cmp, eg_cmp,
-            args, args.output,
+            target_cmp,
+            w_cmp,
+            sid_cmp,
+            kg_cmp,
+            eg_cmp,
+            args,
+            args.output,
         )
         t0 = _toc("plot_per_source_target_distributions", t0)
 
@@ -3317,7 +4022,10 @@ def main():
     # in-memory arrays from the per-source loader because the agg
     # window is intentionally wider.
     plot_aggregated_target_distributions(
-        stats, args.input_files, args, args.output,
+        stats,
+        args.input_files,
+        args,
+        args.output,
     )
     t0 = _toc("plot_aggregated_target_distributions", t0)
 
@@ -3329,8 +4037,10 @@ def main():
         from flow_training_diagnostics import (
             load_flow_from_checkpoint,
         )
+
         flow, flow_stats, _flow_ckpt = load_flow_from_checkpoint(
-            args.flow_checkpoint, device,
+            args.flow_checkpoint,
+            device,
         )
         flow.eval()
         # Stash these on args so plot_polyhead_pred_vs_flow can reach
@@ -3339,18 +4049,34 @@ def main():
         args._polyhead_train_cfg = train_cfg
         args._positivity = positivity
         plot_polyhead_pred_vs_flow(
-            model, arch, flow, flow_stats, stats,
-            target_std, cond, n_features, w,
-            args, args.output,
+            model,
+            arch,
+            flow,
+            flow_stats,
+            stats,
+            target_std,
+            cond,
+            n_features,
+            w,
+            args,
+            args.output,
             sigma_pack_iu=sigma_pack_iu,
             sigma_pack_ju=sigma_pack_ju,
         )
         t0 = _toc("plot_polyhead_pred_vs_flow", t0)
 
         plot_polyhead_axis_logw_error_vs_flow(
-            model, arch, flow, flow_stats, stats,
-            target_std, cond, n_features, w,
-            args, args.output,
+            model,
+            arch,
+            flow,
+            flow_stats,
+            stats,
+            target_std,
+            cond,
+            n_features,
+            w,
+            args,
+            args.output,
             sigma_pack_iu=sigma_pack_iu,
             sigma_pack_ju=sigma_pack_ju,
         )

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
@@ -207,15 +207,33 @@ def parse_args():
         "--shift-factors",
         nargs="+",
         type=float,
-        default=[0.1, 0.3, 0.5, 1.0],
-        help="Shift magnitudes (in standardized-target σ units).",
+        default=[6e-5, 6e-4, 0.1, 0.3, 0.5, 1.0],
+        help="Shift magnitudes (in standardized-target σ units). The "
+        "6e-5 and 6e-4 rows probe the small-u regime that the "
+        "deployed closureA / J/ψ-stats / Z-non-closure paths actually "
+        "query at runtime; the ≥ 0.1 rows probe the operational "
+        "range of an O(1σ) NP pull.",
     )
     p.add_argument(
         "--smear-factors",
         nargs="+",
         type=float,
-        default=[0.1, 0.3, 0.5, 1.0],
-        help="Smear magnitudes (in standardized-target σ units).",
+        default=[6e-5, 6e-4, 0.1, 0.3, 0.5, 1.0],
+        help="Smear magnitudes (in standardized-target σ units). The "
+        "6e-5 and 6e-4 rows probe the small-σ regime.",
+    )
+    p.add_argument(
+        "--lin-noise-thresh",
+        type=float,
+        default=100.0,
+        help="Average per-bin event-crossings threshold below which "
+        "the literal shifted/smeared MC is considered noise-dominated "
+        "and the linearized reference takes over as the ratio-panel "
+        "denominator (and y-range setter). At crossings/bin ≈ thresh "
+        "the literal ratio has per-bin S/N ~ √thresh, so 100 ⇒ S/N≈10 "
+        "needed before the literal becomes primary. Both curves are "
+        "always drawn; this only controls which one anchors the ratio "
+        "comparison.",
     )
     p.add_argument(
         "--smear-gh-K",
@@ -907,6 +925,81 @@ def _stepped_errorbar(ax, centers, h, sigma, color, **kwargs):
     )
 
 
+def _fd_linearized_shift(h_raw, sigma_raw, bins, dy):
+    """First-order finite-difference shifted-MC reference computed
+    directly from the unshifted histogram:
+
+        h_lin(y_j; δy) = h_raw[j] − δy · (∂h/∂y)[j],
+
+    matching h(y − δy) at linear order. ``∂h/∂y`` is built from
+    centered finite differences on ``h_raw`` (forward at the left
+    edge, backward at the right edge). No reference shifted MC is
+    needed — the curve is fully determined by the raw histogram and
+    so carries the raw histogram's noise structure rather than the
+    additional sampling noise of a shifted-events sample.
+
+    Variance propagation treats the per-bin counts as Poisson-
+    independent (overestimates at edges where centered differences
+    pull in neighbours that share events). Bins must be uniformly
+    spaced.
+
+    Returns ``(h_lin, sigma_lin)`` shaped ``(n_bins,)``.
+    """
+    h = np.asarray(h_raw, dtype=np.float64)
+    s = np.asarray(sigma_raw, dtype=np.float64)
+    bw = float(bins[1] - bins[0])
+    dh = np.empty_like(h)
+    var_dh = np.empty_like(h)
+    dh[1:-1] = (h[2:] - h[:-2]) / (2.0 * bw)
+    var_dh[1:-1] = (s[2:] ** 2 + s[:-2] ** 2) / (4.0 * bw ** 2)
+    dh[0] = (h[1] - h[0]) / bw
+    var_dh[0] = (s[1] ** 2 + s[0] ** 2) / bw ** 2
+    dh[-1] = (h[-1] - h[-2]) / bw
+    var_dh[-1] = (s[-1] ** 2 + s[-2] ** 2) / bw ** 2
+    h_lin = h - float(dy) * dh
+    var_lin = s ** 2 + (float(dy) ** 2) * var_dh
+    return h_lin, np.sqrt(np.maximum(var_lin, 0.0))
+
+
+def _fd_linearized_smear(h_raw, sigma_raw, bins, sigma_y):
+    """Leading-order (σ²) smeared-MC reference computed directly from
+    the unshifted histogram:
+
+        h_lin(y_j; σ) = h_raw[j] + (σ²/2) · (∂²h/∂y²)[j],
+
+    matching the Gaussian-convolution mean at second order in σ.
+    ``∂²h/∂y²`` is built from the standard 3-point centered second
+    difference on ``h_raw``; set to zero in the two edge bins where
+    a centered stencil isn't defined. Bins must be uniformly spaced.
+
+    Returns ``(h_lin, sigma_lin)`` shaped ``(n_bins,)``.
+    """
+    h = np.asarray(h_raw, dtype=np.float64)
+    s = np.asarray(sigma_raw, dtype=np.float64)
+    bw = float(bins[1] - bins[0])
+    ddh = np.zeros_like(h)
+    var_ddh = np.zeros_like(h)
+    ddh[1:-1] = (h[2:] - 2.0 * h[1:-1] + h[:-2]) / bw ** 2
+    var_ddh[1:-1] = (
+        s[2:] ** 2 + 4.0 * s[1:-1] ** 2 + s[:-2] ** 2
+    ) / bw ** 4
+    coef = 0.5 * float(sigma_y) ** 2
+    h_lin = h + coef * ddh
+    var_lin = s ** 2 + (coef ** 2) * var_ddh
+    return h_lin, np.sqrt(np.maximum(var_lin, 0.0))
+
+
+def _perbin_crossings_per_bin(values, perturbed_values, bins):
+    """Average count of events that change bin under the perturbation,
+    divided by the number of bins. Used as the noise-dominated
+    criterion for picking between literal and linearized references.
+    """
+    bin_o = np.digitize(values, bins) - 1
+    bin_p = np.digitize(perturbed_values, bins) - 1
+    n_crossed = int(np.sum(bin_o != bin_p))
+    return n_crossed / max(len(bins) - 1, 1)
+
+
 def _common_predict_call(
     model,
     arch,
@@ -991,6 +1084,7 @@ def plot_shift_closure(
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
     factors = args.shift_factors
+    n_thresh = float(args.lin_noise_thresh)
 
     n_rows = len(factors)
     n_cols = len(target_components)
@@ -1029,11 +1123,17 @@ def plot_shift_closure(
                 bins,
                 w_event,
             )
+            h_lin, e_lin = _fd_linearized_shift(h_raw, e_raw, bins, dy)
             h_pred, e_pred = _weighted_hist_err(
                 target[:, tcol],
                 bins,
                 (w_event * r_pred).astype(np.float64),
             )
+
+            avg_cross = _perbin_crossings_per_bin(
+                target[:, tcol], y_shifted, bins
+            )
+            use_lin_ref = avg_cross < n_thresh
 
             ax_main = axes[2 * r][cidx]
             ax_main.step(
@@ -1056,6 +1156,16 @@ def plot_shift_closure(
             _stepped_errorbar(ax_main, centers, h_shifted, e_shifted, "k")
             ax_main.step(
                 centers,
+                h_lin,
+                where="mid",
+                color="C3",
+                linestyle="--",
+                lw=1.0,
+                label="lin shifted MC (FD ∂h/∂y)",
+            )
+            _stepped_errorbar(ax_main, centers, h_lin, e_lin, "C3")
+            ax_main.step(
+                centers,
                 h_pred,
                 where="mid",
                 color="C0",
@@ -1076,29 +1186,79 @@ def plot_shift_closure(
                 ax_main.legend(loc="best", fontsize=7)
 
             ax_ratio = axes[2 * r + 1][cidx]
-            ratio, e_ratio = _ratio_with_err(
-                h_pred,
-                e_pred,
-                h_shifted,
-                e_shifted,
+            ref_h, ref_e, ref_lbl = (
+                (h_lin, e_lin, "lin shifted MC")
+                if use_lin_ref
+                else (h_shifted, e_shifted, "shifted MC")
+            )
+            # Raw MC / reference shifted MC as a "zero prediction"
+            # reference: shows how far the unreweighted MC alone would
+            # be from the (literal or linearized) shifted truth. Drawn
+            # for context; not used to compute the ratio panel y-range.
+            ratio_raw, e_ratio_raw = _ratio_with_err(
+                h_raw,
+                e_raw,
+                ref_h,
+                ref_e,
             )
             ax_ratio.step(
                 centers,
-                ratio,
+                ratio_raw,
                 where="mid",
-                color="C0",
-                linestyle="--",
+                color="0.4",
+                linestyle=":",
                 lw=1.0,
             )
-            _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C0")
+            _stepped_errorbar(
+                ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4"
+            )
+
+            # Always show both ratios; the y-range is set from the
+            # designated reference (literal or linearized) per the
+            # noise-dominated criterion.
+            ratio_shift, e_ratio_shift = _ratio_with_err(
+                h_pred, e_pred, h_shifted, e_shifted,
+            )
+            ratio_lin, e_ratio_lin = _ratio_with_err(
+                h_pred, e_pred, h_lin, e_lin,
+            )
+            # Ratio-panel curves are colored by the *numerator* (pred);
+            # linestyle distinguishes which denominator they use.
+            # Active (primary) reference is drawn on top with full
+            # opacity; the other is faded in the background.
+            if use_lin_ref:
+                ax_ratio.step(
+                    centers, ratio_shift, where="mid",
+                    color="C0", linestyle=":", lw=0.8, alpha=0.4,
+                )
+                ax_ratio.step(
+                    centers, ratio_lin, where="mid",
+                    color="C0", linestyle="--", lw=1.0,
+                )
+                _stepped_errorbar(
+                    ax_ratio, centers, ratio_lin, e_ratio_lin, "C0"
+                )
+            else:
+                ax_ratio.step(
+                    centers, ratio_lin, where="mid",
+                    color="C0", linestyle=":", lw=0.8, alpha=0.4,
+                )
+                ax_ratio.step(
+                    centers, ratio_shift, where="mid",
+                    color="C0", linestyle="--", lw=1.0,
+                )
+                _stepped_errorbar(
+                    ax_ratio, centers, ratio_shift, e_ratio_shift, "C0"
+                )
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
-            ax_ratio.set_ylabel("/ shifted MC", fontsize=8)
+            ax_ratio.set_ylabel(f"/ {ref_lbl}", fontsize=8)
             ax_ratio.set_xlabel(tname)
-            ratios = np.atleast_1d(ratio)
+            ratios_for_ylim = ratio_lin if use_lin_ref else ratio_shift
+            ratios = np.atleast_1d(ratios_for_ylim)
             ratios = ratios[np.isfinite(ratios)]
             if ratios.size:
                 lo_r, hi_r = np.quantile(ratios, [0.05, 0.95])
-                pad = max(0.05, 0.5 * (hi_r - lo_r))
+                pad = 0.5 * (hi_r - lo_r)
                 ax_ratio.set_ylim(
                     max(0.0, min(lo_r - pad, 1.0 - pad)),
                     max(hi_r + pad, 1.0 + pad),
@@ -1157,6 +1317,7 @@ def plot_smear_closure(
     n_features = target.shape[1]
     target_components = list(range(min(n_features, len(TARGET_NAMES), 3)))
     factors = args.smear_factors
+    n_thresh = float(args.lin_noise_thresh)
     rng = np.random.default_rng(args.seed)
 
     n_rows = len(factors)
@@ -1201,11 +1362,17 @@ def plot_smear_closure(
                 bins,
                 w_event,
             )
+            h_lin, e_lin = _fd_linearized_smear(h_raw, e_raw, bins, dy)
             h_pred, e_pred = _weighted_hist_err(
                 target[:, tcol],
                 bins,
                 (w_event * r_pred).astype(np.float64),
             )
+
+            avg_cross = _perbin_crossings_per_bin(
+                target[:, tcol], y_smeared, bins
+            )
+            use_lin_ref = avg_cross < n_thresh
 
             ax_main = axes[2 * r][cidx]
             ax_main.step(
@@ -1226,6 +1393,16 @@ def plot_smear_closure(
                 label=f"smeared MC ({factor:g}·σ_y, K=1)",
             )
             _stepped_errorbar(ax_main, centers, h_smeared, e_smeared, "k")
+            ax_main.step(
+                centers,
+                h_lin,
+                where="mid",
+                color="C3",
+                linestyle="--",
+                lw=1.0,
+                label="lin smeared MC (FD ½σ²·∂²h/∂y²)",
+            )
+            _stepped_errorbar(ax_main, centers, h_lin, e_lin, "C3")
             ax_main.step(
                 centers,
                 h_pred,
@@ -1276,28 +1453,74 @@ def plot_smear_closure(
                 ax_main.legend(loc="best", fontsize=7)
 
             ax_ratio = axes[2 * r + 1][cidx]
-            ratio, e_ratio = _ratio_with_err(
-                h_pred,
-                e_pred,
-                h_smeared,
-                e_smeared,
+            ref_h, ref_e, ref_lbl = (
+                (h_lin, e_lin, "lin smeared MC")
+                if use_lin_ref
+                else (h_smeared, e_smeared, "smeared MC")
+            )
+            # Raw MC / reference smeared MC; not used in y-range.
+            ratio_raw, e_ratio_raw = _ratio_with_err(
+                h_raw,
+                e_raw,
+                ref_h,
+                ref_e,
             )
             ax_ratio.step(
                 centers,
-                ratio,
+                ratio_raw,
                 where="mid",
-                color="C2",
-                linestyle="--",
+                color="0.4",
+                linestyle=":",
                 lw=1.0,
             )
-            _stepped_errorbar(ax_ratio, centers, ratio, e_ratio, "C2")
-            ratios_for_ylim = [ratio]
+            _stepped_errorbar(
+                ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4"
+            )
+
+            # h_pred / h_smeared and h_pred / h_lin always drawn; the
+            # designated reference (controlled by use_lin_ref) anchors
+            # the y-range and is drawn on top.
+            ratio_smear, e_ratio_smear = _ratio_with_err(
+                h_pred, e_pred, h_smeared, e_smeared,
+            )
+            ratio_lin, e_ratio_lin = _ratio_with_err(
+                h_pred, e_pred, h_lin, e_lin,
+            )
+            # Ratio-panel curves are colored by the *numerator* (pred);
+            # linestyle distinguishes which denominator they use.
+            if use_lin_ref:
+                ax_ratio.step(
+                    centers, ratio_smear, where="mid",
+                    color="C2", linestyle=":", lw=0.8, alpha=0.4,
+                )
+                ax_ratio.step(
+                    centers, ratio_lin, where="mid",
+                    color="C2", linestyle="--", lw=1.0,
+                )
+                _stepped_errorbar(
+                    ax_ratio, centers, ratio_lin, e_ratio_lin, "C2"
+                )
+                primary_ratio = ratio_lin
+            else:
+                ax_ratio.step(
+                    centers, ratio_lin, where="mid",
+                    color="C2", linestyle=":", lw=0.8, alpha=0.4,
+                )
+                ax_ratio.step(
+                    centers, ratio_smear, where="mid",
+                    color="C2", linestyle="--", lw=1.0,
+                )
+                _stepped_errorbar(
+                    ax_ratio, centers, ratio_smear, e_ratio_smear, "C2"
+                )
+                primary_ratio = ratio_smear
+            ratios_for_ylim = [primary_ratio]
             if h_pred_gh is not None:
                 ratio_gh, e_ratio_gh = _ratio_with_err(
                     h_pred_gh,
                     e_pred_gh,
-                    h_smeared,
-                    e_smeared,
+                    ref_h,
+                    ref_e,
                 )
                 ax_ratio.step(
                     centers,
@@ -1316,7 +1539,7 @@ def plot_smear_closure(
                 )
                 ratios_for_ylim.append(ratio_gh)
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
-            ax_ratio.set_ylabel("/ smeared MC", fontsize=8)
+            ax_ratio.set_ylabel(f"/ {ref_lbl}", fontsize=8)
             ax_ratio.set_xlabel(tname)
             ratios = (
                 np.concatenate(
@@ -1330,7 +1553,7 @@ def plot_smear_closure(
             )
             if ratios.size:
                 lo_r, hi_r = np.quantile(ratios, [0.05, 0.95])
-                pad = max(0.05, 0.5 * (hi_r - lo_r))
+                pad = 0.5 * (hi_r - lo_r)
                 ax_ratio.set_ylim(
                     max(0.0, min(lo_r - pad, 1.0 - pad)),
                     max(hi_r + pad, 1.0 + pad),
@@ -1812,21 +2035,23 @@ def plot_polyhead_pred_vs_flow(
     w_sub = w_event[idx].astype(np.float32)
 
     # Sample perturbations in standardized target space, matching the
-    # training-time sampler: |δ| uniform on [0, 1.3 · delta_max], v on
-    # the unit sphere. Read magnitudes from the polyhead's training
-    # config when available; fall back to the conventional 1.3.
+    # training-time sampler: |δ|, |σ| ~ product-of-Gaussians with
+    # scale ``delta_max`` / ``sigma_max``, direction on the unit
+    # sphere. Read magnitudes from the polyhead's training config
+    # when available.
     train_cfg = getattr(args, "_polyhead_train_cfg", {}) or {}
     delta_max_train = float(train_cfg.get("delta_max", 1.0))
     sigma_max_train = float(train_cfg.get("sigma_max", 1.0)) or 1.0
-    oversample = 1.3
-    half = oversample * delta_max_train
-    half_sig = oversample * sigma_max_train
 
     g = torch.Generator().manual_seed(0)
-    delta_shift = (torch.rand(n_use, generator=g) * 2.0 - 1.0) * half
+    g1 = torch.randn(n_use, generator=g)
+    g2 = torch.randn(n_use, generator=g).abs()
+    delta_shift = g1 * g2 * delta_max_train
     v_shift = torch.randn(n_use, n_features, generator=g)
     v_shift = v_shift / v_shift.norm(dim=-1, keepdim=True).clamp_min(1e-30)
-    sigma_smear = torch.rand(n_use, generator=g) * half_sig
+    h1 = torch.randn(n_use, generator=g).abs()
+    h2 = torch.randn(n_use, generator=g).abs()
+    sigma_smear = h1 * h2 * sigma_max_train
     v_smear = torch.randn(n_use, n_features, generator=g)
     v_smear = v_smear / v_smear.norm(dim=-1, keepdim=True).clamp_min(1e-30)
     delta_smear = sigma_smear * torch.randn(n_use, generator=g)

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_diagnostics.py
@@ -951,13 +951,13 @@ def _fd_linearized_shift(h_raw, sigma_raw, bins, dy):
     dh = np.empty_like(h)
     var_dh = np.empty_like(h)
     dh[1:-1] = (h[2:] - h[:-2]) / (2.0 * bw)
-    var_dh[1:-1] = (s[2:] ** 2 + s[:-2] ** 2) / (4.0 * bw ** 2)
+    var_dh[1:-1] = (s[2:] ** 2 + s[:-2] ** 2) / (4.0 * bw**2)
     dh[0] = (h[1] - h[0]) / bw
-    var_dh[0] = (s[1] ** 2 + s[0] ** 2) / bw ** 2
+    var_dh[0] = (s[1] ** 2 + s[0] ** 2) / bw**2
     dh[-1] = (h[-1] - h[-2]) / bw
-    var_dh[-1] = (s[-1] ** 2 + s[-2] ** 2) / bw ** 2
+    var_dh[-1] = (s[-1] ** 2 + s[-2] ** 2) / bw**2
     h_lin = h - float(dy) * dh
-    var_lin = s ** 2 + (float(dy) ** 2) * var_dh
+    var_lin = s**2 + (float(dy) ** 2) * var_dh
     return h_lin, np.sqrt(np.maximum(var_lin, 0.0))
 
 
@@ -979,13 +979,11 @@ def _fd_linearized_smear(h_raw, sigma_raw, bins, sigma_y):
     bw = float(bins[1] - bins[0])
     ddh = np.zeros_like(h)
     var_ddh = np.zeros_like(h)
-    ddh[1:-1] = (h[2:] - 2.0 * h[1:-1] + h[:-2]) / bw ** 2
-    var_ddh[1:-1] = (
-        s[2:] ** 2 + 4.0 * s[1:-1] ** 2 + s[:-2] ** 2
-    ) / bw ** 4
+    ddh[1:-1] = (h[2:] - 2.0 * h[1:-1] + h[:-2]) / bw**2
+    var_ddh[1:-1] = (s[2:] ** 2 + 4.0 * s[1:-1] ** 2 + s[:-2] ** 2) / bw**4
     coef = 0.5 * float(sigma_y) ** 2
     h_lin = h + coef * ddh
-    var_lin = s ** 2 + (coef ** 2) * var_ddh
+    var_lin = s**2 + (coef**2) * var_ddh
     return h_lin, np.sqrt(np.maximum(var_lin, 0.0))
 
 
@@ -1130,9 +1128,7 @@ def plot_shift_closure(
                 (w_event * r_pred).astype(np.float64),
             )
 
-            avg_cross = _perbin_crossings_per_bin(
-                target[:, tcol], y_shifted, bins
-            )
+            avg_cross = _perbin_crossings_per_bin(target[:, tcol], y_shifted, bins)
             use_lin_ref = avg_cross < n_thresh
 
             ax_main = axes[2 * r][cidx]
@@ -1209,18 +1205,22 @@ def plot_shift_closure(
                 linestyle=":",
                 lw=1.0,
             )
-            _stepped_errorbar(
-                ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4"
-            )
+            _stepped_errorbar(ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4")
 
             # Always show both ratios; the y-range is set from the
             # designated reference (literal or linearized) per the
             # noise-dominated criterion.
             ratio_shift, e_ratio_shift = _ratio_with_err(
-                h_pred, e_pred, h_shifted, e_shifted,
+                h_pred,
+                e_pred,
+                h_shifted,
+                e_shifted,
             )
             ratio_lin, e_ratio_lin = _ratio_with_err(
-                h_pred, e_pred, h_lin, e_lin,
+                h_pred,
+                e_pred,
+                h_lin,
+                e_lin,
             )
             # Ratio-panel curves are colored by the *numerator* (pred);
             # linestyle distinguishes which denominator they use.
@@ -1228,28 +1228,42 @@ def plot_shift_closure(
             # opacity; the other is faded in the background.
             if use_lin_ref:
                 ax_ratio.step(
-                    centers, ratio_shift, where="mid",
-                    color="C0", linestyle=":", lw=0.8, alpha=0.4,
+                    centers,
+                    ratio_shift,
+                    where="mid",
+                    color="C0",
+                    linestyle=":",
+                    lw=0.8,
+                    alpha=0.4,
                 )
                 ax_ratio.step(
-                    centers, ratio_lin, where="mid",
-                    color="C0", linestyle="--", lw=1.0,
+                    centers,
+                    ratio_lin,
+                    where="mid",
+                    color="C0",
+                    linestyle="--",
+                    lw=1.0,
                 )
-                _stepped_errorbar(
-                    ax_ratio, centers, ratio_lin, e_ratio_lin, "C0"
-                )
+                _stepped_errorbar(ax_ratio, centers, ratio_lin, e_ratio_lin, "C0")
             else:
                 ax_ratio.step(
-                    centers, ratio_lin, where="mid",
-                    color="C0", linestyle=":", lw=0.8, alpha=0.4,
+                    centers,
+                    ratio_lin,
+                    where="mid",
+                    color="C0",
+                    linestyle=":",
+                    lw=0.8,
+                    alpha=0.4,
                 )
                 ax_ratio.step(
-                    centers, ratio_shift, where="mid",
-                    color="C0", linestyle="--", lw=1.0,
+                    centers,
+                    ratio_shift,
+                    where="mid",
+                    color="C0",
+                    linestyle="--",
+                    lw=1.0,
                 )
-                _stepped_errorbar(
-                    ax_ratio, centers, ratio_shift, e_ratio_shift, "C0"
-                )
+                _stepped_errorbar(ax_ratio, centers, ratio_shift, e_ratio_shift, "C0")
             ax_ratio.axhline(1.0, color="k", lw=0.5, alpha=0.5)
             ax_ratio.set_ylabel(f"/ {ref_lbl}", fontsize=8)
             ax_ratio.set_xlabel(tname)
@@ -1369,9 +1383,7 @@ def plot_smear_closure(
                 (w_event * r_pred).astype(np.float64),
             )
 
-            avg_cross = _perbin_crossings_per_bin(
-                target[:, tcol], y_smeared, bins
-            )
+            avg_cross = _perbin_crossings_per_bin(target[:, tcol], y_smeared, bins)
             use_lin_ref = avg_cross < n_thresh
 
             ax_main = axes[2 * r][cidx]
@@ -1473,46 +1485,64 @@ def plot_smear_closure(
                 linestyle=":",
                 lw=1.0,
             )
-            _stepped_errorbar(
-                ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4"
-            )
+            _stepped_errorbar(ax_ratio, centers, ratio_raw, e_ratio_raw, "0.4")
 
             # h_pred / h_smeared and h_pred / h_lin always drawn; the
             # designated reference (controlled by use_lin_ref) anchors
             # the y-range and is drawn on top.
             ratio_smear, e_ratio_smear = _ratio_with_err(
-                h_pred, e_pred, h_smeared, e_smeared,
+                h_pred,
+                e_pred,
+                h_smeared,
+                e_smeared,
             )
             ratio_lin, e_ratio_lin = _ratio_with_err(
-                h_pred, e_pred, h_lin, e_lin,
+                h_pred,
+                e_pred,
+                h_lin,
+                e_lin,
             )
             # Ratio-panel curves are colored by the *numerator* (pred);
             # linestyle distinguishes which denominator they use.
             if use_lin_ref:
                 ax_ratio.step(
-                    centers, ratio_smear, where="mid",
-                    color="C2", linestyle=":", lw=0.8, alpha=0.4,
+                    centers,
+                    ratio_smear,
+                    where="mid",
+                    color="C2",
+                    linestyle=":",
+                    lw=0.8,
+                    alpha=0.4,
                 )
                 ax_ratio.step(
-                    centers, ratio_lin, where="mid",
-                    color="C2", linestyle="--", lw=1.0,
+                    centers,
+                    ratio_lin,
+                    where="mid",
+                    color="C2",
+                    linestyle="--",
+                    lw=1.0,
                 )
-                _stepped_errorbar(
-                    ax_ratio, centers, ratio_lin, e_ratio_lin, "C2"
-                )
+                _stepped_errorbar(ax_ratio, centers, ratio_lin, e_ratio_lin, "C2")
                 primary_ratio = ratio_lin
             else:
                 ax_ratio.step(
-                    centers, ratio_lin, where="mid",
-                    color="C2", linestyle=":", lw=0.8, alpha=0.4,
+                    centers,
+                    ratio_lin,
+                    where="mid",
+                    color="C2",
+                    linestyle=":",
+                    lw=0.8,
+                    alpha=0.4,
                 )
                 ax_ratio.step(
-                    centers, ratio_smear, where="mid",
-                    color="C2", linestyle="--", lw=1.0,
+                    centers,
+                    ratio_smear,
+                    where="mid",
+                    color="C2",
+                    linestyle="--",
+                    lw=1.0,
                 )
-                _stepped_errorbar(
-                    ax_ratio, centers, ratio_smear, e_ratio_smear, "C2"
-                )
+                _stepped_errorbar(ax_ratio, centers, ratio_smear, e_ratio_smear, "C2")
                 primary_ratio = ratio_smear
             ratios_for_ylim = [primary_ratio]
             if h_pred_gh is not None:

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
@@ -36,6 +36,7 @@ Run::
         --output     /path/to/polyhead.pt2 \
         --onnx-output /path/to/polyhead.onnx
 """
+
 from __future__ import annotations
 
 import argparse
@@ -66,10 +67,10 @@ from train_shift_smear_reweight import (  # noqa: E402
     _sigma_pack_indices,
 )
 
-
 # ---------------------------------------------------------------------------
 # Inference wrapper
 # ---------------------------------------------------------------------------
+
 
 class ReweightPolyheadInference(nn.Module):
     """``forward(y_raw, c_raw) → joint_coefs`` with preproc baked in.
@@ -97,7 +98,9 @@ class ReweightPolyheadInference(nn.Module):
         self.register_buffer("cond_std", cond_std)
 
     def forward(
-        self, y_raw: torch.Tensor, c_raw: torch.Tensor,
+        self,
+        y_raw: torch.Tensor,
+        c_raw: torch.Tensor,
     ) -> torch.Tensor:
         c_raw = _remap_muon_source_inplace(c_raw, self.muon_source_idx)
         y_std = (y_raw - self.target_mean) / self.target_std
@@ -151,17 +154,17 @@ class CombinedInference(nn.Module):
         c_raw = _remap_muon_source_inplace(c_raw, self.muon_source_idx)
         y_std = (y_raw - self.target_mean) / self.target_std
         c_std = (c_raw - self.cond_mean) / self.cond_std
-        coefs = self.polyhead(y_std, c_std)              # [B, n_basis]
+        coefs = self.polyhead(y_std, c_std)  # [B, n_basis]
         # Broadcast coefs across N_var without materializing a copy.
         coefs_b = coefs.unsqueeze(1).expand(-1, u.shape[1], -1)
         return evaluate_joint(
-            coefs_b, u, sigma,
+            coefs_b,
+            u,
+            sigma,
             self.polyhead.joint_indices,
             basis=str(getattr(self.polyhead, "basis", "monomial")),
             scale_u=float(getattr(self.polyhead, "basis_scale_u", 1.0)),
-            scale_sigma=float(
-                getattr(self.polyhead, "basis_scale_sigma", 1.0)
-            ),
+            scale_sigma=float(getattr(self.polyhead, "basis_scale_sigma", 1.0)),
             basis_aux=self.polyhead.basis_aux,
         )
 
@@ -180,8 +183,10 @@ class CombinedInference(nn.Module):
 # code without a ``where``-chain.
 # ---------------------------------------------------------------------------
 
+
 def _remap_muon_source_inplace(
-    c_raw: torch.Tensor, muon_source_idx: int,
+    c_raw: torch.Tensor,
+    muon_source_idx: int,
 ) -> torch.Tensor:
     """Return a new tensor identical to ``c_raw`` except column
     ``muon_source_idx`` is remapped from the raw {1, 15, 443} codes
@@ -190,13 +195,13 @@ def _remap_muon_source_inplace(
     if muon_source_idx < 0:
         return c_raw
     idx = muon_source_idx
-    ms_raw = c_raw[:, idx:idx + 1]
+    ms_raw = c_raw[:, idx : idx + 1]
     is_jpsi = (ms_raw == 443).to(c_raw.dtype)
     is_prompt = (ms_raw == 1).to(c_raw.dtype)
     # +1 for J/ψ, -1 for prompt W/Z, 0 for τ-decay (== 15) or anything
     # else — matches the trainer's ``_MUON_SOURCE_CODES`` table.
     ms_compact = is_jpsi - is_prompt
-    return torch.cat([c_raw[:, :idx], ms_compact, c_raw[:, idx + 1:]], dim=1)
+    return torch.cat([c_raw[:, :idx], ms_compact, c_raw[:, idx + 1 :]], dim=1)
 
 
 def _muon_source_idx(stats) -> int:
@@ -304,10 +309,12 @@ class CombinedInferenceMLP(nn.Module):
             # Stash zero-length tensors so torch.export sees consistent
             # state regardless of branch; never actually indexed.
             self.register_buffer(
-                "sigma_pack_iu", torch.zeros(0, dtype=torch.long),
+                "sigma_pack_iu",
+                torch.zeros(0, dtype=torch.long),
             )
             self.register_buffer(
-                "sigma_pack_ju", torch.zeros(0, dtype=torch.long),
+                "sigma_pack_ju",
+                torch.zeros(0, dtype=torch.long),
             )
 
     def forward(
@@ -329,8 +336,8 @@ class CombinedInferenceMLP(nn.Module):
         u = u_raw / self.target_std
         sigma = sigma_raw / self.target_std
         # Trunk runs once per event; broadcast across N_var.
-        e = self.head.trunk_forward(y_std, c_std)              # [B, d_emb]
-        e_b = e.unsqueeze(1).expand(-1, u.shape[1], -1)        # [B, N_var, d_emb]
+        e = self.head.trunk_forward(y_std, c_std)  # [B, d_emb]
+        e_b = e.unsqueeze(1).expand(-1, u.shape[1], -1)  # [B, N_var, d_emb]
 
         if self.shift_only:
             sigma_pack = sigma.new_zeros(
@@ -338,10 +345,12 @@ class CombinedInferenceMLP(nn.Module):
             )
         else:
             sigma_pack = _pack_sigma_outer(
-                sigma, self.sigma_pack_iu, self.sigma_pack_ju,
-            )                                                  # [B, N_var, n_pack]
+                sigma,
+                self.sigma_pack_iu,
+                self.sigma_pack_ju,
+            )  # [B, N_var, n_pack]
 
-        d = self.head.head_forward(e_b, u, sigma_pack)         # [B, N_var]
+        d = self.head.head_forward(e_b, u, sigma_pack)  # [B, N_var]
         if not self.is_factored:
             # Unfactored mlp head doesn't vanish at the origin; subtract
             # ``head(e, 0, 0)`` to recover the trainer's effective d.
@@ -354,6 +363,7 @@ class CombinedInferenceMLP(nn.Module):
         gb = getattr(self.head, "gauss_baseline", None)
         if gb is not None:
             from train_shift_smear_reweight import gauss_baseline_log_r
+
             mu_g, L_g = gb(c_std)
             mu_g_b = mu_g.unsqueeze(1).expand(-1, u.shape[1], -1)
             L_g_b = L_g.unsqueeze(1).expand(-1, u.shape[1], -1, -1)
@@ -365,13 +375,15 @@ class CombinedInferenceMLP(nn.Module):
         # diagnostic path; the trainer's BCE loss uses inf-clamp but
         # the deployment safety clamp is always the finite one.
         return d.clamp(
-            min=-self.positivity_clamp, max=self.positivity_clamp,
+            min=-self.positivity_clamp,
+            max=self.positivity_clamp,
         )
 
 
 # ---------------------------------------------------------------------------
 # Helpers (shared with flow_polyhead_export)
 # ---------------------------------------------------------------------------
+
 
 def _decompose_linear(ep):
     aten = torch.ops.aten
@@ -407,16 +419,12 @@ def _to_tuple(out):
 def _validate_aoti(wrapper, runner, n_features, n_cond, B, n_events, tol):
     rng = np.random.default_rng(0)
     n_events = max(B, ((n_events + B - 1) // B) * B)
-    y = torch.from_numpy(
-        rng.standard_normal((n_events, n_features)).astype(np.float32)
-    )
-    c = torch.from_numpy(
-        rng.standard_normal((n_events, n_cond)).astype(np.float32)
-    )
+    y = torch.from_numpy(rng.standard_normal((n_events, n_features)).astype(np.float32))
+    c = torch.from_numpy(rng.standard_normal((n_events, n_cond)).astype(np.float32))
     eager_chunks, aoti_chunks = [], []
     with torch.no_grad():
         for s in range(0, n_events, B):
-            yi, ci = y[s:s + B], c[s:s + B]
+            yi, ci = y[s : s + B], c[s : s + B]
             eager_chunks.append(_to_tuple(wrapper(yi, ci))[0])
             aoti_chunks.append(_to_tuple(runner(yi, ci))[0])
     et, at = torch.cat(eager_chunks), torch.cat(aoti_chunks)
@@ -432,7 +440,12 @@ def _validate_aoti(wrapper, runner, n_features, n_cond, B, n_events, tol):
 
 
 def _validate_onnx_combined(
-    combined, onnx_path, n_features, n_cond, n_events, tol,
+    combined,
+    onnx_path,
+    n_features,
+    n_cond,
+    n_events,
+    tol,
     n_var: int = 8,
 ):
     """Compare eager vs ORT for the (y, c, u, σ) → d combined graph."""
@@ -442,19 +455,20 @@ def _validate_onnx_combined(
         print("[validate-onnx-combined] onnxruntime not installed — skipping.")
         return True
     sess = ort.InferenceSession(
-        onnx_path, providers=["CPUExecutionProvider"],
+        onnx_path,
+        providers=["CPUExecutionProvider"],
     )
     rng = np.random.default_rng(2)
     y_v = rng.standard_normal((n_events, n_features)).astype(np.float32)
     c_v = rng.standard_normal((n_events, n_cond)).astype(np.float32)
-    u_v = rng.uniform(-1.0, 1.0,
-                      (n_events, n_var, n_features)).astype(np.float32)
-    s_v = rng.uniform(0.0, 1.0,
-                      (n_events, n_var, n_features)).astype(np.float32)
+    u_v = rng.uniform(-1.0, 1.0, (n_events, n_var, n_features)).astype(np.float32)
+    s_v = rng.uniform(0.0, 1.0, (n_events, n_var, n_features)).astype(np.float32)
     with torch.no_grad():
         ref = combined(
-            torch.from_numpy(y_v), torch.from_numpy(c_v),
-            torch.from_numpy(u_v), torch.from_numpy(s_v),
+            torch.from_numpy(y_v),
+            torch.from_numpy(c_v),
+            torch.from_numpy(u_v),
+            torch.from_numpy(s_v),
         ).numpy()
     in_names = [i.name for i in sess.get_inputs()]
     out_names = [o.name for o in sess.get_outputs()]
@@ -472,7 +486,12 @@ def _validate_onnx_combined(
 
 
 def _validate_onnx(
-    wrapper, onnx_path, n_features, n_cond, n_events, tol,
+    wrapper,
+    onnx_path,
+    n_features,
+    n_cond,
+    n_events,
+    tol,
 ):
     try:
         import onnxruntime as ort
@@ -480,14 +499,16 @@ def _validate_onnx(
         print("[validate-onnx] onnxruntime not installed — skipping.")
         return True
     sess = ort.InferenceSession(
-        onnx_path, providers=["CPUExecutionProvider"],
+        onnx_path,
+        providers=["CPUExecutionProvider"],
     )
     rng = np.random.default_rng(1)
     y_v = rng.standard_normal((n_events, n_features)).astype(np.float32)
     c_v = rng.standard_normal((n_events, n_cond)).astype(np.float32)
     with torch.no_grad():
         ref = wrapper(
-            torch.from_numpy(y_v), torch.from_numpy(c_v),
+            torch.from_numpy(y_v),
+            torch.from_numpy(c_v),
         ).numpy()
     out_names = [o.name for o in sess.get_outputs()]
     in_names = [i.name for i in sess.get_inputs()]
@@ -508,6 +529,7 @@ def _validate_onnx(
 # Sidecar — joint_indices in flat per-axis-degree form
 # ---------------------------------------------------------------------------
 
+
 def _emit_indices_sidecar(polyhead, stats, out_path):
     """Write a JSON file describing the polynomial basis so the C++
     side can evaluate it without re-implementing the index logic.
@@ -519,31 +541,27 @@ def _emit_indices_sidecar(polyhead, stats, out_path):
     """
     n_features = int(polyhead.n_features)
     aa, bb = [], []
-    for (a, b) in polyhead._joint_indices:
+    for a, b in polyhead._joint_indices:
         aa.append(_multiindex_to_axis_degrees(a, n_features))
         bb.append(_multiindex_to_axis_degrees(b, n_features))
     payload = {
-        "n_features":     n_features,
-        "n_basis":        int(polyhead.n_basis),
-        "n_pure_u":       int(polyhead._n_pure_u),
-        "n_pure_sigma":   int(polyhead._n_pure_s),
-        "n_cross":        int(polyhead._n_cross),
-        "max_deg_u":      int(polyhead.max_deg_u),
-        "max_deg_sigma":  int(polyhead.max_deg_sigma),
-        "max_cross_deg":  int(polyhead.max_cross_deg),
-        "basis":          str(getattr(polyhead, "basis", "monomial")),
-        "basis_scale_u":  float(
-            getattr(polyhead, "basis_scale_u", 1.0)
-        ),
-        "basis_scale_sigma": float(
-            getattr(polyhead, "basis_scale_sigma", 1.0)
-        ),
-        "alpha_degs":     [list(map(int, row)) for row in aa],
-        "beta_degs":      [list(map(int, row)) for row in bb],
-        "target_std":     [float(x) for x in stats.target_std],
-        "target_mean":    [float(x) for x in stats.target_mean],
-        "cond_std":       [float(x) for x in stats.cond_std],
-        "cond_mean":      [float(x) for x in stats.cond_mean],
+        "n_features": n_features,
+        "n_basis": int(polyhead.n_basis),
+        "n_pure_u": int(polyhead._n_pure_u),
+        "n_pure_sigma": int(polyhead._n_pure_s),
+        "n_cross": int(polyhead._n_cross),
+        "max_deg_u": int(polyhead.max_deg_u),
+        "max_deg_sigma": int(polyhead.max_deg_sigma),
+        "max_cross_deg": int(polyhead.max_cross_deg),
+        "basis": str(getattr(polyhead, "basis", "monomial")),
+        "basis_scale_u": float(getattr(polyhead, "basis_scale_u", 1.0)),
+        "basis_scale_sigma": float(getattr(polyhead, "basis_scale_sigma", 1.0)),
+        "alpha_degs": [list(map(int, row)) for row in aa],
+        "beta_degs": [list(map(int, row)) for row in bb],
+        "target_std": [float(x) for x in stats.target_std],
+        "target_mean": [float(x) for x in stats.target_mean],
+        "cond_std": [float(x) for x in stats.cond_std],
+        "cond_mean": [float(x) for x in stats.cond_mean],
     }
     with open(out_path, "w") as f:
         json.dump(payload, f, indent=2)
@@ -554,30 +572,35 @@ def _emit_indices_sidecar(polyhead, stats, out_path):
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def parse_args():
     p = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
-        "--checkpoint", required=True,
+        "--checkpoint",
+        required=True,
         help="Path to a shift_smear_reweight checkpoint with "
         "model_config.arch == 'polyhead'.",
     )
     p.add_argument(
-        "--output", default=None,
+        "--output",
+        default=None,
         help="AOTI .pt2 output path. Pass empty string or skip to "
         "disable AOTI export. Default: alongside the checkpoint as "
         "shift_smear_reweight_polyhead.pt2.",
     )
     p.add_argument(
-        "--onnx-output", default=None,
+        "--onnx-output",
+        default=None,
         help="ONNX .onnx output path for the trunk-only graph "
         "(forward(y, c) -> coefs). Default: alongside the "
         "checkpoint as shift_smear_reweight_polyhead.onnx.",
     )
     p.add_argument(
-        "--combined-onnx-output", default=None,
+        "--combined-onnx-output",
+        default=None,
         help="ONNX .onnx output path for the combined graph "
         "(forward(y, c, u, sigma) -> d) with the polynomial "
         "evaluation folded in. Default: alongside the checkpoint as "
@@ -585,7 +608,8 @@ def parse_args():
         "string to disable.",
     )
     p.add_argument(
-        "--combined-output", default=None,
+        "--combined-output",
+        default=None,
         help="AOTI .pt2 output path for the combined graph "
         "(forward(y, c, u, sigma) -> d). Compiled with dynamic batch "
         "and dynamic N_var dimensions so a single package handles "
@@ -594,36 +618,44 @@ def parse_args():
         "Pass empty string to disable.",
     )
     p.add_argument(
-        "--indices-output", default=None,
+        "--indices-output",
+        default=None,
         help="JSON sidecar path. Default: derived from --output by "
         "replacing the trailing extension with '.indices.json'.",
     )
     p.add_argument(
-        "--batch", type=int, default=1,
+        "--batch",
+        type=int,
+        default=1,
         help="Static batch size baked into AOTI when "
         "--no-dynamic-batch is in effect.",
     )
     p.add_argument(
         "--dynamic-batch",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Compile a dynamic-batch AOTI package. Off by default "
         "(static batch=1 is the lowest-latency narf path).",
     )
     p.add_argument(
         "--max-autotune",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
     )
     p.add_argument(
         "--freeze",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
     )
     p.add_argument(
         "--prepack",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
     )
     p.add_argument(
         "--link-libtorch",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="If False, AOTI compiles the wrapper.so without "
         "libtorch.so / libtorch_cpu.so as DT_NEEDED, leaving only "
         "the C-ABI aoti_torch_* shim symbols (~20) plus libgomp/"
@@ -641,7 +673,8 @@ def parse_args():
     )
     p.add_argument(
         "--package-cpp-only",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Emit the AOTI .pt2 as source code (.cpp + .h + "
         ".weights.o + CMakeLists.txt) instead of a precompiled "
         ".so. Combined with --no-link-libtorch this gives full "
@@ -666,7 +699,8 @@ def parse_args():
     p.add_argument("--validate-n", type=int, default=128)
     p.add_argument("--validate-tol", type=float, default=1e-4)
     p.add_argument(
-        "--bench", action="store_true",
+        "--bench",
+        action="store_true",
         help="After export, time AOTI runner forward at the static "
         "batch (single core).",
     )
@@ -678,27 +712,33 @@ def parse_args():
 # Main
 # ---------------------------------------------------------------------------
 
+
 def _default_paths(args):
     base = os.path.dirname(os.path.abspath(args.checkpoint))
     if args.output is None:
         args.output = os.path.join(
-            base, "shift_smear_reweight_polyhead.pt2",
+            base,
+            "shift_smear_reweight_polyhead.pt2",
         )
     if args.onnx_output is None:
         args.onnx_output = os.path.join(
-            base, "shift_smear_reweight_polyhead.onnx",
+            base,
+            "shift_smear_reweight_polyhead.onnx",
         )
     if args.combined_onnx_output is None:
         args.combined_onnx_output = os.path.join(
-            base, "shift_smear_reweight_polyhead_combined.onnx",
+            base,
+            "shift_smear_reweight_polyhead_combined.onnx",
         )
     if args.combined_output is None:
         args.combined_output = os.path.join(
-            base, "shift_smear_reweight_polyhead_combined.pt2",
+            base,
+            "shift_smear_reweight_polyhead_combined.pt2",
         )
     if args.indices_output is None:
         args.indices_output = os.path.join(
-            base, "shift_smear_reweight_polyhead.indices.json",
+            base,
+            "shift_smear_reweight_polyhead.indices.json",
         )
 
 
@@ -714,8 +754,10 @@ def _build_wrapper(checkpoint_path):
     and ``main`` only emits the combined (y, c, u, σ) variant.
     """
     from train_muon_response_flow import PreprocStats
+
     model, arch, stats, _ = load_model_from_checkpoint(
-        checkpoint_path, device="cpu",
+        checkpoint_path,
+        device="cpu",
     )
     if arch not in ("polyhead", "mlp", "mlp-factored"):
         raise SystemExit(
@@ -728,22 +770,25 @@ def _build_wrapper(checkpoint_path):
         pp = os.path.join(ck_dir, "preproc.json")
         if not os.path.exists(pp):
             raise SystemExit(
-                f"checkpoint has no PreprocStats and no preproc.json "
-                f"at {pp}"
+                f"checkpoint has no PreprocStats and no preproc.json " f"at {pp}"
             )
         with open(pp) as f:
             stats = PreprocStats(**json.load(f))
     target_mean = torch.tensor(
-        list(stats.target_mean), dtype=torch.float32,
+        list(stats.target_mean),
+        dtype=torch.float32,
     )
     target_std = torch.tensor(
-        list(stats.target_std), dtype=torch.float32,
+        list(stats.target_std),
+        dtype=torch.float32,
     )
     cond_mean = torch.tensor(
-        list(stats.cond_mean), dtype=torch.float32,
+        list(stats.cond_mean),
+        dtype=torch.float32,
     )
     cond_std = torch.tensor(
-        list(stats.cond_std), dtype=torch.float32,
+        list(stats.cond_std),
+        dtype=torch.float32,
     )
     if arch == "polyhead":
         wrapper = ReweightPolyheadInference(
@@ -801,10 +846,8 @@ def main():
     )
     print(f"arch={arch}  n_features={n_features}  n_cond={n_cond}")
 
-    is_polyhead = (arch == "polyhead")
-    is_factored = (arch == "mlp-factored") or bool(
-        getattr(model, "is_factored", False)
-    )
+    is_polyhead = arch == "polyhead"
+    is_factored = (arch == "mlp-factored") or bool(getattr(model, "is_factored", False))
     shift_only = bool(getattr(model, "shift_only", False))
 
     if is_polyhead:
@@ -848,21 +891,21 @@ def main():
                 "y_raw": {0: batch_dim},
                 "c_raw": {0: batch_dim},
             }
-            print(
-                f"\ntorch.export.export (dynamic batch, B_example="
-                f"{B_trace}) ..."
-            )
+            print(f"\ntorch.export.export (dynamic batch, B_example=" f"{B_trace}) ...")
         else:
             dynamic_shapes = None
             print(f"\ntorch.export.export (static B={B}) ...")
         ep = torch.export.export(
-            wrapper, (y, c), dynamic_shapes=dynamic_shapes,
+            wrapper,
+            (y, c),
+            dynamic_shapes=dynamic_shapes,
         )
         ep = _decompose_linear(ep)
         print(f"aoti_compile_and_package -> {args.output}")
         with torch.no_grad():
             torch._inductor.aoti_compile_and_package(
-                ep, package_path=args.output,
+                ep,
+                package_path=args.output,
             )
         size_mb = os.path.getsize(args.output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
@@ -884,9 +927,12 @@ def main():
             # Do so explicitly so users can still validate the
             # exported package round-trips correctly.
             import ctypes
+
             import torch as _torch
+
             _libcpu = os.path.join(
-                os.path.dirname(_torch.__file__), "lib",
+                os.path.dirname(_torch.__file__),
+                "lib",
                 "libtorch_cpu.so",
             )
             ctypes.CDLL(_libcpu, mode=ctypes.RTLD_GLOBAL)
@@ -896,8 +942,13 @@ def main():
             print(f"loaded; max |aoti - eager| joint_coefs = {diff:.2e}")
             if args.validate_n > 0:
                 _validate_aoti(
-                    wrapper, runner, n_features, n_cond, B,
-                    args.validate_n, args.validate_tol,
+                    wrapper,
+                    runner,
+                    n_features,
+                    n_cond,
+                    B,
+                    args.validate_n,
+                    args.validate_tol,
                 )
         else:
             runner = torch._inductor.aoti_load_package(args.output)
@@ -907,8 +958,13 @@ def main():
 
             if args.validate_n > 0:
                 _validate_aoti(
-                    wrapper, runner, n_features, n_cond, B,
-                    args.validate_n, args.validate_tol,
+                    wrapper,
+                    runner,
+                    n_features,
+                    n_cond,
+                    B,
+                    args.validate_n,
+                    args.validate_tol,
                 )
 
         if args.bench:
@@ -947,8 +1003,8 @@ def main():
         dynamic_axes = None
         # Export ONNX with dynamic batch by default — trivial for ORT.
         dynamic_axes = {
-            "y_raw":      {0: "batch"},
-            "c_raw":      {0: "batch"},
+            "y_raw": {0: "batch"},
+            "c_raw": {0: "batch"},
             "joint_coefs": {0: "batch"},
         }
         print(
@@ -956,7 +1012,9 @@ def main():
             f"opset={args.opset}) -> {args.onnx_output}"
         )
         torch.onnx.export(
-            wrapper, (y, c), args.onnx_output,
+            wrapper,
+            (y, c),
+            args.onnx_output,
             input_names=["y_raw", "c_raw"],
             output_names=["joint_coefs"],
             dynamic_axes=dynamic_axes,
@@ -965,16 +1023,18 @@ def main():
             export_params=True,
         )
         if args.inline_weights and _onnx_inline_external_data(args.onnx_output):
-            print(
-                "  external-data sidecars absorbed -> single-file .onnx"
-            )
+            print("  external-data sidecars absorbed -> single-file .onnx")
         size_mb = os.path.getsize(args.onnx_output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
 
         if args.validate_n > 0:
             _validate_onnx(
-                wrapper, args.onnx_output, n_features, n_cond,
-                args.validate_n, args.validate_tol,
+                wrapper,
+                args.onnx_output,
+                n_features,
+                n_cond,
+                args.validate_n,
+                args.validate_tol,
             )
 
     # ---------- Combined AOTI / ONNX share the same wrapper ----------
@@ -991,21 +1051,27 @@ def main():
                 cond_std=wrapper.cond_std,
             )
             combined = CombinedInference(
-                polyhead=model, muon_source_idx=ms_idx, **buffers,
+                polyhead=model,
+                muon_source_idx=ms_idx,
+                **buffers,
             ).eval()
         else:
             buffers = dict(
                 target_mean=torch.tensor(
-                    list(stats.target_mean), dtype=torch.float32,
+                    list(stats.target_mean),
+                    dtype=torch.float32,
                 ),
                 target_std=torch.tensor(
-                    list(stats.target_std), dtype=torch.float32,
+                    list(stats.target_std),
+                    dtype=torch.float32,
                 ),
                 cond_mean=torch.tensor(
-                    list(stats.cond_mean), dtype=torch.float32,
+                    list(stats.cond_mean),
+                    dtype=torch.float32,
                 ),
                 cond_std=torch.tensor(
-                    list(stats.cond_std), dtype=torch.float32,
+                    list(stats.cond_std),
+                    dtype=torch.float32,
                 ),
             )
             combined = CombinedInferenceMLP(
@@ -1030,21 +1096,16 @@ def main():
         s_e = torch.randn(B_ex, N_ex, n_features)
         with torch.no_grad():
             d_e = combined(y_e, c_e, u_e, s_e)
-        print(
-            f"\ncombined eager: out={tuple(d_e.shape)} "
-            f"(B={B_ex}, N_var={N_ex})"
-        )
+        print(f"\ncombined eager: out={tuple(d_e.shape)} " f"(B={B_ex}, N_var={N_ex})")
 
     # ---------- Combined AOTI .pt2 ----------
     if args.combined_output:
         os.makedirs(
-            os.path.dirname(
-                os.path.abspath(args.combined_output)
-            ) or ".",
+            os.path.dirname(os.path.abspath(args.combined_output)) or ".",
             exist_ok=True,
         )
         batch_dim = torch.export.Dim("batch", min=1, max=2**20)
-        nvar_dim  = torch.export.Dim("nvar",  min=1, max=2**20)
+        nvar_dim = torch.export.Dim("nvar", min=1, max=2**20)
         # Positional tuple (matches both ``CombinedInference`` and
         # ``CombinedInferenceMLP``, whose 3rd/4th args are ``u``/``sigma``
         # vs ``u_raw``/``sigma_raw`` respectively — torch.export's dict
@@ -1061,14 +1122,16 @@ def main():
             f"(dynamic batch+nvar, B={B_ex}, N_var={N_ex}) ..."
         )
         ep = torch.export.export(
-            combined, (y_e, c_e, u_e, s_e),
+            combined,
+            (y_e, c_e, u_e, s_e),
             dynamic_shapes=dynamic_shapes_combined,
         )
         ep = _decompose_linear(ep)
         print(f"aoti_compile_and_package -> {args.combined_output}")
         with torch.no_grad():
             torch._inductor.aoti_compile_and_package(
-                ep, package_path=args.combined_output,
+                ep,
+                package_path=args.combined_output,
             )
         size_mb = os.path.getsize(args.combined_output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
@@ -1086,18 +1149,19 @@ def main():
                 # resolve at dlopen time when libtorch isn't in
                 # DT_NEEDED.
                 import ctypes
+
                 import torch as _torch
+
                 _libcpu = os.path.join(
-                    os.path.dirname(_torch.__file__), "lib",
+                    os.path.dirname(_torch.__file__),
+                    "lib",
                     "libtorch_cpu.so",
                 )
                 ctypes.CDLL(_libcpu, mode=ctypes.RTLD_GLOBAL)
             runner = torch._inductor.aoti_load_package(args.combined_output)
             out = _to_tuple(runner(y_e, c_e, u_e, s_e))[0]
             diff = (out - d_e).abs().max().item()
-            print(
-                f"loaded; max |aoti - eager| d = {diff:.2e}"
-            )
+            print(f"loaded; max |aoti - eager| d = {diff:.2e}")
 
         if args.validate_n > 0 and runner is not None:
             # Match the existing combined-ONNX validation: random
@@ -1105,25 +1169,25 @@ def main():
             rng = np.random.default_rng(3)
             n_use = args.validate_n
             n_var = 8
-            y_v = torch.from_numpy(rng.standard_normal(
-                (n_use, n_features)).astype(np.float32))
-            c_v = torch.from_numpy(rng.standard_normal(
-                (n_use, n_cond)).astype(np.float32))
-            u_v = torch.from_numpy(rng.uniform(
-                -1.0, 1.0, (n_use, n_var, n_features)
-            ).astype(np.float32))
-            s_v = torch.from_numpy(rng.uniform(
-                0.0, 1.0, (n_use, n_var, n_features)
-            ).astype(np.float32))
+            y_v = torch.from_numpy(
+                rng.standard_normal((n_use, n_features)).astype(np.float32)
+            )
+            c_v = torch.from_numpy(
+                rng.standard_normal((n_use, n_cond)).astype(np.float32)
+            )
+            u_v = torch.from_numpy(
+                rng.uniform(-1.0, 1.0, (n_use, n_var, n_features)).astype(np.float32)
+            )
+            s_v = torch.from_numpy(
+                rng.uniform(0.0, 1.0, (n_use, n_var, n_features)).astype(np.float32)
+            )
             with torch.no_grad():
                 ref = combined(y_v, c_v, u_v, s_v)
                 aoti_out = _to_tuple(runner(y_v, c_v, u_v, s_v))[0]
             max_abs = (ref - aoti_out).abs().max().item()
             denom = max(ref.abs().max().item(), 1e-30)
             rel = max_abs / denom
-            status = (
-                "OK" if rel < args.validate_tol else "MISMATCH"
-            )
+            status = "OK" if rel < args.validate_tol else "MISMATCH"
             print(
                 f"[validate-aoti-combined] d over N={n_use} "
                 f"N_var={n_var}: max |eager-aoti|={max_abs:.3e} "
@@ -1133,17 +1197,15 @@ def main():
     # ---------- Combined ONNX (trunk + poly) ----------
     if args.combined_onnx_output:
         os.makedirs(
-            os.path.dirname(
-                os.path.abspath(args.combined_onnx_output)
-            ) or ".",
+            os.path.dirname(os.path.abspath(args.combined_onnx_output)) or ".",
             exist_ok=True,
         )
         dynamic_axes_combined = {
-            "y_raw":  {0: "batch"},
-            "c_raw":  {0: "batch"},
-            "u":      {0: "batch", 1: "nvar"},
-            "sigma":  {0: "batch", 1: "nvar"},
-            "d":      {0: "batch", 1: "nvar"},
+            "y_raw": {0: "batch"},
+            "c_raw": {0: "batch"},
+            "u": {0: "batch", 1: "nvar"},
+            "sigma": {0: "batch", 1: "nvar"},
+            "d": {0: "batch", 1: "nvar"},
         }
         print(
             f"torch.onnx.export combined (dynamic batch+nvar, "
@@ -1151,7 +1213,9 @@ def main():
             f"{args.combined_onnx_output}"
         )
         torch.onnx.export(
-            combined, (y_e, c_e, u_e, s_e), args.combined_onnx_output,
+            combined,
+            (y_e, c_e, u_e, s_e),
+            args.combined_onnx_output,
             input_names=["y_raw", "c_raw", "u", "sigma"],
             output_names=["d"],
             dynamic_axes=dynamic_axes_combined,
@@ -1162,16 +1226,18 @@ def main():
         if args.inline_weights and _onnx_inline_external_data(
             args.combined_onnx_output,
         ):
-            print(
-                "  external-data sidecars absorbed -> single-file .onnx"
-            )
+            print("  external-data sidecars absorbed -> single-file .onnx")
         size_mb = os.path.getsize(args.combined_onnx_output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
 
         if args.validate_n > 0:
             _validate_onnx_combined(
-                combined, args.combined_onnx_output, n_features,
-                n_cond, args.validate_n, args.validate_tol,
+                combined,
+                args.combined_onnx_output,
+                n_features,
+                n_cond,
+                args.validate_n,
+                args.validate_tol,
             )
 
 

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
@@ -1,0 +1,866 @@
+"""Export a ``train_shift_smear_reweight.py --arch polyhead`` checkpoint
+to AOTI (``.pt2``) and ONNX (``.onnx``) plus a small JSON sidecar
+that the C++ benchmarks consume to do polynomial evaluation outside
+the model graph.
+
+Inference signature
+
+    forward(y_raw, c_raw) -> joint_coefs
+
+i.e., trunk-only — the polynomial evaluation at any (u, σ_vec) is
+done outside the package by the deployment-side ``evaluate_joint``
+(C++ or python). The trunk forward dominates per-event NN cost and
+amortizes across many (u, σ_vec) variations per event, which is the
+realistic deployment pattern for the shift+smear reweight.
+
+The sidecar JSON ``<output>.indices.json`` carries the structural
+priors needed to evaluate the polynomial:
+
+    {
+      "n_features": 3,
+      "n_basis":    <int>,
+      "max_deg_u":  <int>,
+      "max_deg_sigma": <int>,
+      "basis":      "monomial" | "chebyshev",
+      "basis_scale_u":  <float>,
+      "basis_scale_sigma": <float>,
+      "alpha_degs": [[k_u_0, ..., k_u_{d-1}] for each basis index],
+      "beta_degs":  [[k_s_0, ..., k_s_{d-1}] for each basis index],
+      "target_std": [...]   # for converting raw u/σ -> standardized
+    }
+
+Run::
+
+    python shift_smear_reweight_export.py \
+        --checkpoint /path/to/checkpoint.pt \
+        --output     /path/to/polyhead.pt2 \
+        --onnx-output /path/to/polyhead.onnx
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch._inductor import config as ind_cfg
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from shift_smear_reweight_diagnostics import (  # noqa: E402
+    load_model_from_checkpoint,
+)
+from train_muon_response_flow import (  # noqa: E402
+    _multiindex_to_axis_degrees,
+    evaluate_joint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Inference wrapper
+# ---------------------------------------------------------------------------
+
+class ReweightPolyheadInference(nn.Module):
+    """``forward(y_raw, c_raw) → joint_coefs`` with preproc baked in.
+
+    Pure tensor ops; torch.export and ONNX both trace it directly.
+    Dynamic batch is supported via ``torch.export.Dim``. The polynomial
+    evaluation at ``(u, σ_vec)`` is done outside the package.
+    """
+
+    def __init__(
+        self,
+        polyhead: nn.Module,
+        target_mean: torch.Tensor,
+        target_std: torch.Tensor,
+        cond_mean: torch.Tensor,
+        cond_std: torch.Tensor,
+    ):
+        super().__init__()
+        self.polyhead = polyhead
+        self.register_buffer("target_mean", target_mean)
+        self.register_buffer("target_std", target_std)
+        self.register_buffer("cond_mean", cond_mean)
+        self.register_buffer("cond_std", cond_std)
+
+    def forward(
+        self, y_raw: torch.Tensor, c_raw: torch.Tensor,
+    ) -> torch.Tensor:
+        y_std = (y_raw - self.target_mean) / self.target_std
+        c_std = (c_raw - self.cond_mean) / self.cond_std
+        return self.polyhead(y_std, c_std)
+
+
+class CombinedInference(nn.Module):
+    """``forward(y_raw, c_raw, u, sigma) → d`` with the polynomial
+    evaluation folded into the graph.
+
+    Trunk amortizes: one trunk forward per ``(y, c)`` event, the
+    coefs are broadcast across the ``N_var`` perturbations and the
+    polynomial sum is evaluated in-graph via :func:`evaluate_joint`.
+
+    Shapes (all float32):
+        y_raw  [B, F]
+        c_raw  [B, n_cond]
+        u      [B, N_var, F]
+        sigma  [B, N_var, F]
+        d      [B, N_var]
+
+    Both batch dimensions can be marked dynamic at export time so a
+    single deployed graph handles any (B, N_var) at runtime.
+    """
+
+    def __init__(
+        self,
+        polyhead: nn.Module,
+        target_mean: torch.Tensor,
+        target_std: torch.Tensor,
+        cond_mean: torch.Tensor,
+        cond_std: torch.Tensor,
+    ):
+        super().__init__()
+        self.polyhead = polyhead
+        self.register_buffer("target_mean", target_mean)
+        self.register_buffer("target_std", target_std)
+        self.register_buffer("cond_mean", cond_mean)
+        self.register_buffer("cond_std", cond_std)
+
+    def forward(
+        self,
+        y_raw: torch.Tensor,
+        c_raw: torch.Tensor,
+        u: torch.Tensor,
+        sigma: torch.Tensor,
+    ) -> torch.Tensor:
+        y_std = (y_raw - self.target_mean) / self.target_std
+        c_std = (c_raw - self.cond_mean) / self.cond_std
+        coefs = self.polyhead(y_std, c_std)              # [B, n_basis]
+        # Broadcast coefs across N_var without materializing a copy.
+        coefs_b = coefs.unsqueeze(1).expand(-1, u.shape[1], -1)
+        return evaluate_joint(
+            coefs_b, u, sigma,
+            self.polyhead.joint_indices,
+            basis=str(getattr(self.polyhead, "basis", "monomial")),
+            scale_u=float(getattr(self.polyhead, "basis_scale_u", 1.0)),
+            scale_sigma=float(
+                getattr(self.polyhead, "basis_scale_sigma", 1.0)
+            ),
+            basis_aux=self.polyhead.basis_aux,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with flow_polyhead_export)
+# ---------------------------------------------------------------------------
+
+def _decompose_linear(ep):
+    aten = torch.ops.aten
+
+    def _linear_decomp(input, weight, bias=None):
+        if bias is None:
+            return aten.mm.default(input, weight.permute(1, 0))
+        return aten.addmm.default(bias, input, weight.permute(1, 0))
+
+    return ep.run_decompositions({aten.linear.default: _linear_decomp})
+
+
+def _to_tuple(out):
+    if isinstance(out, (tuple, list)):
+        return tuple(out)
+    return (out,)
+
+
+def _validate_aoti(wrapper, runner, n_features, n_cond, B, n_events, tol):
+    rng = np.random.default_rng(0)
+    n_events = max(B, ((n_events + B - 1) // B) * B)
+    y = torch.from_numpy(
+        rng.standard_normal((n_events, n_features)).astype(np.float32)
+    )
+    c = torch.from_numpy(
+        rng.standard_normal((n_events, n_cond)).astype(np.float32)
+    )
+    eager_chunks, aoti_chunks = [], []
+    with torch.no_grad():
+        for s in range(0, n_events, B):
+            yi, ci = y[s:s + B], c[s:s + B]
+            eager_chunks.append(_to_tuple(wrapper(yi, ci))[0])
+            aoti_chunks.append(_to_tuple(runner(yi, ci))[0])
+    et, at = torch.cat(eager_chunks), torch.cat(aoti_chunks)
+    max_abs = (et - at).abs().max().item()
+    denom = max(et.abs().max().item(), 1e-30)
+    rel = max_abs / denom
+    status = "OK" if rel < tol else "MISMATCH"
+    print(
+        f"[validate-aoti] joint_coefs: max |eager-aoti|={max_abs:.3e} "
+        f"rel={rel:.2e}  {status}"
+    )
+    return rel < tol
+
+
+def _validate_onnx_combined(
+    combined, onnx_path, n_features, n_cond, n_events, tol,
+    n_var: int = 8,
+):
+    """Compare eager vs ORT for the (y, c, u, σ) → d combined graph."""
+    try:
+        import onnxruntime as ort
+    except ImportError:
+        print("[validate-onnx-combined] onnxruntime not installed — skipping.")
+        return True
+    sess = ort.InferenceSession(
+        onnx_path, providers=["CPUExecutionProvider"],
+    )
+    rng = np.random.default_rng(2)
+    y_v = rng.standard_normal((n_events, n_features)).astype(np.float32)
+    c_v = rng.standard_normal((n_events, n_cond)).astype(np.float32)
+    u_v = rng.uniform(-1.0, 1.0,
+                      (n_events, n_var, n_features)).astype(np.float32)
+    s_v = rng.uniform(0.0, 1.0,
+                      (n_events, n_var, n_features)).astype(np.float32)
+    with torch.no_grad():
+        ref = combined(
+            torch.from_numpy(y_v), torch.from_numpy(c_v),
+            torch.from_numpy(u_v), torch.from_numpy(s_v),
+        ).numpy()
+    in_names = [i.name for i in sess.get_inputs()]
+    out_names = [o.name for o in sess.get_outputs()]
+    feeds = dict(zip(in_names, [y_v, c_v, u_v, s_v]))
+    ort_out = sess.run([out_names[0]], feeds)[0]
+    max_abs = float(np.abs(ref - ort_out).max())
+    denom = max(float(np.abs(ref).max()), 1e-30)
+    rel = max_abs / denom
+    status = "OK" if rel < tol else "MISMATCH"
+    print(
+        f"[validate-onnx-combined] d over N={n_events} N_var={n_var}: "
+        f"max |eager-ort|={max_abs:.3e} rel={rel:.2e}  {status}"
+    )
+    return rel < tol
+
+
+def _validate_onnx(
+    wrapper, onnx_path, n_features, n_cond, n_events, tol,
+):
+    try:
+        import onnxruntime as ort
+    except ImportError:
+        print("[validate-onnx] onnxruntime not installed — skipping.")
+        return True
+    sess = ort.InferenceSession(
+        onnx_path, providers=["CPUExecutionProvider"],
+    )
+    rng = np.random.default_rng(1)
+    y_v = rng.standard_normal((n_events, n_features)).astype(np.float32)
+    c_v = rng.standard_normal((n_events, n_cond)).astype(np.float32)
+    with torch.no_grad():
+        ref = wrapper(
+            torch.from_numpy(y_v), torch.from_numpy(c_v),
+        ).numpy()
+    out_names = [o.name for o in sess.get_outputs()]
+    in_names = [i.name for i in sess.get_inputs()]
+    feeds = {in_names[0]: y_v, in_names[1]: c_v}
+    ort_out = sess.run([out_names[0]], feeds)[0]
+    max_abs = float(np.abs(ref - ort_out).max())
+    denom = max(float(np.abs(ref).max()), 1e-30)
+    rel = max_abs / denom
+    status = "OK" if rel < tol else "MISMATCH"
+    print(
+        f"[validate-onnx] joint_coefs over N={n_events}: "
+        f"max |eager-ort|={max_abs:.3e} rel={rel:.2e}  {status}"
+    )
+    return rel < tol
+
+
+# ---------------------------------------------------------------------------
+# Sidecar — joint_indices in flat per-axis-degree form
+# ---------------------------------------------------------------------------
+
+def _emit_indices_sidecar(polyhead, stats, out_path):
+    """Write a JSON file describing the polynomial basis so the C++
+    side can evaluate it without re-implementing the index logic.
+
+    For each basis index i, ``alpha_degs[i, j]`` is the degree of the
+    j-th u-axis monomial factor (0 if axis j absent) and similarly
+    for ``beta_degs``. This is the same layout used by
+    ``train_muon_response_flow._build_basis_aux``.
+    """
+    n_features = int(polyhead.n_features)
+    aa, bb = [], []
+    for (a, b) in polyhead._joint_indices:
+        aa.append(_multiindex_to_axis_degrees(a, n_features))
+        bb.append(_multiindex_to_axis_degrees(b, n_features))
+    payload = {
+        "n_features":     n_features,
+        "n_basis":        int(polyhead.n_basis),
+        "n_pure_u":       int(polyhead._n_pure_u),
+        "n_pure_sigma":   int(polyhead._n_pure_s),
+        "n_cross":        int(polyhead._n_cross),
+        "max_deg_u":      int(polyhead.max_deg_u),
+        "max_deg_sigma":  int(polyhead.max_deg_sigma),
+        "max_cross_deg":  int(polyhead.max_cross_deg),
+        "basis":          str(getattr(polyhead, "basis", "monomial")),
+        "basis_scale_u":  float(
+            getattr(polyhead, "basis_scale_u", 1.0)
+        ),
+        "basis_scale_sigma": float(
+            getattr(polyhead, "basis_scale_sigma", 1.0)
+        ),
+        "alpha_degs":     [list(map(int, row)) for row in aa],
+        "beta_degs":      [list(map(int, row)) for row in bb],
+        "target_std":     [float(x) for x in stats.target_std],
+        "target_mean":    [float(x) for x in stats.target_mean],
+        "cond_std":       [float(x) for x in stats.cond_std],
+        "cond_mean":      [float(x) for x in stats.cond_mean],
+    }
+    with open(out_path, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"wrote {out_path} (n_basis={payload['n_basis']})")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--checkpoint", required=True,
+        help="Path to a shift_smear_reweight checkpoint with "
+        "model_config.arch == 'polyhead'.",
+    )
+    p.add_argument(
+        "--output", default=None,
+        help="AOTI .pt2 output path. Pass empty string or skip to "
+        "disable AOTI export. Default: alongside the checkpoint as "
+        "shift_smear_reweight_polyhead.pt2.",
+    )
+    p.add_argument(
+        "--onnx-output", default=None,
+        help="ONNX .onnx output path for the trunk-only graph "
+        "(forward(y, c) -> coefs). Default: alongside the "
+        "checkpoint as shift_smear_reweight_polyhead.onnx.",
+    )
+    p.add_argument(
+        "--combined-onnx-output", default=None,
+        help="ONNX .onnx output path for the combined graph "
+        "(forward(y, c, u, sigma) -> d) with the polynomial "
+        "evaluation folded in. Default: alongside the checkpoint as "
+        "shift_smear_reweight_polyhead_combined.onnx. Pass empty "
+        "string to disable.",
+    )
+    p.add_argument(
+        "--combined-output", default=None,
+        help="AOTI .pt2 output path for the combined graph "
+        "(forward(y, c, u, sigma) -> d). Compiled with dynamic batch "
+        "and dynamic N_var dimensions so a single package handles "
+        "any (B, N_var) at runtime. Default: alongside the "
+        "checkpoint as shift_smear_reweight_polyhead_combined.pt2. "
+        "Pass empty string to disable.",
+    )
+    p.add_argument(
+        "--indices-output", default=None,
+        help="JSON sidecar path. Default: derived from --output by "
+        "replacing the trailing extension with '.indices.json'.",
+    )
+    p.add_argument(
+        "--batch", type=int, default=1,
+        help="Static batch size baked into AOTI when "
+        "--no-dynamic-batch is in effect.",
+    )
+    p.add_argument(
+        "--dynamic-batch",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="Compile a dynamic-batch AOTI package. Off by default "
+        "(static batch=1 is the lowest-latency narf path).",
+    )
+    p.add_argument(
+        "--max-autotune",
+        action=argparse.BooleanOptionalAction, default=True,
+    )
+    p.add_argument(
+        "--freeze",
+        action=argparse.BooleanOptionalAction, default=True,
+    )
+    p.add_argument(
+        "--prepack",
+        action=argparse.BooleanOptionalAction, default=True,
+    )
+    p.add_argument(
+        "--link-libtorch",
+        action=argparse.BooleanOptionalAction, default=True,
+        help="If False, AOTI compiles the wrapper.so without "
+        "libtorch.so / libtorch_cpu.so as DT_NEEDED, leaving only "
+        "the C-ABI aoti_torch_* shim symbols (~20) plus libgomp/"
+        "glibc as runtime deps. The shim must be resolved at app "
+        "link time — either from libtorch_cpu (already needed for "
+        "AOTIModelPackageLoader at the harness level), or from a "
+        "minimal hand-rolled implementation. Tradeoff: with "
+        "link_libtorch=False inductor's vec-ISA dry-compile fails "
+        "(its probe code calls .exp() → Sleef_*, which isn't "
+        "linkable without libtorch_cpu) so pick_vec_isa() falls "
+        "back to INVALID and the autotuner is restricted to the "
+        "scalar reference micro-gemm. On this trunk that's roughly "
+        "5x slower than the AVX2 FP32Vec path. Use only if "
+        "deployment-size constraints outweigh the per-event cost.",
+    )
+    p.add_argument(
+        "--package-cpp-only",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="Emit the AOTI .pt2 as source code (.cpp + .h + "
+        ".weights.o + CMakeLists.txt) instead of a precompiled "
+        ".so. Combined with --no-link-libtorch this gives full "
+        "control over the link line — e.g. statically link a "
+        "custom shim, set custom CFLAGS, target an embedded "
+        "toolchain. Off by default.",
+    )
+    p.add_argument("--opset", type=int, default=17)
+    p.add_argument("--validate-n", type=int, default=128)
+    p.add_argument("--validate-tol", type=float, default=1e-4)
+    p.add_argument(
+        "--bench", action="store_true",
+        help="After export, time AOTI runner forward at the static "
+        "batch (single core).",
+    )
+    p.add_argument("--bench-duration", type=float, default=2.0)
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _default_paths(args):
+    base = os.path.dirname(os.path.abspath(args.checkpoint))
+    if args.output is None:
+        args.output = os.path.join(
+            base, "shift_smear_reweight_polyhead.pt2",
+        )
+    if args.onnx_output is None:
+        args.onnx_output = os.path.join(
+            base, "shift_smear_reweight_polyhead.onnx",
+        )
+    if args.combined_onnx_output is None:
+        args.combined_onnx_output = os.path.join(
+            base, "shift_smear_reweight_polyhead_combined.onnx",
+        )
+    if args.combined_output is None:
+        args.combined_output = os.path.join(
+            base, "shift_smear_reweight_polyhead_combined.pt2",
+        )
+    if args.indices_output is None:
+        args.indices_output = os.path.join(
+            base, "shift_smear_reweight_polyhead.indices.json",
+        )
+
+
+def _build_wrapper(checkpoint_path):
+    """Load checkpoint via the diagnostic loader (handles both old and
+    current model_config schemas) and wrap it for export.
+    """
+    from train_muon_response_flow import PreprocStats
+    model, arch, stats, _ = load_model_from_checkpoint(
+        checkpoint_path, device="cpu",
+    )
+    if arch != "polyhead":
+        raise SystemExit(
+            f"--checkpoint arch={arch!r}; only 'polyhead' is supported "
+            "by this exporter. For 'mlp' / 'mlp-factored' arches use "
+            "the combined-MLP exporter "
+            "(scripts/corrections/muon_calibration/"
+            "train_shift_reweight_mlp_export.py for legacy shift-only "
+            "MLP; or the bench_mlp_combined_export.py pattern adapted "
+            "to whichever head class the checkpoint carries — "
+            "ReweightMLP_B for 'mlp' or ReweightMLPFactored for "
+            "'mlp-factored')."
+        )
+    if stats is None:
+        # Fall back to preproc.json next to the checkpoint.
+        ck_dir = os.path.dirname(os.path.abspath(checkpoint_path))
+        pp = os.path.join(ck_dir, "preproc.json")
+        if not os.path.exists(pp):
+            raise SystemExit(
+                f"checkpoint has no PreprocStats and no preproc.json "
+                f"at {pp}"
+            )
+        with open(pp) as f:
+            stats = PreprocStats(**json.load(f))
+    target_mean = torch.tensor(
+        list(stats.target_mean), dtype=torch.float32,
+    )
+    target_std = torch.tensor(
+        list(stats.target_std), dtype=torch.float32,
+    )
+    cond_mean = torch.tensor(
+        list(stats.cond_mean), dtype=torch.float32,
+    )
+    cond_std = torch.tensor(
+        list(stats.cond_std), dtype=torch.float32,
+    )
+    wrapper = ReweightPolyheadInference(
+        polyhead=model.eval(),
+        target_mean=target_mean,
+        target_std=target_std,
+        cond_mean=cond_mean,
+        cond_std=cond_std,
+    ).eval()
+    n_features = int(target_mean.shape[0])
+    n_cond = int(cond_mean.shape[0])
+    return wrapper, model, stats, n_features, n_cond
+
+
+def main():
+    args = parse_args()
+    _default_paths(args)
+
+    if args.freeze:
+        ind_cfg.freezing = True
+    if args.prepack:
+        ind_cfg.cpp.weight_prepack = True
+    if args.max_autotune:
+        ind_cfg.max_autotune = True
+        ind_cfg.max_autotune_gemm = True
+    # AOTI runtime-dependency knobs. ``link_libtorch=False`` strips
+    # libtorch / libtorch_cpu from the wrapper.so's DT_NEEDED, leaving
+    # only the ~20 aoti_torch_* C-shim symbols plus glibc/libstdc++/
+    # libgomp. ``package_cpp_only=True`` emits source + CMakeLists in
+    # the .pt2 instead of a compiled .so so the caller can choose how
+    # to satisfy the shim (e.g. static-link a custom implementation).
+    if not args.link_libtorch:
+        ind_cfg.aot_inductor.link_libtorch = False
+    if args.package_cpp_only:
+        ind_cfg.aot_inductor.package_cpp_only = True
+        # Pair with embed_kernel_binary so the .weights.o is bundled.
+        ind_cfg.aot_inductor.embed_kernel_binary = True
+    print(
+        f"inductor: freezing={ind_cfg.freezing} "
+        f"weight_prepack={ind_cfg.cpp.weight_prepack} "
+        f"max_autotune={getattr(ind_cfg, 'max_autotune', False)} "
+        f"link_libtorch={ind_cfg.aot_inductor.link_libtorch} "
+        f"package_cpp_only={getattr(ind_cfg.aot_inductor, 'package_cpp_only', False)}"
+    )
+
+    print(f"loading checkpoint {args.checkpoint}")
+    wrapper, polyhead, stats, n_features, n_cond = _build_wrapper(
+        args.checkpoint,
+    )
+    print(
+        f"polyhead: n_basis={polyhead.n_basis} "
+        f"(pu={polyhead._n_pure_u} ps={polyhead._n_pure_s} "
+        f"cr={polyhead._n_cross}) "
+        f"max_deg_u={polyhead.max_deg_u} "
+        f"max_deg_sigma={polyhead.max_deg_sigma} "
+        f"max_cross_deg={polyhead.max_cross_deg} "
+        f"basis={getattr(polyhead, 'basis', 'monomial')}"
+    )
+
+    # Always emit the sidecar (cheap; needed for both ORT and AOTI).
+    _emit_indices_sidecar(polyhead, stats, args.indices_output)
+
+    B = args.batch
+    B_trace = max(B, 2) if args.dynamic_batch else B
+    y = torch.randn(B_trace, n_features)
+    c = torch.randn(B_trace, n_cond)
+    with torch.no_grad():
+        ref = wrapper(y, c)
+    print(f"eager: joint_coefs={tuple(ref.shape)}")
+
+    # ---------- AOTI ----------
+    if args.output:
+        os.makedirs(
+            os.path.dirname(os.path.abspath(args.output)) or ".",
+            exist_ok=True,
+        )
+        if args.dynamic_batch:
+            batch_dim = torch.export.Dim("batch", min=1, max=2**20)
+            dynamic_shapes = {
+                "y_raw": {0: batch_dim},
+                "c_raw": {0: batch_dim},
+            }
+            print(
+                f"\ntorch.export.export (dynamic batch, B_example="
+                f"{B_trace}) ..."
+            )
+        else:
+            dynamic_shapes = None
+            print(f"\ntorch.export.export (static B={B}) ...")
+        ep = torch.export.export(
+            wrapper, (y, c), dynamic_shapes=dynamic_shapes,
+        )
+        ep = _decompose_linear(ep)
+        print(f"aoti_compile_and_package -> {args.output}")
+        with torch.no_grad():
+            torch._inductor.aoti_compile_and_package(
+                ep, package_path=args.output,
+            )
+        size_mb = os.path.getsize(args.output) / 1e6
+        print(f" OK ({size_mb:.2f} MB)")
+
+        if args.package_cpp_only:
+            # cpp-only .pt2 has no precompiled wrapper.so — caller
+            # builds it via the bundled CMakeLists. Skip in-process
+            # validation; round-trip must be done with the built
+            # artifact externally.
+            print(
+                "package_cpp_only=True: skipping in-process AOTI "
+                "round-trip (no .so in package; build via CMake)."
+            )
+        elif not args.link_libtorch:
+            # ``aoti_load_package`` dlopens the wrapper.so with
+            # RTLD_LOCAL by default, so the aoti_torch_* shim
+            # symbols (provided by libtorch_cpu) aren't visible
+            # unless we promote libtorch_cpu to RTLD_GLOBAL first.
+            # Do so explicitly so users can still validate the
+            # exported package round-trips correctly.
+            import ctypes
+            import torch as _torch
+            _libcpu = os.path.join(
+                os.path.dirname(_torch.__file__), "lib",
+                "libtorch_cpu.so",
+            )
+            ctypes.CDLL(_libcpu, mode=ctypes.RTLD_GLOBAL)
+            runner = torch._inductor.aoti_load_package(args.output)
+            out = _to_tuple(runner(y, c))[0]
+            diff = (out - ref).abs().max().item()
+            print(f"loaded; max |aoti - eager| joint_coefs = {diff:.2e}")
+            if args.validate_n > 0:
+                _validate_aoti(
+                    wrapper, runner, n_features, n_cond, B,
+                    args.validate_n, args.validate_tol,
+                )
+        else:
+            runner = torch._inductor.aoti_load_package(args.output)
+            out = _to_tuple(runner(y, c))[0]
+            diff = (out - ref).abs().max().item()
+            print(f"loaded; max |aoti - eager| joint_coefs = {diff:.2e}")
+
+            if args.validate_n > 0:
+                _validate_aoti(
+                    wrapper, runner, n_features, n_cond, B,
+                    args.validate_n, args.validate_tol,
+                )
+
+        if args.bench:
+            try:
+                os.sched_setaffinity(0, {0})
+            except Exception:
+                pass
+            torch.set_num_threads(1)
+            torch.set_num_interop_threads(1)
+            for _ in range(20):
+                runner(y, c)
+            n = 0
+            t0 = time.perf_counter()
+            deadline = t0 + args.bench_duration
+            while True:
+                runner(y, c)
+                n += 1
+                if n >= 5 and time.perf_counter() >= deadline:
+                    break
+            elapsed = time.perf_counter() - t0
+            ms_b = 1000.0 * elapsed / n
+            us_e = 1e6 * elapsed / n / B
+            ev_s = n * B / elapsed
+            print(
+                f"\naoti bench (B={B}, 1 core): "
+                f"{ms_b:.3f} ms/call  {us_e:.3f} us/event  "
+                f"{ev_s:.1f} ev/s  ({n} iters)"
+            )
+
+    # ---------- ONNX ----------
+    if args.onnx_output:
+        os.makedirs(
+            os.path.dirname(os.path.abspath(args.onnx_output)) or ".",
+            exist_ok=True,
+        )
+        dynamic_axes = None
+        # Export ONNX with dynamic batch by default — trivial for ORT.
+        dynamic_axes = {
+            "y_raw":      {0: "batch"},
+            "c_raw":      {0: "batch"},
+            "joint_coefs": {0: "batch"},
+        }
+        print(
+            f"\ntorch.onnx.export (dynamic batch, B_example={B_trace}, "
+            f"opset={args.opset}) -> {args.onnx_output}"
+        )
+        torch.onnx.export(
+            wrapper, (y, c), args.onnx_output,
+            input_names=["y_raw", "c_raw"],
+            output_names=["joint_coefs"],
+            dynamic_axes=dynamic_axes,
+            opset_version=args.opset,
+            do_constant_folding=True,
+            export_params=True,
+        )
+        size_mb = os.path.getsize(args.onnx_output) / 1e6
+        print(f" OK ({size_mb:.2f} MB)")
+
+        if args.validate_n > 0:
+            _validate_onnx(
+                wrapper, args.onnx_output, n_features, n_cond,
+                args.validate_n, args.validate_tol,
+            )
+
+    # ---------- Combined AOTI / ONNX share the same wrapper ----------
+    combined = None
+    if args.combined_output or args.combined_onnx_output:
+        combined = CombinedInference(
+            polyhead=polyhead,
+            target_mean=wrapper.target_mean,
+            target_std=wrapper.target_std,
+            cond_mean=wrapper.cond_mean,
+            cond_std=wrapper.cond_std,
+        ).eval()
+        # Eager smoke check at a non-trivial (B, N_var). Both dims
+        # must be > 1 to avoid torch.export specializing them.
+        B_ex, N_ex = max(B_trace, 2), 4
+        y_e = torch.randn(B_ex, n_features)
+        c_e = torch.randn(B_ex, n_cond)
+        u_e = torch.randn(B_ex, N_ex, n_features)
+        s_e = torch.randn(B_ex, N_ex, n_features)
+        with torch.no_grad():
+            d_e = combined(y_e, c_e, u_e, s_e)
+        print(
+            f"\ncombined eager: d={tuple(d_e.shape)} "
+            f"(B={B_ex}, N_var={N_ex})"
+        )
+
+    # ---------- Combined AOTI .pt2 ----------
+    if args.combined_output:
+        os.makedirs(
+            os.path.dirname(
+                os.path.abspath(args.combined_output)
+            ) or ".",
+            exist_ok=True,
+        )
+        batch_dim = torch.export.Dim("batch", min=1, max=2**20)
+        nvar_dim  = torch.export.Dim("nvar",  min=1, max=2**20)
+        dynamic_shapes_combined = {
+            "y_raw":  {0: batch_dim},
+            "c_raw":  {0: batch_dim},
+            "u":      {0: batch_dim, 1: nvar_dim},
+            "sigma":  {0: batch_dim, 1: nvar_dim},
+        }
+        print(
+            f"torch.export.export combined "
+            f"(dynamic batch+nvar, B={B_ex}, N_var={N_ex}) ..."
+        )
+        ep = torch.export.export(
+            combined, (y_e, c_e, u_e, s_e),
+            dynamic_shapes=dynamic_shapes_combined,
+        )
+        ep = _decompose_linear(ep)
+        print(f"aoti_compile_and_package -> {args.combined_output}")
+        with torch.no_grad():
+            torch._inductor.aoti_compile_and_package(
+                ep, package_path=args.combined_output,
+            )
+        size_mb = os.path.getsize(args.combined_output) / 1e6
+        print(f" OK ({size_mb:.2f} MB)")
+
+        if args.package_cpp_only:
+            print(
+                "package_cpp_only=True: skipping in-process combined "
+                "AOTI round-trip (no .so in package; build via CMake)."
+            )
+            runner = None
+        else:
+            if not args.link_libtorch:
+                # See trunk export: promote libtorch_cpu to RTLD_GLOBAL
+                # so the wrapper.so's aoti_torch_* shim symbols
+                # resolve at dlopen time when libtorch isn't in
+                # DT_NEEDED.
+                import ctypes
+                import torch as _torch
+                _libcpu = os.path.join(
+                    os.path.dirname(_torch.__file__), "lib",
+                    "libtorch_cpu.so",
+                )
+                ctypes.CDLL(_libcpu, mode=ctypes.RTLD_GLOBAL)
+            runner = torch._inductor.aoti_load_package(args.combined_output)
+            out = _to_tuple(runner(y_e, c_e, u_e, s_e))[0]
+            diff = (out - d_e).abs().max().item()
+            print(
+                f"loaded; max |aoti - eager| d = {diff:.2e}"
+            )
+
+        if args.validate_n > 0 and runner is not None:
+            # Match the existing combined-ONNX validation: random
+            # (y, c, u, σ) at N_var=8.
+            rng = np.random.default_rng(3)
+            n_use = args.validate_n
+            n_var = 8
+            y_v = torch.from_numpy(rng.standard_normal(
+                (n_use, n_features)).astype(np.float32))
+            c_v = torch.from_numpy(rng.standard_normal(
+                (n_use, n_cond)).astype(np.float32))
+            u_v = torch.from_numpy(rng.uniform(
+                -1.0, 1.0, (n_use, n_var, n_features)
+            ).astype(np.float32))
+            s_v = torch.from_numpy(rng.uniform(
+                0.0, 1.0, (n_use, n_var, n_features)
+            ).astype(np.float32))
+            with torch.no_grad():
+                ref = combined(y_v, c_v, u_v, s_v)
+                aoti_out = _to_tuple(runner(y_v, c_v, u_v, s_v))[0]
+            max_abs = (ref - aoti_out).abs().max().item()
+            denom = max(ref.abs().max().item(), 1e-30)
+            rel = max_abs / denom
+            status = (
+                "OK" if rel < args.validate_tol else "MISMATCH"
+            )
+            print(
+                f"[validate-aoti-combined] d over N={n_use} "
+                f"N_var={n_var}: max |eager-aoti|={max_abs:.3e} "
+                f"rel={rel:.2e}  {status}"
+            )
+
+    # ---------- Combined ONNX (trunk + poly) ----------
+    if args.combined_onnx_output:
+        os.makedirs(
+            os.path.dirname(
+                os.path.abspath(args.combined_onnx_output)
+            ) or ".",
+            exist_ok=True,
+        )
+        dynamic_axes_combined = {
+            "y_raw":  {0: "batch"},
+            "c_raw":  {0: "batch"},
+            "u":      {0: "batch", 1: "nvar"},
+            "sigma":  {0: "batch", 1: "nvar"},
+            "d":      {0: "batch", 1: "nvar"},
+        }
+        print(
+            f"torch.onnx.export combined (dynamic batch+nvar, "
+            f"B={B_ex} N_var={N_ex}, opset={args.opset}) -> "
+            f"{args.combined_onnx_output}"
+        )
+        torch.onnx.export(
+            combined, (y_e, c_e, u_e, s_e), args.combined_onnx_output,
+            input_names=["y_raw", "c_raw", "u", "sigma"],
+            output_names=["d"],
+            dynamic_axes=dynamic_axes_combined,
+            opset_version=args.opset,
+            do_constant_folding=True,
+            export_params=True,
+        )
+        size_mb = os.path.getsize(args.combined_onnx_output) / 1e6
+        print(f" OK ({size_mb:.2f} MB)")
+
+        if args.validate_n > 0:
+            _validate_onnx_combined(
+                combined, args.combined_onnx_output, n_features,
+                n_cond, args.validate_n, args.validate_tol,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
+++ b/scripts/corrections/muon_calibration/shift_smear_reweight_export.py
@@ -60,6 +60,11 @@ from train_muon_response_flow import (  # noqa: E402
     _multiindex_to_axis_degrees,
     evaluate_joint,
 )
+from train_shift_smear_reweight import (  # noqa: E402
+    _LOG_W_CLAMP,
+    _pack_sigma_outer,
+    _sigma_pack_indices,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -81,9 +86,11 @@ class ReweightPolyheadInference(nn.Module):
         target_std: torch.Tensor,
         cond_mean: torch.Tensor,
         cond_std: torch.Tensor,
+        muon_source_idx: int = -1,
     ):
         super().__init__()
         self.polyhead = polyhead
+        self.muon_source_idx = int(muon_source_idx)
         self.register_buffer("target_mean", target_mean)
         self.register_buffer("target_std", target_std)
         self.register_buffer("cond_mean", cond_mean)
@@ -92,6 +99,7 @@ class ReweightPolyheadInference(nn.Module):
     def forward(
         self, y_raw: torch.Tensor, c_raw: torch.Tensor,
     ) -> torch.Tensor:
+        c_raw = _remap_muon_source_inplace(c_raw, self.muon_source_idx)
         y_std = (y_raw - self.target_mean) / self.target_std
         c_std = (c_raw - self.cond_mean) / self.cond_std
         return self.polyhead(y_std, c_std)
@@ -123,9 +131,11 @@ class CombinedInference(nn.Module):
         target_std: torch.Tensor,
         cond_mean: torch.Tensor,
         cond_std: torch.Tensor,
+        muon_source_idx: int = -1,
     ):
         super().__init__()
         self.polyhead = polyhead
+        self.muon_source_idx = int(muon_source_idx)
         self.register_buffer("target_mean", target_mean)
         self.register_buffer("target_std", target_std)
         self.register_buffer("cond_mean", cond_mean)
@@ -138,6 +148,7 @@ class CombinedInference(nn.Module):
         u: torch.Tensor,
         sigma: torch.Tensor,
     ) -> torch.Tensor:
+        c_raw = _remap_muon_source_inplace(c_raw, self.muon_source_idx)
         y_std = (y_raw - self.target_mean) / self.target_std
         c_std = (c_raw - self.cond_mean) / self.cond_std
         coefs = self.polyhead(y_std, c_std)              # [B, n_basis]
@@ -156,6 +167,209 @@ class CombinedInference(nn.Module):
 
 
 # ---------------------------------------------------------------------------
+# Per-muon ``muon_source`` remap baked into the graph.
+#
+# The trainer compacts the raw integer code {1 = prompt W/Z muon,
+# 15 = secondary from a τ decay, 443 = J/ψ leg} into {-1, 0, +1}
+# before standardising (see ``arrow_shard_loader._MUON_SOURCE_CODES``).
+# We want callers (the C++ ``Muon_genPartFlav`` plumbing) to pass the
+# *raw* integer in physical units; the graph does the remap as part
+# of the preproc so there is one less convention for the C++ side to
+# track. The mapping is exclusive (each row is exactly one of 1/15/
+# 443), so ``+1 * (ms==443) - 1 * (ms==1)`` reproduces the compact
+# code without a ``where``-chain.
+# ---------------------------------------------------------------------------
+
+def _remap_muon_source_inplace(
+    c_raw: torch.Tensor, muon_source_idx: int,
+) -> torch.Tensor:
+    """Return a new tensor identical to ``c_raw`` except column
+    ``muon_source_idx`` is remapped from the raw {1, 15, 443} codes
+    to compact {-1, 0, +1} via a concat (export-friendly, no
+    in-place mutation of caller buffers)."""
+    if muon_source_idx < 0:
+        return c_raw
+    idx = muon_source_idx
+    ms_raw = c_raw[:, idx:idx + 1]
+    is_jpsi = (ms_raw == 443).to(c_raw.dtype)
+    is_prompt = (ms_raw == 1).to(c_raw.dtype)
+    # +1 for J/ψ, -1 for prompt W/Z, 0 for τ-decay (== 15) or anything
+    # else — matches the trainer's ``_MUON_SOURCE_CODES`` table.
+    ms_compact = is_jpsi - is_prompt
+    return torch.cat([c_raw[:, :idx], ms_compact, c_raw[:, idx + 1:]], dim=1)
+
+
+def _muon_source_idx(stats) -> int:
+    """Return the index of ``muon_source`` in ``stats.cond_names``,
+    or -1 if the model wasn't trained with it (back-compat)."""
+    names = list(getattr(stats, "cond_names", None) or ())
+    return names.index("muon_source") if "muon_source" in names else -1
+
+
+def _onnx_inline_external_data(path: str) -> bool:
+    """If ``path`` was written with external-data sidecars (the dynamo
+    exporter spills weights above ~1 KB by default), absorb the
+    sidecars back into the protobuf so the result is a single self-
+    contained .onnx. No-op when there is no external data.
+
+    Sidecar files referenced by the original model are removed after
+    the inline rewrite. Returns ``True`` if a rewrite was performed,
+    ``False`` if the model was already inline.
+    """
+    import onnx
+
+    base_dir = os.path.dirname(os.path.abspath(path)) or "."
+    # First, inspect *without* loading external bytes — that gives us
+    # the exact set of sidecar paths to clean up after the rewrite.
+    m_meta = onnx.load(path, load_external_data=False)
+    sidecars = set()
+    for init in m_meta.graph.initializer:
+        if init.data_location == onnx.TensorProto.EXTERNAL:
+            for d in init.external_data:
+                if d.key == "location":
+                    sidecars.add(os.path.join(base_dir, d.value))
+    if not sidecars:
+        return False
+    # Reload with external data inlined into the protobuf, then save
+    # back as a single file.
+    m = onnx.load(path)  # default: load_external_data=True
+    onnx.save(m, path, save_as_external_data=False)
+    for s in sidecars:
+        try:
+            os.remove(s)
+        except OSError:
+            pass
+    return True
+
+
+class CombinedInferenceMLP(nn.Module):
+    """``forward(y_raw, c_raw, u_raw, sigma_raw) → log_r`` for the
+    ``mlp`` / ``mlp-factored`` archs.
+
+    Mirrors :class:`CombinedInference` but routes the head through the
+    MLP/factored-MLP heads instead of the polynomial. The graph carries
+    the full preprocessing — y/c mean+std, u/σ std (no mean: they're
+    deltas in target space) — so the caller passes everything in
+    physical target units and no ``preproc.json`` is needed at runtime.
+    ``sigma_pack`` is built inside the graph from the standardised
+    ``sigma``.
+
+    Output is the final ``log_r`` after the trained positivity wrap
+    (``exp`` -> a symmetric clamp at ``±_LOG_W_CLAMP``) so the C++ side
+    just calls ``exp(log_r)`` to get the alt-weight directly. The
+    factored arch's head structurally vanishes at ``(u, σ) = (0, 0)``,
+    so no dual-forward subtraction is needed; the unfactored ``mlp``
+    arch does need it and that's handled here.
+
+    Shapes (all float32):
+        y_raw      [B, F]              (physical r_κ, δλ, δφ)
+        c_raw      [B, n_cond]         (physical log p_T, charge, λ, sφ, cφ)
+        u_raw      [B, N_var, F]       (physical Δy = δr_κ, δλ, δφ)
+        sigma_raw  [B, N_var, F]       (physical σ in the same units)
+        log_r      [B, N_var]
+    """
+
+    def __init__(
+        self,
+        head: nn.Module,
+        target_mean: torch.Tensor,
+        target_std: torch.Tensor,
+        cond_mean: torch.Tensor,
+        cond_std: torch.Tensor,
+        is_factored: bool,
+        shift_only: bool,
+        positivity_clamp: float = _LOG_W_CLAMP,
+        muon_source_idx: int = -1,
+    ):
+        super().__init__()
+        self.head = head
+        self.is_factored = bool(is_factored)
+        self.shift_only = bool(shift_only)
+        self.positivity_clamp = float(positivity_clamp)
+        n_features = int(target_mean.shape[0])
+        self.n_features = n_features
+        # Index of ``muon_source`` inside ``c_raw``; -1 means the model
+        # was trained without it and the remap is a no-op. Static int
+        # (not a buffer) — torch.export specialises on it.
+        self.muon_source_idx = int(muon_source_idx)
+        self.register_buffer("target_mean", target_mean)
+        self.register_buffer("target_std", target_std)
+        self.register_buffer("cond_mean", cond_mean)
+        self.register_buffer("cond_std", cond_std)
+        if not self.shift_only:
+            iu, ju = _sigma_pack_indices(n_features)
+            self.register_buffer("sigma_pack_iu", iu)
+            self.register_buffer("sigma_pack_ju", ju)
+        else:
+            # Stash zero-length tensors so torch.export sees consistent
+            # state regardless of branch; never actually indexed.
+            self.register_buffer(
+                "sigma_pack_iu", torch.zeros(0, dtype=torch.long),
+            )
+            self.register_buffer(
+                "sigma_pack_ju", torch.zeros(0, dtype=torch.long),
+            )
+
+    def forward(
+        self,
+        y_raw: torch.Tensor,
+        c_raw: torch.Tensor,
+        u_raw: torch.Tensor,
+        sigma_raw: torch.Tensor,
+    ) -> torch.Tensor:
+        # Remap ``muon_source`` from the raw integer code (1, 15, 443)
+        # to the compact {-1, 0, +1} the trainer saw. No-op if the
+        # model wasn't trained with the column.
+        c_raw = _remap_muon_source_inplace(c_raw, self.muon_source_idx)
+        # Full preproc inside the graph. y / c get mean+std (absolute
+        # observables); u / σ get std-only (they're deltas / magnitudes
+        # in target space, so the mean is meaningless).
+        y_std = (y_raw - self.target_mean) / self.target_std
+        c_std = (c_raw - self.cond_mean) / self.cond_std
+        u = u_raw / self.target_std
+        sigma = sigma_raw / self.target_std
+        # Trunk runs once per event; broadcast across N_var.
+        e = self.head.trunk_forward(y_std, c_std)              # [B, d_emb]
+        e_b = e.unsqueeze(1).expand(-1, u.shape[1], -1)        # [B, N_var, d_emb]
+
+        if self.shift_only:
+            sigma_pack = sigma.new_zeros(
+                (u.shape[0], u.shape[1], 0),
+            )
+        else:
+            sigma_pack = _pack_sigma_outer(
+                sigma, self.sigma_pack_iu, self.sigma_pack_ju,
+            )                                                  # [B, N_var, n_pack]
+
+        d = self.head.head_forward(e_b, u, sigma_pack)         # [B, N_var]
+        if not self.is_factored:
+            # Unfactored mlp head doesn't vanish at the origin; subtract
+            # ``head(e, 0, 0)`` to recover the trainer's effective d.
+            u_zero = torch.zeros_like(u)
+            sp_zero = torch.zeros_like(sigma_pack)
+            d0 = self.head.head_forward(e_b, u_zero, sp_zero)
+            d = d - d0
+
+        # Optional analytic-Gaussian baseline (additive contribution).
+        gb = getattr(self.head, "gauss_baseline", None)
+        if gb is not None:
+            from train_shift_smear_reweight import gauss_baseline_log_r
+            mu_g, L_g = gb(c_std)
+            mu_g_b = mu_g.unsqueeze(1).expand(-1, u.shape[1], -1)
+            L_g_b = L_g.unsqueeze(1).expand(-1, u.shape[1], -1, -1)
+            y_std_b = y_std.unsqueeze(1).expand(-1, u.shape[1], -1)
+            d = d + gauss_baseline_log_r(y_std_b, mu_g_b, L_g_b, u, sigma)
+
+        # Positivity wrap == "exp": a symmetric clamp on the log so
+        # ``exp(log_r)`` stays finite. ±_LOG_W_CLAMP matches the
+        # diagnostic path; the trainer's BCE loss uses inf-clamp but
+        # the deployment safety clamp is always the finite one.
+        return d.clamp(
+            min=-self.positivity_clamp, max=self.positivity_clamp,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Helpers (shared with flow_polyhead_export)
 # ---------------------------------------------------------------------------
 
@@ -163,9 +377,23 @@ def _decompose_linear(ep):
     aten = torch.ops.aten
 
     def _linear_decomp(input, weight, bias=None):
+        # ``aten.linear`` is rank-agnostic but the prim ``aten.mm`` /
+        # ``aten.addmm`` are 2D-only. For N-D inputs (e.g. the MLP
+        # head's ``[B, N_var, d_emb]`` after broadcasting across
+        # variations) reshape to 2D, run the matmul, then reshape
+        # back — for 2D inputs the reshapes are identity.
+        orig_shape = list(input.shape)
+        out_features = weight.shape[0]
+        if len(orig_shape) == 2:
+            if bias is None:
+                return aten.mm.default(input, weight.permute(1, 0))
+            return aten.addmm.default(bias, input, weight.permute(1, 0))
+        in_2d = input.reshape(-1, orig_shape[-1])
         if bias is None:
-            return aten.mm.default(input, weight.permute(1, 0))
-        return aten.addmm.default(bias, input, weight.permute(1, 0))
+            out_2d = aten.mm.default(in_2d, weight.permute(1, 0))
+        else:
+            out_2d = aten.addmm.default(bias, in_2d, weight.permute(1, 0))
+        return out_2d.reshape(orig_shape[:-1] + [out_features])
 
     return ep.run_decompositions({aten.linear.default: _linear_decomp})
 
@@ -422,6 +650,19 @@ def parse_args():
         "toolchain. Off by default.",
     )
     p.add_argument("--opset", type=int, default=17)
+    p.add_argument(
+        "--inline-weights",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="After ``torch.onnx.export``, absorb any external-data "
+        "sidecar (``*.onnx.data`` / ``*.weight``) back into the "
+        ".onnx protobuf so the model ships as a single self-"
+        "contained file. The dynamo exporter spills weights above a "
+        "small threshold into a sidecar by default; this option "
+        "reload+resaves them inline and removes the sidecars. "
+        "Subject to the 2 GB protobuf limit. Default on; pass "
+        "``--no-inline-weights`` to keep the sidecar layout.",
+    )
     p.add_argument("--validate-n", type=int, default=128)
     p.add_argument("--validate-tol", type=float, default=1e-4)
     p.add_argument(
@@ -464,22 +705,22 @@ def _default_paths(args):
 def _build_wrapper(checkpoint_path):
     """Load checkpoint via the diagnostic loader (handles both old and
     current model_config schemas) and wrap it for export.
+
+    Returns ``(wrapper, model, arch, stats, n_features, n_cond)``.
+    ``wrapper`` is the trunk-only export form. For ``polyhead`` it is
+    :class:`ReweightPolyheadInference` and ``forward(y, c) -> coefs``;
+    for ``mlp`` / ``mlp-factored`` the trunk-only form is meaningless
+    (the head is an MLP, not a polynomial) so ``wrapper`` is ``None``
+    and ``main`` only emits the combined (y, c, u, σ) variant.
     """
     from train_muon_response_flow import PreprocStats
     model, arch, stats, _ = load_model_from_checkpoint(
         checkpoint_path, device="cpu",
     )
-    if arch != "polyhead":
+    if arch not in ("polyhead", "mlp", "mlp-factored"):
         raise SystemExit(
-            f"--checkpoint arch={arch!r}; only 'polyhead' is supported "
-            "by this exporter. For 'mlp' / 'mlp-factored' arches use "
-            "the combined-MLP exporter "
-            "(scripts/corrections/muon_calibration/"
-            "train_shift_reweight_mlp_export.py for legacy shift-only "
-            "MLP; or the bench_mlp_combined_export.py pattern adapted "
-            "to whichever head class the checkpoint carries — "
-            "ReweightMLP_B for 'mlp' or ReweightMLPFactored for "
-            "'mlp-factored')."
+            f"--checkpoint arch={arch!r}; supported archs are "
+            "'polyhead', 'mlp', and 'mlp-factored'."
         )
     if stats is None:
         # Fall back to preproc.json next to the checkpoint.
@@ -504,16 +745,23 @@ def _build_wrapper(checkpoint_path):
     cond_std = torch.tensor(
         list(stats.cond_std), dtype=torch.float32,
     )
-    wrapper = ReweightPolyheadInference(
-        polyhead=model.eval(),
-        target_mean=target_mean,
-        target_std=target_std,
-        cond_mean=cond_mean,
-        cond_std=cond_std,
-    ).eval()
+    if arch == "polyhead":
+        wrapper = ReweightPolyheadInference(
+            polyhead=model.eval(),
+            target_mean=target_mean,
+            target_std=target_std,
+            cond_mean=cond_mean,
+            cond_std=cond_std,
+            muon_source_idx=_muon_source_idx(stats),
+        ).eval()
+    else:
+        # Trunk-only form is polyhead-specific; mlp / mlp-factored only
+        # support the combined export.
+        wrapper = None
+        model.eval()
     n_features = int(target_mean.shape[0])
     n_cond = int(cond_mean.shape[0])
-    return wrapper, model, stats, n_features, n_cond
+    return wrapper, model, arch, stats, n_features, n_cond
 
 
 def main():
@@ -548,32 +796,48 @@ def main():
     )
 
     print(f"loading checkpoint {args.checkpoint}")
-    wrapper, polyhead, stats, n_features, n_cond = _build_wrapper(
+    wrapper, model, arch, stats, n_features, n_cond = _build_wrapper(
         args.checkpoint,
     )
-    print(
-        f"polyhead: n_basis={polyhead.n_basis} "
-        f"(pu={polyhead._n_pure_u} ps={polyhead._n_pure_s} "
-        f"cr={polyhead._n_cross}) "
-        f"max_deg_u={polyhead.max_deg_u} "
-        f"max_deg_sigma={polyhead.max_deg_sigma} "
-        f"max_cross_deg={polyhead.max_cross_deg} "
-        f"basis={getattr(polyhead, 'basis', 'monomial')}"
-    )
+    print(f"arch={arch}  n_features={n_features}  n_cond={n_cond}")
 
-    # Always emit the sidecar (cheap; needed for both ORT and AOTI).
-    _emit_indices_sidecar(polyhead, stats, args.indices_output)
+    is_polyhead = (arch == "polyhead")
+    is_factored = (arch == "mlp-factored") or bool(
+        getattr(model, "is_factored", False)
+    )
+    shift_only = bool(getattr(model, "shift_only", False))
+
+    if is_polyhead:
+        polyhead = model
+        print(
+            f"polyhead: n_basis={polyhead.n_basis} "
+            f"(pu={polyhead._n_pure_u} ps={polyhead._n_pure_s} "
+            f"cr={polyhead._n_cross}) "
+            f"max_deg_u={polyhead.max_deg_u} "
+            f"max_deg_sigma={polyhead.max_deg_sigma} "
+            f"max_cross_deg={polyhead.max_cross_deg} "
+            f"basis={getattr(polyhead, 'basis', 'monomial')}"
+        )
+
+        # Always emit the sidecar (cheap; needed for both ORT and AOTI).
+        _emit_indices_sidecar(polyhead, stats, args.indices_output)
+    else:
+        print(
+            f"mlp head: is_factored={is_factored} shift_only={shift_only} "
+            "(trunk-only export not applicable; emitting combined only)"
+        )
 
     B = args.batch
     B_trace = max(B, 2) if args.dynamic_batch else B
     y = torch.randn(B_trace, n_features)
     c = torch.randn(B_trace, n_cond)
-    with torch.no_grad():
-        ref = wrapper(y, c)
-    print(f"eager: joint_coefs={tuple(ref.shape)}")
+    if is_polyhead:
+        with torch.no_grad():
+            ref = wrapper(y, c)
+        print(f"eager: joint_coefs={tuple(ref.shape)}")
 
-    # ---------- AOTI ----------
-    if args.output:
+    # ---------- AOTI (trunk-only, polyhead only) ----------
+    if args.output and is_polyhead:
         os.makedirs(
             os.path.dirname(os.path.abspath(args.output)) or ".",
             exist_ok=True,
@@ -674,8 +938,8 @@ def main():
                 f"{ev_s:.1f} ev/s  ({n} iters)"
             )
 
-    # ---------- ONNX ----------
-    if args.onnx_output:
+    # ---------- ONNX (trunk-only, polyhead only) ----------
+    if args.onnx_output and is_polyhead:
         os.makedirs(
             os.path.dirname(os.path.abspath(args.onnx_output)) or ".",
             exist_ok=True,
@@ -700,6 +964,10 @@ def main():
             do_constant_folding=True,
             export_params=True,
         )
+        if args.inline_weights and _onnx_inline_external_data(args.onnx_output):
+            print(
+                "  external-data sidecars absorbed -> single-file .onnx"
+            )
         size_mb = os.path.getsize(args.onnx_output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
 
@@ -712,13 +980,47 @@ def main():
     # ---------- Combined AOTI / ONNX share the same wrapper ----------
     combined = None
     if args.combined_output or args.combined_onnx_output:
-        combined = CombinedInference(
-            polyhead=polyhead,
-            target_mean=wrapper.target_mean,
-            target_std=wrapper.target_std,
-            cond_mean=wrapper.cond_mean,
-            cond_std=wrapper.cond_std,
-        ).eval()
+        # Build PreprocStats-derived buffers (the polyhead wrapper
+        # carries them; for mlp we have to derive them from ``stats``).
+        ms_idx = _muon_source_idx(stats)
+        if is_polyhead:
+            buffers = dict(
+                target_mean=wrapper.target_mean,
+                target_std=wrapper.target_std,
+                cond_mean=wrapper.cond_mean,
+                cond_std=wrapper.cond_std,
+            )
+            combined = CombinedInference(
+                polyhead=model, muon_source_idx=ms_idx, **buffers,
+            ).eval()
+        else:
+            buffers = dict(
+                target_mean=torch.tensor(
+                    list(stats.target_mean), dtype=torch.float32,
+                ),
+                target_std=torch.tensor(
+                    list(stats.target_std), dtype=torch.float32,
+                ),
+                cond_mean=torch.tensor(
+                    list(stats.cond_mean), dtype=torch.float32,
+                ),
+                cond_std=torch.tensor(
+                    list(stats.cond_std), dtype=torch.float32,
+                ),
+            )
+            combined = CombinedInferenceMLP(
+                head=model,
+                is_factored=is_factored,
+                shift_only=shift_only,
+                muon_source_idx=ms_idx,
+                **buffers,
+            ).eval()
+        if ms_idx >= 0:
+            print(
+                f"muon_source remap baked in: c_raw[:, {ms_idx}] "
+                f"will be mapped {{1, 15, 443}} -> {{-1, 0, +1}} "
+                f"inside the graph"
+            )
         # Eager smoke check at a non-trivial (B, N_var). Both dims
         # must be > 1 to avoid torch.export specializing them.
         B_ex, N_ex = max(B_trace, 2), 4
@@ -729,7 +1031,7 @@ def main():
         with torch.no_grad():
             d_e = combined(y_e, c_e, u_e, s_e)
         print(
-            f"\ncombined eager: d={tuple(d_e.shape)} "
+            f"\ncombined eager: out={tuple(d_e.shape)} "
             f"(B={B_ex}, N_var={N_ex})"
         )
 
@@ -743,12 +1045,17 @@ def main():
         )
         batch_dim = torch.export.Dim("batch", min=1, max=2**20)
         nvar_dim  = torch.export.Dim("nvar",  min=1, max=2**20)
-        dynamic_shapes_combined = {
-            "y_raw":  {0: batch_dim},
-            "c_raw":  {0: batch_dim},
-            "u":      {0: batch_dim, 1: nvar_dim},
-            "sigma":  {0: batch_dim, 1: nvar_dim},
-        }
+        # Positional tuple (matches both ``CombinedInference`` and
+        # ``CombinedInferenceMLP``, whose 3rd/4th args are ``u``/``sigma``
+        # vs ``u_raw``/``sigma_raw`` respectively — torch.export's dict
+        # form keys on the parameter names, so a tuple sidesteps the
+        # name mismatch).
+        dynamic_shapes_combined = (
+            {0: batch_dim},
+            {0: batch_dim},
+            {0: batch_dim, 1: nvar_dim},
+            {0: batch_dim, 1: nvar_dim},
+        )
         print(
             f"torch.export.export combined "
             f"(dynamic batch+nvar, B={B_ex}, N_var={N_ex}) ..."
@@ -852,6 +1159,12 @@ def main():
             do_constant_folding=True,
             export_params=True,
         )
+        if args.inline_weights and _onnx_inline_external_data(
+            args.combined_onnx_output,
+        ):
+            print(
+                "  external-data sidecars absorbed -> single-file .onnx"
+            )
         size_mb = os.path.getsize(args.combined_onnx_output) / 1e6
         print(f" OK ({size_mb:.2f} MB)")
 

--- a/scripts/corrections/muon_calibration/train_muon_response_flow.py
+++ b/scripts/corrections/muon_calibration/train_muon_response_flow.py
@@ -75,7 +75,7 @@ import json
 import os
 import sys
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import List, Tuple
 
 import numpy as np
@@ -148,11 +148,11 @@ def parse_args():
         "--val-fraction",
         type=float,
         default=0.1,
-        help="[default: %(default)s] Fraction of muons held out for "
-        "validation.",
+        help="[default: %(default)s] Fraction of muons held out for " "validation.",
     )
     p.add_argument(
-        "--shard-split", choices=["train", "val", "holdout", "all"],
+        "--shard-split",
+        choices=["train", "val", "holdout", "all"],
         default="train",
         help="[default: %(default)s] Per-shard record-batch range to "
         "load. The shards are partitioned by ``arrow_shard_loader."
@@ -163,7 +163,9 @@ def parse_args():
         "diagnostic script evaluates the model on.",
     )
     p.add_argument(
-        "--shard-holdout-fraction", type=float, default=0.1,
+        "--shard-holdout-fraction",
+        type=float,
+        default=0.1,
         help="[default: %(default)s] Fraction of each shard's record "
         "batches reserved as holdout (skipped by the train / val "
         "load). Matches the trainer / diagnostic convention.",
@@ -196,8 +198,7 @@ def parse_args():
         "--patience",
         type=int,
         default=5,
-        help="[default: %(default)s] Early-stopping patience on "
-        "validation NLL.",
+        help="[default: %(default)s] Early-stopping patience on " "validation NLL.",
     )
     p.add_argument(
         "--no-early-stop",
@@ -226,8 +227,7 @@ def parse_args():
         "--n-transforms",
         type=int,
         default=5,
-        help="[default: %(default)s] Number of coupling layers in the "
-        "flow.",
+        help="[default: %(default)s] Number of coupling layers in the " "flow.",
     )
     p.add_argument(
         "--hidden-features",
@@ -446,7 +446,8 @@ def parse_args():
     )
     p.add_argument(
         "--prefetch-shuffle",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="[default: on] Hide the per-epoch ``torch.randperm(n)`` "
         "stall by computing the next epoch's permutation in a "
         "background thread while the current epoch is still training. "
@@ -464,7 +465,8 @@ def parse_args():
     )
     p.add_argument(
         "--profile",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="[default: off] If set, run a short ``torch.profiler`` "
         "diagnostic pass on the first few training steps of the "
         "current ``train()`` invocation and exit before the normal "
@@ -475,17 +477,22 @@ def parse_args():
         "load the flow from a prior checkpoint).",
     )
     p.add_argument(
-        "--profile-warmup", type=int, default=3,
+        "--profile-warmup",
+        type=int,
+        default=3,
         help="[default: %(default)s] Profile schedule warmup steps "
         "(executed but not recorded).",
     )
     p.add_argument(
-        "--profile-active", type=int, default=5,
+        "--profile-active",
+        type=int,
+        default=5,
         help="[default: %(default)s] Profile schedule active steps "
         "(recorded by the profiler).",
     )
     p.add_argument(
-        "--profile-output", default=None,
+        "--profile-output",
+        default=None,
         help="[default: %(default)s] Optional path for Chrome-trace "
         "export of the profile (viewable in chrome://tracing or "
         "Perfetto). Under DDP, the rank index is appended before "
@@ -574,22 +581,19 @@ def parse_args():
         "--trunk-layers",
         type=int,
         default=2,
-        help="[default: %(default)s] Number of trunk MLP hidden layers "
-        "(shared).",
+        help="[default: %(default)s] Number of trunk MLP hidden layers " "(shared).",
     )
     p.add_argument(
         "--d-emb",
         type=int,
         default=32,
-        help="[default: %(default)s] (--head-arch mlp) Trunk embedding "
-        "dimension.",
+        help="[default: %(default)s] (--head-arch mlp) Trunk embedding " "dimension.",
     )
     p.add_argument(
         "--head-hidden",
         type=int,
         default=32,
-        help="[default: %(default)s] (--head-arch mlp) Head hidden "
-        "width.",
+        help="[default: %(default)s] (--head-arch mlp) Head hidden " "width.",
     )
     p.add_argument(
         "--head-layers",
@@ -842,9 +846,13 @@ def parse_args():
 # -----------------------------------------------------------------------------
 
 PER_MUON_COLUMNS = [
-    "eta_reco", "phi_reco",
-    "eta_gen",  "phi_gen",
-    "kappa_reco", "kappa_gen", "nominal_weight",
+    "eta_reco",
+    "phi_reco",
+    "eta_gen",
+    "phi_gen",
+    "kappa_reco",
+    "kappa_gen",
+    "nominal_weight",
     "source_id",
     "muon_source",
 ]
@@ -867,6 +875,7 @@ def _expand_input_paths(paths: List[str]) -> List[str]:
             manifest_path = os.path.join(p, "manifest.json")
             if os.path.exists(manifest_path):
                 import json
+
                 with open(manifest_path) as f:
                     manifest = json.load(f)
                 for entry in manifest["shard_files"]:
@@ -878,8 +887,11 @@ def _expand_input_paths(paths: List[str]) -> List[str]:
 
 def _filter_block(
     blocks: dict,
-    pt_min: float, pt_max: float, eta_max: float,
-    n_read: int, max_rows: int,
+    pt_min: float,
+    pt_max: float,
+    eta_max: float,
+    n_read: int,
+    max_rows: int,
     weight_mode: str = "drop",
 ):
     eta_g = blocks["eta_gen"]
@@ -921,8 +933,12 @@ def _filter_block(
 
 
 def _load_arrow_shards(
-    paths: List[str], pt_min: float, pt_max: float, eta_max: float,
-    max_rows: int, weight_mode: str = "drop",
+    paths: List[str],
+    pt_min: float,
+    pt_max: float,
+    eta_max: float,
+    max_rows: int,
+    weight_mode: str = "drop",
     split: str = "all",
     val_fraction: float = 0.1,
     holdout_fraction: float = 0.1,
@@ -948,13 +964,14 @@ def _load_arrow_shards(
                 reader = ipc.open_file(f)
                 n_b = reader.num_record_batches
                 lo, hi = split_batch_range(
-                    n_b, split, val_fraction, holdout_fraction,
+                    n_b,
+                    split,
+                    val_fraction,
+                    holdout_fraction,
                 )
                 if hi <= lo:
                     continue
-                t = pa.Table.from_batches(
-                    [reader.get_batch(i) for i in range(lo, hi)]
-                )
+                t = pa.Table.from_batches([reader.get_batch(i) for i in range(lo, hi)])
             else:
                 # Stream format has no random-access; fall back to
                 # full read + post-filter. (Sharder writes file
@@ -966,7 +983,12 @@ def _load_arrow_shards(
                     pass  # not supported on stream format
         block = {c: t[c].to_numpy() for c in PER_MUON_COLUMNS}
         mask = _filter_block(
-            block, pt_min, pt_max, eta_max, n_read, max_rows,
+            block,
+            pt_min,
+            pt_max,
+            eta_max,
+            n_read,
+            max_rows,
             weight_mode=weight_mode,
         )
         # In ``abs`` mode the surviving rows still carry the signed
@@ -995,8 +1017,17 @@ def load_ntuples(
     split: str = "all",
     val_fraction: float = 0.1,
     holdout_fraction: float = 0.1,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray,
-            np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+]:
     """Return per-muon arrays of (eta_reco, phi_reco, eta_gen,
     phi_gen, kappa_reco, kappa_gen, weight, source_id) loaded from
     per-muon snapshots produced by :mod:`flow_training_snapshot`.
@@ -1040,7 +1071,11 @@ def load_ntuples(
             "shards."
         )
     blocks_per_col = _load_arrow_shards(
-        paths, pt_min, pt_max, eta_max, max_events,
+        paths,
+        pt_min,
+        pt_max,
+        eta_max,
+        max_events,
         weight_mode=weight_mode,
         split=split,
         val_fraction=val_fraction,
@@ -1067,8 +1102,15 @@ def load_ntuples(
     source_id = concat["source_id"]
     muon_source = concat["muon_source"]
     arrs = (
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
-        source_id, muon_source,
+        eta_r,
+        phi_r,
+        eta_g,
+        phi_g,
+        kappa_r,
+        kappa_g,
+        w,
+        source_id,
+        muon_source,
     )
 
     n = arrs[0].shape[0]
@@ -1086,10 +1128,7 @@ def load_ntuples(
     # the mode r_kappa absorbs.
     n_flip = int(np.sum(np.sign(arrs[4]) != np.sign(arrs[5])))
     if n_flip:
-        print(
-            f"  charge mismeasurement: {n_flip} / {n} rows "
-            f"({100*n_flip/n:.3f}%)"
-        )
+        print(f"  charge mismeasurement: {n_flip} / {n} rows " f"({100*n_flip/n:.3f}%)")
     # Diagnostic: per-source-id row counts (visible to downstream code
     # for split / validation by dataset).
     sid_arr = arrs[7]
@@ -1097,7 +1136,9 @@ def load_ntuples(
     if len(unique_sids) > 1 or unique_sids[0] != 0:
         print(
             f"  source_id breakdown: "
-            + ", ".join(f"{int(s)}: {int(c):,}" for s, c in zip(unique_sids, sid_counts))
+            + ", ".join(
+                f"{int(s)}: {int(c):,}" for s, c in zip(unique_sids, sid_counts)
+            )
         )
 
     if max_muons > 0 and n > max_muons:
@@ -1110,7 +1151,13 @@ def load_ntuples(
 
 
 def compute_targets_and_conditioning(
-    eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, muon_source=None,
+    eta_r,
+    phi_r,
+    eta_g,
+    phi_g,
+    kappa_r,
+    kappa_g,
+    muon_source=None,
 ):
     """Return (target [N,3], cond_raw dict).
 
@@ -1135,9 +1182,7 @@ def compute_targets_and_conditioning(
     r_kappa = kappa_r / kappa_g - 1.0
 
     # Wrap dphi to [-pi, pi]
-    dphi = np.arctan2(
-        np.sin(phi_r - phi_g), np.cos(phi_r - phi_g)
-    )
+    dphi = np.arctan2(np.sin(phi_r - phi_g), np.cos(phi_r - phi_g))
     dlambda = lam_r - lam_g
 
     # Target order is (r_kappa, dlambda, dphi) so that the reco
@@ -1197,13 +1242,14 @@ _PASSTHROUGH_COND_FEATURES = ("charge", "muon_source")
 # Preprocessing
 # -----------------------------------------------------------------------------
 
+
 @dataclass
 class PreprocStats:
     target_names: List[str]
     target_mean: List[float]
     target_std: List[float]
 
-    cond_names: List[str]     # order matters: matches flow input order
+    cond_names: List[str]  # order matters: matches flow input order
     cond_mean: List[float]
     cond_std: List[float]
 
@@ -1233,9 +1279,7 @@ def build_preproc(target: np.ndarray, cond_raw: dict) -> PreprocStats:
             cond_std.append(1.0)
         else:
             cond_mean.append(float(arr.mean()))
-            cond_std.append(
-                float(arr.std()) if arr.std() > 1e-6 else 1.0
-            )
+            cond_std.append(float(arr.std()) if arr.std() > 1e-6 else 1.0)
 
     return PreprocStats(
         target_names=target_names,
@@ -1305,13 +1349,14 @@ def _build_glow(
     initialization and modest learning rate, this never happens
     for this problem. If it does, reduce ``--lr``.
     """
-    import zuko
+    from zuko.distributions import DiagNormal
     from zuko.flows import (
-        Flow, GeneralCouplingTransform, UnconditionalTransform,
+        Flow,
+        GeneralCouplingTransform,
         UnconditionalDistribution,
+        UnconditionalTransform,
     )
     from zuko.transforms import LULinearTransform
-    from zuko.distributions import DiagNormal
 
     # Reproducible per-call initialization of the LU perturbation
     # and (optionally) the random masks. Not a model seed — model
@@ -1323,23 +1368,24 @@ def _build_glow(
         # LU linear mixing, initialized near-identity.
         LU_init = torch.eye(n_features, dtype=torch.float32)
         noise = 0.05 * torch.randn(
-            n_features, n_features, generator=rng,
+            n_features,
+            n_features,
+            generator=rng,
         )
         # Perturb only the off-diagonal entries; keep diagonal
         # near 1 so log|det| starts finite.
         LU_init = LU_init + noise.tril(-1) + noise.triu(1)
         transforms_list.append(
             UnconditionalTransform(
-                LULinearTransform, LU_init, buffer=False,
+                LULinearTransform,
+                LU_init,
+                buffer=False,
             )
         )
 
         # Affine coupling (same as RealNVP).
         if randmask:
-            mask = (
-                torch.randperm(n_features, generator=rng) % 2
-                == i % 2
-            )
+            mask = torch.randperm(n_features, generator=rng) % 2 == i % 2
         else:
             mask = torch.arange(n_features) % 2 == i % 2
         transforms_list.append(
@@ -1389,13 +1435,12 @@ def _build_sospf(
     masked-autoregressive transforms (keeps inputs inside the
     ``[-10, 10]`` SOSPolynomialTransform invertibility window).
     """
-    import zuko
     from zuko.flows import MAF, UnconditionalTransform
     from zuko.transforms import (
-        ComposedTransform,
         AdditiveTransform,
-        SOSPolynomialTransform,
+        ComposedTransform,
         SoftclipTransform,
+        SOSPolynomialTransform,
         UnconstrainedMonotonicTransform,
     )
 
@@ -1409,7 +1454,11 @@ def _build_sospf(
 
         def __init__(self, a, slope: float = 1e-3, **kwargs):
             UnconstrainedMonotonicTransform.__init__(
-                self, None, phi=(a,), n=int(quad_n), **kwargs,
+                self,
+                None,
+                phi=(a,),
+                n=int(quad_n),
+                **kwargs,
             )
             self.a = a
             self.i = torch.arange(a.shape[-1], device=a.device)
@@ -1438,7 +1487,8 @@ def _build_sospf(
     transforms = flow.transform.transforms
     for i in reversed(range(1, len(transforms))):
         transforms.insert(
-            i, UnconditionalTransform(SoftclipTransform, bound=11.0),
+            i,
+            UnconditionalTransform(SoftclipTransform, bound=11.0),
         )
     return flow
 
@@ -1521,15 +1571,12 @@ def build_flow(
     try:
         import zuko
     except ImportError as e:
-        raise ImportError(
-            "zuko is required for training (pip install zuko)."
-        ) from e
+        raise ImportError("zuko is required for training (pip install zuko).") from e
 
     act_cls = ACTIVATIONS.get(activation.lower())
     if act_cls is None:
         raise ValueError(
-            f"unknown activation '{activation}'; "
-            f"available: {sorted(ACTIVATIONS)}"
+            f"unknown activation '{activation}'; " f"available: {sorted(ACTIVATIONS)}"
         )
 
     arch = architecture.lower()
@@ -1649,9 +1696,8 @@ def build_flow(
 import itertools as _itertools
 import math as _math
 
-
 _LOG_LOG2 = _math.log(_math.log(2.0))
-_LOG_W_CLAMP = 30.0   # exp-positivity clamp on log W to keep fp32 finite
+_LOG_W_CLAMP = 30.0  # exp-positivity clamp on log W to keep fp32 finite
 
 
 # ============================================================================
@@ -1673,6 +1719,7 @@ _LOG_W_CLAMP = 30.0   # exp-positivity clamp on log W to keep fp32 finite
 #                      (``√(j²+1) > |j|``), grows only logarithmically in
 #                      |j| in log-space. Needs *no* clamp at all.
 # ============================================================================
+
 
 def _apply_positivity_W(j: torch.Tensor, positivity: str) -> torch.Tensor:
     """Return ``W(j)`` directly, without going through ``log W``."""
@@ -1762,9 +1809,14 @@ def _joint_indices(
 # only "stales" if the indices object is GC'd and a new list ends up
 # at the same memory address, which doesn't happen during a normal
 # polyhead lifetime.
-def _run_profile_pass(step_fn, n_warmup: int, n_active: int,
-                      output_path: str = None, label: str = "",
-                      row_limit: int = 30):
+def _run_profile_pass(
+    step_fn,
+    n_warmup: int,
+    n_active: int,
+    output_path: str = None,
+    label: str = "",
+    row_limit: int = 30,
+):
     """Run ``step_fn(i)`` for ``n_warmup + n_active`` iterations under
     ``torch.profiler``; print the top-``row_limit`` hot ops sorted by
     self CUDA time (or self CPU time when CUDA isn't available).
@@ -1778,14 +1830,18 @@ def _run_profile_pass(step_fn, n_warmup: int, n_active: int,
     diagnostic pass that the caller invokes from a ``--profile``
     branch and then exits.
     """
-    from torch.profiler import profile, schedule, ProfilerActivity
+    from torch.profiler import ProfilerActivity, profile, schedule
+
     activities = [ProfilerActivity.CPU]
     cuda_ok = torch.cuda.is_available()
     if cuda_ok:
         activities.append(ProfilerActivity.CUDA)
     n_total = int(n_warmup) + int(n_active)
     sched = schedule(
-        wait=0, warmup=int(n_warmup), active=int(n_active), repeat=1,
+        wait=0,
+        warmup=int(n_warmup),
+        active=int(n_active),
+        repeat=1,
     )
     print(
         f"[profile{label}] running {n_total} steps "
@@ -1836,12 +1892,8 @@ def _build_basis_aux(indices, n_features: int):
         (pure-u or pure-σ).
       * ``max_deg_u`` / ``max_deg_sigma``: int.
     """
-    alpha_list = [
-        _multiindex_to_axis_degrees(a, n_features) for a, _ in indices
-    ]
-    beta_list = [
-        _multiindex_to_axis_degrees(b, n_features) for _, b in indices
-    ]
+    alpha_list = [_multiindex_to_axis_degrees(a, n_features) for a, _ in indices]
+    beta_list = [_multiindex_to_axis_degrees(b, n_features) for _, b in indices]
     if alpha_list:
         alpha_degs = torch.tensor(alpha_list, dtype=torch.long)
     else:
@@ -1978,11 +2030,13 @@ def joint_monomial_basis(
     phi = None
     for j in range(n_features):
         u_j = u_pow[..., j, :].index_select(
-            dim=-1, index=alpha_degs[:, j],
+            dim=-1,
+            index=alpha_degs[:, j],
         )
         if has_sigma:
             s_j = s_pow[..., j, :].index_select(
-                dim=-1, index=beta_degs[:, j],
+                dim=-1,
+                index=beta_degs[:, j],
             )
             factor_j = u_j * s_j
         else:
@@ -2007,9 +2061,9 @@ def _cheb_table(x_norm: torch.Tensor, max_deg: int) -> torch.Tensor:
     an empty trailing dim."""
     if max_deg < 0:
         return x_norm.unsqueeze(-1)[..., :0]
-    cols = [torch.ones_like(x_norm)]   # T_0 = 1
+    cols = [torch.ones_like(x_norm)]  # T_0 = 1
     if max_deg >= 1:
-        cols.append(x_norm)            # T_1 = x
+        cols.append(x_norm)  # T_1 = x
     for n in range(2, max_deg + 1):
         cols.append(2 * x_norm * cols[-1] - cols[-2])
     return torch.stack(cols, dim=-1)
@@ -2017,7 +2071,7 @@ def _cheb_table(x_norm: torch.Tensor, max_deg: int) -> torch.Tensor:
 
 def _T_at_zero(n: int) -> float:
     """Value of the n-th first-kind Chebyshev polynomial at x=0:
-       T_0(0)=1, T_n(0)=0 for odd n, T_n(0)=(-1)^(n/2) for even n>0.
+    T_0(0)=1, T_n(0)=0 for odd n, T_n(0)=(-1)^(n/2) for even n>0.
     """
     if n == 0:
         return 1.0
@@ -2098,14 +2152,16 @@ def joint_chebyshev_basis(
     u_factor = None
     for j in range(n_features):
         u_j = Tu[..., j, :].index_select(
-            dim=-1, index=alpha_degs[:, j],
+            dim=-1,
+            index=alpha_degs[:, j],
         )
         u_factor = u_j if u_factor is None else u_factor * u_j
     if has_sigma:
         v_factor = None
         for j in range(n_features):
             s_j = Ts[..., j, :].index_select(
-                dim=-1, index=beta_degs[:, j],
+                dim=-1,
+                index=beta_degs[:, j],
             )
             v_factor = s_j if v_factor is None else v_factor * s_j
         return (u_factor - u_const) * (v_factor - v_const)
@@ -2132,7 +2188,12 @@ def _select_basis(
         return joint_monomial_basis(u, sigma_vec, indices, aux=aux)
     if basis == "chebyshev":
         return joint_chebyshev_basis(
-            u, sigma_vec, indices, scale_u, scale_sigma, aux=aux,
+            u,
+            sigma_vec,
+            indices,
+            scale_u,
+            scale_sigma,
+            aux=aux,
         )
     raise ValueError(f"unknown basis {basis!r}")
 
@@ -2207,23 +2268,16 @@ class PolyHead(nn.Module):
         # contraction read the right phi slice without scatter/
         # gather. Total set is unchanged.
         raw_indices = _joint_indices(
-            n_features, max_deg_u, max_deg_sigma, max_cross_deg,
+            n_features,
+            max_deg_u,
+            max_deg_sigma,
+            max_cross_deg,
         )
-        idx_pure_u = [
-            (a, b) for (a, b) in raw_indices
-            if len(b) == 0 and len(a) > 0
-        ]
-        idx_pure_s = [
-            (a, b) for (a, b) in raw_indices
-            if len(a) == 0 and len(b) > 0
-        ]
-        idx_cross = [
-            (a, b) for (a, b) in raw_indices
-            if len(a) > 0 and len(b) > 0
-        ]
-        assert (
-            len(idx_pure_u) + len(idx_pure_s) + len(idx_cross)
-            == len(raw_indices)
+        idx_pure_u = [(a, b) for (a, b) in raw_indices if len(b) == 0 and len(a) > 0]
+        idx_pure_s = [(a, b) for (a, b) in raw_indices if len(a) == 0 and len(b) > 0]
+        idx_cross = [(a, b) for (a, b) in raw_indices if len(a) > 0 and len(b) > 0]
+        assert len(idx_pure_u) + len(idx_pure_s) + len(idx_cross) == len(
+            raw_indices
         ), "non-exhaustive split of joint indices"
         self._joint_indices = idx_pure_u + idx_pure_s + idx_cross
         self.n_joint_basis = len(self._joint_indices)
@@ -2254,18 +2308,24 @@ class PolyHead(nn.Module):
         # via ``self.basis_aux`` for use in :func:`evaluate_joint`.
         _aux = _build_basis_aux(self._joint_indices, n_features)
         self.register_buffer(
-            "_basis_alpha_degs", _aux["alpha_degs"], persistent=False,
+            "_basis_alpha_degs",
+            _aux["alpha_degs"],
+            persistent=False,
         )
         self.register_buffer(
-            "_basis_beta_degs", _aux["beta_degs"], persistent=False,
+            "_basis_beta_degs",
+            _aux["beta_degs"],
+            persistent=False,
         )
         self.register_buffer(
             "_basis_cheb_u_const",
-            _aux["cheb_u_const"], persistent=False,
+            _aux["cheb_u_const"],
+            persistent=False,
         )
         self.register_buffer(
             "_basis_cheb_v_const",
-            _aux["cheb_v_const"], persistent=False,
+            _aux["cheb_v_const"],
+            persistent=False,
         )
         self._basis_max_deg_u = _aux["max_deg_u"]
         self._basis_max_deg_sigma = _aux["max_deg_sigma"]
@@ -2274,9 +2334,7 @@ class PolyHead(nn.Module):
         # smear-weight target. K=1 → empty buffers (no GH; loss step
         # falls back to the K=1 stochastic estimator).
         if self.smear_K > 1:
-            nodes_np, w_np = np.polynomial.hermite_e.hermegauss(
-                self.smear_K
-            )
+            nodes_np, w_np = np.polynomial.hermite_e.hermegauss(self.smear_K)
             w_norm = w_np / np.sqrt(2.0 * np.pi)
             gh_nodes = torch.tensor(nodes_np, dtype=torch.float32)
             gh_log_w = torch.tensor(np.log(w_norm), dtype=torch.float32)
@@ -2285,7 +2343,9 @@ class PolyHead(nn.Module):
             gh_log_w = torch.zeros(0, dtype=torch.float32)
         self.register_buffer("gh_nodes", gh_nodes, persistent=False)
         self.register_buffer(
-            "gh_log_weights", gh_log_w, persistent=False,
+            "gh_log_weights",
+            gh_log_w,
+            persistent=False,
         )
 
         # Trunk: ``[y, c] → e ∈ R^trunk_hidden``. The final coefficient
@@ -2310,21 +2370,18 @@ class PolyHead(nn.Module):
         # only created if the corresponding block is non-empty (e.g.
         # in shift-only mode, pure_s and cross are empty).
         self.head_pure_u = (
-            nn.Linear(prev, self._n_pure_u)
-            if self._n_pure_u > 0 else None
+            nn.Linear(prev, self._n_pure_u) if self._n_pure_u > 0 else None
         )
         self.head_pure_sigma = (
-            nn.Linear(prev, self._n_pure_s)
-            if self._n_pure_s > 0 else None
+            nn.Linear(prev, self._n_pure_s) if self._n_pure_s > 0 else None
         )
-        self.head_cross = (
-            nn.Linear(prev, self._n_cross)
-            if self._n_cross > 0 else None
-        )
+        self.head_cross = nn.Linear(prev, self._n_cross) if self._n_cross > 0 else None
         # Init heads near zero so coefs ≈ 0 at start.
         with torch.no_grad():
             for head in (
-                self.head_pure_u, self.head_pure_sigma, self.head_cross,
+                self.head_pure_u,
+                self.head_pure_sigma,
+                self.head_cross,
             ):
                 if head is not None:
                     head.weight.mul_(0.01)
@@ -2380,10 +2437,9 @@ class PolyHead(nn.Module):
         if not net_keys:
             return state_dict
         # Find the index of the final layer (largest ``net.{N}.weight``).
-        net_layer_idxs = sorted({
-            int(k.split(".")[1]) for k in net_keys
-            if k.endswith(".weight")
-        })
+        net_layer_idxs = sorted(
+            {int(k.split(".")[1]) for k in net_keys if k.endswith(".weight")}
+        )
         if not net_layer_idxs:
             return state_dict
         last_idx = net_layer_idxs[-1]
@@ -2441,7 +2497,8 @@ class PolyHead(nn.Module):
         after running :meth:`_remap_legacy_state_dict`."""
         return super().load_state_dict(
             self._remap_legacy_state_dict(state_dict),
-            strict=strict, assign=assign,
+            strict=strict,
+            assign=assign,
         )
 
     def trunk_forward(
@@ -2482,7 +2539,10 @@ class PolyHead(nn.Module):
             parts.append(self.head_cross(e))
         if not parts:
             return torch.zeros(
-                e.shape[0], 0, device=e.device, dtype=e.dtype,
+                e.shape[0],
+                0,
+                device=e.device,
+                dtype=e.dtype,
             )
         return torch.cat(parts, dim=-1)
 
@@ -2508,7 +2568,9 @@ def _sigma_pack_outer(sigma: torch.Tensor) -> torch.Tensor:
     """
     F = sigma.shape[-1]
     iu, ju = torch.triu_indices(
-        F, F, device=sigma.device,
+        F,
+        F,
+        device=sigma.device,
     ).unbind(0)
     return sigma[..., iu] * sigma[..., ju]
 
@@ -2540,8 +2602,13 @@ def evaluate_joint(
     tensors inside the compiled forward, which CUDA graphs captures
     as outputs and then errors on overwrite."""
     phi = _select_basis(
-        basis, u, sigma_vec, joint_indices,
-        scale_u, scale_sigma, aux=basis_aux,
+        basis,
+        u,
+        sigma_vec,
+        joint_indices,
+        scale_u,
+        scale_sigma,
+        aux=basis_aux,
     )
     return torch.einsum("...b,...b->...", joint_coefs, phi)
 
@@ -2567,8 +2634,13 @@ def predicted_W(
     options (``"monomial"`` or ``"chebyshev"``).
     """
     j = evaluate_joint(
-        joint_coefs, u_shift, sigma_vec, joint_indices,
-        basis=basis, scale_u=scale_u, scale_sigma=scale_sigma,
+        joint_coefs,
+        u_shift,
+        sigma_vec,
+        joint_indices,
+        basis=basis,
+        scale_u=scale_u,
+        scale_sigma=scale_sigma,
         basis_aux=basis_aux,
     )
     return _apply_positivity_W(j, positivity)
@@ -2593,8 +2665,13 @@ def predicted_log_W(
     ``basis`` and ``scale_*`` are forwarded to :func:`evaluate_joint`.
     """
     j = evaluate_joint(
-        joint_coefs, u_shift, sigma_vec, joint_indices,
-        basis=basis, scale_u=scale_u, scale_sigma=scale_sigma,
+        joint_coefs,
+        u_shift,
+        sigma_vec,
+        joint_indices,
+        basis=basis,
+        scale_u=scale_u,
+        scale_sigma=scale_sigma,
         basis_aux=basis_aux,
     )
     return _apply_positivity_logW(j, positivity)
@@ -2657,7 +2734,9 @@ def sample_perturbations(
         v_smear[:, 0] = 1.0
         sigma_vec = torch.zeros(batch_size, n_dim, device=device)
         mode_id = torch.zeros(
-            batch_size, device=device, dtype=torch.long,
+            batch_size,
+            device=device,
+            dtype=torch.long,
         )
         return u_shift, sigma_vec, zeros, v_smear, mode_id
 
@@ -2679,13 +2758,15 @@ def sample_perturbations(
     # lowest-noise / highest-leverage gradient signal.
     base = batch_size // 3
     extra = batch_size - 3 * base
-    mode_id = torch.cat([
-        torch.full((base + extra,), 0, device=device, dtype=torch.long),
-        torch.full((base,), 1, device=device, dtype=torch.long),
-        torch.full((base,), 2, device=device, dtype=torch.long),
-    ])
-    shift_active = (mode_id != 1).to(delta_shift.dtype)   # SHIFT or JOINT
-    smear_active = (mode_id != 0).to(delta_smear.dtype)   # SMEAR or JOINT
+    mode_id = torch.cat(
+        [
+            torch.full((base + extra,), 0, device=device, dtype=torch.long),
+            torch.full((base,), 1, device=device, dtype=torch.long),
+            torch.full((base,), 2, device=device, dtype=torch.long),
+        ]
+    )
+    shift_active = (mode_id != 1).to(delta_shift.dtype)  # SHIFT or JOINT
+    smear_active = (mode_id != 0).to(delta_smear.dtype)  # SMEAR or JOINT
 
     u_shift = (delta_shift * shift_active).unsqueeze(-1) * v_shift
     sigma_vec = (sigma_smear * smear_active).unsqueeze(-1) * v_smear
@@ -2711,9 +2792,7 @@ def _lagrange_basis_at(eps, gh_nodes):
         for j in range(K):
             if j == k:
                 continue
-            L[:, k] = L[:, k] * (eps - gh_nodes[j]) / (
-                gh_nodes[k] - gh_nodes[j]
-            )
+            L[:, k] = L[:, k] * (eps - gh_nodes[j]) / (gh_nodes[k] - gh_nodes[j])
     return L
 
 
@@ -2808,9 +2887,7 @@ def _compute_target_lw(
 
         def _eval_direct():
             z_p, ladj_p = _flow_z_ladj(flow, y_pert, c_pert)
-            log_p_p = (
-                -0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p
-            )
+            log_p_p = -0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p
             return log_p_p - log_p.detach()
 
         if detach_target:
@@ -2831,8 +2908,9 @@ def _compute_target_lw(
         if smear_residual:
             eps_extra = torch.randn(B, device=y_std.device, dtype=y_std.dtype)
             eps_all = torch.cat(
-                [eps_nodes.to(eps_extra.dtype), eps_extra], dim=0,
-            )           # [K+1]
+                [eps_nodes.to(eps_extra.dtype), eps_extra],
+                dim=0,
+            )  # [K+1]
             n_eps = K_smear + 1
         else:
             eps_all = eps_nodes
@@ -2841,52 +2919,52 @@ def _compute_target_lw(
         # For GH nodes ε_k is per-quadrature-node (broadcast across B);
         # for the extra slot ε_extra is per-event.
         if smear_residual:
-            eps_view = torch.cat([
-                eps_nodes.view(K_smear, 1).expand(K_smear, B),
-                eps_extra.view(1, B),
-            ], dim=0)                                      # [K+1, B]
-            u_eval_k = (
-                u_shift.unsqueeze(0)
-                + eps_view.unsqueeze(-1) * sigma_vec.unsqueeze(0)
-            )                                              # [K+1, B, n_features]
+            eps_view = torch.cat(
+                [
+                    eps_nodes.view(K_smear, 1).expand(K_smear, B),
+                    eps_extra.view(1, B),
+                ],
+                dim=0,
+            )  # [K+1, B]
+            u_eval_k = u_shift.unsqueeze(0) + eps_view.unsqueeze(
+                -1
+            ) * sigma_vec.unsqueeze(
+                0
+            )  # [K+1, B, n_features]
         else:
-            u_eval_k = (
-                u_shift.unsqueeze(0)
-                + eps_nodes.view(K_smear, 1, 1) * sigma_vec.unsqueeze(0)
-            )                                              # [K, B, n_features]
+            u_eval_k = u_shift.unsqueeze(0) + eps_nodes.view(
+                K_smear, 1, 1
+            ) * sigma_vec.unsqueeze(
+                0
+            )  # [K, B, n_features]
         nB = n_eps * B
-        perturbed_y = (
-            y_std.unsqueeze(0).expand(n_eps, -1, -1) - u_eval_k
-        ).reshape(nB, n_features)
-        perturbed_c = (
-            c_std.unsqueeze(0)
-            .expand(n_eps, -1, -1)
-            .reshape(nB, n_cond)
+        perturbed_y = (y_std.unsqueeze(0).expand(n_eps, -1, -1) - u_eval_k).reshape(
+            nB, n_features
         )
+        perturbed_c = c_std.unsqueeze(0).expand(n_eps, -1, -1).reshape(nB, n_cond)
 
         def _eval():
             z_p, ladj_p = _flow_z_ladj(flow, perturbed_y, perturbed_c)
-            log_p_p = (
-                -0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p
-            ).view(n_eps, B)
+            log_p_p = (-0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p).view(
+                n_eps, B
+            )
             true_lw_all = log_p_p - log_p.detach().unsqueeze(0)
             log_W_K = torch.logsumexp(
-                true_lw_all[:K_smear] + log_gh_w.view(K_smear, 1), dim=0,
-            )                                              # [B]
+                true_lw_all[:K_smear] + log_gh_w.view(K_smear, 1),
+                dim=0,
+            )  # [B]
             if not smear_residual:
                 return log_W_K
 
             # log W_K is the dominant term; we add log1p of a small
             # control-variate correction. All ratios are formed
             # against W_K so the absolute scale of W cancels.
-            log_W_extra = true_lw_all[K_smear]            # [B]
+            log_W_extra = true_lw_all[K_smear]  # [B]
             ratio_extra = torch.exp(log_W_extra - log_W_K)  # [B]
             # exp(true_lw_all[:K] - log_W_K) ∈ [0, 1/w_min] is well-
             # conditioned because log_W_K ≥ max_k(log_w_k + log_W_k).
-            ratio_K = torch.exp(
-                true_lw_all[:K_smear] - log_W_K.unsqueeze(0)
-            )                                              # [K, B]
-            L_at_eps = _lagrange_basis_at(eps_extra, eps_nodes)   # [B, K]
+            ratio_K = torch.exp(true_lw_all[:K_smear] - log_W_K.unsqueeze(0))  # [K, B]
+            L_at_eps = _lagrange_basis_at(eps_extra, eps_nodes)  # [B, K]
             ratio_g = torch.einsum("kb,bk->b", ratio_K, L_at_eps)  # [B]
             delta = ratio_extra - ratio_g
             # delta ∈ (-∞, ∞) per event; the control variate guarantees
@@ -2912,9 +2990,7 @@ def _compute_target_lw(
 
     def _eval_stoch():
         z_e, ladj_e = _flow_z_ladj(flow, y_std - u_eval, c_std)
-        log_p_e = (
-            -0.5 * (z_e * z_e).sum(dim=-1) - log_const + ladj_e
-        )
+        log_p_e = -0.5 * (z_e * z_e).sum(dim=-1) - log_const + ladj_e
         return log_p_e - log_p.detach()
 
     if detach_target:
@@ -2936,8 +3012,8 @@ def _detach_pure_coefs_in_joint(
     the pure terms — those parameters are still trained by the
     deterministic SHIFT (pure-u) and lower-cross-coupling SMEAR
     (pure-σ) events, which carry a lower-noise signal."""
-    is_joint = (mode == 2)
-    pure_basis = head.is_pure_u | head.is_pure_sigma
+    is_joint = mode == 2
+    pure_basis = polyhead.is_pure_u | polyhead.is_pure_sigma
     detach_mask = is_joint.unsqueeze(-1) & pure_basis.unsqueeze(0)
     return torch.where(detach_mask, joint_coefs.detach(), joint_coefs)
 
@@ -3008,15 +3084,18 @@ def _polyhead_d_per_mode(
         extra = B - 3 * base
         n_shift_b, n_smear_b, n_joint_b = base + extra, base, base
 
-    e = polyhead.trunk_forward(y_std, c_std)         # [B, d_emb]
+    e = polyhead.trunk_forward(y_std, c_std)  # [B, d_emb]
     d_emb = e.shape[-1]
 
     phi = _select_basis(
-        polyhead.basis, u_shift, sigma_vec, polyhead.joint_indices,
+        polyhead.basis,
+        u_shift,
+        sigma_vec,
+        polyhead.joint_indices,
         scale_u=polyhead.basis_scale_u,
         scale_sigma=polyhead.basis_scale_sigma,
         aux=polyhead.basis_aux,
-    )                                                 # [B, n_basis]
+    )  # [B, n_basis]
 
     n_pu = polyhead._n_pure_u
     n_ps = polyhead._n_pure_s
@@ -3027,10 +3106,12 @@ def _polyhead_d_per_mode(
         ``head`` ``nn.Linear(d_emb, n_out)``. Returns ``[N]``."""
         if head is None:
             return torch.zeros(
-                e_blk.shape[0], device=e_blk.device, dtype=e_blk.dtype,
+                e_blk.shape[0],
+                device=e_blk.device,
+                dtype=e_blk.dtype,
             )
-        temp = phi_blk @ head.weight                  # [N, d_emb]
-        bias_term = phi_blk @ head.bias               # [N]
+        temp = phi_blk @ head.weight  # [N, d_emb]
+        bias_term = phi_blk @ head.bias  # [N]
         return (e_blk * temp).sum(-1) + bias_term
 
     d_chunks = []
@@ -3045,7 +3126,8 @@ def _polyhead_d_per_mode(
     if n_smear_b > 0:
         e_m = e[n_shift_b : n_shift_b + n_smear_b]
         phi_m_ps = phi[
-            n_shift_b : n_shift_b + n_smear_b, n_pu : n_pu + n_ps,
+            n_shift_b : n_shift_b + n_smear_b,
+            n_pu : n_pu + n_ps,
         ]
         d_chunks.append(_order2(e_m, phi_m_ps, polyhead.head_pure_sigma))
 
@@ -3058,10 +3140,14 @@ def _polyhead_d_per_mode(
         phi_j = phi[j0:]
         d_j_pu = _order2(e_j, phi_j[:, :n_pu], polyhead.head_pure_u)
         d_j_ps = _order2(
-            e_j, phi_j[:, n_pu : n_pu + n_ps], polyhead.head_pure_sigma,
+            e_j,
+            phi_j[:, n_pu : n_pu + n_ps],
+            polyhead.head_pure_sigma,
         )
         d_j_cr = _order2(
-            e_j, phi_j[:, n_pu + n_ps :], polyhead.head_cross,
+            e_j,
+            phi_j[:, n_pu + n_ps :],
+            polyhead.head_cross,
         )
         if detach_pure_in_joint:
             d_j_pu = d_j_pu.detach()
@@ -3104,25 +3190,29 @@ def _mlp_d_per_mode(
     :func:`sample_perturbations` and ``_polyhead_d_per_mode``).
     """
     B = y_std.shape[0]
-    e = mlp.trunk_forward(y_std, c_std)                  # [B, d_emb]
+    e = mlp.trunk_forward(y_std, c_std)  # [B, d_emb]
     if mlp.head_layer1_sigma is not None:
         sigma_pack = (
-            sigma_vec[..., mlp.sigma_pack_iu]
-            * sigma_vec[..., mlp.sigma_pack_ju]
+            sigma_vec[..., mlp.sigma_pack_iu] * sigma_vec[..., mlp.sigma_pack_ju]
         )
     else:
         sigma_pack = torch.zeros(
-            B, 0, device=y_std.device, dtype=y_std.dtype,
+            B,
+            0,
+            device=y_std.device,
+            dtype=y_std.dtype,
         )
 
     if not detach_pure_in_joint:
         # 2·B head queries: f(e, u, σ_pack) and f(e, 0, 0).
         e_dual = torch.cat([e, e], dim=0)
         u_dual = torch.cat(
-            [u_shift, torch.zeros_like(u_shift)], dim=0,
+            [u_shift, torch.zeros_like(u_shift)],
+            dim=0,
         )
         sp_dual = torch.cat(
-            [sigma_pack, torch.zeros_like(sigma_pack)], dim=0,
+            [sigma_pack, torch.zeros_like(sigma_pack)],
+            dim=0,
         )
         f = mlp.head_forward(e_dual, u_dual, sp_dual)
         return f[:B] - f[B:]
@@ -3133,13 +3223,14 @@ def _mlp_d_per_mode(
     zeros_sp = torch.zeros_like(sigma_pack)
     u_q = torch.cat([u_shift, zeros_u, u_shift, zeros_u], dim=0)
     sp_q = torch.cat(
-        [sigma_pack, zeros_sp, zeros_sp, sigma_pack], dim=0,
+        [sigma_pack, zeros_sp, zeros_sp, sigma_pack],
+        dim=0,
     )
     f = mlp.head_forward(e_q, u_q, sp_q)
     f_full = f[0 * B : 1 * B]
     f_zero = f[1 * B : 2 * B]
-    f_us   = f[2 * B : 3 * B]
-    f_sm   = f[3 * B : 4 * B]
+    f_us = f[2 * B : 3 * B]
+    f_sm = f[3 * B : 4 * B]
     d_full = f_full - f_zero
     d_pure_u = f_us - f_zero
     d_pure_s = f_sm - f_zero
@@ -3154,7 +3245,7 @@ def _mlp_d_per_mode(
     n_joint_b = base
     is_joint = torch.zeros(B, dtype=torch.bool, device=y_std.device)
     if n_joint_b > 0:
-        is_joint[n_shift_b + n_smear_b:] = True
+        is_joint[n_shift_b + n_smear_b :] = True
     d_pure_u_used = torch.where(is_joint, d_pure_u.detach(), d_pure_u)
     d_pure_s_used = torch.where(is_joint, d_pure_s.detach(), d_pure_s)
     d_mixed = d_full - d_pure_u - d_pure_s
@@ -3183,12 +3274,14 @@ def _mlp_factored_d_per_mode(
     e = head.trunk_forward(y_std, c_std)
     if head.n_sigma_pack > 0:
         sigma_pack = (
-            sigma_vec[..., head.sigma_pack_iu]
-            * sigma_vec[..., head.sigma_pack_ju]
+            sigma_vec[..., head.sigma_pack_iu] * sigma_vec[..., head.sigma_pack_ju]
         )
     else:
         sigma_pack = torch.zeros(
-            B, 0, device=y_std.device, dtype=y_std.dtype,
+            B,
+            0,
+            device=y_std.device,
+            dtype=y_std.dtype,
         )
     pu, ps, cr = head.head_forward_components(e, u_shift, sigma_pack)
     if head.detach_pure_shift_in_joint or head.detach_pure_smear_in_joint:
@@ -3201,7 +3294,7 @@ def _mlp_factored_d_per_mode(
         n_joint_b = base
         is_joint = torch.zeros(B, dtype=torch.bool, device=y_std.device)
         if n_joint_b > 0:
-            is_joint[n_shift_b + n_smear_b:] = True
+            is_joint[n_shift_b + n_smear_b :] = True
         if head.detach_pure_shift_in_joint:
             pu = torch.where(is_joint, pu.detach(), pu)
         if head.detach_pure_smear_in_joint:
@@ -3233,15 +3326,27 @@ def _head_d_per_mode(
     """
     if isinstance(head, PolyHead):
         return _polyhead_d_per_mode(
-            head, y_std, c_std, u_shift, sigma_vec,
+            head,
+            y_std,
+            c_std,
+            u_shift,
+            sigma_vec,
             detach_pure_in_joint=detach_pure_in_joint,
         )
     if getattr(head, "is_factored", False):
         return _mlp_factored_d_per_mode(
-            head, y_std, c_std, u_shift, sigma_vec,
+            head,
+            y_std,
+            c_std,
+            u_shift,
+            sigma_vec,
         )
     return _mlp_d_per_mode(
-        head, y_std, c_std, u_shift, sigma_vec,
+        head,
+        y_std,
+        c_std,
+        u_shift,
+        sigma_vec,
         detach_pure_in_joint=detach_pure_in_joint,
     )
 
@@ -3268,7 +3373,8 @@ def _per_event_loss(
 
 
 def _expkl_per_event(
-    pred_log: torch.Tensor, target_log: torch.Tensor,
+    pred_log: torch.Tensor,
+    target_log: torch.Tensor,
 ) -> torch.Tensor:
     """Per-event expKL (f-GAN-KL / I-divergence) loss:
 
@@ -3293,13 +3399,15 @@ def _expkl_per_event(
     ``asinh`` positivity wraps the natural range of ``δ`` is well
     inside the clamp."""
     delta = (target_log - pred_log).clamp(
-        min=-_LOG_W_CLAMP, max=_LOG_W_CLAMP,
+        min=-_LOG_W_CLAMP,
+        max=_LOG_W_CLAMP,
     )
     return torch.exp(delta) - delta - 1.0
 
 
 def _wbce_per_event(
-    pred_log: torch.Tensor, target_log: torch.Tensor,
+    pred_log: torch.Tensor,
+    target_log: torch.Tensor,
 ) -> torch.Tensor:
     """Per-event importance-sampled BCE / single-sample CARL loss:
 
@@ -3388,16 +3496,20 @@ def joint_loss_step(
     device = y_std.device
 
     u_shift, sigma_vec, delta_smear, v_smear, mode = sample_perturbations(
-        B, n_features, delta_max, sigma_max, device, oversample=oversample,
+        B,
+        n_features,
+        delta_max,
+        sigma_max,
+        device,
+        oversample=oversample,
         include_smear=head.include_smear,
     )
 
     # Baseline flow forward — gradients DO flow back through this
     # (drives the NLL term).
     z, ladj = _flow_z_ladj(flow, y_std, c_std)
-    log_phi = (
-        -0.5 * (z * z).sum(dim=-1)
-        - 0.5 * float(n_features) * _math.log(2.0 * _math.pi)
+    log_phi = -0.5 * (z * z).sum(dim=-1) - 0.5 * float(n_features) * _math.log(
+        2.0 * _math.pi
     )
     log_p = log_phi + ladj
     nll = -log_p
@@ -3407,9 +3519,17 @@ def joint_loss_step(
     # ``head.smear_K``. K perturbed forwards are run under
     # no_grad when ``detach_target`` (default True).
     true_lw = _compute_target_lw(
-        flow, head, y_std, c_std, log_p,
-        u_shift, sigma_vec, delta_smear, v_smear,
-        n_features, detach_target=detach_target,
+        flow,
+        head,
+        y_std,
+        c_std,
+        log_p,
+        u_shift,
+        sigma_vec,
+        delta_smear,
+        v_smear,
+        n_features,
+        detach_target=detach_target,
     )
 
     # Trustable-target mask. The Gaussian tail of δ_smear can place
@@ -3418,14 +3538,16 @@ def joint_loss_step(
     # These events aren't representative of any real reweight regime
     # (we don't deploy at 5σ shifts), so we simply drop them from
     # the polyhead loss contribution.
-    target_threshold = 10.0   # |log w| up to 10 → |w| up to ~22000
+    target_threshold = 10.0  # |log w| up to 10 → |w| up to ~22000
     trustable = torch.isfinite(true_lw) & (true_lw.abs() < target_threshold)
     trustable_f = trustable.to(true_lw.dtype)
     # Replace non-trustable targets with 0 so subsequent ops (exp,
     # diff) don't propagate inf/NaN; the per-event contribution is
     # zeroed by the mask at the end either way.
     true_lw_safe = torch.where(
-        trustable, true_lw, torch.zeros_like(true_lw),
+        trustable,
+        true_lw,
+        torch.zeros_like(true_lw),
     )
 
     # Per-mode Order-2 contraction: avoids materialising the full
@@ -3435,7 +3557,11 @@ def joint_loss_step(
     # form (W or log W) it needs. Each wrap returns its target form
     # directly — no exp(log W) or log(W) round trips.
     j = _head_d_per_mode(
-        head, y_std, c_std, u_shift, sigma_vec,
+        head,
+        y_std,
+        c_std,
+        u_shift,
+        sigma_vec,
         detach_pure_in_joint=detach_pure_in_joint,
     )
     if loss_fn == "expkl":
@@ -3457,7 +3583,9 @@ def joint_loss_step(
         # which is stable for any finite input, and the clamp would
         # zero gradients in the |log W| > 30 regions.
         pred_log = _apply_positivity_logW(
-            j, head.positivity, clamp=_math.inf,
+            j,
+            head.positivity,
+            clamp=_math.inf,
         )
         per_event_raw = _wbce_per_event(pred_log, true_lw_safe)
         per_event = per_event_raw * trustable_f
@@ -3558,20 +3686,30 @@ def head_only_loss_step(
         nll = -log_p
 
         # Sample perturbations using the same scheme as joint_loss_step.
-        u_shift, sigma_vec, delta_smear, v_smear, mode = (
-            sample_perturbations(
-                B, n_features, delta_max, sigma_max, device,
-                oversample=oversample,
-                include_smear=head.include_smear,
-            )
+        u_shift, sigma_vec, delta_smear, v_smear, mode = sample_perturbations(
+            B,
+            n_features,
+            delta_max,
+            sigma_max,
+            device,
+            oversample=oversample,
+            include_smear=head.include_smear,
         )
 
     # Target log-weight via the same K=1 / K>1 GH branch as
     # joint_loss_step; the helper handles its own no_grad.
     true_lw = _compute_target_lw(
-        flow, head, y_std, c_std, log_p,
-        u_shift, sigma_vec, delta_smear, v_smear,
-        n_features, detach_target=True,
+        flow,
+        head,
+        y_std,
+        c_std,
+        log_p,
+        u_shift,
+        sigma_vec,
+        delta_smear,
+        v_smear,
+        n_features,
+        detach_target=True,
     )
 
     # Trustable-target mask (same as joint_loss_step).
@@ -3579,7 +3717,9 @@ def head_only_loss_step(
     trustable = torch.isfinite(true_lw) & (true_lw.abs() < target_threshold)
     trustable_f = trustable.to(true_lw.dtype)
     true_lw_safe = torch.where(
-        trustable, true_lw, torch.zeros_like(true_lw),
+        trustable,
+        true_lw,
+        torch.zeros_like(true_lw),
     )
 
     # Polyhead forward — only this part has gradients. Per-mode
@@ -3587,7 +3727,11 @@ def head_only_loss_step(
     # only the polyhead under gradient (the flow forward above is
     # under no_grad).
     j = _head_d_per_mode(
-        head, y_std, c_std, u_shift, sigma_vec,
+        head,
+        y_std,
+        c_std,
+        u_shift,
+        sigma_vec,
         detach_pure_in_joint=detach_pure_in_joint,
     )
     if loss_fn == "expkl":
@@ -3598,7 +3742,9 @@ def head_only_loss_step(
         # See joint_loss_step's wbce branch for the clamp=inf
         # rationale (softplus-only consumption ⇒ no overflow risk).
         pred_log = _apply_positivity_logW(
-            j, head.positivity, clamp=_math.inf,
+            j,
+            head.positivity,
+            clamp=_math.inf,
         )
         per_event_raw = _wbce_per_event(pred_log, true_lw_safe)
         per_event = per_event_raw * trustable_f
@@ -3642,6 +3788,7 @@ def head_only_loss_step(
 # Flow-only and flow+polyhead training wrappers
 # -----------------------------------------------------------------------------
 
+
 class FlowWithLogProb(nn.Module):
     """DDP-friendly wrapper that returns log p(x|c) from forward().
 
@@ -3650,6 +3797,7 @@ class FlowWithLogProb(nn.Module):
     forward to return tensors/standard containers). Wrapping the
     log_prob call in a standard nn.Module.forward makes DDP happy.
     """
+
     def __init__(self, flow: nn.Module):
         super().__init__()
         self.flow = flow
@@ -3669,6 +3817,7 @@ class FlowHeadModel(nn.Module):
     arguments are passed in as Python floats, not buffers, so the
     same module can be reused across schedules without re-wrapping.
     """
+
     def __init__(
         self,
         flow: nn.Module,
@@ -3700,18 +3849,31 @@ class FlowHeadModel(nn.Module):
         # at the MC c).
         if self.head_only:
             return head_only_loss_step(
-                self.flow, self.head, c_std, w,
-                delta_max=delta_max, sigma_max=sigma_max,
-                loss_target=loss_target, weight_power=weight_power,
-                loss_fn=loss_fn, huber_delta=huber_delta,
+                self.flow,
+                self.head,
+                c_std,
+                w,
+                delta_max=delta_max,
+                sigma_max=sigma_max,
+                loss_target=loss_target,
+                weight_power=weight_power,
+                loss_fn=loss_fn,
+                huber_delta=huber_delta,
                 detach_pure_in_joint=detach_pure_in_joint,
             )
         return joint_loss_step(
-            self.flow, self.head, x_std, c_std, w,
-            delta_max=delta_max, sigma_max=sigma_max,
+            self.flow,
+            self.head,
+            x_std,
+            c_std,
+            w,
+            delta_max=delta_max,
+            sigma_max=sigma_max,
             aux_jacobian_weight=aux_jacobian_weight,
-            loss_target=loss_target, weight_power=weight_power,
-            loss_fn=loss_fn, huber_delta=huber_delta,
+            loss_target=loss_target,
+            weight_power=weight_power,
+            loss_fn=loss_fn,
+            huber_delta=huber_delta,
             detach_pure_in_joint=detach_pure_in_joint,
             detach_target=detach_target,
         )
@@ -3721,6 +3883,7 @@ def _all_reduce_sum_(t: torch.Tensor, is_dist: bool) -> torch.Tensor:
     """In-place all-reduce(sum) when distributed, otherwise a no-op."""
     if is_dist:
         import torch.distributed as dist
+
         dist.all_reduce(t, op=dist.ReduceOp.SUM)
     return t
 
@@ -3746,7 +3909,10 @@ def _state_dict_to_cpu(module: nn.Module) -> dict:
         if v.is_cuda:
             any_cuda = True
             dst = torch.empty(
-                v.shape, dtype=v.dtype, device="cpu", pin_memory=True,
+                v.shape,
+                dtype=v.dtype,
+                device="cpu",
+                pin_memory=True,
             )
             dst.copy_(v, non_blocking=True)
             cpu[k] = dst
@@ -3760,6 +3926,7 @@ def _state_dict_to_cpu(module: nn.Module) -> dict:
 # -----------------------------------------------------------------------------
 # Training loop
 # -----------------------------------------------------------------------------
+
 
 def train(
     model: nn.Module,
@@ -3818,9 +3985,7 @@ def train(
     the flow's density quality drives selection.
     """
     use_polyhead = head_config is not None
-    optimizer = torch.optim.AdamW(
-        model.parameters(), lr=lr, weight_decay=weight_decay
-    )
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
         optimizer, mode="min", factor=0.5, patience=max(1, patience // 2)
     )
@@ -3846,9 +4011,7 @@ def train(
     # phase 1 (flow-only) with σ-conditioning enabled and active
     # (apply_smearing=True). Phase 2 (polyhead) has its own (sh, sm,
     # jt) split. Plain NLL training has no split.
-    track_nll_sigma_split = (
-        cond_on_smear and apply_smearing and not use_polyhead
-    )
+    track_nll_sigma_split = cond_on_smear and apply_smearing and not use_polyhead
 
     # How often to refresh the tqdm postfix with the running NLL. Each
     # refresh triggers an .item() on GPU scalars (= a H2D sync), which
@@ -3876,7 +4039,8 @@ def train(
     # range and doesn't need loss scaling). When disabled, all
     # scaler calls below are no-ops.
     scaler = torch.amp.GradScaler(
-        amp_device_type, enabled=(precision == "fp16"),
+        amp_device_type,
+        enabled=(precision == "fp16"),
     )
 
     # Smear-conditioning helper: per-batch, augment ``(x, c) →
@@ -3901,7 +4065,8 @@ def train(
                 "tensor of standardized σ upper bounds)."
             )
         sigma_max_std_dev = sigma_max_std.to(
-            device=device, dtype=torch.float32,
+            device=device,
+            dtype=torch.float32,
         )
         smear_zero_frac = float(cond_smear_zero_fraction)
     else:
@@ -3965,23 +4130,28 @@ def train(
         F = x.shape[1]
         if not cond_on_smear:
             return (
-                x, c,
+                x,
+                c,
                 torch.ones(B, dtype=torch.bool, device=x.device),
             )
         if sample_smear:
             # Ball sampling: ‖σ‖₂ ~ U[0, σ_max_radius], v on S^{F−1}.
-            sigma_max_radius = (
-                sigma_max_std_dev.max().to(dtype=x.dtype)
-            )
+            sigma_max_radius = sigma_max_std_dev.max().to(dtype=x.dtype)
             sigma_mag = (
                 torch.rand(
-                    B, 1, device=x.device, dtype=x.dtype,
+                    B,
+                    1,
+                    device=x.device,
+                    dtype=x.dtype,
                     generator=generator,
                 )
                 * sigma_max_radius
             )
             v = torch.randn(
-                B, F, device=x.device, dtype=x.dtype,
+                B,
+                F,
+                device=x.device,
+                dtype=x.dtype,
                 generator=generator,
             )
             v = v / v.norm(dim=-1, keepdim=True).clamp_min(1e-30)
@@ -3989,24 +4159,34 @@ def train(
             if smear_zero_frac > 0.0:
                 zero_mask_2d = (
                     torch.rand(
-                        B, 1, device=x.device, dtype=x.dtype,
+                        B,
+                        1,
+                        device=x.device,
+                        dtype=x.dtype,
                         generator=generator,
                     )
                     < smear_zero_frac
                 )
                 sigma_std = torch.where(
-                    zero_mask_2d, torch.zeros_like(sigma_std), sigma_std,
+                    zero_mask_2d,
+                    torch.zeros_like(sigma_std),
+                    sigma_std,
                 )
                 is_zero = zero_mask_2d.squeeze(-1)
             else:
                 is_zero = torch.zeros(
-                    B, dtype=torch.bool, device=x.device,
+                    B,
+                    dtype=torch.bool,
+                    device=x.device,
                 )
             # Single scalar ε per event (rank-1 correlated smear): all
             # F components share the same ε, so y' − y = ε · σ ~
             # N(0, σσᵀ). Matches the head's _make_y_pert_stack.
             eps = torch.randn(
-                B, 1, device=x.device, dtype=x.dtype,
+                B,
+                1,
+                device=x.device,
+                dtype=x.dtype,
                 generator=generator,
             )
             x_aug = x + sigma_std * eps
@@ -4019,15 +4199,15 @@ def train(
         return x_aug, c_aug, is_zero
 
     head_only_mode = (
-        bool(head_config.get("head_only", False))
-        if head_config is not None else False
+        bool(head_config.get("head_only", False)) if head_config is not None else False
     )
     # Track best by val_wmse in polyhead-only mode (val_nll is
     # essentially constant since the flow is frozen — its only
     # variation comes from the per-batch random y sample).
     track_by_wmse = head_only_mode
     phase_label = (
-        "polyhead only (frozen flow)" if head_only_mode
+        "polyhead only (frozen flow)"
+        if head_only_mode
         else ("flow + polyhead" if use_polyhead else "flow only")
     )
 
@@ -4070,7 +4250,8 @@ def train(
                 # same way during phase 1 (apply_smearing=True), or
                 # forced to zero in phase 2 (apply_smearing=False).
                 x, c, is_zero = _augment_x_c(
-                    x, c,
+                    x,
+                    c,
                     sample_smear=apply_smearing,
                     generator=val_gen,
                 )
@@ -4078,7 +4259,9 @@ def train(
                     with amp_ctx():
                         # Aux loss off in val — pure flow + polyhead loss.
                         _, nll_w, wloss_w, _, wloss_split = model(
-                            x, c, w,
+                            x,
+                            c,
+                            w,
                             head_config["delta_max"],
                             head_config["sigma_max"],
                             0.0,
@@ -4087,15 +4270,14 @@ def train(
                             head_config.get("loss_fn", "huber"),
                             head_config.get("huber_delta", 1.0),
                             head_config.get(
-                                "detach_pure_in_joint", False,
+                                "detach_pure_in_joint",
+                                False,
                             ),
                             head_config.get("detach_target", True),
                         )
                     total_nll = total_nll + nll_w.float() * wb
                     total_wloss = total_wloss + wloss_w.float() * wb
-                    total_wloss_split = (
-                        total_wloss_split + wloss_split.float() * wb
-                    )
+                    total_wloss_split = total_wloss_split + wloss_split.float() * wb
                 else:
                     with amp_ctx():
                         log_p = model(x, c)
@@ -4106,7 +4288,9 @@ def train(
                     # early-stopping signal).
                     finite_mask = torch.isfinite(log_p)
                     log_p = torch.where(
-                        finite_mask, log_p, torch.zeros_like(log_p),
+                        finite_mask,
+                        log_p,
+                        torch.zeros_like(log_p),
                     )
                     w_eff = w * finite_mask.to(dtype=log_p.dtype)
                     wb_eff = w_eff.sum()
@@ -4119,20 +4303,16 @@ def train(
                         mask_zero = is_zero.to(dtype=neg_log_p_w.dtype)
                         mask_nz = 1.0 - mask_zero
                         total_nll_sigma_split[0] = (
-                            total_nll_sigma_split[0]
-                            + (mask_zero * neg_log_p_w).sum()
+                            total_nll_sigma_split[0] + (mask_zero * neg_log_p_w).sum()
                         )
                         total_nll_sigma_split[1] = (
-                            total_nll_sigma_split[1]
-                            + (mask_nz * neg_log_p_w).sum()
+                            total_nll_sigma_split[1] + (mask_nz * neg_log_p_w).sum()
                         )
                         wsum_sigma_split[0] = (
-                            wsum_sigma_split[0]
-                            + (mask_zero * w_eff).sum()
+                            wsum_sigma_split[0] + (mask_zero * w_eff).sum()
                         )
                         wsum_sigma_split[1] = (
-                            wsum_sigma_split[1]
-                            + (mask_nz * w_eff).sum()
+                            wsum_sigma_split[1] + (mask_nz * w_eff).sum()
                         )
                 wsum = wsum + wb
         _all_reduce_sum_(total_nll, is_dist)
@@ -4183,13 +4363,17 @@ def train(
             c = c.to(device, non_blocking=True)
             w = w.to(device, non_blocking=True)
             x, c, _is_zero = _augment_x_c(
-                x, c, sample_smear=apply_smearing,
+                x,
+                c,
+                sample_smear=apply_smearing,
             )
             optimizer.zero_grad(set_to_none=True)
             if use_polyhead:
                 with amp_ctx():
                     loss, _nll_w, _wloss_w, _aux_w, _wloss_split = model(
-                        x, c, w,
+                        x,
+                        c,
+                        w,
                         head_config["delta_max"],
                         head_config["sigma_max"],
                         head_config.get("aux_jacobian_weight", 0.0),
@@ -4198,7 +4382,8 @@ def train(
                         head_config.get("loss_fn", "huber"),
                         head_config.get("huber_delta", 1.0),
                         head_config.get(
-                            "detach_pure_in_joint", False,
+                            "detach_pure_in_joint",
+                            False,
                         ),
                         head_config.get("detach_target", True),
                     )
@@ -4211,7 +4396,8 @@ def train(
             if precision == "fp16":
                 scaler.unscale_(optimizer)
             torch.nn.utils.clip_grad_norm_(
-                model.parameters(), max_norm=10.0,
+                model.parameters(),
+                max_norm=10.0,
             )
             scaler.step(optimizer)
             scaler.update()
@@ -4220,6 +4406,7 @@ def train(
             output = profile_output
             if is_dist and output:
                 import torch.distributed as _dist
+
                 rank_i = _dist.get_rank()
                 base, ext = os.path.splitext(output)
                 output = f"{base}.rank{rank_i}{ext}"
@@ -4272,14 +4459,18 @@ def train(
             wsum_b = wb.clamp_min(1e-30)
             # Augment (x, c) with smear conditioning when enabled.
             x, c, is_zero = _augment_x_c(
-                x, c, sample_smear=apply_smearing,
+                x,
+                c,
+                sample_smear=apply_smearing,
             )
 
             optimizer.zero_grad(set_to_none=True)
             if use_polyhead:
                 with amp_ctx():
                     loss, nll_w, wloss_w, _aux_w, wloss_split = model(
-                        x, c, w,
+                        x,
+                        c,
+                        w,
                         head_config["delta_max"],
                         head_config["sigma_max"],
                         head_config.get("aux_jacobian_weight", 0.0),
@@ -4317,23 +4508,22 @@ def train(
                 finite_mask = torch.isfinite(log_p)
                 n_nonfinite = int((~finite_mask).sum().item())
                 if n_nonfinite > 0:
-                    n_nonfinite_total = (
-                        n_nonfinite_total + n_nonfinite
-                    )
-                    n_finite_events_total = (
-                        n_finite_events_total
-                        + int(finite_mask.numel() - n_nonfinite)
+                    n_nonfinite_total = n_nonfinite_total + n_nonfinite
+                    n_finite_events_total = n_finite_events_total + int(
+                        finite_mask.numel() - n_nonfinite
                     )
                     log_p = torch.where(
-                        finite_mask, log_p, torch.zeros_like(log_p),
+                        finite_mask,
+                        log_p,
+                        torch.zeros_like(log_p),
                     )
                     finite_mask_f = finite_mask.to(dtype=log_p.dtype)
                     w_eff = w * finite_mask_f
                     wb_eff = w_eff.sum()
                     wsum_b_eff = wb_eff.clamp_min(1e-30)
                 else:
-                    n_finite_events_total = (
-                        n_finite_events_total + int(finite_mask.numel())
+                    n_finite_events_total = n_finite_events_total + int(
+                        finite_mask.numel()
                     )
                     w_eff = w
                     wb_eff = wb
@@ -4347,18 +4537,10 @@ def train(
                 if track_nll_sigma_split:
                     mask_zero = is_zero.to(dtype=neg_log_p_w.dtype)
                     mask_nz = 1.0 - mask_zero
-                    running_nll_sigma_zero = (
-                        (mask_zero * neg_log_p_w).sum().detach()
-                    )
-                    running_nll_sigma_nz = (
-                        (mask_nz * neg_log_p_w).sum().detach()
-                    )
-                    running_wsum_sigma_zero = (
-                        (mask_zero * w_eff).sum().detach()
-                    )
-                    running_wsum_sigma_nz = (
-                        (mask_nz * w_eff).sum().detach()
-                    )
+                    running_nll_sigma_zero = (mask_zero * neg_log_p_w).sum().detach()
+                    running_nll_sigma_nz = (mask_nz * neg_log_p_w).sum().detach()
+                    running_wsum_sigma_zero = (mask_zero * w_eff).sum().detach()
+                    running_wsum_sigma_nz = (mask_nz * w_eff).sum().detach()
                 # Whole-batch guard: skip backward/step if either
                 #   (a) the loss itself is non-finite, or
                 #   (b) every event in the batch was non-finite
@@ -4366,7 +4548,7 @@ def train(
                 #       but devoid of gradient signal).
                 # In either case, the optimiser step would corrupt
                 # the parameters or do nothing useful.
-                all_nonfinite_batch = (n_nonfinite == int(log_p.numel()))
+                all_nonfinite_batch = n_nonfinite == int(log_p.numel())
                 if (not torch.isfinite(loss)) or all_nonfinite_batch:
                     n_skipped_batches += 1
                     optimizer.zero_grad(set_to_none=True)
@@ -4380,9 +4562,7 @@ def train(
             # Running accumulators stay on device.
             total_nll = total_nll + running_nll_term.detach()
             total_wloss = total_wloss + running_wloss_term.detach()
-            total_wloss_split = (
-                total_wloss_split + running_wloss_split_term.detach()
-            )
+            total_wloss_split = total_wloss_split + running_wloss_split_term.detach()
             if track_nll_sigma_split:
                 total_nll_sigma_split[0] = (
                     total_nll_sigma_split[0] + running_nll_sigma_zero
@@ -4390,12 +4570,8 @@ def train(
                 total_nll_sigma_split[1] = (
                     total_nll_sigma_split[1] + running_nll_sigma_nz
                 )
-                wsum_sigma_split[0] = (
-                    wsum_sigma_split[0] + running_wsum_sigma_zero
-                )
-                wsum_sigma_split[1] = (
-                    wsum_sigma_split[1] + running_wsum_sigma_nz
-                )
+                wsum_sigma_split[0] = wsum_sigma_split[0] + running_wsum_sigma_zero
+                wsum_sigma_split[1] = wsum_sigma_split[1] + running_wsum_sigma_nz
             wsum = wsum + wb
             if is_rank0 and (i + 1) % postfix_every == 0:
                 # rank-0-local running metrics (not globally reduced;
@@ -4404,9 +4580,7 @@ def train(
                 running_nll = total_nll.item() / wsum_py_now
                 if use_polyhead:
                     running_wloss = total_wloss.item() / wsum_py_now
-                    sh, sm, jt = (
-                        total_wloss_split / wsum_py_now
-                    ).cpu().tolist()
+                    sh, sm, jt = (total_wloss_split / wsum_py_now).cpu().tolist()
                     bar.set_postfix(
                         nll=f"{running_nll:+.4f}",
                         wmse=f"{running_wloss:.4f}",
@@ -4474,21 +4648,13 @@ def train(
         # Append NaN-event accounting when active (flow-only path).
         # Quiet by default: only annotate epochs where something
         # actually went wrong.
-        if (not use_polyhead) and (
-            n_nonfinite_total > 0 or n_skipped_batches > 0
-        ):
+        if (not use_polyhead) and (n_nonfinite_total > 0 or n_skipped_batches > 0):
             n_total_events = n_finite_events_total + n_nonfinite_total
-            nf_frac = (
-                n_nonfinite_total / max(n_total_events, 1)
-            )
-            line = (
-                f"{line}  nan_evt {n_nonfinite_total} "
-                f"({nf_frac*100:.3g}%)"
-                + (
-                    f"  skipped {n_skipped_batches} batch(es)"
-                    if n_skipped_batches > 0
-                    else ""
-                )
+            nf_frac = n_nonfinite_total / max(n_total_events, 1)
+            line = f"{line}  nan_evt {n_nonfinite_total} " f"({nf_frac*100:.3g}%)" + (
+                f"  skipped {n_skipped_batches} batch(es)"
+                if n_skipped_batches > 0
+                else ""
             )
         if is_rank0:
             print(line, flush=True)
@@ -4531,8 +4697,7 @@ def train(
                     comp_imp = val_comp < best_val_split[i]
                 else:
                     comp_imp = val_comp < best_val_split[i] - (
-                        patience_rel_threshold
-                        * abs(best_val_split[i])
+                        patience_rel_threshold * abs(best_val_split[i])
                     )
                 if comp_imp:
                     best_val_split[i] = val_comp
@@ -4613,10 +4778,7 @@ def train(
                         print(line)
                     log_lines.append(line)
             else:
-                line = (
-                    f"early stopping at epoch {epoch} "
-                    f"(best val {best_val:+.4f})"
-                )
+                line = f"early stopping at epoch {epoch} " f"(best val {best_val:+.4f})"
                 if is_rank0:
                     print(line)
                 log_lines.append(line)
@@ -4632,6 +4794,7 @@ def train(
 # -----------------------------------------------------------------------------
 # TorchScript export
 # -----------------------------------------------------------------------------
+
 
 class FlowWrapper(nn.Module):
     """TorchScript-friendly wrapper exposing log_density and score.
@@ -4678,7 +4841,10 @@ class FlowWrapper(nn.Module):
         return (c_raw - self.cond_mean) / self.cond_std
 
     def _augment_cond_with_sigma(
-        self, c_std: torch.Tensor, sigma_raw, x_ref: torch.Tensor,
+        self,
+        c_std: torch.Tensor,
+        sigma_raw,
+        x_ref: torch.Tensor,
     ) -> torch.Tensor:
         """Return c_std augmented with the F·(F+1)/2-component pack
         of ``σσᵀ`` (in standardized target units), when smear-
@@ -4689,16 +4855,20 @@ class FlowWrapper(nn.Module):
         n_features = self.target_std.shape[0]
         if sigma_raw is None:
             sigma_std = torch.zeros(
-                c_std.shape[0], n_features,
-                device=c_std.device, dtype=c_std.dtype,
+                c_std.shape[0],
+                n_features,
+                device=c_std.device,
+                dtype=c_std.dtype,
             )
         else:
             sigma_std = sigma_raw.to(
-                device=c_std.device, dtype=c_std.dtype,
+                device=c_std.device,
+                dtype=c_std.dtype,
             )
             if sigma_std.dim() == 1:
                 sigma_std = sigma_std.unsqueeze(0).expand(
-                    c_std.shape[0], -1,
+                    c_std.shape[0],
+                    -1,
                 )
             sigma_std = sigma_std / self.target_std
         sigma_pack = _sigma_pack_outer(sigma_std)
@@ -4798,8 +4968,9 @@ def export_flow(
     # the ``log_density`` forward but skips the ``score`` path
     # (autograd.grad isn't traceable). If C++ score inference is
     # needed, use flow_export_onnx.py's dynamo-based export.
-    import zuko.utils
     import zuko.transforms
+    import zuko.utils
+
     _orig_gl_utils = zuko.utils.gauss_legendre
     _orig_gl_transforms = zuko.transforms.gauss_legendre
 
@@ -4808,7 +4979,9 @@ def export_flow(
             n, dtype=a.dtype, device=a.device
         )
         x_nodes = torch.lerp(
-            a[..., None], b[..., None], nodes,
+            a[..., None],
+            b[..., None],
+            nodes,
         ).movedim(-1, 0)
         return (b - a) * torch.tensordot(weights, f(x_nodes), dims=1)
 
@@ -4834,6 +5007,7 @@ def export_flow(
 
         trace_inputs = (x_example, c_example, sigma_example)
     else:
+
         class _TracedLogDensity(nn.Module):
             def __init__(self, inner: nn.Module):
                 super().__init__()
@@ -4853,10 +5027,7 @@ def export_flow(
                 strict=False,
             )
         traced.save(outpath_ts)
-        print(
-            f"saved TorchScript (traced, log_density only) to "
-            f"{outpath_ts}"
-        )
+        print(f"saved TorchScript (traced, log_density only) to " f"{outpath_ts}")
     except Exception as e:
         print(
             f"[note] torch.jit.trace export skipped "
@@ -4871,6 +5042,7 @@ def export_flow(
 # -----------------------------------------------------------------------------
 # In-memory loader
 # -----------------------------------------------------------------------------
+
 
 class InMemoryLoader:
     """Bulk-indexed per-batch iterator over in-RAM CPU tensors.
@@ -4904,9 +5076,18 @@ class InMemoryLoader:
         profiler around the training loop.
     """
 
-    def __init__(self, x, c, w, batch_size, shuffle, drop_last,
-                 pin_memory=True, prefetch_shuffle=False,
-                 time_iter=False):
+    def __init__(
+        self,
+        x,
+        c,
+        w,
+        batch_size,
+        shuffle,
+        drop_last,
+        pin_memory=True,
+        prefetch_shuffle=False,
+        time_iter=False,
+    ):
         self.x, self.c, self.w = x, c, w
         self.batch_size = batch_size
         self.shuffle = shuffle
@@ -4915,7 +5096,8 @@ class InMemoryLoader:
         self.n = x.shape[0]
         self.prefetch_shuffle = bool(prefetch_shuffle) and shuffle
         self.time_iter = bool(time_iter) or os.environ.get(
-            "LOADER_TIME", "0",
+            "LOADER_TIME",
+            "0",
         ) not in ("", "0", "false", "False")
 
         # Async prefetch state: background thread + a stashed
@@ -4924,6 +5106,7 @@ class InMemoryLoader:
         self._next_perm_future = None
         if self.prefetch_shuffle:
             import concurrent.futures as _futures
+
             self._executor = _futures.ThreadPoolExecutor(max_workers=1)
             # Kick off the *first* epoch's permutation now, so it
             # overlaps with whatever happens between loader
@@ -4943,12 +5126,10 @@ class InMemoryLoader:
         """Submit a randperm task to run in the background; the result
         is consumed by the next ``__iter__`` call. No-op if prefetch
         is disabled or a previous future already exists."""
-        if (
-            self._executor is not None
-            and self._next_perm_future is None
-        ):
+        if self._executor is not None and self._next_perm_future is None:
             self._next_perm_future = self._executor.submit(
-                torch.randperm, self.n,
+                torch.randperm,
+                self.n,
             )
 
     def __iter__(self):
@@ -4982,12 +5163,10 @@ class InMemoryLoader:
             # tiny gap between iterators.
             self._kick_off_next_perm()
 
-            n_batches = self.n // bs if self.drop_last else (
-                (self.n + bs - 1) // bs
-            )
+            n_batches = self.n // bs if self.drop_last else ((self.n + bs - 1) // bs)
             t_first = None
             for i in range(n_batches):
-                idx = perm[i * bs:min((i + 1) * bs, self.n)]
+                idx = perm[i * bs : min((i + 1) * bs, self.n)]
                 xb = self.x.index_select(0, idx)
                 cb = self.c.index_select(0, idx)
                 wb = self.w.index_select(0, idx)
@@ -5008,9 +5187,7 @@ class InMemoryLoader:
                     )
                 yield xb, cb, wb
         else:
-            n_batches = self.n // bs if self.drop_last else (
-                (self.n + bs - 1) // bs
-            )
+            n_batches = self.n // bs if self.drop_last else ((self.n + bs - 1) // bs)
             t_first = None
             for i in range(n_batches):
                 s = i * bs
@@ -5076,6 +5253,7 @@ def _zuko_base_remap(flow_state, target_module):
 # Worker (runs once per GPU in distributed mode, once total otherwise)
 # -----------------------------------------------------------------------------
 
+
 def main_worker(
     rank,
     args,
@@ -5095,6 +5273,7 @@ def main_worker(
     # Device selection + optional process-group init.
     if is_dist:
         import torch.distributed as dist
+
         os.environ["MASTER_ADDR"] = "localhost"
         os.environ["MASTER_PORT"] = str(master_port)
         if args.device.startswith("cuda"):
@@ -5104,9 +5283,7 @@ def main_worker(
         else:
             device = "cpu"
             backend = "gloo"
-        dist.init_process_group(
-            backend=backend, rank=rank, world_size=world_size
-        )
+        dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
     else:
         if args.device.startswith("cuda"):
             torch.cuda.set_device(0)
@@ -5116,12 +5293,8 @@ def main_worker(
 
     # Per-rank index shard. With world_size==1 this is a no-op.
     if is_dist:
-        train_sel_rank = torch.chunk(
-            train_sel, world_size
-        )[rank].contiguous()
-        val_sel_rank = torch.chunk(
-            val_sel, world_size
-        )[rank].contiguous()
+        train_sel_rank = torch.chunk(train_sel, world_size)[rank].contiguous()
+        val_sel_rank = torch.chunk(val_sel, world_size)[rank].contiguous()
     else:
         train_sel_rank = train_sel
         val_sel_rank = val_sel
@@ -5136,14 +5309,22 @@ def main_worker(
     n_val_rank = val_x_cpu.shape[0]
 
     train_loader = InMemoryLoader(
-        train_x_cpu, train_c_cpu, train_w_cpu,
-        batch_size=args.batch_size, shuffle=True, drop_last=True,
+        train_x_cpu,
+        train_c_cpu,
+        train_w_cpu,
+        batch_size=args.batch_size,
+        shuffle=True,
+        drop_last=True,
         prefetch_shuffle=bool(getattr(args, "prefetch_shuffle", True)),
         time_iter=bool(getattr(args, "time_loader", False)),
     )
     val_loader = InMemoryLoader(
-        val_x_cpu, val_c_cpu, val_w_cpu,
-        batch_size=args.batch_size, shuffle=False, drop_last=False,
+        val_x_cpu,
+        val_c_cpu,
+        val_w_cpu,
+        batch_size=args.batch_size,
+        shuffle=False,
+        drop_last=False,
         time_iter=bool(getattr(args, "time_loader", False)),
     )
     if is_rank0:
@@ -5168,15 +5349,12 @@ def main_worker(
     if cond_on_smear:
         sigma_max_std = torch.full(
             (int(flow_config["n_features"]),),
-            _flow_smear_oversample
-            * float(flow_config["cond_smear_sigma_max"]),
+            _flow_smear_oversample * float(flow_config["cond_smear_sigma_max"]),
             dtype=torch.float32,
         )
     else:
         sigma_max_std = None
-    cond_smear_zero_fraction = float(
-        flow_config.get("cond_smear_zero_fraction", 0.5)
-    )
+    cond_smear_zero_fraction = float(flow_config.get("cond_smear_zero_fraction", 0.5))
     if is_rank0 and cond_on_smear:
         print(
             f"smear conditioning: σ_max_std="
@@ -5220,7 +5398,7 @@ def main_worker(
             flow_state = ckpt["state_dict"]
         elif "wrapper_state_dict" in ckpt:
             flow_state = {
-                k[len("flow."):]: v
+                k[len("flow.") :]: v
                 for k, v in ckpt["wrapper_state_dict"].items()
                 if k.startswith("flow.")
             }
@@ -5244,27 +5422,17 @@ def main_worker(
                 " (also head state)"
                 if loaded_head_state is not None
                 else (
-                    " (head state in checkpoint ignored — "
-                    "--reset-head)"
-                    if "polyhead_state_dict" in ckpt
-                    and args.reset_head
+                    " (head state in checkpoint ignored — " "--reset-head)"
+                    if "polyhead_state_dict" in ckpt and args.reset_head
                     else ""
                 )
             )
-            print(
-                f"loaded flow state from {args.load_flow_checkpoint}"
-                + ph_msg
-            )
+            print(f"loaded flow state from {args.load_flow_checkpoint}" + ph_msg)
     if head_only_mode:
         if args.load_flow_checkpoint is None:
-            raise SystemExit(
-                "--head-only requires --load-flow-checkpoint"
-            )
+            raise SystemExit("--head-only requires --load-flow-checkpoint")
         if not args.head:
-            raise SystemExit(
-                "--head-only implies --head but --no-head "
-                "was passed"
-            )
+            raise SystemExit("--head-only implies --head but --no-head " "was passed")
         zuko_flow.eval()
         for p in zuko_flow.parameters():
             p.requires_grad_(False)
@@ -5286,7 +5454,8 @@ def main_worker(
         # ``sample_perturbations``.
         _oversample = 1.3
         activation_cls = ACTIVATIONS.get(
-            flow_config.get("activation", "gelu").lower(), nn.GELU,
+            flow_config.get("activation", "gelu").lower(),
+            nn.GELU,
         )
         if args.head_arch == "polyhead":
             head = PolyHead(
@@ -5310,8 +5479,11 @@ def main_worker(
             # Lazy import to avoid the train_shift_smear_reweight.py →
             # train_muon_response_flow.py module-level import cycle.
             from train_shift_smear_reweight import (
-                ReweightMLP_B, ReweightMLPFactored, _sigma_pack_indices,
+                ReweightMLP_B,
+                ReweightMLPFactored,
+                _sigma_pack_indices,
             )
+
             if args.head_arch == "mlp":
                 head = ReweightMLP_B(
                     n_features=flow_config["n_features"],
@@ -5335,12 +5507,8 @@ def main_worker(
                     head_layers=int(args.head_layers),
                     activation=activation_cls,
                     shift_only=not bool(args.include_smear),
-                    detach_pure_shift_in_joint=bool(
-                        args.detach_pure_shift_in_joint
-                    ),
-                    detach_pure_smear_in_joint=bool(
-                        args.detach_pure_smear_in_joint
-                    ),
+                    detach_pure_shift_in_joint=bool(args.detach_pure_shift_in_joint),
+                    detach_pure_smear_in_joint=bool(args.detach_pure_smear_in_joint),
                 ).to(device)
             # The MLP head doesn't carry the smear-quadrature config
             # natively (PolyHead does). Attach the same fields the
@@ -5360,15 +5528,11 @@ def main_worker(
                 eff_smear_K = int(args.smear_K)
                 eff_smear_residual = bool(args.smear_residual)
                 if eff_smear_residual and eff_smear_K <= 1:
-                    raise SystemExit(
-                        "--smear-residual requires --smear-K > 1."
-                    )
+                    raise SystemExit("--smear-residual requires --smear-K > 1.")
             head.smear_K = eff_smear_K
             head.smear_residual = eff_smear_residual
             if eff_smear_K > 1:
-                nodes_np, w_np = np.polynomial.hermite_e.hermegauss(
-                    eff_smear_K
-                )
+                nodes_np, w_np = np.polynomial.hermite_e.hermegauss(eff_smear_K)
                 w_norm = w_np / np.sqrt(2.0 * np.pi)
                 gh_nodes = torch.tensor(nodes_np, dtype=torch.float32)
                 gh_log_w = torch.tensor(np.log(w_norm), dtype=torch.float32)
@@ -5376,17 +5540,25 @@ def main_worker(
                 gh_nodes = torch.zeros(0, dtype=torch.float32)
                 gh_log_w = torch.zeros(0, dtype=torch.float32)
             head.register_buffer(
-                "gh_nodes", gh_nodes.to(device), persistent=False,
+                "gh_nodes",
+                gh_nodes.to(device),
+                persistent=False,
             )
             head.register_buffer(
-                "gh_log_weights", gh_log_w.to(device), persistent=False,
+                "gh_log_weights",
+                gh_log_w.to(device),
+                persistent=False,
             )
             iu, ju = _sigma_pack_indices(int(flow_config["n_features"]))
             head.register_buffer(
-                "sigma_pack_iu", iu.to(device), persistent=False,
+                "sigma_pack_iu",
+                iu.to(device),
+                persistent=False,
             )
             head.register_buffer(
-                "sigma_pack_ju", ju.to(device), persistent=False,
+                "sigma_pack_ju",
+                ju.to(device),
+                persistent=False,
             )
         else:
             raise SystemExit(f"unknown --head-arch {args.head_arch!r}")
@@ -5408,20 +5580,14 @@ def main_worker(
         # via attributes on the head module.
         cond_smear_target_choice = str(args.cond_smear_target)
         if cond_smear_target_choice == "auto":
-            cond_smear_target_choice = (
-                "direct" if cond_on_smear else "gh"
-            )
+            cond_smear_target_choice = "direct" if cond_on_smear else "gh"
         if cond_smear_target_choice == "direct" and not cond_on_smear:
             raise SystemExit(
                 "--cond-smear-target=direct requires --cond-on-smear "
                 "(no σ-conditioned flow to query otherwise)."
             )
-        head.cond_smear_target_direct = (
-            cond_smear_target_choice == "direct"
-        )
-        head.n_cond_base = int(
-            flow_config.get("n_cond_base", flow_config["n_cond"])
-        )
+        head.cond_smear_target_direct = cond_smear_target_choice == "direct"
+        head.n_cond_base = int(flow_config.get("n_cond_base", flow_config["n_cond"]))
         if is_rank0:
             print(
                 f"head smear target: {cond_smear_target_choice} "
@@ -5437,9 +5603,7 @@ def main_worker(
             "max_cross_deg": int(args.max_cross_deg),
             "basis": str(args.basis),
             "basis_scale_u": _oversample * float(args.delta_max),
-            "basis_scale_sigma": (
-                _oversample * float(args.sigma_max)
-            ),
+            "basis_scale_sigma": (_oversample * float(args.sigma_max)),
             # MLP-only sizing fields.
             "d_emb": int(args.d_emb),
             "head_hidden": int(args.head_hidden),
@@ -5472,10 +5636,7 @@ def main_worker(
         n_flow = sum(p.numel() for p in zuko_flow.parameters())
         if head is not None:
             n_head = sum(p.numel() for p in head.parameters())
-            print(
-                f"flow parameters: {n_flow:,}  "
-                f"head parameters: {n_head:,}"
-            )
+            print(f"flow parameters: {n_flow:,}  " f"head parameters: {n_head:,}")
         else:
             print(f"flow parameters: {n_flow:,}")
         log_lines.append(f"flow parameters: {n_flow}")
@@ -5491,8 +5652,8 @@ def main_worker(
                 f"max_cross_deg={head.max_cross_deg} "
                 f"n_joint_basis={head.n_joint_basis} "
                 f"basis={head.basis} "
-                if args.head_arch == "polyhead" else
-                f"d_emb={args.d_emb} "
+                if args.head_arch == "polyhead"
+                else f"d_emb={args.d_emb} "
                 f"head_hidden={args.head_hidden} "
                 f"head_layers={args.head_layers} "
             )
@@ -5542,10 +5703,7 @@ def main_worker(
             _quad_n_eff = (
                 _qn if _qn > 0 else int(flow_config.get("sospf_degree", 4)) + 1
             )
-            _qn_tag = (
-                f"{_quad_n_eff}"
-                if _qn > 0 else f"{_quad_n_eff} (auto = L+1)"
-            )
+            _qn_tag = f"{_quad_n_eff}" if _qn > 0 else f"{_quad_n_eff} (auto = L+1)"
             print(
                 f"architecture: SOSPF (sum-of-squares polynomial)  "
                 f"transforms={flow_config['n_transforms']}  "
@@ -5555,9 +5713,7 @@ def main_worker(
             )
         print(f"precision: {precision}")
 
-    checkpoint_path = (
-        os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
-    )
+    checkpoint_path = os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
 
     # ---- Sequential training: phase 1 (flow only) → phase 2 (head). -
     # Phase 1 is skipped when --head-only (flow comes pre-trained from
@@ -5580,9 +5736,7 @@ def main_worker(
                 )
             else:
                 flow_model = nn.parallel.DistributedDataParallel(flow_model)
-        inner_flow_p1 = (
-            flow_model.module.flow if is_dist else flow_model.flow
-        )
+        inner_flow_p1 = flow_model.module.flow if is_dist else flow_model.flow
         # Compile *after* DDP wrap and after capturing inner refs:
         # checkpoint capture goes through ``inner_flow_p1`` directly,
         # bypassing the OptimizedModule, so state_dict access is
@@ -5627,7 +5781,8 @@ def main_worker(
                 _reason = (
                     " (CUDA Graphs disabled — incompatible with "
                     "zuko's Gauss–Legendre node cache)"
-                    if _arch == "sospf" else ""
+                    if _arch == "sospf"
+                    else ""
                 )
                 print(
                     f"torch.compile: enabled (mode={_compile_mode})"
@@ -5636,14 +5791,25 @@ def main_worker(
                 )
             flow_model = torch.compile(flow_model, mode=_compile_mode)
         zuko_flow_trained, best_phase1_val = train(
-            flow_model, inner_flow_p1, train_loader, val_loader,
-            args.epochs, args.lr, args.weight_decay, args.patience,
-            device, log_lines,
-            is_dist=is_dist, is_rank0=is_rank0,
+            flow_model,
+            inner_flow_p1,
+            train_loader,
+            val_loader,
+            args.epochs,
+            args.lr,
+            args.weight_decay,
+            args.patience,
+            device,
+            log_lines,
+            is_dist=is_dist,
+            is_rank0=is_rank0,
             checkpoint_path=checkpoint_path,
-            stats=stats, flow_config=flow_config, precision=precision,
+            stats=stats,
+            flow_config=flow_config,
+            precision=precision,
             checkpoint_every=int(args.checkpoint_every),
-            head_config=None, inner_head=None,
+            head_config=None,
+            inner_head=None,
             patience_rel_threshold=float(args.patience_rel_threshold),
             profile=bool(args.profile),
             profile_warmup=int(args.profile_warmup),
@@ -5669,18 +5835,17 @@ def main_worker(
             p.requires_grad_(False)
         if is_rank0:
             print(
-                f"\n=== phase 2: head training "
-                f"(frozen flow) ===",
+                f"\n=== phase 2: head training " f"(frozen flow) ===",
                 flush=True,
             )
-            log_lines.append(
-                "=== phase 2: head training (frozen flow) ==="
-            )
+            log_lines.append("=== phase 2: head training (frozen flow) ===")
         # Force head_only=True for the phase-2 model and config.
         phase2_head_config = dict(head_config)
         phase2_head_config["head_only"] = True
         poly_model = FlowHeadModel(
-            zuko_flow, head, head_only=True,
+            zuko_flow,
+            head,
+            head_only=True,
         ).to(device)
         if is_dist:
             if args.device.startswith("cuda"):
@@ -5689,12 +5854,8 @@ def main_worker(
                 )
             else:
                 poly_model = nn.parallel.DistributedDataParallel(poly_model)
-        inner_flow_p2 = (
-            poly_model.module.flow if is_dist else poly_model.flow
-        )
-        inner_head_p2 = (
-            poly_model.module.head if is_dist else poly_model.head
-        )
+        inner_flow_p2 = poly_model.module.flow if is_dist else poly_model.flow
+        inner_head_p2 = poly_model.module.head if is_dist else poly_model.head
         # Same architecture-specific compile handling as phase 1: GF
         # is skipped entirely (double-autograd in MonotonicTransform);
         # SOSPF falls back to mode='default' (CUDA Graphs disabled —
@@ -5723,7 +5884,8 @@ def main_worker(
                 _reason_p2 = (
                     " (CUDA Graphs disabled — incompatible with "
                     "zuko's Gauss–Legendre node cache)"
-                    if _arch_p2 == "sospf" else ""
+                    if _arch_p2 == "sospf"
+                    else ""
                 )
                 print(
                     f"torch.compile: enabled (mode={_compile_mode_p2})"
@@ -5732,12 +5894,22 @@ def main_worker(
                 )
             poly_model = torch.compile(poly_model, mode=_compile_mode_p2)
         _, best_phase2_val = train(
-            poly_model, inner_flow_p2, train_loader, val_loader,
-            args.epochs, args.lr, args.weight_decay, args.patience,
-            device, log_lines,
-            is_dist=is_dist, is_rank0=is_rank0,
+            poly_model,
+            inner_flow_p2,
+            train_loader,
+            val_loader,
+            args.epochs,
+            args.lr,
+            args.weight_decay,
+            args.patience,
+            device,
+            log_lines,
+            is_dist=is_dist,
+            is_rank0=is_rank0,
             checkpoint_path=checkpoint_path,
-            stats=stats, flow_config=flow_config, precision=precision,
+            stats=stats,
+            flow_config=flow_config,
+            precision=precision,
             checkpoint_every=int(args.checkpoint_every),
             head_config=phase2_head_config,
             inner_head=inner_head_p2,
@@ -5755,9 +5927,7 @@ def main_worker(
         del poly_model
         if is_rank0:
             print(f"phase 2 best val wmse: {best_phase2_val:.4e}")
-            log_lines.append(
-                f"phase 2 best val_wmse: {best_phase2_val:.4e}"
-            )
+            log_lines.append(f"phase 2 best val_wmse: {best_phase2_val:.4e}")
 
     if is_rank0:
         with open(os.path.join(args.output, "training.log"), "w") as f:
@@ -5775,12 +5945,14 @@ def main_worker(
 
     if is_dist:
         import torch.distributed as dist
+
         dist.destroy_process_group()
 
 
 # -----------------------------------------------------------------------------
 # Main (dispatcher: loads data once, then spawns worker(s))
 # -----------------------------------------------------------------------------
+
 
 def main():
     args = parse_args()
@@ -5791,8 +5963,15 @@ def main():
 
     print(f"loading ntuples from {len(args.input_files)} file(s)")
     (
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
-        _source_id, muon_source,
+        eta_r,
+        phi_r,
+        eta_g,
+        phi_g,
+        kappa_r,
+        kappa_g,
+        w,
+        _source_id,
+        muon_source,
     ) = load_ntuples(
         args.input_files,
         args.tree,
@@ -5809,7 +5988,12 @@ def main():
     )
 
     target, cond_raw = compute_targets_and_conditioning(
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+        eta_r,
+        phi_r,
+        eta_g,
+        phi_g,
+        kappa_r,
+        kappa_g,
         muon_source=muon_source,
     )
 
@@ -5875,14 +6059,16 @@ def main():
     # query time hits the same conditioning point as the
     # corresponding |σ| training event.
     n_sigma_pack = (
-        int(n_features) * (int(n_features) + 1) // 2
-        if args.cond_on_smear else 0
+        int(n_features) * (int(n_features) + 1) // 2 if args.cond_on_smear else 0
     )
     n_cond_total = int(n_cond) + n_sigma_pack
     flow_config = {
         "flow_type": {
-            "realnvp": "RealNVP", "glow": "Glow", "maf": "MAF",
-            "gf": "GF", "sospf": "SOSPF",
+            "realnvp": "RealNVP",
+            "glow": "Glow",
+            "maf": "MAF",
+            "gf": "GF",
+            "sospf": "SOSPF",
         }[arch],
         "architecture": arch,
         "n_features": int(n_features),
@@ -5911,8 +6097,17 @@ def main():
 
     if world_size == 1:
         main_worker(
-            0, args, 1, 0, stats, flow_config,
-            target_std_t, cond_t, w_t, train_sel, val_sel,
+            0,
+            args,
+            1,
+            0,
+            stats,
+            flow_config,
+            target_std_t,
+            cond_t,
+            w_t,
+            train_sel,
+            val_sel,
         )
     else:
         # Share memory so child workers attach rather than copy.
@@ -5923,16 +6118,26 @@ def main():
         val_sel.share_memory_()
         # Pick a free port on localhost for the rendezvous.
         import socket
+
         sock = socket.socket()
         sock.bind(("", 0))
         master_port = sock.getsockname()[1]
         sock.close()
         import torch.multiprocessing as mp
+
         mp.spawn(
             main_worker,
             args=(
-                args, world_size, master_port, stats, flow_config,
-                target_std_t, cond_t, w_t, train_sel, val_sel,
+                args,
+                world_size,
+                master_port,
+                stats,
+                flow_config,
+                target_std_t,
+                cond_t,
+                w_t,
+                train_sel,
+                val_sel,
             ),
             nprocs=world_size,
             join=True,

--- a/scripts/corrections/muon_calibration/train_muon_response_flow.py
+++ b/scripts/corrections/muon_calibration/train_muon_response_flow.py
@@ -1,0 +1,5800 @@
+"""Train a conditional affine-coupling flow for the muon response density.
+
+Architecture: RealNVP (Dinh et al. 2016) — a stack of affine coupling
+transforms with alternating checkered masks. Each coupling layer
+conditions a smooth MLP on the context + the unmasked half of y,
+and uses its outputs as per-component (scale, shift) to transform
+the masked half. Because the coupling scale and shift are smooth
+functions of the inputs (through the conditioner MLP with smooth
+activations), the resulting log-density is C^∞ in y — no knot
+discontinuities like those of rational-quadratic spline flows, and
+no polynomial artifacts like those of SOSPF. This is the flow path
+of choice for downstream consumers that finite-difference the log-
+density for reweighting (muon calibration systematics), where per-
+event weight noise from density-derivative kinks is harmful.
+
+Expects the input to be the flat snapshot produced by
+``flow_training_snapshot.py`` (or an equivalently-formatted ROOT file):
+one row per J/psi event, with post-LBL Mu{plus,minus}cor_{pt,eta,phi}
+and Mu{plus,minus}gen_{pt,eta,phi} branches. Running LBL corrections
+here would re-do the RDF/narf work on every training iteration — do it
+once upstream.
+
+
+Targets the 3D conditional density
+
+    p(r_kappa, dlambda, dphi | kappa_gen, phi_gen, lambda_gen)
+
+where
+    kappa   = q / p                         (q = charge, p = 3-momentum magnitude)
+    r_kappa = kappa_reco / kappa_gen - 1
+    dphi    = phi_reco - phi_gen            (wrapped to [-pi, pi])
+    dlambda = lambda_reco - lambda_gen      (lambda = pi/2 - theta)
+
+The ntuple only stores (pt, eta, phi, charge), so the script derives
+kappa and lambda from those. Both mu+ and mu- are pooled into a single
+training set (one row per muon, not per J/psi pair), since the response
+is charge-symmetric on average and the remaining charge dependence is
+captured by the sign of kappa.
+
+Conditioning preprocessing (the numerical inputs the flow sees):
+    c0 = log(pt_gen)                        # dynamic range 5..200 GeV
+    c1 = sign(charge) * 1.0
+    c2 = lambda_gen                         # bounded in (-pi/2, pi/2)
+    c3 = sin(phi_gen)
+    c4 = cos(phi_gen)
+kappa_gen can be reconstructed from (c0, c1, c2) at inference time as
+    kappa_gen = c1 * cos(c2) / exp(c0)
+
+Target preprocessing: standardize each of (r_kappa, dlambda, dphi) to
+zero mean / unit std using dataset-wide statistics. Stored in the output
+json so the RDF inference side can apply the same transform. Target
+order is chosen so that the target index aligns with the reco-level
+(kappa, lambda, phi) ordering — downstream reco-shift weights then use
+a simple diagonal Jacobian.
+
+Outputs (to --output):
+    flow.pt         TorchScript module with two entry points
+                    (`log_density`, `score`) wrapped via a small nn.Module
+    preproc.json    preprocessing stats and config
+    training.log    epoch-by-epoch training / validation metrics
+
+Multi-GPU: ``--num-gpus N`` (or auto-detect by default) spawns N worker
+processes internally via torch.multiprocessing.spawn. Each worker takes
+one CUDA device and an even shard of the training/validation indices.
+Global metrics are computed by all-reducing the per-rank accumulators
+at each epoch boundary. Only rank 0 prints and writes output files.
+Data is loaded once in the main process and shared read-only across
+workers via ``tensor.share_memory_()`` — no re-loading per rank.
+
+Requires: torch, uproot, numpy, zuko.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, asdict
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm import tqdm
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--input-files",
+        nargs="+",
+        required=True,
+        help="[required] Either (a) a shard directory containing "
+        "``manifest.json`` (expanded to its Arrow IPC shards), or "
+        "(b) explicit ``.arrow`` shard files (shell globs OK). "
+        "RVec RNTuple snapshots (``.root``) are no longer accepted "
+        "here — run flow_training_snapshot.py --shard-only first.",
+    )
+    p.add_argument(
+        "--tree",
+        default="tree",
+        help="[default: %(default)s] TTree name inside the input files.",
+    )
+    p.add_argument(
+        "--output",
+        default="./muon_response_flow/",
+        help="[default: %(default)s] Output directory.",
+    )
+    p.add_argument(
+        "--max-muons",
+        type=int,
+        default=-1,
+        help="[default: %(default)s] Cap on number of muon rows loaded "
+        "(mu+ and mu- each count as one row). -1 loads all. Applied "
+        "post-filter, by random subsampling. Useful for quick test runs.",
+    )
+    p.add_argument(
+        "--max-events",
+        type=int,
+        default=-1,
+        help="[default: %(default)s] Cap on the number of raw muon "
+        "rows read from the Arrow shards before the pt/eta filter. "
+        "-1 reads all. Applies *before* the quality cuts and "
+        "``--max-muons`` post-filter cap. (Name retained for "
+        "back-compat; in the per-muon schema it caps rows, not "
+        "events.)",
+    )
+    p.add_argument(
+        "--val-fraction",
+        type=float,
+        default=0.1,
+        help="[default: %(default)s] Fraction of muons held out for "
+        "validation.",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="[default: 32768 on CUDA, 16384 on CPU] Training batch size.",
+    )
+    p.add_argument(
+        "--epochs",
+        type=int,
+        default=100,
+        help="[default: %(default)s] Maximum number of training epochs.",
+    )
+    p.add_argument(
+        "--lr",
+        type=float,
+        default=1e-3,
+        help="[default: %(default)s] Initial Adam learning rate.",
+    )
+    p.add_argument(
+        "--weight-decay",
+        type=float,
+        default=0.0,
+        help="[default: %(default)s] Adam weight decay (L2 regularization).",
+    )
+    p.add_argument(
+        "--patience",
+        type=int,
+        default=5,
+        help="[default: %(default)s] Early-stopping patience on "
+        "validation NLL.",
+    )
+    p.add_argument(
+        "--no-early-stop",
+        action="store_true",
+        help="Disable early stopping without changing the LR-decay "
+        "schedule. The ReduceLROnPlateau scheduler still halves the "
+        "LR after ``--patience // 2`` non-improving epochs; the run "
+        "continues until ``--epochs`` is reached. Useful for forcing "
+        "training to use the full epoch budget when you want to see "
+        "the long-tail behaviour at very small LR.",
+    )
+    p.add_argument(
+        "--patience-rel-threshold",
+        type=float,
+        default=1e-4,
+        help="[default: %(default)s] *Phase-2 only*: minimum "
+        "relative improvement in val_wmse to count as 'improvement' "
+        "against the patience clock; an epoch counts as improvement "
+        "only if ``val_wmse < best_val − rel_threshold · |best_val|``. "
+        "Phase 1 (NLL) uses an absolute 1e-4 threshold instead, which "
+        "is appropriate at val_nll ~ O(1). Relative is needed for "
+        "phase 2 because val_wmse ~ 1e-2 makes 1e-4 absolute a ~1%% "
+        "relative test — too strict, masks slow real progress.",
+    )
+    p.add_argument(
+        "--n-transforms",
+        type=int,
+        default=5,
+        help="[default: %(default)s] Number of coupling layers in the "
+        "flow.",
+    )
+    p.add_argument(
+        "--hidden-features",
+        type=int,
+        default=128,
+        help="[default: %(default)s] Hidden-layer width of each "
+        "conditioner network.",
+    )
+    p.add_argument(
+        "--n-hidden-layers",
+        type=int,
+        default=3,
+        help="[default: %(default)s] Number of hidden layers in each "
+        "conditioner network.",
+    )
+    p.add_argument(
+        "--activation",
+        default="gelu",
+        choices=sorted(ACTIVATIONS),
+        help="[default: %(default)s] Conditioner-MLP activation "
+        "function. 'gelu' is C^inf smooth and keeps the flow's "
+        "log-density C^inf in y. Avoid 'relu' here — piecewise-linear "
+        "conditioners introduce kinks in dp/dx that propagate into "
+        "small-δ reweight noise.",
+    )
+    p.add_argument(
+        "--architecture",
+        default="realnvp",
+        choices=["realnvp", "glow", "maf", "gf", "sospf"],
+        help="[default: %(default)s] Flow architecture: 'realnvp' — "
+        "affine-coupling layers with alternating checkered masks. "
+        "'glow' — realnvp plus a learnable LU-parameterized "
+        "invertible linear mixing layer before each coupling (minimal "
+        "Glow: no actnorm, preproc already standardizes). 'maf' — "
+        "masked autoregressive flow (Papamakarios et al. 2017): "
+        "same affine transform as RealNVP but every feature gets "
+        "warped per layer via autoregressive (MADE) conditioning "
+        "instead of only the unmasked half. Cheap forward (NLL), "
+        "expensive inverse (sampling); irrelevant here since we only "
+        "evaluate density. 'gf' — Gaussianization flow (Meng et al. "
+        "2020): per-dimension Gaussian-mixture CDF transforms "
+        "interleaved with fixed random orthogonal rotations. 'sospf' "
+        "— sum-of-squares polynomial flow (Jaini et al. 2019): "
+        "masked-autoregressive stack where each transform is the "
+        "integral of a sum of K squared degree-L polynomials. All "
+        "five are C^∞ with smooth conditioner activations.",
+    )
+    p.add_argument(
+        "--randmask",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="[default: off] (realnvp/glow only) Use random coupling "
+        "masks instead of alternating checkered ones. Ignored for "
+        "--architecture maf / gf / sospf (no coupling masks there).",
+    )
+    p.add_argument(
+        "--gf-components",
+        type=int,
+        default=8,
+        help="[default: %(default)s] (gf only) Number of Gaussian-"
+        "mixture components per GF layer's per-dimension transform. "
+        "Ignored for --architecture realnvp / sospf.",
+    )
+    p.add_argument(
+        "--sospf-degree",
+        type=int,
+        default=4,
+        help="[default: %(default)s] (sospf only) Degree L of each "
+        "squared polynomial. The transform is the integral of "
+        "(1/K) Σ_i (1 + Σ_j a_{i,j} u^j)². Higher L → more expressive "
+        "but more parameters and slower. Invertibility holds within "
+        "the standardised range [−10, 10].",
+    )
+    p.add_argument(
+        "--sospf-polynomials",
+        type=int,
+        default=3,
+        help="[default: %(default)s] (sospf only) Number of squared "
+        "polynomials K averaged inside each SOSPF transform.",
+    )
+    p.add_argument(
+        "--sospf-quad-n",
+        type=int,
+        default=-1,
+        help="[default: -1 → auto] (sospf only) Number of "
+        "Gauss–Legendre quadrature nodes used to compute the SOSPF "
+        "transform's defining integral ``f(x) = ∫₀^x g(u) du``. "
+        "Auto = ``--sospf-degree + 1``, the minimum exact for the "
+        "degree-2L polynomial integrand (Gauss–Legendre with n "
+        "nodes integrates polynomials of degree ≤ 2n−1 exactly). "
+        "zuko also defaults to L+1; setting this explicitly lets "
+        "you go lower (lossy but faster) or higher (defensive "
+        "overshoot — has no theoretical benefit for the exact "
+        "polynomial case but may help under fp16/bf16 round-off).",
+    )
+    p.add_argument(
+        "--cond-on-smear",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="[default: off] Condition the flow on a per-event "
+        "per-dimension smear scale ``σ_vec ∈ R^{n_features}``. At "
+        "training, σ is drawn per event (component-wise uniform on "
+        "[0, sigma_max]; with probability ``--cond-smear-zero-fraction`` "
+        "the entire vector is forced to 0 — the unsmeared baseline) "
+        "and the target is smeared as ``y_smeared = y + σ ⊙ ε``, "
+        "ε ~ N(0, I). σ (in standardized target units) is concatenated "
+        "to the conditioning vector, so the flow learns "
+        "``p(y_smeared | c, σ)``. ``σ = 0`` recovers the unconditional "
+        "trained density. Bumps ``n_cond`` by ``n_features``.",
+    )
+    p.add_argument(
+        "--cond-smear-sigma-max",
+        type=float,
+        default=1.0,
+        help="[default: %(default)s] Per-dimension upper bound for σ "
+        "during smear-conditioned flow training, in **standardized "
+        "target units** (i.e., target_std-relative). Matches "
+        "``train_shift_smear_reweight.py``'s ``--sigma-max``: "
+        "σ_d_std ~ U[−σ_max, +σ_max] per dimension (signed) when not "
+        "zeroed, with the 1.3× oversample factor applied internally "
+        "so the trained range covers the head's query range "
+        "(σ_vec_pert magnitude ≤ 1.3·σ_max in standardized units). "
+        "Used only with --cond-on-smear.",
+    )
+    p.add_argument(
+        "--cond-smear-zero-fraction",
+        type=float,
+        default=0.5,
+        help="[default: %(default)s] Probability per event that the "
+        "smear vector is forced to ``σ = 0`` (unsmeared baseline) "
+        "during training. Used only with --cond-on-smear.",
+    )
+    p.add_argument(
+        "--cond-smear-target",
+        choices=["auto", "direct", "gh"],
+        default="auto",
+        help="[default: %(default)s] How the head's smear-weight "
+        "target is computed. 'gh': K-node Gauss-Hermite (or K=1 "
+        "stochastic) quadrature over ε against the *unsmeared* flow "
+        "at ``(y − u_shift − ε_k·σ_vec, c)`` — the default before "
+        "smear conditioning was available; cost K perturbed forwards. "
+        "'direct': single perturbed forward at "
+        "``(y − u_shift, c, σ_vec_pert)`` against the σ-conditioned "
+        "flow — the σ-integration is already baked in by training. "
+        "Cost: 1 forward, no GH polynomial-truncation bias, no K=1 "
+        "stochastic noise. 'auto' (default): 'direct' iff "
+        "--cond-on-smear is on, else 'gh'. Choosing 'direct' without "
+        "--cond-on-smear errors out — there's no σ-conditioned flow "
+        "to query.",
+    )
+    p.add_argument(
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="[default: %(default)s; resolved at parse time from "
+        "torch.cuda.is_available()] cuda or cpu. Multi-GPU requires "
+        "cuda (see --num-gpus).",
+    )
+    p.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=1,
+        help="[default: %(default)s] Per-epoch checkpoint snapshot "
+        "frequency (rank 0 only writes). 1 = every epoch. Set to N>1 "
+        "to save only every N-th epoch — significantly cuts the "
+        "epoch-boundary pause when fast training makes the snapshot "
+        "I/O dominate. Set to 0 to disable per-epoch snapshots "
+        "entirely; the in-memory ``best_state`` is still tracked and "
+        "loaded back at the end of training.",
+    )
+    p.add_argument(
+        "--compile",
+        action="store_true",
+        help="[default: off] Wrap the model in ``torch.compile(..., "
+        "mode='reduce-overhead')`` to fuse small kernels and apply "
+        "CUDA Graphs where possible. The launch-overhead-bound regime "
+        "of small flow + polyhead models on V100 / A100 is where this "
+        "helps most (typical 1.5–3× throughput, with proportional "
+        "power-draw increase). Compilation happens lazily on the first "
+        "forward (~30–60 s); ragged validation batches trigger a "
+        "second compilation. Falls back to eager for any ops the "
+        "tracer can't capture (graph breaks are non-fatal). "
+        "**Automatically skipped for --architecture gf** because "
+        "Gaussianization Flow computes its Jacobian via an inner "
+        "``torch.autograd.grad`` call which dynamo cannot trace. "
+        "For ``--architecture sospf`` the mode is downgraded to "
+        "``default`` (CUDA Graphs disabled) because zuko's "
+        "Gauss–Legendre node cache aliases memory under CUDA Graphs.",
+    )
+    p.add_argument(
+        "--precision",
+        choices=["fp32", "bf16", "fp16"],
+        default="fp32",
+        help="[default: %(default)s] Training/validation forward-pass "
+        "precision. 'fp32': full single-precision, no autocast. "
+        "'bf16': bfloat16 autocast — wide exponent range, no loss "
+        "scaling needed; hardware-accelerated on Ampere+ GPUs "
+        "(A100/H100). On Volta (V100) bf16 falls back to CUDA cores "
+        "and is slower than fp16. Leaves ~1e-3 relative noise in the "
+        "final weights. 'fp16': float16 autocast with GradScaler for "
+        "loss scaling. Hardware-accelerated on Volta+ Tensor Cores "
+        "(typically faster than bf16 on V100). Tighter dynamic range "
+        "(max ~65 504); fp16-unsafe combinations include "
+        "--loss-target=w with the default trustable cap "
+        "(true_W up to ~22 000, squared residual can overflow). The "
+        "default head config (logw + exp + smear_K=5) is fp16-"
+        "safe end-to-end.",
+    )
+    p.add_argument(
+        "--num-gpus",
+        type=int,
+        default=-1,
+        help="[default: %(default)s] Number of GPUs to use when "
+        "--device=cuda. -1 auto-detects via "
+        "torch.cuda.device_count(). Set to 1 to force "
+        "single-GPU even on multi-GPU hosts.",
+    )
+    p.add_argument(
+        "--prefetch-shuffle",
+        action=argparse.BooleanOptionalAction, default=True,
+        help="[default: on] Hide the per-epoch ``torch.randperm(n)`` "
+        "stall by computing the next epoch's permutation in a "
+        "background thread while the current epoch is still training. "
+        "At ~10⁸-row training sets the shuffle alone is ~5–10 s per "
+        "epoch; with prefetch on, only the first epoch pays this. "
+        "Disable with --no-prefetch-shuffle.",
+    )
+    p.add_argument(
+        "--time-loader",
+        action="store_true",
+        help="Print one-line timing per epoch start: how long the "
+        "shuffle / first-batch gather + pin took. Useful for "
+        "diagnosing the per-epoch startup latency. Same as "
+        "``LOADER_TIME=1`` env var.",
+    )
+    p.add_argument(
+        "--profile",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="[default: off] If set, run a short ``torch.profiler`` "
+        "diagnostic pass on the first few training steps of the "
+        "current ``train()`` invocation and exit before the normal "
+        "epoch loop. Useful for identifying CUDA-time hotspots. "
+        "Profiles whichever phase runs first under the current "
+        "``--do-phase1`` / ``--do-phase2`` selection — to profile "
+        "phase 2 specifically, combine with ``--no-do-phase1`` (and "
+        "load the flow from a prior checkpoint).",
+    )
+    p.add_argument(
+        "--profile-warmup", type=int, default=3,
+        help="[default: %(default)s] Profile schedule warmup steps "
+        "(executed but not recorded).",
+    )
+    p.add_argument(
+        "--profile-active", type=int, default=5,
+        help="[default: %(default)s] Profile schedule active steps "
+        "(recorded by the profiler).",
+    )
+    p.add_argument(
+        "--profile-output", default=None,
+        help="[default: %(default)s] Optional path for Chrome-trace "
+        "export of the profile (viewable in chrome://tracing or "
+        "Perfetto). Under DDP, the rank index is appended before "
+        "the extension.",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="[default: %(default)s] Random seed for the train/val "
+        "split and dataloader shuffling.",
+    )
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=0,
+        help="[default: %(default)s] Number of threads for "
+        "RDataFrame's ImplicitMT during the snapshot load. 0 leaves "
+        "ROOT to choose (typically all available cores); 1 disables "
+        "multithreading.",
+    )
+    p.add_argument(
+        "--pt-min",
+        type=float,
+        default=2.0,
+        help="[default: %(default)s] Minimum gen pt (GeV) for each "
+        "muon. Matches flow_training_snapshot.py.",
+    )
+    p.add_argument(
+        "--pt-max",
+        type=float,
+        default=200.0,
+        help="[default: %(default)s] Maximum gen pt (GeV) — tail "
+        "events discarded to keep training well-supported.",
+    )
+    p.add_argument(
+        "--eta-max",
+        type=float,
+        default=2.5,
+        help="[default: %(default)s] |gen eta| cut, applied to both "
+        "muons. Reco eta is kept unrestricted — the flow learns the "
+        "conditional response density for any reco eta given the gen "
+        "kinematics.",
+    )
+
+    # Reweight head (joint training).
+    p.add_argument(
+        "--head",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="[default: on] Train a reweight head jointly with the "
+        "flow. The head approximates the per-event log-density-ratio "
+        "log p(y - u | c, σ) - log p(y | c, σ=0) so a single AOTI/ORT "
+        "forward exposes everything needed to evaluate shift/smear "
+        "weights without runtime autograd. Pass --no-head to train a "
+        "flow-only checkpoint. Architecture is selected by --head-arch.",
+    )
+    p.add_argument(
+        "--head-arch",
+        choices=["polyhead", "mlp", "mlp-factored"],
+        default="polyhead",
+        help="[default: %(default)s] Reweight-head architecture. "
+        "'polyhead' (default): trunk(y, c) → polynomial coefficients in "
+        "(u, σ_vec) with structural priors (smear-symmetry, no constant "
+        "term, per-axis degree caps). 'mlp': dual-scalar-forward MLP "
+        "where ``log r = positivity( head(e, u, Σ_pack) − head(e, 0, 0) "
+        ")`` with ``e = trunk(y, c)`` — same construction as "
+        "train_shift_smear_reweight's ``--arch mlp``. 'mlp-factored': "
+        "structurally factored MLP head returning "
+        "``log r = ⟨u, A(e, ·)⟩ + ⟨σ_pack, B(e, ·)⟩"
+        " [ + ⟨u⊗σ_pack, C(e, u, σ_pack)⟩ ]`` with the structural "
+        "zeros at (u=0, σ=0) and σ-evenness built in by construction "
+        "rather than via dual-forward subtraction. The detach flags "
+        "--detach-pure-{shift,smear}-in-joint select between the "
+        "full-cross default, the partially-factored two-term form, "
+        "and the fully-factored three-term form.",
+    )
+    p.add_argument(
+        "--trunk-hidden",
+        type=int,
+        default=64,
+        help="[default: %(default)s] Trunk MLP hidden width (shared "
+        "between polyhead and mlp arches).",
+    )
+    p.add_argument(
+        "--trunk-layers",
+        type=int,
+        default=2,
+        help="[default: %(default)s] Number of trunk MLP hidden layers "
+        "(shared).",
+    )
+    p.add_argument(
+        "--d-emb",
+        type=int,
+        default=32,
+        help="[default: %(default)s] (--head-arch mlp) Trunk embedding "
+        "dimension.",
+    )
+    p.add_argument(
+        "--head-hidden",
+        type=int,
+        default=32,
+        help="[default: %(default)s] (--head-arch mlp) Head hidden "
+        "width.",
+    )
+    p.add_argument(
+        "--head-layers",
+        type=int,
+        default=2,
+        help="[default: %(default)s] (--head-arch mlp) Number of head "
+        "hidden layers.",
+    )
+    p.add_argument(
+        "--delta-max",
+        type=float,
+        default=1.0,
+        help="[default: %(default)s] Training-time delta range: "
+        "delta ~ U(-1.3*delta_max, +1.3*delta_max). delta is in units "
+        "of one standard deviation of the target component "
+        "(perturbations are y-space shifts and v_dir is sampled on the "
+        "unit sphere in standardized target space), so delta_max ~ 1 "
+        "covers ±1σ_y shifts. The 1.3x oversample factor trains a bit "
+        "beyond the typical inference range.",
+    )
+    p.add_argument(
+        "--aux-jacobian-weight",
+        type=float,
+        default=0.0,
+        help="[default: %(default)s] If > 0, add an auxiliary loss "
+        "that pins the polyhead's first-order coefficients to the "
+        "flow's analytic Jacobian via a forward-mode JVP. The joint "
+        "MSE on log w alone usually suffices. Costs an extra JVP per "
+        "training step (~1x flow forward) when on. polyhead-only.",
+    )
+    p.add_argument(
+        "--loss-target",
+        choices=["w", "logw"],
+        default="logw",
+        help="[default: %(default)s] Reconstruction loss target: "
+        "'logw' — squared error on log w; 'w' — squared error on "
+        "w = exp(log w). 'logw' pairs naturally with --positivity=exp "
+        "(j ≡ log W directly, no exp computed in the loss path) and "
+        "is fp16-safe end-to-end. 'w' matches the binned-template fit "
+        "metric but materializes exp(true_lw) ∈ [e⁻¹⁰, e¹⁰] ≈ [5e-5, "
+        "22 000] which is near the fp16 range edge — requires fp32 "
+        "cast inside the loss step or a tighter trustable cap.",
+    )
+    p.add_argument(
+        "--positivity",
+        choices=["softplus", "exp", "asinh"],
+        default="exp",
+        help="[default: %(default)s] Functional form of the W "
+        "positivity constraint applied to the head's pre-positivity "
+        "scalar j. 'exp': W = exp(j) with j clamped to ±30 — symmetric "
+        "in log W (j ≡ log W), so positive and negative log W are "
+        "equally easy to fit at low polynomial degree. Combined with "
+        "--loss-target=logw the exp is never actually evaluated (the "
+        "loss compares j directly to true_lw). 'softplus': "
+        "W = softplus(j)/log 2 — exact W=1 at j=0, no overflow risk, "
+        "but asymmetric in log W. 'asinh': W = j + √(j²+1), log W = "
+        "asinh(j) — closed form, strictly positive, symmetric, no "
+        "clamp needed.",
+    )
+    p.add_argument(
+        "--basis",
+        choices=["monomial", "chebyshev"],
+        default="monomial",
+        help="[default: %(default)s] (--head-arch polyhead) Polynomial "
+        "basis. 'monomial' uses raw u^α · σ^β; coefficients have "
+        "direct physical meaning but are correlated across degrees. "
+        "'chebyshev' uses tensor-product Chebyshev T_n with per-axis "
+        "normalization to the trained perturbation range — better-"
+        "conditioned, more uniform fit accuracy. Smear-symmetry is "
+        "preserved by both choices via the existing |β|-even "
+        "multi-index constraint.",
+    )
+    p.add_argument(
+        "--include-smear",
+        action="store_true",
+        help="[default: off] Include the smear/cross-term machinery "
+        "in the head architecture and training. By default the head "
+        "is shift-only: polyhead skips the σ_vec and cross basis "
+        "terms; mlp drops Σ_pack from layer 1. Training samples only "
+        "SHIFT events, and the smear-target estimator is bypassed "
+        "(one perturbed flow forward per event). Pass --include-smear "
+        "to restore the full architecture with stratified SHIFT/SMEAR/"
+        "JOINT sampling and the smear-target machinery (--smear-K, "
+        "--smear-residual, --sigma-max, --max-deg-sigma, "
+        "--max-cross-deg are silently ignored when this flag is off).",
+    )
+    p.add_argument(
+        "--smear-K",
+        type=int,
+        default=5,
+        help="[default: %(default)s] Smear-weight target estimator. "
+        "5 = 5-node deterministic Gauss-Hermite (probabilist's) "
+        "quadrature over the smear Gaussian (exact through degree 9 "
+        "in ε). K=1 falls back to a single stochastic Gaussian draw "
+        "of δ_smear per event (cheap, unbiased for E[W] but biased "
+        "for log E[W] via Jensen); K>1 fixes both the K=1 noise floor "
+        "and the Jensen bias on the logw target, at the cost of "
+        "K-fold extra perturbed flow forwards per step (all under "
+        "no_grad). K=3 is exact through degree 5; K=5 through 9; "
+        "K=7 through 13. Requires --include-smear.",
+    )
+    p.add_argument(
+        "--smear-residual",
+        action="store_true",
+        help="[default: off] Use the GH+residual control-variate "
+        "target instead of pure GH. Adds one extra random ε~ ~ N(0,1) "
+        "per event on top of the K GH nodes; the target becomes "
+        "W_K + (W(ε~) − g(ε~)) where g is the Lagrange interpolant "
+        "through the K GH nodes (E[g(ε~)] = W_K, so the residual is "
+        "mean-zero). Removes the GH polynomial-truncation bias for "
+        "any finite K. Cost is K+1 perturbed flow forwards per event. "
+        "Requires --smear-K > 1.",
+    )
+    p.add_argument(
+        "--detach-pure-in-joint",
+        action="store_true",
+        help="[default: off] (polyhead / mlp) In JOINT-mode events "
+        "(both u and σ_vec nonzero) detach the pure-u and pure-σ "
+        "contributions so only the cross-term path receives gradients "
+        "from the JOINT loss. polyhead: zero cost (mask on pure-u/"
+        "pure-σ basis-coef slots). mlp: ~2× head cost from two extra "
+        "head forwards f(e, u, 0) and f(e, 0, sigma_pack) used to "
+        "decompose d_full = d_pure_u + d_pure_sigma + d_mixed. For "
+        "the mlp-factored arch use the structural "
+        "--detach-pure-{shift,smear}-in-joint flags instead.",
+    )
+    p.add_argument(
+        "--detach-pure-shift-in-joint",
+        action="store_true",
+        help="[default: off] (mlp-factored only) Detach the pure-"
+        "shift block A on JOINT events. Equivalent to structurally "
+        "factoring A so it depends only on (e, u) and not on σ_pack; "
+        "cross-term absorption lives in B's u-dependence. A's "
+        "gradients flow only from SHIFT-mode events.",
+    )
+    p.add_argument(
+        "--detach-pure-smear-in-joint",
+        action="store_true",
+        help="[default: off] (mlp-factored only) Detach the pure-"
+        "smear block B on JOINT events. Equivalent to structurally "
+        "factoring B so it depends only on (e, σ_pack) and not on u; "
+        "cross-term absorption lives in A's σ_pack-dependence. B's "
+        "gradients flow only from SMEAR-mode events. When combined "
+        "with --detach-pure-shift-in-joint the head becomes the full "
+        "three-block factored form with a separate cross head "
+        "C(e, u, σ_pack).",
+    )
+    p.add_argument(
+        "--loss-fn",
+        choices=["mse", "huber", "expkl", "wbce"],
+        default="huber",
+        help="[default: %(default)s] Per-event loss form. "
+        "'mse' = r² for all r (with r the residual selected by "
+        "--loss-target). 'huber' = r² for |r| ≤ δ and 2δ|r| − δ² "
+        "beyond. With --loss-target=w the heavy-right-tailed W target "
+        "(up to ~22 000 under the trustable mask) makes Huber more "
+        "stable than MSE. 'expkl' = f-GAN-KL / I-divergence: optimum "
+        "s* = log E[W_target] (the unique loss recovering log E[W] "
+        "without Jensen bias on the logw target). 'wbce' = importance-"
+        "sampled BCE / single-sample CARL: same unbiased optimum as "
+        "expKL but with linear-in-W_target tail growth on the "
+        "underestimate side. Both expKL and wbce always work in log-"
+        "space; --loss-target is ignored.",
+    )
+    p.add_argument(
+        "--huber-delta",
+        type=float,
+        default=1.0,
+        help="[default: %(default)s] Huber transition |r| at which "
+        "the per-event residual switches from quadratic to linear. "
+        "Only used when --loss-fn=huber.",
+    )
+    p.add_argument(
+        "--weight-power",
+        type=int,
+        choices=[1, 2],
+        default=1,
+        help="[default: %(default)s] Per-event weighting of the "
+        "head loss: w_n^p with p = 1 or 2. p=1 matches the bin-"
+        "content bias (N_b is a w_n-linear sum); p=2 matches its "
+        "variance (Σ w_n² · err²). p=1 matches the dominant fit "
+        "sensitivity. Note: the flow NLL term always uses linear "
+        "w_n weighting regardless.",
+    )
+    p.add_argument(
+        "--max-deg-u",
+        type=int,
+        default=3,
+        help="[default: %(default)s] (--head-arch polyhead) Maximum "
+        "polynomial degree of the joint polynomial along the u-only "
+        "(pure-shift) axis.",
+    )
+    p.add_argument(
+        "--max-deg-sigma",
+        type=int,
+        default=4,
+        help="[default: %(default)s] (--head-arch polyhead) Maximum "
+        "polynomial degree of the joint polynomial in σ_vec (must be "
+        "even — smear-symmetry constraint).",
+    )
+    p.add_argument(
+        "--max-cross-deg",
+        type=int,
+        default=3,
+        help="[default: %(default)s] (--head-arch polyhead) Maximum "
+        "total degree |α|+|β| of cross terms in the joint polynomial "
+        "(terms with |α|≥1 and |β|≥1).",
+    )
+    p.add_argument(
+        "--sigma-max",
+        type=float,
+        default=1.0,
+        help="[default: %(default)s] Training-time σ range for the "
+        "smear sampler: σ_smear ~ U[0, 1.3*sigma_max]. Same units as "
+        "--delta-max (standardized target units).",
+    )
+    p.add_argument(
+        "--head-only",
+        action="store_true",
+        help="[default: off] Skip phase-1 flow training and train "
+        "only the head against a frozen flow loaded via "
+        "--load-flow-checkpoint. Useful for iterating on the head "
+        "alone when a flow checkpoint already exists.",
+    )
+    p.add_argument(
+        "--load-flow-checkpoint",
+        default=None,
+        help="[default: %(default)s] Path to an existing flow "
+        "checkpoint (per-epoch checkpoint.pt or final flow.pt) to "
+        "initialize from. Required for --head-only. If the "
+        "checkpoint also contains a head_state_dict the head "
+        "is resumed from it; otherwise the head is initialized "
+        "fresh. Pass --reset-head to ignore any head state "
+        "in the checkpoint and train the head from scratch.",
+    )
+    p.add_argument(
+        "--reset-head",
+        action="store_true",
+        help="[default: off] Even if --load-flow-checkpoint contains "
+        "a head_state_dict, ignore it and initialize the head "
+        "fresh. Useful for re-training the head (e.g., with "
+        "different hyperparameters: degrees, hidden size, "
+        "delta/sigma_max, ...) on top of an already-converged flow.",
+    )
+    return p.parse_args()
+
+
+# -----------------------------------------------------------------------------
+# Data loading
+# -----------------------------------------------------------------------------
+
+PER_MUON_COLUMNS = [
+    "eta_reco", "phi_reco",
+    "eta_gen",  "phi_gen",
+    "kappa_reco", "kappa_gen", "nominal_weight",
+    "source_id",
+]
+
+# Columns kept as integer dtype on the read side; everything else is
+# concatenated into float64. Mirrors the int-column handling in the
+# sharder. Used by ``load_ntuples``.
+_INT_PER_MUON_COLUMNS = {"source_id"}
+
+WEIGHT_BRANCH = "nominal_weight"
+
+
+def _expand_input_paths(paths: List[str]) -> List[str]:
+    """Expand a shard-directory entry (one containing ``manifest.json``)
+    into its list of shard files. Pass-through for explicit file paths.
+    """
+    out: List[str] = []
+    for p in paths:
+        if os.path.isdir(p):
+            manifest_path = os.path.join(p, "manifest.json")
+            if os.path.exists(manifest_path):
+                import json
+                with open(manifest_path) as f:
+                    manifest = json.load(f)
+                for entry in manifest["shard_files"]:
+                    out.append(os.path.join(p, entry))
+                continue
+        out.append(p)
+    return out
+
+
+def _filter_block(
+    blocks: dict,
+    pt_min: float, pt_max: float, eta_max: float,
+    n_read: int, max_rows: int,
+):
+    eta_g = blocks["eta_gen"]
+    kappa_g = blocks["kappa_gen"]
+    kappa_r = blocks["kappa_reco"]
+    w = blocks["nominal_weight"]
+    n_in_block = eta_g.shape[0]
+    # pt = 1 / (|kappa| * cosh(eta)); reconstruct pt_gen for the
+    # original pt-range cut. ``kappa_r`` finite-ness stands in for the
+    # legacy ``pt_reco > 0`` guard (pt_reco == 0 would make kappa
+    # non-finite at snapshot time).
+    pt_g = 1.0 / (np.fabs(kappa_g) * np.cosh(eta_g))
+    mask = (
+        (pt_g > pt_min)
+        & (pt_g < pt_max)
+        & (np.fabs(eta_g) < eta_max)
+        & np.isfinite(kappa_r)
+        & np.isfinite(kappa_g)
+        & (kappa_g != 0.0)
+        & (w > 0.0)
+    )
+    if max_rows > 0 and n_read + n_in_block > max_rows:
+        n_take = max_rows - n_read
+        trim = np.zeros(n_in_block, dtype=bool)
+        trim[:n_take] = True
+        mask = mask & trim
+    return mask
+
+
+def _load_arrow_shards(
+    paths: List[str], pt_min: float, pt_max: float, eta_max: float,
+    max_rows: int,
+):
+    """Read per-muon rows from Arrow IPC shards, applying
+    pt/eta/weight filters per shard so the working set stays bounded
+    to a single shard at a time. Auto-detects file vs stream format
+    (sharder writes file format now; older stream-format shards
+    still readable).
+    """
+    import pyarrow as pa
+    import pyarrow.ipc as ipc
+
+    _MAGIC = b"ARROW1"
+    blocks_per_col = {c: [] for c in PER_MUON_COLUMNS}
+    n_read = 0
+    for p in paths:
+        with pa.memory_map(p, "r") as f:
+            head = f.read(len(_MAGIC))
+            f.seek(0)
+            if head == _MAGIC:
+                t = ipc.open_file(f).read_all()
+            else:
+                t = ipc.open_stream(f).read_all()
+        block = {c: t[c].to_numpy() for c in PER_MUON_COLUMNS}
+        mask = _filter_block(
+            block, pt_min, pt_max, eta_max, n_read, max_rows,
+        )
+        for c in PER_MUON_COLUMNS:
+            blocks_per_col[c].append(block[c][mask])
+        n_read += block["eta_reco"].shape[0]
+        if max_rows > 0 and n_read >= max_rows:
+            break
+    return blocks_per_col
+
+
+def load_ntuples(
+    paths: List[str],
+    tree_name: str,
+    max_muons: int,
+    pt_min: float,
+    pt_max: float,
+    eta_max: float,
+    threads: int = 0,
+    max_events: int = -1,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray,
+            np.ndarray, np.ndarray, np.ndarray]:
+    """Return per-muon arrays of (eta_reco, phi_reco, eta_gen,
+    phi_gen, kappa_reco, kappa_gen, weight, source_id) loaded from
+    per-muon snapshots produced by :mod:`flow_training_snapshot`.
+    ``pt`` is not stored — recover via ``pt = 1 / (|kappa| *
+    cosh(eta))``. ``source_id`` is kept int32 (dataset tag) for
+    downstream filtering / splitting.
+
+    Input formats supported (sniffed from ``paths``):
+
+    * Directory containing ``manifest.json`` -- treated as a shard
+      directory; expanded to its listed Arrow IPC ``shard_*.arrow``
+      files.
+    * Explicit ``.arrow`` files -- Arrow IPC streaming shards.
+
+    ``kappa = q / |p|`` is the signed inverse momentum stored
+    directly in the snapshot; charge is recovered as
+    ``sign(kappa_gen)`` for conditioning.
+    ``compute_targets_and_conditioning`` forms ``r_kappa =
+    kappa_reco / kappa_gen - 1``, which inherits the
+    charge-mismeasurement mode (~-2) when reco/gen charges differ.
+
+    Per-shard / per-file pt/eta/weight filters are applied before
+    concatenation so peak memory is bounded to one block at a time.
+    ``max_events`` is reinterpreted in the new schema as a cap on
+    *raw muon rows read* (before the pt/eta filter); ``max_muons``
+    caps post-filter row count via uniform random subsampling. The
+    legacy ``threads`` argument is unused in the new loader (no
+    ROOT/RDataFrame on the read path).
+    """
+    del threads  # legacy ROOT-MT knob; new loader is pyarrow / uproot.
+
+    paths = _expand_input_paths(paths)
+    if not paths:
+        raise ValueError("load_ntuples: no input paths after expansion")
+    if not all(p.endswith(".arrow") for p in paths):
+        raise ValueError(
+            "load_ntuples: only Arrow IPC shards (.arrow) or a shard "
+            "directory with manifest.json are supported. Run "
+            "scripts/corrections/muon_calibration/flow_training_snapshot.py "
+            "--shard-only to convert RVec RNTuple snapshots into Arrow "
+            "shards."
+        )
+    blocks_per_col = _load_arrow_shards(
+        paths, pt_min, pt_max, eta_max, max_events,
+    )
+    fmt = "arrow-ipc"
+
+    concat = {}
+    for c in PER_MUON_COLUMNS:
+        arr = np.concatenate(blocks_per_col[c])
+        if c in _INT_PER_MUON_COLUMNS:
+            concat[c] = arr.astype(np.int32, copy=False)
+        else:
+            concat[c] = arr.astype(np.float64)
+    eta_r = concat["eta_reco"]
+    phi_r = concat["phi_reco"]
+    eta_g = concat["eta_gen"]
+    phi_g = concat["phi_gen"]
+    kappa_r = concat["kappa_reco"]
+    kappa_g = concat["kappa_gen"]
+    w = concat["nominal_weight"]
+    source_id = concat["source_id"]
+    arrs = (eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, source_id)
+
+    n = arrs[0].shape[0]
+    print(
+        f"loaded {n} muons after filters from {len(paths)} {fmt} input(s) "
+        f"({pt_min} < pt_gen < {pt_max}, |eta_gen| < {eta_max}, w > 0)"
+    )
+    w_arr = arrs[6]
+    print(
+        f"  weight: mean {w_arr.mean():.4f}  std {w_arr.std():.4f}  "
+        f"min {w_arr.min():.4f}  max {w_arr.max():.4f}"
+    )
+    # Diagnostic: charge-flip rate (sign(kappa_reco) != sign(kappa_gen)),
+    # the mode r_kappa absorbs.
+    n_flip = int(np.sum(np.sign(arrs[4]) != np.sign(arrs[5])))
+    if n_flip:
+        print(
+            f"  charge mismeasurement: {n_flip} / {n} rows "
+            f"({100*n_flip/n:.3f}%)"
+        )
+    # Diagnostic: per-source-id row counts (visible to downstream code
+    # for split / validation by dataset).
+    sid_arr = arrs[7]
+    unique_sids, sid_counts = np.unique(sid_arr, return_counts=True)
+    if len(unique_sids) > 1 or unique_sids[0] != 0:
+        print(
+            f"  source_id breakdown: "
+            + ", ".join(f"{int(s)}: {int(c):,}" for s, c in zip(unique_sids, sid_counts))
+        )
+
+    if max_muons > 0 and n > max_muons:
+        rng = np.random.default_rng(0)
+        idx = rng.choice(n, size=max_muons, replace=False)
+        arrs = tuple(a[idx] for a in arrs)
+        print(f"subsampled to {max_muons} muons for training")
+
+    return arrs
+
+
+def compute_targets_and_conditioning(
+    eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g
+):
+    """Return (target [N,3], cond_raw dict).
+
+    ``kappa_reco`` and ``kappa_gen`` are stored directly in the
+    snapshot, so ``r_kappa = kappa_reco / kappa_gen - 1`` is a single
+    divide here. Charge mismeasurement (sign flip between reco and
+    gen) appears as ``r_kappa`` near ``-2``, a mode the flow learns
+    explicitly. Conditioning's ``charge`` is reconstructed as
+    ``sign(kappa_gen)``; ``log_pt_gen`` is reconstructed from
+    ``-log(|kappa_gen| * cosh(eta_gen))``.
+    """
+    lam_r = np.arctan(np.sinh(eta_r))
+    lam_g = np.arctan(np.sinh(eta_g))
+
+    r_kappa = kappa_r / kappa_g - 1.0
+
+    # Wrap dphi to [-pi, pi]
+    dphi = np.arctan2(
+        np.sin(phi_r - phi_g), np.cos(phi_r - phi_g)
+    )
+    dlambda = lam_r - lam_g
+
+    # Target order is (r_kappa, dlambda, dphi) so that the reco
+    # coordinates (kappa, lambda, phi) map index-for-index onto the
+    # flow targets, making the reco-space Jacobian for downstream
+    # weight computations a simple diag(1/kappa_gen, 1, 1).
+    target = np.stack([r_kappa, dlambda, dphi], axis=1).astype(np.float32)
+
+    log_pt_gen = -np.log(np.fabs(kappa_g) * np.cosh(eta_g))
+
+    cond_raw = {
+        "log_pt_gen": log_pt_gen.astype(np.float32),
+        "charge": np.sign(kappa_g).astype(np.float32),
+        "lambda_gen": lam_g.astype(np.float32),
+        "sin_phi_gen": np.sin(phi_g).astype(np.float32),
+        "cos_phi_gen": np.cos(phi_g).astype(np.float32),
+    }
+
+    return target, cond_raw
+
+
+# -----------------------------------------------------------------------------
+# Preprocessing
+# -----------------------------------------------------------------------------
+
+@dataclass
+class PreprocStats:
+    target_names: List[str]
+    target_mean: List[float]
+    target_std: List[float]
+
+    cond_names: List[str]     # order matters: matches flow input order
+    cond_mean: List[float]
+    cond_std: List[float]
+
+
+def build_preproc(target: np.ndarray, cond_raw: dict) -> PreprocStats:
+    target_names = ["r_kappa", "dlambda", "dphi"]
+    target_mean = target.mean(axis=0).tolist()
+    target_std = target.std(axis=0).tolist()
+
+    cond_names = [
+        "log_pt_gen",
+        "charge",
+        "lambda_gen",
+        "sin_phi_gen",
+        "cos_phi_gen",
+    ]
+    cond_mean, cond_std = [], []
+    for name in cond_names:
+        arr = cond_raw[name]
+        cond_mean.append(float(arr.mean()))
+        cond_std.append(float(arr.std()) if arr.std() > 1e-6 else 1.0)
+
+    return PreprocStats(
+        target_names=target_names,
+        target_mean=target_mean,
+        target_std=target_std,
+        cond_names=cond_names,
+        cond_mean=cond_mean,
+        cond_std=cond_std,
+    )
+
+
+def apply_preproc(
+    target: np.ndarray, cond_raw: dict, stats: PreprocStats
+) -> Tuple[np.ndarray, np.ndarray]:
+    tmean = np.asarray(stats.target_mean, dtype=np.float32)
+    tstd = np.asarray(stats.target_std, dtype=np.float32)
+    target_std = (target - tmean) / tstd
+
+    cond_cols = []
+    for name, mean, std in zip(stats.cond_names, stats.cond_mean, stats.cond_std):
+        cond_cols.append((cond_raw[name] - mean) / std)
+    cond = np.stack(cond_cols, axis=1).astype(np.float32)
+
+    return target_std, cond
+
+
+# -----------------------------------------------------------------------------
+# Flow
+# -----------------------------------------------------------------------------
+
+ACTIVATIONS = {
+    "gelu": nn.GELU,
+    "silu": nn.SiLU,
+    "mish": nn.Mish,
+    "elu": nn.ELU,
+    "relu": nn.ReLU,
+    "tanh": nn.Tanh,
+}
+
+
+def _build_glow(
+    n_features: int,
+    n_cond: int,
+    n_transforms: int,
+    randmask: bool,
+    hidden_features: int,
+    n_hidden_layers: int,
+    activation: type,
+):
+    """Minimal Glow-like flow assembled from zuko primitives.
+
+    Matches RealNVP's affine-coupling structure, but inserts a
+    learnable invertible LU-parameterized linear mixing layer
+    (``LULinearTransform``) *before* each coupling. At d=3 each
+    LU layer has 9 learnable parameters — negligible on top of
+    the coupling MLPs but lets the flow learn the feature mixing
+    rather than relying on fixed alternating checkered masks.
+
+    Initialization: LU = I + small random perturbation in the
+    off-diagonal entries, so each LU layer starts as (near-)
+    identity and the flow is effectively RealNVP at step 0. The
+    learned mixing is acquired during training.
+
+    Stability: zuko's ``LULinearTransform`` does not clamp the
+    diagonal of L, so in principle a diagonal entry could reach
+    zero and make the layer singular. In practice, with unit-ish
+    initialization and modest learning rate, this never happens
+    for this problem. If it does, reduce ``--lr``.
+    """
+    import zuko
+    from zuko.flows import (
+        Flow, GeneralCouplingTransform, UnconditionalTransform,
+        UnconditionalDistribution,
+    )
+    from zuko.transforms import LULinearTransform
+    from zuko.distributions import DiagNormal
+
+    # Reproducible per-call initialization of the LU perturbation
+    # and (optionally) the random masks. Not a model seed — model
+    # weights are seeded by torch's global RNG as usual.
+    rng = torch.Generator().manual_seed(0)
+
+    transforms_list = []
+    for i in range(n_transforms):
+        # LU linear mixing, initialized near-identity.
+        LU_init = torch.eye(n_features, dtype=torch.float32)
+        noise = 0.05 * torch.randn(
+            n_features, n_features, generator=rng,
+        )
+        # Perturb only the off-diagonal entries; keep diagonal
+        # near 1 so log|det| starts finite.
+        LU_init = LU_init + noise.tril(-1) + noise.triu(1)
+        transforms_list.append(
+            UnconditionalTransform(
+                LULinearTransform, LU_init, buffer=False,
+            )
+        )
+
+        # Affine coupling (same as RealNVP).
+        if randmask:
+            mask = (
+                torch.randperm(n_features, generator=rng) % 2
+                == i % 2
+            )
+        else:
+            mask = torch.arange(n_features) % 2 == i % 2
+        transforms_list.append(
+            GeneralCouplingTransform(
+                features=n_features,
+                context=n_cond,
+                mask=mask,
+                hidden_features=[hidden_features] * n_hidden_layers,
+                activation=activation,
+            )
+        )
+
+    base = UnconditionalDistribution(
+        DiagNormal,
+        loc=torch.zeros(n_features),
+        scale=torch.ones(n_features),
+        buffer=True,
+    )
+    return Flow(transforms_list, base)
+
+
+def _build_sospf(
+    n_features: int,
+    n_cond: int,
+    n_transforms: int,
+    hidden_features: int,
+    n_hidden_layers: int,
+    activation,
+    degree: int,
+    polynomials: int,
+    quad_n: int,
+):
+    """Build a sum-of-squares polynomial flow with explicit Gauss–Legendre
+    quadrature node count.
+
+    Reproduces ``zuko.flows.SOSPF`` (Jaini et al., 2019) but overrides the
+    quadrature ``n`` used by the inner ``SOSPolynomialTransform``. zuko's
+    default is ``n = degree + 1`` (the minimum value that integrates the
+    degree-``2·degree`` polynomial integrand exactly under Gauss–Legendre's
+    polynomial-exactness rule). This wrapper accepts any ``quad_n >= 1`` —
+    set lower for faster but biased quadrature, higher for defensive
+    overshoot.
+
+    Built directly via ``zuko.flows.MAF`` with a custom ``univariate``
+    factory that closes over ``quad_n`` plus the SOSPF post-init pass
+    that interleaves ``SoftclipTransform(bound=11)`` between successive
+    masked-autoregressive transforms (keeps inputs inside the
+    ``[-10, 10]`` SOSPolynomialTransform invertibility window).
+    """
+    import zuko
+    from zuko.flows import MAF, UnconditionalTransform
+    from zuko.transforms import (
+        ComposedTransform,
+        AdditiveTransform,
+        SOSPolynomialTransform,
+        SoftclipTransform,
+        UnconstrainedMonotonicTransform,
+    )
+
+    class _SOSPolyTQN(SOSPolynomialTransform):
+        """SOSPolynomialTransform with overridable quadrature n.
+
+        zuko's parent ``__init__`` hardcodes ``n=a.shape[-1]`` when
+        chaining to ``UnconstrainedMonotonicTransform``; we bypass it
+        by calling the grandparent constructor directly with our n.
+        """
+
+        def __init__(self, a, slope: float = 1e-3, **kwargs):
+            UnconstrainedMonotonicTransform.__init__(
+                self, None, phi=(a,), n=int(quad_n), **kwargs,
+            )
+            self.a = a
+            self.i = torch.arange(a.shape[-1], device=a.device)
+            self.slope = slope
+
+    def _shifted_sosp(a, constant):
+        return ComposedTransform(
+            _SOSPolyTQN(a=a),
+            AdditiveTransform(shift=constant),
+        )
+
+    flow = MAF(
+        features=n_features,
+        context=n_cond,
+        transforms=n_transforms,
+        univariate=_shifted_sosp,
+        shapes=[(polynomials, degree + 1), ()],
+        hidden_features=[hidden_features] * n_hidden_layers,
+        activation=activation,
+    )
+
+    # SOSPF post-init: interleave a Softclip between successive MAF
+    # transforms to keep the inputs to each SOSPolynomialTransform
+    # within its [-10, 10] invertibility window. Matches zuko's SOSPF
+    # exactly (bound=11.0).
+    transforms = flow.transform.transforms
+    for i in reversed(range(1, len(transforms))):
+        transforms.insert(
+            i, UnconditionalTransform(SoftclipTransform, bound=11.0),
+        )
+    return flow
+
+
+def build_flow(
+    n_features: int,
+    n_cond: int,
+    n_transforms: int,
+    hidden_features: int,
+    n_hidden_layers: int,
+    activation: str = "gelu",
+    architecture: str = "realnvp",
+    randmask: bool = False,
+    gf_components: int = 8,
+    sospf_degree: int = 4,
+    sospf_polynomials: int = 3,
+    sospf_quad_n: int = -1,
+) -> nn.Module:
+    """Build a conditional flow via zuko. Architecture-dispatched.
+
+    ``architecture="realnvp"`` (default):
+        RealNVP-style affine coupling. Each of ``n_transforms``
+        coupling layers splits y under a checkered mask and applies
+        a *monotonic affine* ``y_masked → y_masked · exp(s) + t``
+        where ``(s, t)`` are the outputs of a conditioner MLP on
+        the (unmasked half, context). With smooth conditioner
+        activations (GELU default), the log-abs-det Jacobian — and
+        therefore the flow's log-density — is C^∞ in y.
+        ``randmask`` (default False) uses random coupling masks
+        instead of the standard alternating checkered masks.
+
+    ``architecture="glow"``:
+        Glow-like (Kingma & Dhariwal 2018) — RealNVP plus a
+        learnable invertible LU-parameterized linear mixing layer
+        (``LULinearTransform``) before each coupling. Replaces
+        the fixed alternating-mask mixing with a learned
+        per-layer rotation, typically giving comparable NLL at
+        fewer coupling layers. Minimal build: identity-init LU
+        with small noise, no actnorm (the data preproc already
+        standardizes). Adds d² learnable parameters per LU
+        layer — negligible at d = 3.
+
+    ``architecture="maf"``:
+        Masked Autoregressive Flow (Papamakarios et al., 2017).
+        Same affine ``y_d → y_d · exp(s_d) + t_d`` transform as
+        RealNVP, but conditioned autoregressively — each ``(s_d,
+        t_d)`` depends on ``y_<d`` (and the context) via a single
+        masked MLP (MADE) per layer instead of on a fixed half via
+        a coupling MLP. All F features get warped every layer,
+        which typically gives better NLL than RealNVP at fewer
+        transforms, at the cost of expensive sequential
+        sampling. Forward (NLL) cost ≈ RealNVP. Closed-form
+        Jacobian, ``torch.compile``-safe.
+
+    ``architecture="gf"``:
+        Gaussianization Flow (Meng et al., 2020). Each layer is a
+        context-conditional per-dimension monotonic transform
+        (Gaussian-mixture CDF with ``gf_components`` components),
+        interleaved with fixed random orthogonal rotations that mix
+        features between layers. Typically more parameter-efficient
+        than RealNVP for near-Gaussian-shaped conditional densities
+        and also C^∞ with smooth conditioner activations.
+        Invertibility is only guaranteed on ``[-10, 10]`` in
+        standardized inputs — preproc already gives zero-mean/unit-
+        std targets, so this is respected.
+
+    ``architecture="sospf"``:
+        Sum-of-Squares Polynomial Flow (Jaini et al., 2019). Masked
+        autoregressive stack where each transform is the integral of
+        a sum of ``sospf_polynomials`` squared polynomials of degree
+        ``sospf_degree``: ``f(x) = ∫₀^x (1/K) Σᵢ (1 + Σⱼ aᵢⱼ uʲ)² du``.
+        Closed-form analytic Jacobian (no inner ``autograd.grad`` —
+        torch.compile-safe), and structurally invertible across the
+        standardised range ``[−10, 10]``. Strong inductive bias for
+        smooth one-dimensional warpings.
+
+    ``hidden_features`` × ``n_hidden_layers`` sizes each
+    conditioner MLP in all four architectures.
+    """
+    try:
+        import zuko
+    except ImportError as e:
+        raise ImportError(
+            "zuko is required for training (pip install zuko)."
+        ) from e
+
+    act_cls = ACTIVATIONS.get(activation.lower())
+    if act_cls is None:
+        raise ValueError(
+            f"unknown activation '{activation}'; "
+            f"available: {sorted(ACTIVATIONS)}"
+        )
+
+    arch = architecture.lower()
+    if arch == "realnvp":
+        return zuko.flows.RealNVP(
+            features=n_features,
+            context=n_cond,
+            transforms=n_transforms,
+            randmask=randmask,
+            hidden_features=[hidden_features] * n_hidden_layers,
+            activation=act_cls,
+        )
+    if arch == "maf":
+        return zuko.flows.MAF(
+            features=n_features,
+            context=n_cond,
+            transforms=n_transforms,
+            hidden_features=[hidden_features] * n_hidden_layers,
+            activation=act_cls,
+        )
+    if arch == "glow":
+        return _build_glow(
+            n_features=n_features,
+            n_cond=n_cond,
+            n_transforms=n_transforms,
+            randmask=randmask,
+            hidden_features=hidden_features,
+            n_hidden_layers=n_hidden_layers,
+            activation=act_cls,
+        )
+    if arch == "gf":
+        return zuko.flows.GF(
+            features=n_features,
+            context=n_cond,
+            transforms=n_transforms,
+            components=gf_components,
+            hidden_features=[hidden_features] * n_hidden_layers,
+            activation=act_cls,
+        )
+    if arch == "sospf":
+        # ``sospf_quad_n <= 0`` → auto: use the minimum exact n for
+        # the degree-2*degree polynomial integrand under Gauss–Legendre
+        # (n=L+1, matching zuko's own default).
+        _quad_n = (
+            int(sospf_quad_n)
+            if sospf_quad_n is not None and int(sospf_quad_n) > 0
+            else int(sospf_degree) + 1
+        )
+        return _build_sospf(
+            n_features=n_features,
+            n_cond=n_cond,
+            n_transforms=n_transforms,
+            hidden_features=hidden_features,
+            n_hidden_layers=n_hidden_layers,
+            activation=act_cls,
+            degree=sospf_degree,
+            polynomials=sospf_polynomials,
+            quad_n=_quad_n,
+        )
+    raise ValueError(
+        f"unknown architecture '{architecture}'; "
+        f"available: 'realnvp', 'glow', 'maf', 'gf', 'sospf'"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Polynomial-correction head (joint training, joint polynomial)
+#
+# Perturbations live in **target space** (y), not conditioning space:
+# the calibration shifts and smears we want to model are reco-level
+# (e.g., a momentum-scale shift on pt_reco changes r_kappa), while
+# c is purely gen-level. So the polyhead predicts the per-event
+# weight for a y-space perturbation:
+#
+#     w(u_y) = p(y - u_y | c) / p(y | c)
+#
+# at fixed c. The head's output is, per event and as a function of
+# (y_std, c_std):
+#
+#     joint_coefs    shape [B, n_joint_basis]
+#                    polynomial in (u, σ_vec) ∈ R^{n_features} × R^{n_features},
+#                    even in σ_vec, no constant term, with degree caps
+#                    (max_deg_u, max_deg_sigma, max_cross_deg).
+#
+# At evaluation:
+#
+#     W_pred(u_shift, σ_vec) = softplus( joint(u_shift, σ_vec) ) / log 2
+#
+# The ``softplus(·)/log 2`` rectifier maps the (unrestricted-sign)
+# joint polynomial to a strictly-positive multiplier with
+# ``softplus(0)/log 2 = 1`` so ``W_pred(0, 0) = 1`` is exact.
+#
+# All perturbation vectors are in **standardized target space** —
+# divide by ``target_std`` to convert from raw target units. The
+# downstream caller forms ``u_shift_std = u_shift_raw / target_std``
+# and ``σ_vec_std = σ_vec_raw / target_std``.
+#
+# Reductions:
+#   * pure shift   (σ_vec = 0): joint(u, 0) is a polynomial in u alone.
+#   * pure smear   (u_shift = 0): joint(0, σ_vec) is even in σ_vec.
+#   * shift+smear  (both ≠ 0): the full joint polynomial.
+#
+# The joint polynomial enforces:
+#   * no constant term  ⇒ W = softplus(0)/log 2 = 1 at (0, 0)
+#   * even in σ_vec     ⇒ smear-symmetry under σ_vec → -σ_vec
+#   * degree caps       ⇒ bounded number of head outputs
+#
+# The polyhead's prediction has zero gradient path to the flow params
+# (no z in the formula), so flow training is decoupled from polyhead
+# training even when both losses are active.
+#
+# This block is self-contained so the script runs without sibling
+# files. The inference wrapper (FlowPolyheadInference, used at AOTI
+# export) lives in flow_polyhead.py and re-imports these symbols.
+# -----------------------------------------------------------------------------
+
+import itertools as _itertools
+import math as _math
+
+
+_LOG_LOG2 = _math.log(_math.log(2.0))
+_LOG_W_CLAMP = 30.0   # exp-positivity clamp on log W to keep fp32 finite
+
+
+# ============================================================================
+# Positivity wrap (shared between predicted_W / predicted_log_W and the loss
+# steps). Each wrap is applied to the raw joint-polynomial scalar ``j`` and
+# returns either ``W`` (positive) or ``log W`` directly — no ``log(exp(·))``
+# or ``exp(log(·))`` round trips, and no protection beyond the minimum each
+# wrap intrinsically needs.
+#
+#   * ``"exp"``      — log W = j (clamped ±_LOG_W_CLAMP); W = exp(log W).
+#                      The clamp is the ONLY protection here and is
+#                      intrinsic to ``exp`` overflow in fp32.
+#   * ``"softplus"`` — W = softplus(j) / log 2; log W = log(W). For log W
+#                      we floor ``softplus(j)`` to the dtype's smallest
+#                      normal so ``log`` stays finite when ``j ≪ 0``
+#                      makes softplus underflow to 0. No input clamp.
+#   * ``"asinh"``    — log W = asinh(j); W = j + √(j² + 1) = exp(asinh(j)).
+#                      Closed form, strictly positive for any finite j
+#                      (``√(j²+1) > |j|``), grows only logarithmically in
+#                      |j| in log-space. Needs *no* clamp at all.
+# ============================================================================
+
+def _apply_positivity_W(j: torch.Tensor, positivity: str) -> torch.Tensor:
+    """Return ``W(j)`` directly, without going through ``log W``."""
+    if positivity == "exp":
+        return torch.exp(j.clamp(min=-_LOG_W_CLAMP, max=_LOG_W_CLAMP))
+    if positivity == "softplus":
+        return F.softplus(j) / _math.log(2.0)
+    if positivity == "asinh":
+        # Stable closed form for ``W = exp(asinh(j))``:
+        #   half = |j| + √(j²+1)   (always > 1, no cancellation)
+        # then ``W = half`` for ``j ≥ 0`` and ``W = 1/half`` for
+        # ``j < 0``. Algebraically identical to ``j + √(j²+1)`` but
+        # avoids fp catastrophic cancellation when ``j ≪ 0`` makes
+        # ``√(j²+1) ≈ |j|`` round to ``-j`` exactly.
+        half = j.abs() + torch.sqrt(j * j + 1.0)
+        return torch.where(j >= 0, half, 1.0 / half)
+    raise ValueError(f"unknown positivity {positivity!r}")
+
+
+def _apply_positivity_logW(
+    j: torch.Tensor,
+    positivity: str,
+    clamp: float = _LOG_W_CLAMP,
+) -> torch.Tensor:
+    """Return ``log W(j)`` directly, without going through ``W``.
+
+    ``clamp`` only affects the ``"exp"`` branch (the other wraps are
+    intrinsically bounded). ``clamp=inf`` (or any non-finite value)
+    disables the input clamp — appropriate for losses that don't
+    take a downstream ``exp`` of ``log W`` and so don't need the
+    fp32-overflow safety net (e.g., :func:`_wbce_per_event`, which
+    only feeds ``log W`` into ``softplus``)."""
+    if positivity == "exp":
+        if not _math.isfinite(clamp):
+            return j
+        return j.clamp(min=-clamp, max=clamp)
+    if positivity == "softplus":
+        tiny = torch.finfo(j.dtype).tiny
+        return torch.log(F.softplus(j).clamp_min(tiny)) - _LOG_LOG2
+    if positivity == "asinh":
+        return torch.asinh(j)
+    raise ValueError(f"unknown positivity {positivity!r}")
+
+
+def _joint_indices(
+    n_vars: int,
+    max_deg_u: int,
+    max_deg_sigma: int,
+    max_cross_deg: int,
+) -> List[Tuple[Tuple[int, ...], Tuple[int, ...]]]:
+    """Build (α, β) multi-index pairs for the joint polynomial.
+
+    Constraints:
+      * 1 ≤ |α| + |β|              (no constant term)
+      * |β| even                   (smear-symmetry: σ_vec → -σ_vec)
+      * if |β| = 0:  1 ≤ |α| ≤ max_deg_u                  (pure-shift slice)
+      * if |α| = 0:  2 ≤ |β| ≤ max_deg_sigma  even         (pure-smear slice)
+      * else (cross): 1 ≤ |α| ≤ max_deg_u, 2 ≤ |β| ≤ max_deg_sigma even,
+                       and |α| + |β| ≤ max_cross_deg
+    """
+    out: List[Tuple[Tuple[int, ...], Tuple[int, ...]]] = []
+    rng = list(range(n_vars))
+    # pure-u slice (β = ()): degrees 1..max_deg_u in α.
+    for d_a in range(1, max_deg_u + 1):
+        for alpha in _itertools.combinations_with_replacement(rng, d_a):
+            out.append((alpha, ()))
+    # pure-σ slice (α = ()): even degrees 2..max_deg_sigma in β.
+    for d_b in range(2, max_deg_sigma + 1, 2):
+        for beta in _itertools.combinations_with_replacement(rng, d_b):
+            out.append(((), beta))
+    # cross terms: |α| ≥ 1, |β| ≥ 2 even, |α|+|β| ≤ max_cross_deg.
+    for d_a in range(1, max_deg_u + 1):
+        for d_b in range(2, max_deg_sigma + 1, 2):
+            if d_a + d_b > max_cross_deg:
+                continue
+            for alpha in _itertools.combinations_with_replacement(rng, d_a):
+                for beta in _itertools.combinations_with_replacement(rng, d_b):
+                    out.append((alpha, beta))
+    return out
+
+
+# Module-level cache for the auxiliary tensors needed by the
+# vectorized basis functions. Keyed by ``(id(indices), n_features,
+# device-string)``. ``indices`` is the polyhead's joint-multi-index
+# list, which is created once at polyhead-init time and reused
+# throughout training, so id-based caching is safe in practice — it
+# only "stales" if the indices object is GC'd and a new list ends up
+# at the same memory address, which doesn't happen during a normal
+# polyhead lifetime.
+def _run_profile_pass(step_fn, n_warmup: int, n_active: int,
+                      output_path: str = None, label: str = "",
+                      row_limit: int = 30):
+    """Run ``step_fn(i)`` for ``n_warmup + n_active`` iterations under
+    ``torch.profiler``; print the top-``row_limit`` hot ops sorted by
+    self CUDA time (or self CPU time when CUDA isn't available).
+    Optionally export a Chrome trace at ``output_path`` for
+    visualization in chrome://tracing or Perfetto.
+
+    The profiler schedule is ``wait=0, warmup=n_warmup, active=n_active,
+    repeat=1`` — one warmup window followed by one active window.
+    Profiling overhead is non-negligible (graph recording, op stats),
+    so this is not meant to drive normal training; it's a one-off
+    diagnostic pass that the caller invokes from a ``--profile``
+    branch and then exits.
+    """
+    from torch.profiler import profile, schedule, ProfilerActivity
+    activities = [ProfilerActivity.CPU]
+    cuda_ok = torch.cuda.is_available()
+    if cuda_ok:
+        activities.append(ProfilerActivity.CUDA)
+    n_total = int(n_warmup) + int(n_active)
+    sched = schedule(
+        wait=0, warmup=int(n_warmup), active=int(n_active), repeat=1,
+    )
+    print(
+        f"[profile{label}] running {n_total} steps "
+        f"({n_warmup} warmup + {n_active} active); device={'cuda' if cuda_ok else 'cpu'}",
+        flush=True,
+    )
+    with profile(activities=activities, schedule=sched, record_shapes=False) as prof:
+        for i in range(n_total):
+            step_fn(i)
+            prof.step()
+    sort_key = "self_cuda_time_total" if cuda_ok else "self_cpu_time_total"
+    print(
+        f"[profile{label}] top-{row_limit} ops by {sort_key}:",
+        flush=True,
+    )
+    print(
+        prof.key_averages().table(sort_by=sort_key, row_limit=row_limit),
+        flush=True,
+    )
+    if output_path:
+        prof.export_chrome_trace(output_path)
+        print(
+            f"[profile{label}] chrome trace exported: {output_path}",
+            flush=True,
+        )
+
+
+_basis_aux_cache: dict = {}
+
+
+def _build_basis_aux(indices, n_features: int):
+    """Build basis-evaluation auxiliary tensors on **CPU** from the
+    multi-index list. Returns a dict identical in structure to
+    :func:`_get_basis_aux`'s output, with tensors on CPU.
+
+    Used by polyhead ``__init__`` to register these tensors as
+    ``nn.Module`` buffers, which then move with ``.to(device)`` and
+    are seen as stable inputs by ``torch.compile`` / CUDA graphs.
+
+    The returned values:
+
+      * ``alpha_degs`` / ``beta_degs``: ``[n_basis, n_features]``
+        LongTensor of per-axis degrees.
+      * ``cheb_u_const`` / ``cheb_v_const``: ``[n_basis]`` float64
+        tensors with the per-side origin constants
+        ``Π_j T_{α_j}(0)`` (resp. β-side); zeroed on the empty side
+        so each multi-index drops to its singly-centered limit
+        (pure-u or pure-σ).
+      * ``max_deg_u`` / ``max_deg_sigma``: int.
+    """
+    alpha_list = [
+        _multiindex_to_axis_degrees(a, n_features) for a, _ in indices
+    ]
+    beta_list = [
+        _multiindex_to_axis_degrees(b, n_features) for _, b in indices
+    ]
+    if alpha_list:
+        alpha_degs = torch.tensor(alpha_list, dtype=torch.long)
+    else:
+        alpha_degs = torch.zeros(0, n_features, dtype=torch.long)
+    if beta_list:
+        beta_degs = torch.tensor(beta_list, dtype=torch.long)
+    else:
+        beta_degs = torch.zeros(0, n_features, dtype=torch.long)
+    # Per-side origin constants for the doubly-centered chebyshev
+    # factorization phi[k] = (Π T_α(u_norm) − u_const[k]) ·
+    # (Π T_β(σ_norm) − v_const[k]), where the subtraction is enabled
+    # only when the corresponding multi-index side is non-empty. This
+    # ensures cross terms (both α, β nonempty) vanish at u=0 OR σ=0
+    # separately — without per-side centering the cross block leaks
+    # a u-dependent offset at σ=0 (and σ-dependent at u=0), which
+    # violates the structural prior log W(u=0, σ=0) = 0 along each
+    # axis and corrupts axis-aligned closure plots.
+    u_const_list = []
+    v_const_list = []
+    for a_d, b_d in zip(alpha_list, beta_list):
+        if any(d > 0 for d in a_d):
+            cu = 1.0
+            for d in a_d:
+                if d > 0:
+                    cu *= _T_at_zero(d)
+                    if cu == 0.0:
+                        break
+        else:
+            cu = 0.0
+        if any(d > 0 for d in b_d):
+            cv = 1.0
+            for d in b_d:
+                if d > 0:
+                    cv *= _T_at_zero(d)
+                    if cv == 0.0:
+                        break
+        else:
+            cv = 0.0
+        u_const_list.append(cu)
+        v_const_list.append(cv)
+    cheb_u_const = torch.tensor(u_const_list, dtype=torch.float64)
+    cheb_v_const = torch.tensor(v_const_list, dtype=torch.float64)
+    max_du = int(alpha_degs.max()) if alpha_degs.numel() else 0
+    max_ds = int(beta_degs.max()) if beta_degs.numel() else 0
+    return {
+        "alpha_degs": alpha_degs,
+        "beta_degs": beta_degs,
+        "cheb_u_const": cheb_u_const,
+        "cheb_v_const": cheb_v_const,
+        "max_deg_u": max_du,
+        "max_deg_sigma": max_ds,
+    }
+
+
+def _get_basis_aux(indices, n_features: int, device: torch.device):
+    """Return cached auxiliary tensors for the vectorized basis
+    functions, computing them once per (indices, n_features, device).
+    Used by external callers (diagnostics, exports) where the
+    ``torch.compile`` / CUDA-graph constraints don't apply. Inside a
+    compiled module's forward, prefer passing pre-registered buffers
+    via ``basis_aux=`` to :func:`evaluate_joint` instead — this
+    avoids creating tensors inside the compile path (which CUDA
+    graphs interprets as captured outputs and then errors on
+    overwrite).
+    """
+    key = (id(indices), n_features, str(device))
+    if key in _basis_aux_cache:
+        return _basis_aux_cache[key]
+    cpu_aux = _build_basis_aux(indices, n_features)
+    out = {
+        "alpha_degs": cpu_aux["alpha_degs"].to(device),
+        "beta_degs": cpu_aux["beta_degs"].to(device),
+        "cheb_u_const": cpu_aux["cheb_u_const"].to(device),
+        "cheb_v_const": cpu_aux["cheb_v_const"].to(device),
+        "max_deg_u": cpu_aux["max_deg_u"],
+        "max_deg_sigma": cpu_aux["max_deg_sigma"],
+    }
+    _basis_aux_cache[key] = out
+    return out
+
+
+def _power_table(x: torch.Tensor, max_deg: int) -> torch.Tensor:
+    """Return ``[..., n_features, max_deg + 1]`` power table where
+    ``out[..., j, k] = x[..., j]^k`` for k = 0..max_deg. Built in
+    O(max_deg) tensor ops via repeated multiplication (vs. a Python
+    loop of O(n_basis) ops in the legacy basis evaluation, which is
+    the source of the polyhead-order training slowdown on GPU)."""
+    if max_deg == 0:
+        return torch.ones_like(x).unsqueeze(-1)
+    cols = [torch.ones_like(x), x]
+    for k in range(2, max_deg + 1):
+        cols.append(cols[-1] * x)
+    return torch.stack(cols, dim=-1)
+
+
+def joint_monomial_basis(
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    indices,
+    *,
+    aux=None,
+) -> torch.Tensor:
+    """Evaluate the joint (α, β) basis at ``(u, σ_vec)`` — vectorized.
+
+    Each entry contributes ``u^α · σ_vec^β`` (product of selected
+    components). Output shape: ``[..., len(indices)]``, identical to
+    the previous loop-over-multi-indices reference.
+
+    If ``aux`` (a dict with ``alpha_degs``, ``beta_degs``,
+    ``max_deg_u``, ``max_deg_sigma``) is provided, those tensors /
+    ints are used directly — no cache lookup. This is required when
+    called from a ``torch.compile``-wrapped module: register the aux
+    tensors as buffers on the polyhead and pass ``aux=polyhead
+    .basis_aux`` so the compiled forward sees them as stable inputs
+    rather than allocating ephemeral tensors that CUDA graphs
+    interpret as captured outputs.
+
+    Reduces autograd-graph node count from ``O(n_basis · n_features)``
+    in the legacy loop to ``O(max_deg_u + max_deg_sigma + n_features)``
+    — the dominant per-call cost on GPU due to kernel-launch overhead.
+    """
+    if aux is None:
+        n_features = u.shape[-1]
+        aux = _get_basis_aux(indices, n_features, u.device)
+    alpha_degs = aux["alpha_degs"]
+    beta_degs = aux["beta_degs"]
+    max_du = aux["max_deg_u"]
+    max_ds = aux["max_deg_sigma"]
+    n_features = u.shape[-1]
+    u_pow = _power_table(u, max_du)
+    has_sigma = max_ds > 0
+    if has_sigma:
+        s_pow = _power_table(sigma_vec, max_ds)
+    phi = None
+    for j in range(n_features):
+        u_j = u_pow[..., j, :].index_select(
+            dim=-1, index=alpha_degs[:, j],
+        )
+        if has_sigma:
+            s_j = s_pow[..., j, :].index_select(
+                dim=-1, index=beta_degs[:, j],
+            )
+            factor_j = u_j * s_j
+        else:
+            factor_j = u_j
+        phi = factor_j if phi is None else phi * factor_j
+    return phi
+
+
+def _multiindex_to_axis_degrees(idx, n_features):
+    """Convert a sorted-tuple multi-index (e.g. (0, 0, 1)) into a list
+    of per-axis degrees (e.g. [2, 1, 0] for n_features=3)."""
+    degs = [0] * n_features
+    for i in idx:
+        degs[i] += 1
+    return degs
+
+
+def _cheb_table(x_norm: torch.Tensor, max_deg: int) -> torch.Tensor:
+    """First-kind Chebyshev polynomials T_0..T_max_deg of ``x_norm``,
+    via the standard recurrence T_n(x) = 2 x T_{n-1}(x) − T_{n-2}(x).
+    Returns shape ``[..., max_deg + 1]``. ``max_deg < 0`` returns
+    an empty trailing dim."""
+    if max_deg < 0:
+        return x_norm.unsqueeze(-1)[..., :0]
+    cols = [torch.ones_like(x_norm)]   # T_0 = 1
+    if max_deg >= 1:
+        cols.append(x_norm)            # T_1 = x
+    for n in range(2, max_deg + 1):
+        cols.append(2 * x_norm * cols[-1] - cols[-2])
+    return torch.stack(cols, dim=-1)
+
+
+def _T_at_zero(n: int) -> float:
+    """Value of the n-th first-kind Chebyshev polynomial at x=0:
+       T_0(0)=1, T_n(0)=0 for odd n, T_n(0)=(-1)^(n/2) for even n>0.
+    """
+    if n == 0:
+        return 1.0
+    if n % 2 == 1:
+        return 0.0
+    return (-1.0) ** (n // 2)
+
+
+def joint_chebyshev_basis(
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    indices,
+    scale_u: float = 1.0,
+    scale_sigma: float = 1.0,
+    *,
+    aux=None,
+) -> torch.Tensor:
+    """Evaluate the joint (α, β) basis at ``(u, σ_vec)`` using
+    *tensor-product Chebyshev* polynomials with **per-side
+    zero-anchoring**. Each entry is
+
+        (Π_j T_{d_α_j}(u_j / scale_u)   − u_const[k])
+            · (Π_j T_{d_β_j}(σ_j / scale_sigma) − v_const[k])
+
+    where ``u_const[k] = Π_j T_{d_α_j}(0)`` if ``α`` is non-empty
+    else ``0``, and similarly for ``v_const[k]`` (β-side).
+
+    Per-side anchoring (vs a single joint-origin subtraction) is
+    essential to preserve the structural priors that the monomial
+    basis enjoyed automatically:
+
+      * pure-u (β = ∅): φ vanishes at u = 0;
+      * pure-σ (α = ∅): φ vanishes at σ = 0;
+      * cross  (α, β both nonempty): φ vanishes at u = 0 *or* σ = 0.
+
+    A single joint-origin subtraction (`Π T_α(0)·Π T_β(0)`) leaves a
+    nonzero residual ``T_β(0) · (Π T_α(u/scale) − Π T_α(0))`` for
+    cross terms at σ = 0 (and the analogous u → 0 leak), which
+    cross-trained coefficients then absorb into joint-mode events
+    and leak back into shift / smear closure. With per-side
+    anchoring, cross factors vanish independently, so SHIFT-mode
+    events see d = c_pu·U(α; u) and SMEAR-mode events see
+    d = c_ps·V(β; σ) — matching the per-mode losses.
+
+    ``scale_u`` and ``scale_sigma`` map the trained perturbation
+    ranges to ``[-1, 1]`` (typical choice: ``oversample · delta_max``
+    and ``oversample · sigma_max``). Outside the trained range the
+    Chebyshev polynomials grow rapidly — better fit-quality inside,
+    less stable extrapolation outside, vs the monomial basis.
+
+    Smear-symmetry (σ_vec → −σ_vec): preserved by the existing
+    |β|-even constraint on multi-indices, since T_n is even iff n
+    is even, and the per-side ``v_const`` subtraction is itself
+    smear-symmetric.
+    """
+    if aux is None:
+        n_features = u.shape[-1]
+        aux = _get_basis_aux(indices, n_features, u.device)
+    alpha_degs = aux["alpha_degs"]
+    beta_degs = aux["beta_degs"]
+    max_du = aux["max_deg_u"]
+    max_ds = aux["max_deg_sigma"]
+    u_const = aux["cheb_u_const"].to(dtype=u.dtype)
+    v_const = aux["cheb_v_const"].to(dtype=u.dtype)
+    n_features = u.shape[-1]
+    u_norm = u / float(scale_u)
+    sigma_norm = sigma_vec / float(scale_sigma)
+    # Vectorized Chebyshev table on the full ``[..., n_features]``
+    # input — single Clenshaw recurrence shared across all axes,
+    # producing ``[..., n_features, max_deg + 1]``.
+    Tu = _cheb_table(u_norm, max_du)
+    has_sigma = max_ds > 0
+    if has_sigma:
+        Ts = _cheb_table(sigma_norm, max_ds)
+    # Compute the un-anchored per-side products separately so we
+    # can subtract the per-side origin constants before the final
+    # cross multiplication.
+    u_factor = None
+    for j in range(n_features):
+        u_j = Tu[..., j, :].index_select(
+            dim=-1, index=alpha_degs[:, j],
+        )
+        u_factor = u_j if u_factor is None else u_factor * u_j
+    if has_sigma:
+        v_factor = None
+        for j in range(n_features):
+            s_j = Ts[..., j, :].index_select(
+                dim=-1, index=beta_degs[:, j],
+            )
+            v_factor = s_j if v_factor is None else v_factor * s_j
+        return (u_factor - u_const) * (v_factor - v_const)
+    # Pure-u-only basis (no σ): pure-u case has β=∅ → v_const=0,
+    # v_factor=1, so the cross-side factor reduces to 1.
+    return u_factor - u_const
+
+
+def _select_basis(
+    basis: str,
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    indices,
+    scale_u: float = 1.0,
+    scale_sigma: float = 1.0,
+    *,
+    aux=None,
+) -> torch.Tensor:
+    """Dispatch to ``joint_monomial_basis`` or
+    ``joint_chebyshev_basis`` based on ``basis`` name. ``aux`` is
+    forwarded if provided (used for torch.compile-friendly polyhead
+    paths to avoid in-graph cache lookups)."""
+    if basis == "monomial":
+        return joint_monomial_basis(u, sigma_vec, indices, aux=aux)
+    if basis == "chebyshev":
+        return joint_chebyshev_basis(
+            u, sigma_vec, indices, scale_u, scale_sigma, aux=aux,
+        )
+    raise ValueError(f"unknown basis {basis!r}")
+
+
+class PolyHead(nn.Module):
+    """MLP from ``[y_std, c_std]`` to joint polynomial coefficients.
+
+    Output:
+      * ``joint_coefs`` shape ``[B, n_joint_basis]`` — scalar
+        polynomial in ``(u, σ_vec) ∈ R^{n_features} × R^{n_features}``
+        (target / y-space), with the parity / degree constraints
+        enumerated by ``_joint_indices``.
+
+    The final layer is initialized near zero so training starts with
+    ``joint ≈ 0`` (i.e., predicted ``W ≈ softplus(0)/log 2 = 1``).
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_cond: int,
+        hidden_features: int = 64,
+        n_hidden_layers: int = 2,
+        max_deg_u: int = 3,
+        max_deg_sigma: int = 4,
+        max_cross_deg: int = 3,
+        activation=nn.GELU,
+        smear_K: int = 1,
+        smear_residual: bool = False,
+        include_smear: bool = False,
+        positivity: str = "softplus",
+        basis: str = "monomial",
+        basis_scale_u: float = 1.0,
+        basis_scale_sigma: float = 1.0,
+    ):
+        super().__init__()
+        self.n_features = n_features
+        self.n_cond = n_cond
+        self.include_smear = bool(include_smear)
+        if basis not in ("monomial", "chebyshev"):
+            raise ValueError(f"unknown basis {basis!r}")
+        self.basis = str(basis)
+        self.basis_scale_u = float(basis_scale_u)
+        self.basis_scale_sigma = float(basis_scale_sigma)
+        # Shift-only collapse: pure-u polynomial only, no σ basis,
+        # K=1 stochastic smear path disabled. The smear-related CLI
+        # values are silently overridden so the mode is internally
+        # consistent end-to-end.
+        if not self.include_smear:
+            max_deg_sigma = 0
+            max_cross_deg = 0
+            smear_K = 1
+            smear_residual = False
+        self.max_deg_u = max_deg_u
+        self.max_deg_sigma = max_deg_sigma
+        self.max_cross_deg = max_cross_deg
+        self.smear_K = int(smear_K)
+        self.smear_residual = bool(smear_residual)
+        if self.smear_residual and self.smear_K <= 1:
+            raise ValueError(
+                "smear_residual=True requires smear_K > 1 "
+                "(K=1 stochastic has no GH base to correct)."
+            )
+        if positivity not in ("softplus", "exp", "asinh"):
+            raise ValueError(f"unknown positivity {positivity!r}")
+        self.positivity = str(positivity)
+        # Polynomial basis on R^{n_features} — perturbations are in
+        # target / y-space. Reorder so pure-u indices come first,
+        # pure-σ second, cross last — this lets the three-head split
+        # below produce contiguous coefficient blocks that align with
+        # the basis ordering, and lets the per-mode loss-step
+        # contraction read the right phi slice without scatter/
+        # gather. Total set is unchanged.
+        raw_indices = _joint_indices(
+            n_features, max_deg_u, max_deg_sigma, max_cross_deg,
+        )
+        idx_pure_u = [
+            (a, b) for (a, b) in raw_indices
+            if len(b) == 0 and len(a) > 0
+        ]
+        idx_pure_s = [
+            (a, b) for (a, b) in raw_indices
+            if len(a) == 0 and len(b) > 0
+        ]
+        idx_cross = [
+            (a, b) for (a, b) in raw_indices
+            if len(a) > 0 and len(b) > 0
+        ]
+        assert (
+            len(idx_pure_u) + len(idx_pure_s) + len(idx_cross)
+            == len(raw_indices)
+        ), "non-exhaustive split of joint indices"
+        self._joint_indices = idx_pure_u + idx_pure_s + idx_cross
+        self.n_joint_basis = len(self._joint_indices)
+        self._n_pure_u = len(idx_pure_u)
+        self._n_pure_s = len(idx_pure_s)
+        self._n_cross = len(idx_cross)
+        # Boolean masks over (reordered) basis indices: pure-u
+        # (β = ()), pure-σ (α = ()), and cross (both nonempty). Now
+        # contiguous blocks: [0, n_pure_u), [n_pure_u, n_pure_u +
+        # n_pure_s), [n_pure_u + n_pure_s, n_basis).
+        is_pure_u = torch.tensor(
+            [len(b) == 0 for (_, b) in self._joint_indices],
+            dtype=torch.bool,
+        )
+        is_pure_sigma = torch.tensor(
+            [len(a) == 0 for (a, _) in self._joint_indices],
+            dtype=torch.bool,
+        )
+        is_cross = ~(is_pure_u | is_pure_sigma)
+        self.register_buffer("is_pure_u", is_pure_u, persistent=False)
+        self.register_buffer("is_pure_sigma", is_pure_sigma, persistent=False)
+        self.register_buffer("is_cross", is_cross, persistent=False)
+
+        # Basis-evaluation auxiliary tensors registered as buffers
+        # (so they move with ``.to(device)`` and are seen as stable
+        # inputs by ``torch.compile`` / CUDA graphs). Computed once
+        # at init from ``_joint_indices``; the polyhead exposes them
+        # via ``self.basis_aux`` for use in :func:`evaluate_joint`.
+        _aux = _build_basis_aux(self._joint_indices, n_features)
+        self.register_buffer(
+            "_basis_alpha_degs", _aux["alpha_degs"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_beta_degs", _aux["beta_degs"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_cheb_u_const",
+            _aux["cheb_u_const"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_cheb_v_const",
+            _aux["cheb_v_const"], persistent=False,
+        )
+        self._basis_max_deg_u = _aux["max_deg_u"]
+        self._basis_max_deg_sigma = _aux["max_deg_sigma"]
+
+        # Gauss-Hermite (probabilist's) nodes & log-weights for the
+        # smear-weight target. K=1 → empty buffers (no GH; loss step
+        # falls back to the K=1 stochastic estimator).
+        if self.smear_K > 1:
+            nodes_np, w_np = np.polynomial.hermite_e.hermegauss(
+                self.smear_K
+            )
+            w_norm = w_np / np.sqrt(2.0 * np.pi)
+            gh_nodes = torch.tensor(nodes_np, dtype=torch.float32)
+            gh_log_w = torch.tensor(np.log(w_norm), dtype=torch.float32)
+        else:
+            gh_nodes = torch.zeros(0, dtype=torch.float32)
+            gh_log_w = torch.zeros(0, dtype=torch.float32)
+        self.register_buffer("gh_nodes", gh_nodes, persistent=False)
+        self.register_buffer(
+            "gh_log_weights", gh_log_w, persistent=False,
+        )
+
+        # Trunk: ``[y, c] → e ∈ R^trunk_hidden``. The final coefficient
+        # layer is split into three sub-heads (pure_u, pure_σ, cross)
+        # — same total parameter count as a single
+        # ``Linear(trunk_hidden, n_basis)``, but enables mode-
+        # conditional skipping of irrelevant heads at forward time
+        # (e.g. SHIFT events skip pure_σ and cross since σ=0 makes
+        # those terms vanish in the polynomial). Combined with the
+        # stratified mode sampler the per-step cost on the final
+        # layer drops from ``B · d_emb · n_basis`` to roughly
+        # ``B · d_emb · (n_pure_u + n_pure_σ + n_basis) / 3``.
+        in_dim = n_features + n_cond
+        trunk_layers = []
+        prev = in_dim
+        for _ in range(n_hidden_layers):
+            trunk_layers.append(nn.Linear(prev, hidden_features))
+            trunk_layers.append(activation())
+            prev = hidden_features
+        self.trunk = nn.Sequential(*trunk_layers)
+        # Three sub-heads with sizes summing to n_basis. ``Linear`` is
+        # only created if the corresponding block is non-empty (e.g.
+        # in shift-only mode, pure_s and cross are empty).
+        self.head_pure_u = (
+            nn.Linear(prev, self._n_pure_u)
+            if self._n_pure_u > 0 else None
+        )
+        self.head_pure_sigma = (
+            nn.Linear(prev, self._n_pure_s)
+            if self._n_pure_s > 0 else None
+        )
+        self.head_cross = (
+            nn.Linear(prev, self._n_cross)
+            if self._n_cross > 0 else None
+        )
+        # Init heads near zero so coefs ≈ 0 at start.
+        with torch.no_grad():
+            for head in (
+                self.head_pure_u, self.head_pure_sigma, self.head_cross,
+            ):
+                if head is not None:
+                    head.weight.mul_(0.01)
+                    head.bias.zero_()
+
+    @property
+    def joint_indices(self):
+        return self._joint_indices
+
+    @property
+    def basis_aux(self):
+        """Dict of pre-registered basis-evaluation buffers, suitable
+        for passing to :func:`evaluate_joint` as ``basis_aux=`` from
+        compiled call sites. Each access returns a fresh dict (cheap)
+        wrapping the current device's buffer references."""
+        return {
+            "alpha_degs": self._basis_alpha_degs,
+            "beta_degs": self._basis_beta_degs,
+            "cheb_u_const": self._basis_cheb_u_const,
+            "cheb_v_const": self._basis_cheb_v_const,
+            "max_deg_u": self._basis_max_deg_u,
+            "max_deg_sigma": self._basis_max_deg_sigma,
+        }
+
+    def _remap_legacy_state_dict(self, state_dict):
+        """Migrate a pre-split-head checkpoint into the new layout.
+
+        Old layout: a single ``self.net`` ``nn.Sequential`` ending in a
+        ``Linear(prev, n_basis)`` whose row order matched
+        ``_joint_indices(...)`` raw output (no pure_u / pure_σ / cross
+        reordering). State-dict keys: ``net.{2j}.{weight,bias}`` for
+        each Linear layer, with the final ``net.{2L}`` being the
+        coefficient layer of width ``n_basis``.
+
+        New layout: ``self.trunk`` (``nn.Sequential`` of just the
+        hidden layers + activations) plus three ``head_pure_u``,
+        ``head_pure_sigma``, ``head_cross`` ``Linear`` sub-heads
+        sized to the per-block coefficient counts in the *reordered*
+        index list.
+
+        Migration:
+          1. Trunk ``Linear`` layers map 1:1 by stripping ``net.`` →
+             ``trunk.``.
+          2. Final ``Linear`` of the old ``net`` is split into the
+             three sub-heads, with rows permuted from the raw
+             ``_joint_indices`` ordering to the new pure_u / pure_σ /
+             cross-block ordering.
+
+        Returns the (possibly remapped) state_dict. If no ``net.*``
+        keys are present, returns the input unchanged.
+        """
+        net_keys = [k for k in state_dict.keys() if k.startswith("net.")]
+        if not net_keys:
+            return state_dict
+        # Find the index of the final layer (largest ``net.{N}.weight``).
+        net_layer_idxs = sorted({
+            int(k.split(".")[1]) for k in net_keys
+            if k.endswith(".weight")
+        })
+        if not net_layer_idxs:
+            return state_dict
+        last_idx = net_layer_idxs[-1]
+        trunk_idxs = net_layer_idxs[:-1]
+
+        # Reconstruct the OLD basis-index ordering from the same
+        # constructor inputs the polyhead was built with. Map each
+        # old position to its position in the (new) reordered list.
+        raw_indices = _joint_indices(
+            self.n_features,
+            self.max_deg_u,
+            self.max_deg_sigma,
+            self.max_cross_deg,
+        )
+        old_pos_of = {idx: i for i, idx in enumerate(raw_indices)}
+        # ``perm_inv[new_pos] = old_pos`` such that
+        # ``raw_indices[old_pos] == self._joint_indices[new_pos]``.
+        perm_inv = torch.tensor(
+            [old_pos_of[idx] for idx in self._joint_indices],
+            dtype=torch.long,
+        )
+
+        new_state = dict(state_dict)
+        # 1) Trunk layers: net.{j} → trunk.{j}.
+        for j in trunk_idxs:
+            for suf in ("weight", "bias"):
+                k_old = f"net.{j}.{suf}"
+                k_new = f"trunk.{j}.{suf}"
+                if k_old in new_state:
+                    new_state[k_new] = new_state.pop(k_old)
+        # 2) Final layer: split into the three sub-heads with row
+        #    permutation to the new ordering.
+        w_old = new_state.pop(f"net.{last_idx}.weight", None)
+        b_old = new_state.pop(f"net.{last_idx}.bias", None)
+        if w_old is not None and b_old is not None:
+            # Permute rows to new ordering, then slice into blocks.
+            w_perm = w_old[perm_inv]
+            b_perm = b_old[perm_inv]
+            n_pu = self._n_pure_u
+            n_ps = self._n_pure_s
+            blocks = [
+                ("head_pure_u", 0, n_pu, n_pu > 0),
+                ("head_pure_sigma", n_pu, n_pu + n_ps, n_ps > 0),
+                ("head_cross", n_pu + n_ps, w_perm.shape[0], self._n_cross > 0),
+            ]
+            for name, lo, hi, present in blocks:
+                if present:
+                    new_state[f"{name}.weight"] = w_perm[lo:hi]
+                    new_state[f"{name}.bias"] = b_perm[lo:hi]
+        return new_state
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        """Override to transparently migrate legacy single-Linear-head
+        checkpoints. Forwards to :meth:`nn.Module.load_state_dict`
+        after running :meth:`_remap_legacy_state_dict`."""
+        return super().load_state_dict(
+            self._remap_legacy_state_dict(state_dict),
+            strict=strict, assign=assign,
+        )
+
+    def trunk_forward(
+        self,
+        y_std: torch.Tensor,
+        c_std: torch.Tensor,
+    ) -> torch.Tensor:
+        """Trunk embedding ``e ∈ R^{B, hidden_features}``.
+
+        Used by the per-mode contracted loss-step path which calls
+        the per-head sub-modules (``head_pure_u``, ...) directly on
+        per-mode slices of ``e`` to avoid materializing the full
+        ``[B, n_basis]`` coefficient tensor.
+        """
+        return self.trunk(torch.cat([y_std, c_std], dim=-1))
+
+    def forward(
+        self,
+        y_std: torch.Tensor,
+        c_std: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return the full ``[B, n_basis]`` coefficient tensor.
+
+        Used by external callers (diagnostics, ONNX/AOTI export,
+        polyhead-only inference) that consume coefs as the polyhead's
+        output. The compiled training path bypasses this in favor of
+        a per-mode contraction in :func:`joint_loss_step` /
+        :func:`head_only_loss_step`, which avoids the
+        ``[B, n_basis]`` intermediate altogether.
+        """
+        e = self.trunk_forward(y_std, c_std)
+        parts = []
+        if self.head_pure_u is not None:
+            parts.append(self.head_pure_u(e))
+        if self.head_pure_sigma is not None:
+            parts.append(self.head_pure_sigma(e))
+        if self.head_cross is not None:
+            parts.append(self.head_cross(e))
+        if not parts:
+            return torch.zeros(
+                e.shape[0], 0, device=e.device, dtype=e.dtype,
+            )
+        return torch.cat(parts, dim=-1)
+
+
+def _flow_z_ladj(flow, y_std, c_std):
+    z, ladj = flow(c_std).transform.call_and_ladj(y_std)
+    return z, ladj
+
+
+def _sigma_pack_outer(sigma: torch.Tensor) -> torch.Tensor:
+    """Upper-triangular flat of ``σ ⊗ σ``.
+
+    Shape ``[..., F] → [..., F·(F+1)/2]``. Captures the six (for
+    F=3) symmetric components of ``σσᵀ``: three diagonal entries
+    ``σ_d²`` and three off-diagonal cross products ``σ_d·σ_d'``.
+
+    Used as the conditioning input to a smear-conditioned flow so
+    that the σ-dependence is structurally invariant under
+    ``σ → −σ`` (i.e., ``f(σ) = f(σσᵀ) = f(−σ)`` — the smear-
+    symmetry of the underlying density). Off-diagonal cross
+    products preserve sign correlations between components, which a
+    pure ``|σ|`` (component-wise abs) input would discard.
+    """
+    F = sigma.shape[-1]
+    iu, ju = torch.triu_indices(
+        F, F, device=sigma.device,
+    ).unbind(0)
+    return sigma[..., iu] * sigma[..., ju]
+
+
+def evaluate_joint(
+    joint_coefs: torch.Tensor,
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    joint_indices,
+    basis: str = "monomial",
+    scale_u: float = 1.0,
+    scale_sigma: float = 1.0,
+    *,
+    basis_aux=None,
+) -> torch.Tensor:
+    """joint(u, σ_vec) scalar [...]. ``basis`` selects ``"monomial"``
+    (default, raw u^α · σ^β; backwards-compatible) or ``"chebyshev"``
+    (tensor-product Chebyshev with axis-normalization
+    ``scale_u, scale_sigma``).
+
+    ``basis_aux`` (optional dict): pre-computed per-axis-degree
+    tensors (typically ``polyhead.basis_aux`` if the polyhead
+    registers them as buffers — see :class:`PolyHead.basis_aux` and
+    train_shift_smear_reweight.ReweightPolyhead.basis_aux). When
+    passed, the basis function uses these directly instead of
+    looking them up in the runtime cache. Required for
+    ``torch.compile`` + CUDA-graph compatibility (mode='reduce-
+    overhead'): otherwise the cache-miss path creates ephemeral
+    tensors inside the compiled forward, which CUDA graphs captures
+    as outputs and then errors on overwrite."""
+    phi = _select_basis(
+        basis, u, sigma_vec, joint_indices,
+        scale_u, scale_sigma, aux=basis_aux,
+    )
+    return torch.einsum("...b,...b->...", joint_coefs, phi)
+
+
+def predicted_W(
+    joint_coefs: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    joint_indices,
+    positivity: str = "softplus",
+    basis: str = "monomial",
+    scale_u: float = 1.0,
+    scale_sigma: float = 1.0,
+    *,
+    basis_aux=None,
+) -> torch.Tensor:
+    """Polyhead prediction of ``W(u_shift, σ_vec)`` with ``j`` the
+    joint polynomial. Pure function of the head output and the
+    polynomial inputs — no flow-state dependence. Returns ``W``
+    *directly* via the chosen positivity wrap (no ``exp(log W)`` round
+    trip). See :func:`_apply_positivity_W` for the per-wrap algebra
+    and protections, and :func:`evaluate_joint` for the ``basis``
+    options (``"monomial"`` or ``"chebyshev"``).
+    """
+    j = evaluate_joint(
+        joint_coefs, u_shift, sigma_vec, joint_indices,
+        basis=basis, scale_u=scale_u, scale_sigma=scale_sigma,
+        basis_aux=basis_aux,
+    )
+    return _apply_positivity_W(j, positivity)
+
+
+def predicted_log_W(
+    joint_coefs: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    joint_indices,
+    positivity: str = "softplus",
+    basis: str = "monomial",
+    scale_u: float = 1.0,
+    scale_sigma: float = 1.0,
+    *,
+    basis_aux=None,
+) -> torch.Tensor:
+    """``log W_pred`` for the ``logw``-target loss path. Mirror of
+    :func:`predicted_W`, returning ``log W`` directly via the chosen
+    positivity wrap (no ``log(W)`` round trip on the ``"exp"`` /
+    ``"asinh"`` paths). See :func:`_apply_positivity_logW`.
+    ``basis`` and ``scale_*`` are forwarded to :func:`evaluate_joint`.
+    """
+    j = evaluate_joint(
+        joint_coefs, u_shift, sigma_vec, joint_indices,
+        basis=basis, scale_u=scale_u, scale_sigma=scale_sigma,
+        basis_aux=basis_aux,
+    )
+    return _apply_positivity_logW(j, positivity)
+
+
+def sample_perturbations(
+    batch_size: int,
+    n_dim: int,
+    delta_max: float,
+    sigma_max: float,
+    device: torch.device,
+    oversample: float = 1.3,
+    include_smear: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-event sampling of the perturbation `(u_shift, σ_vec)`.
+
+    All vectors live in **standardized target space** (R^{n_features})
+    — perturbations are y-shifts and y-smears.
+
+    ``include_smear = False`` (the shift-only default): every event is
+    SHIFT mode (mode_id = 0); ``σ_vec`` and ``δ_smear`` are zero. The
+    single integration sample point ``u_eval = u_shift``.
+
+    ``include_smear = True``: stratified sampling across three sample
+    modes — SHIFT (σ_vec = 0), SMEAR (u_shift = 0), JOINT (both
+    nonzero). The integration sample point is
+    ``u_eval = u_shift + δ_smear · v_smear``.
+
+    Magnitude sampling:
+      * ``|u|`` uniform on ``[−oversample·delta_max, +oversample·delta_max]``.
+      * ``|σ_vec|`` uniform on ``[0, oversample·sigma_max]``.
+      * Direction uniform on the unit sphere ``S^{n_dim − 1}``.
+      * σ=0 is anchored by the SHIFT mode (1/3 of events).
+
+    Returns ``(u_shift, σ_vec, δ_smear, v_smear, mode_id)`` where:
+      * u_shift     ∈ R^{n_dim}     deterministic shift in target space
+      * σ_vec       ∈ R^{n_dim}     smear scale × direction (zero in
+                                     shift-only mode)
+      * δ_smear     ∈ R             one Gaussian draw with variance
+                                     ‖σ_vec‖² (zero in shift-only mode)
+      * v_smear     ∈ R^{n_dim}     unit smear direction
+      * mode_id     ∈ {0,1,2}       SHIFT=0, SMEAR=1, JOINT=2 — always
+                                     0 in shift-only mode.
+    """
+    half = oversample * delta_max
+    # δ_shift uniform on [-half, +half], v_shift on unit sphere.
+    delta_shift = (torch.rand(batch_size, device=device) * 2.0 - 1.0) * half
+    v_shift = torch.randn(batch_size, n_dim, device=device)
+    v_shift = v_shift / v_shift.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+    u_shift = delta_shift.unsqueeze(-1) * v_shift
+
+    if not include_smear:
+        # Shift-only: zero out the smear leg and force SHIFT mode for
+        # every event. v_smear is a placeholder unit vector — never
+        # used downstream when σ_vec = 0 — but kept shape-compatible
+        # with the include_smear branch so callers don't have to
+        # branch on the shape.
+        zeros = torch.zeros(batch_size, device=device)
+        v_smear = torch.zeros(batch_size, n_dim, device=device)
+        v_smear[:, 0] = 1.0
+        sigma_vec = torch.zeros(batch_size, n_dim, device=device)
+        mode_id = torch.zeros(
+            batch_size, device=device, dtype=torch.long,
+        )
+        return u_shift, sigma_vec, zeros, v_smear, mode_id
+
+    half_sig = oversample * sigma_max
+    # σ_smear uniform on [0, half_sig], v_smear on unit sphere.
+    sigma_smear = torch.rand(batch_size, device=device) * half_sig
+    v_smear = torch.randn(batch_size, n_dim, device=device)
+    v_smear = v_smear / v_smear.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+    # Stochastic K=1 Gaussian sample of δ_smear ~ N(0, σ_smear²).
+    delta_smear = sigma_smear * torch.randn(batch_size, device=device)
+    # Stratified mode: 0=SHIFT, 1=SMEAR, 2=JOINT — exactly 1/3 each
+    # in **sorted contiguous** order ``[0…0, 1…1, 2…2]``. The data
+    # loader already randomizes the ``(y, c)`` ↔ mode pairing, so a
+    # within-batch shuffle here is unnecessary and would break the
+    # contiguous per-mode slicing that the per-mode-contracted
+    # polyhead loss path uses (see :func:`joint_loss_step`'s
+    # ``_polyhead_d_per_mode`` call). The remainder when
+    # ``batch_size`` isn't a multiple of 3 is given to SHIFT — the
+    # lowest-noise / highest-leverage gradient signal.
+    base = batch_size // 3
+    extra = batch_size - 3 * base
+    mode_id = torch.cat([
+        torch.full((base + extra,), 0, device=device, dtype=torch.long),
+        torch.full((base,), 1, device=device, dtype=torch.long),
+        torch.full((base,), 2, device=device, dtype=torch.long),
+    ])
+    shift_active = (mode_id != 1).to(delta_shift.dtype)   # SHIFT or JOINT
+    smear_active = (mode_id != 0).to(delta_smear.dtype)   # SMEAR or JOINT
+
+    u_shift = (delta_shift * shift_active).unsqueeze(-1) * v_shift
+    sigma_vec = (sigma_smear * smear_active).unsqueeze(-1) * v_smear
+    delta_smear = delta_smear * smear_active
+    return u_shift, sigma_vec, delta_smear, v_smear, mode_id
+
+
+def _lagrange_basis_at(eps, gh_nodes):
+    """Lagrange basis ``L_k(ε)`` for each event's ``ε`` at the K
+    Gauss-Hermite nodes. Returns shape ``[B, K]`` with ``L[b, k] =
+    Π_{j≠k} (ε_b - node_j) / (node_k - node_j)``.
+
+    Used by the GH+residual control-variate target: the polynomial
+    interpolant ``g(ε) = Σ_k W_k · L_k(ε)`` passes through ``(ε_k, W_k)``
+    exactly, and ``E_ε[L_k] = w_k`` (the GH weights, since GH-2K-1
+    integrates degree-K-1 polynomials exactly), so ``E_ε[g] = Σ_k W_k
+    · w_k = W_K``. The residual ``W(ε~) − g(ε~)`` therefore has zero
+    mean — it captures only what's beyond the polynomial truncation."""
+    K = gh_nodes.shape[0]
+    B = eps.shape[0]
+    L = torch.ones(B, K, device=eps.device, dtype=eps.dtype)
+    for k in range(K):
+        for j in range(K):
+            if j == k:
+                continue
+            L[:, k] = L[:, k] * (eps - gh_nodes[j]) / (
+                gh_nodes[k] - gh_nodes[j]
+            )
+    return L
+
+
+def _compute_target_lw(
+    flow,
+    head: "nn.Module",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    log_p: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    delta_smear: torch.Tensor,
+    v_smear: torch.Tensor,
+    n_features: int,
+    detach_target: bool = True,
+) -> torch.Tensor:
+    """Per-event target log-weight (shape ``[B]``) used by the head
+    reconstruction loss. Branches on three modes (in order of
+    precedence):
+
+    * ``head.cond_smear_target_direct = True`` (set by
+      ``--cond-smear-target=direct`` / ``auto+cond-on-smear``): the
+      σ-conditioned flow already represents the smear-integrated
+      density by construction (training on ``(y_smeared, c, σ)``
+      teaches it ``p(y | c, σ) = ∫ p_unsmeared(y - σ⊙ε | c) φ(ε) dε``).
+      So the target reduces to a single perturbed forward at
+      ``(y − u_shift, c_orig, σ_vec_pert)`` minus the σ=0 baseline:
+
+          ``log W_target = log p_flow(y - u_shift | c_orig, σ_vec_pert)
+                            − log p_flow(y | c_orig, σ=0)``
+
+      Cost: 1 perturbed flow forward per event, regardless of K. No
+      GH polynomial-truncation bias and no K=1 stochastic noise. The
+      ``σ_vec_pert`` (the head's perturbation σ) is plugged into the
+      flow's σ-conditioning slot in place of any training-time σ
+      that ``c_std`` carried.
+
+    * ``smear_K == 1`` (default when no σ-conditioning): K=1
+      stochastic estimator. One perturbed flow forward at ``y -
+      (u_shift + δ_smear · v_smear)`` with ``δ_smear ~ N(0,
+      ‖σ_vec‖²)`` from :func:`sample_perturbations`.
+
+    * ``smear_K > 1`` and ``smear_residual = False`` (pure GH):
+      deterministic K-node Gauss-Hermite (probabilist's) quadrature
+      over the smear Gaussian. Evaluation points
+      ``u_eval_k = u_shift + ε_k · σ_vec`` with ε_k from
+      :func:`numpy.polynomial.hermite_e.hermegauss` (stored as
+      ``head.gh_nodes``). Aggregation:
+
+          ``log W_target = logsumexp_k ( log w_k + log p(y - u_eval_k)
+                                            − log p(y) )``
+
+      which is the consistent estimator of ``log E_δ[W]`` — fixes both
+      the K=1 noise floor and the Jensen bias on the logw target.
+      Cost: K perturbed flow forwards per event.
+
+    * ``smear_K > 1`` and ``smear_residual = True`` (GH + residual):
+      same K GH nodes plus one extra random ``ε~ ~ N(0,1)`` per
+      event. The control-variate target is
+
+          ``W_target = W_K + (W(ε~) − g(ε~))``
+
+      where ``W_K = Σ_k w_k W_k`` is the GH sum and ``g(ε) = Σ_k W_k
+      L_k(ε)`` is the Lagrange interpolant through the K GH nodes.
+      ``E[g(ε~)] = W_K`` exactly (Lagrange/GH duality), so the
+      residual has zero mean and ``W_target`` is unbiased for
+      ``E_ε[W]``; variance comes only from beyond-degree-(2K-1)
+      features of W(ε). Cost: K + 1 perturbed flow forwards per
+      event.
+
+    ``detach_target=True`` runs the perturbed forward(s) under
+    ``no_grad`` so the target carries no gradient back to the flow.
+    """
+    n_cond = c_std.shape[-1]
+    B = y_std.shape[0]
+    log_const = 0.5 * float(n_features) * _math.log(2.0 * _math.pi)
+
+    # ------------------------------------------------------------------
+    # Direct σ-conditioned target. Single perturbed forward.
+    # ------------------------------------------------------------------
+    if bool(getattr(head, "cond_smear_target_direct", False)):
+        n_cond_base = int(getattr(head, "n_cond_base", n_cond))
+        # ``sigma_vec`` is in standardized target units (same space
+        # as ``u_shift``). The flow's σ-conditioning slot now takes
+        # the upper-triangular pack of ``σσᵀ`` (smear-symmetric by
+        # construction); convert ``sigma_vec`` to ``σ_pack`` before
+        # concatenation.
+        c_orig = c_std[:, :n_cond_base]
+        sigma_pack_pert = _sigma_pack_outer(sigma_vec)
+        c_pert = torch.cat([c_orig, sigma_pack_pert], dim=-1)
+        y_pert = y_std - u_shift
+
+        def _eval_direct():
+            z_p, ladj_p = _flow_z_ladj(flow, y_pert, c_pert)
+            log_p_p = (
+                -0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p
+            )
+            return log_p_p - log_p.detach()
+
+        if detach_target:
+            with torch.no_grad():
+                return _eval_direct()
+        return _eval_direct()
+
+    K_smear = int(head.smear_K)
+    smear_residual = bool(head.smear_residual)
+
+    if K_smear > 1:
+        eps_nodes = head.gh_nodes
+        log_gh_w = head.gh_log_weights
+        # ε_extra ~ N(0,1) per event for the control-variate residual.
+        # Drawn outside no_grad so the same RNG state is consumed
+        # whether or not detach_target is on (the draw is independent
+        # of flow gradients).
+        if smear_residual:
+            eps_extra = torch.randn(B, device=y_std.device, dtype=y_std.dtype)
+            eps_all = torch.cat(
+                [eps_nodes.to(eps_extra.dtype), eps_extra], dim=0,
+            )           # [K+1]
+            n_eps = K_smear + 1
+        else:
+            eps_all = eps_nodes
+            n_eps = K_smear
+        # u_eval_k[k, b, :] = u_shift[b, :] + ε_k(,b) · σ_vec[b, :].
+        # For GH nodes ε_k is per-quadrature-node (broadcast across B);
+        # for the extra slot ε_extra is per-event.
+        if smear_residual:
+            eps_view = torch.cat([
+                eps_nodes.view(K_smear, 1).expand(K_smear, B),
+                eps_extra.view(1, B),
+            ], dim=0)                                      # [K+1, B]
+            u_eval_k = (
+                u_shift.unsqueeze(0)
+                + eps_view.unsqueeze(-1) * sigma_vec.unsqueeze(0)
+            )                                              # [K+1, B, n_features]
+        else:
+            u_eval_k = (
+                u_shift.unsqueeze(0)
+                + eps_nodes.view(K_smear, 1, 1) * sigma_vec.unsqueeze(0)
+            )                                              # [K, B, n_features]
+        nB = n_eps * B
+        perturbed_y = (
+            y_std.unsqueeze(0).expand(n_eps, -1, -1) - u_eval_k
+        ).reshape(nB, n_features)
+        perturbed_c = (
+            c_std.unsqueeze(0)
+            .expand(n_eps, -1, -1)
+            .reshape(nB, n_cond)
+        )
+
+        def _eval():
+            z_p, ladj_p = _flow_z_ladj(flow, perturbed_y, perturbed_c)
+            log_p_p = (
+                -0.5 * (z_p * z_p).sum(dim=-1) - log_const + ladj_p
+            ).view(n_eps, B)
+            true_lw_all = log_p_p - log_p.detach().unsqueeze(0)
+            log_W_K = torch.logsumexp(
+                true_lw_all[:K_smear] + log_gh_w.view(K_smear, 1), dim=0,
+            )                                              # [B]
+            if not smear_residual:
+                return log_W_K
+
+            # log W_K is the dominant term; we add log1p of a small
+            # control-variate correction. All ratios are formed
+            # against W_K so the absolute scale of W cancels.
+            log_W_extra = true_lw_all[K_smear]            # [B]
+            ratio_extra = torch.exp(log_W_extra - log_W_K)  # [B]
+            # exp(true_lw_all[:K] - log_W_K) ∈ [0, 1/w_min] is well-
+            # conditioned because log_W_K ≥ max_k(log_w_k + log_W_k).
+            ratio_K = torch.exp(
+                true_lw_all[:K_smear] - log_W_K.unsqueeze(0)
+            )                                              # [K, B]
+            L_at_eps = _lagrange_basis_at(eps_extra, eps_nodes)   # [B, K]
+            ratio_g = torch.einsum("kb,bk->b", ratio_K, L_at_eps)  # [B]
+            delta = ratio_extra - ratio_g
+            # delta ∈ (-∞, ∞) per event; the control variate guarantees
+            # E[delta] = 0 but per-event values can dip below -1
+            # (giving a negative W_target) when ε~ falls in the tails
+            # and the Lagrange interpolant extrapolates large. Floor
+            # 1+delta away from zero so log stays finite. The
+            # 1e-3 floor caps the per-event bias at |log 1e-3| ≈ 6.9
+            # — small relative to typical |log W| in the smear-bias
+            # regime, while keeping any individual gradient bounded
+            # so Adam can't be hijacked by a single extrapolating
+            # event. These rare events are biased; the bulk of events
+            # is unbiased.
+            return log_W_K + torch.log1p(delta.clamp_min(-1.0 + 1e-3))
+
+        if detach_target:
+            with torch.no_grad():
+                return _eval()
+        return _eval()
+
+    # K=1 stochastic.
+    u_eval = u_shift + delta_smear.unsqueeze(-1) * v_smear
+
+    def _eval_stoch():
+        z_e, ladj_e = _flow_z_ladj(flow, y_std - u_eval, c_std)
+        log_p_e = (
+            -0.5 * (z_e * z_e).sum(dim=-1) - log_const + ladj_e
+        )
+        return log_p_e - log_p.detach()
+
+    if detach_target:
+        with torch.no_grad():
+            return _eval_stoch()
+    return _eval_stoch()
+
+
+def _detach_pure_coefs_in_joint(
+    joint_coefs: torch.Tensor,
+    polyhead: "PolyHead",
+    mode: torch.Tensor,
+) -> torch.Tensor:
+    """Per-event mask that detaches the pure-u (β=∅) and pure-σ
+    (α=∅) coefficient slots only for JOINT-mode events (mode==2),
+    leaving SHIFT/SMEAR events and the cross-term slots untouched.
+
+    Used to route gradients away from the noisier JOINT samples for
+    the pure terms — those parameters are still trained by the
+    deterministic SHIFT (pure-u) and lower-cross-coupling SMEAR
+    (pure-σ) events, which carry a lower-noise signal."""
+    is_joint = (mode == 2)
+    pure_basis = head.is_pure_u | head.is_pure_sigma
+    detach_mask = is_joint.unsqueeze(-1) & pure_basis.unsqueeze(0)
+    return torch.where(detach_mask, joint_coefs.detach(), joint_coefs)
+
+
+def _split_loss_by_mode(
+    per_event: torch.Tensor,
+    loss_w: torch.Tensor,
+    mode: torch.Tensor,
+) -> torch.Tensor:
+    """Aggregate ``per_event * loss_w`` separately over SHIFT/SMEAR/
+    JOINT events. Returns a length-3 tensor in that order; modes
+    with zero population in this batch are reported as 0."""
+    out = []
+    for m in (0, 1, 2):
+        mask = (mode == m).to(per_event.dtype)
+        num = (loss_w * per_event * mask).sum()
+        den = (loss_w * mask).sum().clamp_min(1e-30)
+        out.append(num / den)
+    return torch.stack(out)
+
+
+def _polyhead_d_per_mode(
+    polyhead: "PolyHead",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    detach_pure_in_joint: bool,
+) -> torch.Tensor:
+    """Per-event scalar ``j = polyhead·basis``, evaluated via per-mode
+    Order-2 contraction.
+
+    Replaces the trio
+        ``coefs = polyhead(y, c)`` →
+        (optional ``_detach_pure_coefs_in_joint``) →
+        ``j = evaluate_joint(coefs, u, σ, ...)``
+    with a path that **never materialises the full [B, n_basis]
+    coefficient tensor**. Per event:
+
+        d = (e · (φ_block @ W^T)) + (φ_block @ b)
+
+    where ``e = polyhead.trunk_forward(y, c)`` is the trunk
+    embedding, ``φ_block`` is the basis slice for the head being
+    applied (pure_u / pure_σ / cross), and ``W, b`` are the
+    sub-head's parameters. The intermediate tensor is
+    ``[N_block, d_emb]`` rather than ``[N_block, n_basis]``.
+
+    Per-mode skipping (relies on stratified-contiguous mode_id from
+    :func:`sample_perturbations`):
+      * SHIFT events (σ = 0): only ``head_pure_u`` runs.
+      * SMEAR events (u = 0): only ``head_pure_sigma`` runs.
+      * JOINT events (both nonzero): all three heads run; if
+        ``detach_pure_in_joint``, the pure-u and pure-σ contributions
+        are ``.detach()``-ed so JOINT-mode gradient flows only
+        through ``head_cross``.
+
+    For the shift-only configuration (``head_pure_sigma`` and
+    ``head_cross`` both ``None``) every event is treated as SHIFT.
+    """
+    B = y_std.shape[0]
+
+    # Mode-block boundaries — derived from B (deterministic given the
+    # stratified sampler in sample_perturbations: [0…0, 1…1, 2…2]).
+    if polyhead.head_pure_sigma is None and polyhead.head_cross is None:
+        n_shift_b, n_smear_b, n_joint_b = B, 0, 0
+    else:
+        base = B // 3
+        extra = B - 3 * base
+        n_shift_b, n_smear_b, n_joint_b = base + extra, base, base
+
+    e = polyhead.trunk_forward(y_std, c_std)         # [B, d_emb]
+    d_emb = e.shape[-1]
+
+    phi = _select_basis(
+        polyhead.basis, u_shift, sigma_vec, polyhead.joint_indices,
+        scale_u=polyhead.basis_scale_u,
+        scale_sigma=polyhead.basis_scale_sigma,
+        aux=polyhead.basis_aux,
+    )                                                 # [B, n_basis]
+
+    n_pu = polyhead._n_pure_u
+    n_ps = polyhead._n_pure_s
+
+    def _order2(e_blk, phi_blk, head):
+        """``d = (e · (φ @ W^T)) + (φ @ b)`` per event. ``e_blk``
+        ``[N, d_emb]``, ``phi_blk`` ``[N, n_out]``,
+        ``head`` ``nn.Linear(d_emb, n_out)``. Returns ``[N]``."""
+        if head is None:
+            return torch.zeros(
+                e_blk.shape[0], device=e_blk.device, dtype=e_blk.dtype,
+            )
+        temp = phi_blk @ head.weight                  # [N, d_emb]
+        bias_term = phi_blk @ head.bias               # [N]
+        return (e_blk * temp).sum(-1) + bias_term
+
+    d_chunks = []
+
+    # SHIFT events: only pure_u contributes (σ = 0).
+    if n_shift_b > 0:
+        e_s = e[:n_shift_b]
+        phi_s_pu = phi[:n_shift_b, :n_pu]
+        d_chunks.append(_order2(e_s, phi_s_pu, polyhead.head_pure_u))
+
+    # SMEAR events: only pure_σ contributes (u = 0).
+    if n_smear_b > 0:
+        e_m = e[n_shift_b : n_shift_b + n_smear_b]
+        phi_m_ps = phi[
+            n_shift_b : n_shift_b + n_smear_b, n_pu : n_pu + n_ps,
+        ]
+        d_chunks.append(_order2(e_m, phi_m_ps, polyhead.head_pure_sigma))
+
+    # JOINT events: all three head contributions; optionally detach
+    # the pure-u and pure-σ contributions so JOINT-mode gradient
+    # flows only through head_cross.
+    if n_joint_b > 0:
+        j0 = n_shift_b + n_smear_b
+        e_j = e[j0:]
+        phi_j = phi[j0:]
+        d_j_pu = _order2(e_j, phi_j[:, :n_pu], polyhead.head_pure_u)
+        d_j_ps = _order2(
+            e_j, phi_j[:, n_pu : n_pu + n_ps], polyhead.head_pure_sigma,
+        )
+        d_j_cr = _order2(
+            e_j, phi_j[:, n_pu + n_ps :], polyhead.head_cross,
+        )
+        if detach_pure_in_joint:
+            d_j_pu = d_j_pu.detach()
+            d_j_ps = d_j_ps.detach()
+        d_chunks.append(d_j_pu + d_j_ps + d_j_cr)
+
+    return torch.cat(d_chunks, dim=0)
+
+
+def _mlp_d_per_mode(
+    mlp: "nn.Module",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    detach_pure_in_joint: bool,
+) -> torch.Tensor:
+    """Per-event pre-positivity scalar ``d`` for the MLP-arch head, via
+    dual-forward:
+
+        ``d = head(e, u_shift, σ_pack) − head(e, 0, 0)``
+
+    so ``r = 1`` exactly at ``(u, σ) = (0, 0)``. ``Σ_pack`` is the
+    upper-triangular outer-product of ``σ_vec`` (invariant under
+    ``σ_vec → −σ_vec``, so the smear symmetry is structural, just like
+    in the polyhead's even-|β| basis).
+
+    With ``detach_pure_in_joint=True`` the dual-forward is replaced by
+    a 4-call decomposition
+
+        ``d_full = f_full − f_zero``,
+        ``d_pure_u = f_us − f_zero``,
+        ``d_pure_s = f_sm − f_zero``,
+        ``d_mixed = d_full − d_pure_u − d_pure_s``,
+
+    and on JOINT-mode events (mode == 2) the pure-u / pure-σ
+    contributions are detached, so JOINT-mode gradients flow only
+    through ``d_mixed``. Mode boundaries are derived from ``B`` (the
+    same stratified-contiguous convention used by
+    :func:`sample_perturbations` and ``_polyhead_d_per_mode``).
+    """
+    B = y_std.shape[0]
+    e = mlp.trunk_forward(y_std, c_std)                  # [B, d_emb]
+    if mlp.head_layer1_sigma is not None:
+        sigma_pack = (
+            sigma_vec[..., mlp.sigma_pack_iu]
+            * sigma_vec[..., mlp.sigma_pack_ju]
+        )
+    else:
+        sigma_pack = torch.zeros(
+            B, 0, device=y_std.device, dtype=y_std.dtype,
+        )
+
+    if not detach_pure_in_joint:
+        # 2·B head queries: f(e, u, σ_pack) and f(e, 0, 0).
+        e_dual = torch.cat([e, e], dim=0)
+        u_dual = torch.cat(
+            [u_shift, torch.zeros_like(u_shift)], dim=0,
+        )
+        sp_dual = torch.cat(
+            [sigma_pack, torch.zeros_like(sigma_pack)], dim=0,
+        )
+        f = mlp.head_forward(e_dual, u_dual, sp_dual)
+        return f[:B] - f[B:]
+
+    # 4·B head queries to decompose d into pure-u, pure-σ, mixed.
+    e_q = torch.cat([e, e, e, e], dim=0)
+    zeros_u = torch.zeros_like(u_shift)
+    zeros_sp = torch.zeros_like(sigma_pack)
+    u_q = torch.cat([u_shift, zeros_u, u_shift, zeros_u], dim=0)
+    sp_q = torch.cat(
+        [sigma_pack, zeros_sp, zeros_sp, sigma_pack], dim=0,
+    )
+    f = mlp.head_forward(e_q, u_q, sp_q)
+    f_full = f[0 * B : 1 * B]
+    f_zero = f[1 * B : 2 * B]
+    f_us   = f[2 * B : 3 * B]
+    f_sm   = f[3 * B : 4 * B]
+    d_full = f_full - f_zero
+    d_pure_u = f_us - f_zero
+    d_pure_s = f_sm - f_zero
+    # JOINT events live in the contiguous tail of the batch (the
+    # stratified mode sampler emits ``[0…0, 1…1, 2…2]``). Build the
+    # is_joint mask from B alone — same convention as
+    # ``_polyhead_d_per_mode``.
+    base = B // 3
+    extra = B - 3 * base
+    n_shift_b = base + extra
+    n_smear_b = base
+    n_joint_b = base
+    is_joint = torch.zeros(B, dtype=torch.bool, device=y_std.device)
+    if n_joint_b > 0:
+        is_joint[n_shift_b + n_smear_b:] = True
+    d_pure_u_used = torch.where(is_joint, d_pure_u.detach(), d_pure_u)
+    d_pure_s_used = torch.where(is_joint, d_pure_s.detach(), d_pure_s)
+    d_mixed = d_full - d_pure_u - d_pure_s
+    return d_pure_u_used + d_pure_s_used + d_mixed
+
+
+def _mlp_factored_d_per_mode(
+    head: "nn.Module",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+) -> torch.Tensor:
+    """Per-event pre-positivity scalar ``d`` for the factored MLP head.
+
+    ``log W = ⟨u, A(e, ·)⟩ + ⟨σ_pack, B(e, ·)⟩ [ + ⟨u⊗σ_pack, C(e, u, σ_pack)⟩ ]``
+    is computed via :meth:`ReweightMLPFactored.head_forward_components`,
+    then per-event ``.detach()`` is applied on JOINT-mode events to the
+    pure-shift and/or pure-smear blocks per the head's
+    ``detach_pure_shift_in_joint`` / ``detach_pure_smear_in_joint``
+    flags. Mode boundaries follow the same stratified-contiguous
+    convention as :func:`_mlp_d_per_mode` and
+    :func:`_polyhead_d_per_mode`.
+    """
+    B = y_std.shape[0]
+    e = head.trunk_forward(y_std, c_std)
+    if head.n_sigma_pack > 0:
+        sigma_pack = (
+            sigma_vec[..., head.sigma_pack_iu]
+            * sigma_vec[..., head.sigma_pack_ju]
+        )
+    else:
+        sigma_pack = torch.zeros(
+            B, 0, device=y_std.device, dtype=y_std.dtype,
+        )
+    pu, ps, cr = head.head_forward_components(e, u_shift, sigma_pack)
+    if head.detach_pure_shift_in_joint or head.detach_pure_smear_in_joint:
+        # JOINT events live in the contiguous tail of the batch (same
+        # convention as ``_polyhead_d_per_mode``).
+        base = B // 3
+        extra = B - 3 * base
+        n_shift_b = base + extra
+        n_smear_b = base
+        n_joint_b = base
+        is_joint = torch.zeros(B, dtype=torch.bool, device=y_std.device)
+        if n_joint_b > 0:
+            is_joint[n_shift_b + n_smear_b:] = True
+        if head.detach_pure_shift_in_joint:
+            pu = torch.where(is_joint, pu.detach(), pu)
+        if head.detach_pure_smear_in_joint:
+            ps = torch.where(is_joint, ps.detach(), ps)
+    d = pu + ps
+    if cr is not None:
+        d = d + cr
+    return d
+
+
+def _head_d_per_mode(
+    head: "nn.Module",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    u_shift: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    detach_pure_in_joint: bool,
+) -> torch.Tensor:
+    """Arch-agnostic dispatch to per-event ``d`` (or ``j``).
+
+    ``PolyHead`` → :func:`_polyhead_d_per_mode` (Order-2 contraction
+    on the polynomial basis); ``ReweightMLPFactored`` (marker
+    ``is_factored`` set) → :func:`_mlp_factored_d_per_mode`
+    (structural factorisation, per-mode detach via head flags);
+    ``ReweightMLP_B`` (default) → :func:`_mlp_d_per_mode`
+    (dual-forward on the MLP head). All return shape ``[B]``; the
+    caller wraps with the chosen positivity and computes the
+    per-event loss against ``true_lw``.
+    """
+    if isinstance(head, PolyHead):
+        return _polyhead_d_per_mode(
+            head, y_std, c_std, u_shift, sigma_vec,
+            detach_pure_in_joint=detach_pure_in_joint,
+        )
+    if getattr(head, "is_factored", False):
+        return _mlp_factored_d_per_mode(
+            head, y_std, c_std, u_shift, sigma_vec,
+        )
+    return _mlp_d_per_mode(
+        head, y_std, c_std, u_shift, sigma_vec,
+        detach_pure_in_joint=detach_pure_in_joint,
+    )
+
+
+def _per_event_loss(
+    poly_err: torch.Tensor,
+    loss_fn: str,
+    huber_delta: float,
+) -> torch.Tensor:
+    """Per-event loss on residual ``poly_err``. ``mse`` returns
+    ``r²``; ``huber`` returns ``r²`` for ``|r| ≤ δ`` and
+    ``2δ|r| − δ²`` beyond — i.e., 2× the standard Huber so the
+    quadratic regime coincides exactly with MSE (no scale jump
+    when switching shapes)."""
+    if loss_fn == "mse":
+        return poly_err * poly_err
+    elif loss_fn == "huber":
+        abs_r = poly_err.abs()
+        quad = poly_err * poly_err
+        lin = 2.0 * huber_delta * abs_r - huber_delta * huber_delta
+        return torch.where(abs_r <= huber_delta, quad, lin)
+    else:
+        raise ValueError(f"unknown loss_fn {loss_fn!r}")
+
+
+def _expkl_per_event(
+    pred_log: torch.Tensor, target_log: torch.Tensor,
+) -> torch.Tensor:
+    """Per-event expKL (f-GAN-KL / I-divergence) loss:
+
+        f(r) = r − log r − 1,   r = W_target / W_pred = exp(log W_target − s)
+
+    Equivalently in log-space: ``L = exp(δ) − δ − 1`` with
+    ``δ = log W_target − s``. Convex in ``s``; minimum 0 at ``δ = 0``
+    (i.e., ``s = log W_target``); strictly positive otherwise.
+
+    The expectation
+    ``E[L(s)] = exp(−s)·E[W_target] − E[log W_target] + s − 1``
+    has its minimum at ``s* = log E[W_target]``. So whenever
+    ``W_target`` is an unbiased estimator of ``E[W]`` in linear
+    space — true for K=1 stochastic and for ``--smear-residual`` —
+    expKL recovers ``s* = log E[W]`` exactly, with no Jensen bias
+    from working in log space (unlike MSE on logw).
+
+    ``δ`` is clamped to ``±_LOG_W_CLAMP`` (=30) so ``exp(δ)`` stays
+    finite in fp32. The clamp is only ever active in pathological
+    regimes (e.g., ``--positivity=softplus`` driving
+    ``pred_log`` to its dtype-tiny floor); for the ``exp`` and
+    ``asinh`` positivity wraps the natural range of ``δ`` is well
+    inside the clamp."""
+    delta = (target_log - pred_log).clamp(
+        min=-_LOG_W_CLAMP, max=_LOG_W_CLAMP,
+    )
+    return torch.exp(delta) - delta - 1.0
+
+
+def _wbce_per_event(
+    pred_log: torch.Tensor, target_log: torch.Tensor,
+) -> torch.Tensor:
+    """Per-event importance-sampled BCE / single-sample CARL loss:
+
+        L(s) = softplus(s) + W_target · softplus(−s),
+        s = pred_log,  W_target = exp(target_log).
+
+    Per-event gradient is
+
+        ∂L/∂s = σ(s) − W_target · σ(−s)
+
+    so under sampling from p_nom with E[W_target] = E[W],
+
+        E[∂L/∂s] = σ(s) − E[W] · σ(−s) = 0
+                   ⟺ s* = log E[W].
+
+    Same unbiased optimum as :func:`_expkl_per_event` for any unbiased
+    W-side target (K=1 stochastic, smear_residual). Difference is the
+    underestimate-side tail behaviour: expKL has gradient
+    ``−W_target · exp(−s)`` (exponential blow-up when ``s ≪ log W_target``),
+    while wbce has ``−W_target · σ(−s)`` (linear in ``W_target``,
+    bounded by ``W_target`` regardless of how negative ``s`` gets).
+    Numerically more stable on rare large-W tail events; lets you
+    relax the ``target_threshold`` mask if desired.
+
+    Equivalent in expectation to standard CARL-BCE under importance
+    sampling: ``E_pert[softplus(−s)] = E_nom[r · softplus(−s)]``,
+    with the per-event ``W_target`` standing in for ``r``.
+
+    Computed via ``F.softplus`` for numerical stability across the
+    full range of ``pred_log``."""
+    return F.softplus(pred_log) + torch.exp(target_log) * F.softplus(-pred_log)
+
+
+def joint_loss_step(
+    flow,
+    head: "nn.Module",
+    y_std: torch.Tensor,
+    c_std: torch.Tensor,
+    weights: torch.Tensor,
+    delta_max: float,
+    sigma_max: float,
+    aux_jacobian_weight: float = 0.0,
+    oversample: float = 1.3,
+    loss_target: str = "w",
+    weight_power: int = 1,
+    loss_fn: str = "huber",
+    huber_delta: float = 1.0,
+    detach_pure_in_joint: bool = False,
+    detach_target: bool = True,
+):
+    """Combined NLL (flow) + reconstruction loss (polyhead) over a
+    stratified mix of (pure-shift, pure-smear, joint shift+smear)
+    perturbations in **target / y-space** — one sample per event
+    per step.
+
+    Per event: draw a mode ∈ {SHIFT, SMEAR, JOINT}, build
+    ``(u_shift, σ_vec, δ_smear)`` in standardized y-space, compute
+    ``u_eval = u_shift + δ_smear · v_smear``, and run the flow at
+    ``(y_std − u_eval, c_std)`` to get the unbiased target
+
+        ``log w_true = log p(y - u_eval | c) - log p(y | c)``
+
+    which is the per-event reweight from the nominal distribution to
+    the y-shifted (or y-smeared) distribution. Compare against the
+    polyhead's ``W_pred(u_shift, σ_vec)``. For pure-smear and joint
+    modes the single Gaussian draw of ``δ_smear`` is the K=1 stochastic
+    estimator for ``E_δ[w(...)] = W_smear``.
+
+    With ``detach_target=True`` (default) the perturbed flow forward
+    runs under ``no_grad`` — its output is a target only, so cutting
+    the backward through it saves one full flow backward per step
+    without changing gradients for either the flow (still trained on
+    its own NLL) or the polyhead (still trained on the recon loss).
+
+    With ``detach_pure_in_joint=True``, JOINT-mode events detach the
+    pure-u and pure-σ basis-coefficient contributions before the
+    polynomial evaluation, so JOINT-mode gradients only update the
+    cross-term coefficients. Stabilizes training when K=1 stochastic
+    smear sampling makes the JOINT loss noisy.
+
+    Returns ``(loss, nll_w, w_loss_w, aux_w, w_loss_split)`` with
+    ``w_loss_split`` of shape ``[3]`` = (shift, smear, joint).
+    """
+    n_features = y_std.shape[-1]
+    B = y_std.shape[0]
+    device = y_std.device
+
+    u_shift, sigma_vec, delta_smear, v_smear, mode = sample_perturbations(
+        B, n_features, delta_max, sigma_max, device, oversample=oversample,
+        include_smear=head.include_smear,
+    )
+
+    # Baseline flow forward — gradients DO flow back through this
+    # (drives the NLL term).
+    z, ladj = _flow_z_ladj(flow, y_std, c_std)
+    log_phi = (
+        -0.5 * (z * z).sum(dim=-1)
+        - 0.5 * float(n_features) * _math.log(2.0 * _math.pi)
+    )
+    log_p = log_phi + ladj
+    nll = -log_p
+
+    # Target log-weight: K=1 stochastic or K>1 Gauss-Hermite
+    # quadrature over the smear Gaussian, depending on
+    # ``head.smear_K``. K perturbed forwards are run under
+    # no_grad when ``detach_target`` (default True).
+    true_lw = _compute_target_lw(
+        flow, head, y_std, c_std, log_p,
+        u_shift, sigma_vec, delta_smear, v_smear,
+        n_features, detach_target=detach_target,
+    )
+
+    # Trustable-target mask. The Gaussian tail of δ_smear can place
+    # y - u_eval many σ outside the data manifold; with a partially-
+    # trained flow that gives ``|true_lw|`` in the tens or hundreds.
+    # These events aren't representative of any real reweight regime
+    # (we don't deploy at 5σ shifts), so we simply drop them from
+    # the polyhead loss contribution.
+    target_threshold = 10.0   # |log w| up to 10 → |w| up to ~22000
+    trustable = torch.isfinite(true_lw) & (true_lw.abs() < target_threshold)
+    trustable_f = trustable.to(true_lw.dtype)
+    # Replace non-trustable targets with 0 so subsequent ops (exp,
+    # diff) don't propagate inf/NaN; the per-event contribution is
+    # zeroed by the mask at the end either way.
+    true_lw_safe = torch.where(
+        trustable, true_lw, torch.zeros_like(true_lw),
+    )
+
+    # Per-mode Order-2 contraction: avoids materialising the full
+    # ``[B, n_basis]`` coefficient tensor and skips irrelevant heads
+    # per mode (SHIFT skips pure_σ + cross, SMEAR skips pure_u +
+    # cross). The loss family then picks which positivity-wrapped
+    # form (W or log W) it needs. Each wrap returns its target form
+    # directly — no exp(log W) or log(W) round trips.
+    j = _head_d_per_mode(
+        head, y_std, c_std, u_shift, sigma_vec,
+        detach_pure_in_joint=detach_pure_in_joint,
+    )
+    if loss_fn == "expkl":
+        # expKL is a complete (pred, target) loss in log-space: it
+        # uses ``s = pred_log`` and ``log W_target`` jointly, not a
+        # residual. Optimum is ``s* = log E[W_target]``, which equals
+        # ``log E[W]`` whenever the target's W-side is unbiased
+        # (K=1 stochastic or smear_residual). ``loss_target`` is
+        # ignored for this branch — expKL always works in log-space.
+        pred_log = _apply_positivity_logW(j, head.positivity)
+        per_event_raw = _expkl_per_event(pred_log, true_lw_safe)
+        per_event = per_event_raw * trustable_f
+    elif loss_fn == "wbce":
+        # Importance-sampled BCE. Same unbiased optimum as expKL but
+        # with linear-in-W_target tail growth on the underestimate
+        # side (vs expKL's exp blow-up). loss_target is ignored.
+        # Disable the exp-positivity ±_LOG_W_CLAMP defensive clamp on
+        # ``pred_log`` — wbce only feeds ``pred_log`` into ``softplus``
+        # which is stable for any finite input, and the clamp would
+        # zero gradients in the |log W| > 30 regions.
+        pred_log = _apply_positivity_logW(
+            j, head.positivity, clamp=_math.inf,
+        )
+        per_event_raw = _wbce_per_event(pred_log, true_lw_safe)
+        per_event = per_event_raw * trustable_f
+    else:
+        if loss_target == "w":
+            pred_W = _apply_positivity_W(j, head.positivity)
+            true_W = torch.exp(true_lw_safe)
+            poly_err = (pred_W - true_W) * trustable_f
+        elif loss_target == "logw":
+            pred_log = _apply_positivity_logW(j, head.positivity)
+            poly_err = (pred_log - true_lw_safe) * trustable_f
+        else:
+            raise ValueError(f"unknown loss_target {loss_target!r}")
+        per_event = _per_event_loss(poly_err, loss_fn, huber_delta)
+
+    # Per-event weighting power.
+    if weight_power == 1:
+        loss_w = weights
+    elif weight_power == 2:
+        loss_w = weights * weights
+    else:
+        raise ValueError(f"unsupported weight_power {weight_power!r}")
+
+    wsum = weights.sum().clamp_min(1e-30)
+    loss_wsum = loss_w.sum().clamp_min(1e-30)
+    nll_w = (weights * nll).sum() / wsum
+    w_loss_w = (loss_w * per_event).sum() / loss_wsum
+    w_loss_split = _split_loss_by_mode(per_event, loss_w, mode)
+
+    # The aux-jacobian path (matching head's first-order coefs to the
+    # flow's analytic JVP) was tied to the Δz polynomial; with the
+    # Δz-free design that route no longer exists. The argument is
+    # accepted for backwards-compatible call signatures but is a
+    # no-op. The polyhead's first-order coefs are still trained
+    # implicitly by the reconstruction loss.
+    aux_w = torch.zeros((), device=device, dtype=nll_w.dtype)
+    _ = aux_jacobian_weight  # accepted for compat, unused
+
+    total = nll_w + w_loss_w
+    return (
+        total,
+        nll_w.detach(),
+        w_loss_w.detach(),
+        aux_w.detach(),
+        w_loss_split.detach(),
+    )
+
+
+def head_only_loss_step(
+    flow,
+    head: "nn.Module",
+    c_std: torch.Tensor,
+    weights: torch.Tensor,
+    delta_max: float,
+    sigma_max: float,
+    oversample: float = 1.3,
+    loss_target: str = "w",
+    weight_power: int = 1,
+    loss_fn: str = "huber",
+    huber_delta: float = 1.0,
+    detach_pure_in_joint: bool = False,
+):
+    """Polyhead-only training step against a frozen flow.
+
+    The flow is used purely as a fixed conditional density:
+      * ``y_std`` is sampled from the flow at each event's MC
+        ``c_std``, so ``(y, c)`` is jointly distributed according to
+        the flow's learned p(y, c) on the data marginal of c.
+      * The flow at the y-perturbed point ``(y - u_eval, c)``
+        provides the unbiased ground-truth ``log w`` target (K=1
+        stochastic estimator when smear is involved).
+
+    All flow forwards are under ``torch.no_grad()``. Only the
+    polyhead receives gradients. Returns the same 4-tuple shape as
+    :func:`joint_loss_step` so the train-loop bookkeeping doesn't
+    branch — ``nll_w`` is the (frozen-flow) NLL evaluated for free
+    along the way; it stays roughly constant across epochs and is
+    informational only.
+    """
+    B = c_std.shape[0]
+    device = c_std.device
+
+    with torch.no_grad():
+        # Sample ``y_std`` and obtain ``log p(y_std | c)`` in a single
+        # flow pass via ``rsample_and_log_prob``. The previous form
+        # (``flow(c).sample(...)`` followed by an explicit
+        # ``_flow_z_ladj(flow, y, c)``) ran the flow twice on the same
+        # ``y_std`` — one decode (z → y, ladj_inv) inside ``sample`` and
+        # one encode (y → z, ladj_fwd) for the log-density. zuko's
+        # combined API uses just the inverse direction's
+        # ``call_and_ladj`` and reconstitutes ``log p`` from the base
+        # density and the inverse log-det in one pass.
+        y_std, log_p = flow(c_std).rsample_and_log_prob(torch.Size([]))
+        y_std = y_std.detach()
+        log_p = log_p.detach()
+        n_features = y_std.shape[-1]
+        # Informational NLL only (flow is frozen here).
+        nll = -log_p
+
+        # Sample perturbations using the same scheme as joint_loss_step.
+        u_shift, sigma_vec, delta_smear, v_smear, mode = (
+            sample_perturbations(
+                B, n_features, delta_max, sigma_max, device,
+                oversample=oversample,
+                include_smear=head.include_smear,
+            )
+        )
+
+    # Target log-weight via the same K=1 / K>1 GH branch as
+    # joint_loss_step; the helper handles its own no_grad.
+    true_lw = _compute_target_lw(
+        flow, head, y_std, c_std, log_p,
+        u_shift, sigma_vec, delta_smear, v_smear,
+        n_features, detach_target=True,
+    )
+
+    # Trustable-target mask (same as joint_loss_step).
+    target_threshold = 10.0
+    trustable = torch.isfinite(true_lw) & (true_lw.abs() < target_threshold)
+    trustable_f = trustable.to(true_lw.dtype)
+    true_lw_safe = torch.where(
+        trustable, true_lw, torch.zeros_like(true_lw),
+    )
+
+    # Polyhead forward — only this part has gradients. Per-mode
+    # Order-2 contraction; same path as joint_loss_step but with
+    # only the polyhead under gradient (the flow forward above is
+    # under no_grad).
+    j = _head_d_per_mode(
+        head, y_std, c_std, u_shift, sigma_vec,
+        detach_pure_in_joint=detach_pure_in_joint,
+    )
+    if loss_fn == "expkl":
+        pred_log = _apply_positivity_logW(j, head.positivity)
+        per_event_raw = _expkl_per_event(pred_log, true_lw_safe)
+        per_event = per_event_raw * trustable_f
+    elif loss_fn == "wbce":
+        # See joint_loss_step's wbce branch for the clamp=inf
+        # rationale (softplus-only consumption ⇒ no overflow risk).
+        pred_log = _apply_positivity_logW(
+            j, head.positivity, clamp=_math.inf,
+        )
+        per_event_raw = _wbce_per_event(pred_log, true_lw_safe)
+        per_event = per_event_raw * trustable_f
+    else:
+        if loss_target == "w":
+            pred_W = _apply_positivity_W(j, head.positivity)
+            true_W = torch.exp(true_lw_safe)
+            poly_err = (pred_W - true_W) * trustable_f
+        elif loss_target == "logw":
+            pred_log = _apply_positivity_logW(j, head.positivity)
+            poly_err = (pred_log - true_lw_safe) * trustable_f
+        else:
+            raise ValueError(f"unknown loss_target {loss_target!r}")
+        per_event = _per_event_loss(poly_err, loss_fn, huber_delta)
+
+    if weight_power == 1:
+        loss_w = weights
+    elif weight_power == 2:
+        loss_w = weights * weights
+    else:
+        raise ValueError(f"unsupported weight_power {weight_power!r}")
+
+    wsum = weights.sum().clamp_min(1e-30)
+    loss_wsum = loss_w.sum().clamp_min(1e-30)
+    nll_w = (weights * nll).sum() / wsum
+    w_loss_w = (loss_w * per_event).sum() / loss_wsum
+    w_loss_split = _split_loss_by_mode(per_event, loss_w, mode)
+
+    aux_w = torch.zeros((), device=device, dtype=nll_w.dtype)
+    total = w_loss_w
+    return (
+        total,
+        nll_w.detach(),
+        w_loss_w.detach(),
+        aux_w.detach(),
+        w_loss_split.detach(),
+    )
+
+
+# -----------------------------------------------------------------------------
+# Flow-only and flow+polyhead training wrappers
+# -----------------------------------------------------------------------------
+
+class FlowWithLogProb(nn.Module):
+    """DDP-friendly wrapper that returns log p(x|c) from forward().
+
+    zuko flows return a distribution object from their __call__, which
+    DDP can't instrument for gradient synchronization (DDP expects
+    forward to return tensors/standard containers). Wrapping the
+    log_prob call in a standard nn.Module.forward makes DDP happy.
+    """
+    def __init__(self, flow: nn.Module):
+        super().__init__()
+        self.flow = flow
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        return self.flow(c).log_prob(x)
+
+
+class FlowHeadModel(nn.Module):
+    """DDP-friendly wrapper around (flow, polyhead) that, given a
+    standardized batch, returns the joint loss components.
+
+    forward(x_std, c_std, w, delta_max, sigma_max, ...) →
+        (total, nll_w, w_loss_w, aux_w, w_loss_split)
+
+    Using a tensor-only return keeps DDP happy. The scalar config
+    arguments are passed in as Python floats, not buffers, so the
+    same module can be reused across schedules without re-wrapping.
+    """
+    def __init__(
+        self,
+        flow: nn.Module,
+        head: nn.Module,
+        head_only: bool = False,
+    ):
+        super().__init__()
+        self.flow = flow
+        self.head = head
+        self.head_only = head_only
+
+    def forward(
+        self,
+        x_std: torch.Tensor,
+        c_std: torch.Tensor,
+        w: torch.Tensor,
+        delta_max: float,
+        sigma_max: float,
+        aux_jacobian_weight: float = 0.0,
+        loss_target: str = "w",
+        weight_power: int = 1,
+        loss_fn: str = "huber",
+        huber_delta: float = 1.0,
+        detach_pure_in_joint: bool = False,
+        detach_target: bool = True,
+    ):
+        # Polyhead-only (sequential phase 2): flow is frozen, x_std
+        # from the data loader is ignored (we sample y from the flow
+        # at the MC c).
+        if self.head_only:
+            return head_only_loss_step(
+                self.flow, self.head, c_std, w,
+                delta_max=delta_max, sigma_max=sigma_max,
+                loss_target=loss_target, weight_power=weight_power,
+                loss_fn=loss_fn, huber_delta=huber_delta,
+                detach_pure_in_joint=detach_pure_in_joint,
+            )
+        return joint_loss_step(
+            self.flow, self.head, x_std, c_std, w,
+            delta_max=delta_max, sigma_max=sigma_max,
+            aux_jacobian_weight=aux_jacobian_weight,
+            loss_target=loss_target, weight_power=weight_power,
+            loss_fn=loss_fn, huber_delta=huber_delta,
+            detach_pure_in_joint=detach_pure_in_joint,
+            detach_target=detach_target,
+        )
+
+
+def _all_reduce_sum_(t: torch.Tensor, is_dist: bool) -> torch.Tensor:
+    """In-place all-reduce(sum) when distributed, otherwise a no-op."""
+    if is_dist:
+        import torch.distributed as dist
+        dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    return t
+
+
+def _state_dict_to_cpu(module: nn.Module) -> dict:
+    """Snapshot ``module.state_dict()`` to CPU memory in one bulk
+    pass. Allocates pinned destination buffers (where copy-from
+    source is on CUDA), issues all H2D copies onto the current stream
+    asynchronously, and blocks once at the end.
+
+    The naive ``{k: v.detach().cpu().clone() for k, v in
+    module.state_dict().items()}`` triggers a separate stream sync
+    per parameter — for a model with ~100 named parameters this
+    serializes ~100 cudaStreamSynchronize calls, each with kernel-
+    launch overhead, and dominates the epoch boundary on fast GPUs.
+    The bulk path queues all copies and syncs once.
+    """
+    sd = module.state_dict()
+    cpu = {}
+    any_cuda = False
+    for k, v in sd.items():
+        v = v.detach()
+        if v.is_cuda:
+            any_cuda = True
+            dst = torch.empty(
+                v.shape, dtype=v.dtype, device="cpu", pin_memory=True,
+            )
+            dst.copy_(v, non_blocking=True)
+            cpu[k] = dst
+        else:
+            cpu[k] = v.clone()
+    if any_cuda:
+        torch.cuda.synchronize()
+    return cpu
+
+
+# -----------------------------------------------------------------------------
+# Training loop
+# -----------------------------------------------------------------------------
+
+def train(
+    model: nn.Module,
+    inner_flow: nn.Module,
+    train_loader,
+    val_loader,
+    epochs: int,
+    lr: float,
+    weight_decay: float,
+    patience: int,
+    device: str,
+    log_lines: List[str],
+    is_dist: bool = False,
+    is_rank0: bool = True,
+    checkpoint_path=None,
+    stats=None,
+    flow_config=None,
+    precision: str = "fp32",
+    checkpoint_every: int = 1,
+    head_config=None,
+    inner_head: nn.Module = None,
+    patience_rel_threshold: float = 1e-4,
+    profile: bool = False,
+    profile_warmup: int = 3,
+    profile_active: int = 5,
+    profile_output: str = None,
+    cond_on_smear: bool = False,
+    sigma_max_std: torch.Tensor = None,
+    cond_smear_zero_fraction: float = 0.5,
+    apply_smearing: bool = True,
+    no_early_stop: bool = False,
+):
+    """Train ``model``. ``inner_flow`` is the un-wrapped zuko flow used
+    only for state_dict capture (independent of any DDP wrapping of
+    ``model``). Weighted NLL metrics are reduced across ranks at each
+    epoch boundary so all ranks see the same values.
+
+    When ``checkpoint_path`` is provided (rank 0 only writes), a
+    per-epoch snapshot is saved to that path each epoch, overwriting
+    the previous epoch's file.
+
+    ``precision`` selects the forward-pass dtype:
+      * ``"fp32"`` (default) — no autocast, no GradScaler.
+      * ``"bf16"`` — bfloat16 autocast; no GradScaler (bf16's exponent
+        range matches FP32).
+      * ``"fp16"`` — float16 autocast + GradScaler for loss scaling
+        (fp16's narrower exponent range underflows gradients without
+        scaling).
+
+    When ``head_config`` is provided the model is expected to be a
+    :class:`FlowHeadModel` and is called as ``model(x, c, w,
+    delta_max, sigma_max, ...)`` returning the joint loss components
+    ``(total, nll, w_loss, aux, w_loss_split)``. The early-stopping
+    / checkpointing metric stays the validation NLL — the polyhead
+    reconstruction loss is reported alongside but not gated on, so
+    the flow's density quality drives selection.
+    """
+    use_polyhead = head_config is not None
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=lr, weight_decay=weight_decay
+    )
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5, patience=max(1, patience // 2)
+    )
+
+    best_val = float("inf")
+    # Per-mode component bests (phase 2 / polyhead only). Used by the
+    # patience logic: an epoch counts as "improvement" if either the
+    # combined val metric or *any* of the (sh, sm, jt) split
+    # components improves vs its own running best. Avoids premature
+    # stopping when one noisy component (typically smear) plateaus
+    # while another (typically shift) is still descending.
+    best_val_split = [float("inf"), float("inf"), float("inf")]
+    # Per-σ-component bests for phase 1 with σ-conditioning: the flow
+    # NLL is split by event into the σ=0 zero-fraction vs the σ>0
+    # smear-augmented fraction, and the patience clock resets if
+    # either component improves vs its own running best. Same role as
+    # ``best_val_split`` for phase 2 but along the σ-zero axis.
+    best_val_nll_split = [float("inf"), float("inf")]
+    best_state = None
+    best_polyhead_state = None
+    no_improve = 0
+    # Whether to track the σ=0 / σ>0 NLL split. Only meaningful in
+    # phase 1 (flow-only) with σ-conditioning enabled and active
+    # (apply_smearing=True). Phase 2 (polyhead) has its own (sh, sm,
+    # jt) split. Plain NLL training has no split.
+    track_nll_sigma_split = (
+        cond_on_smear and apply_smearing and not use_polyhead
+    )
+
+    # How often to refresh the tqdm postfix with the running NLL. Each
+    # refresh triggers an .item() on GPU scalars (= a H2D sync), which
+    # can stall the pipeline if done every batch. Keep it infrequent.
+    postfix_every = 50
+
+    amp_device_type = "cuda" if str(device).startswith("cuda") else "cpu"
+    if precision == "fp32":
+        amp_dtype = torch.float32
+        amp_enabled = False
+    elif precision == "bf16":
+        amp_dtype = torch.bfloat16
+        amp_enabled = True
+    elif precision == "fp16":
+        amp_dtype = torch.float16
+        amp_enabled = True
+    else:
+        raise ValueError(f"unknown precision {precision!r}")
+    amp_ctx = lambda: torch.amp.autocast(
+        device_type=amp_device_type,
+        dtype=amp_dtype,
+        enabled=amp_enabled,
+    )
+    # GradScaler only for fp16 (bf16 has fp32-equivalent exponent
+    # range and doesn't need loss scaling). When disabled, all
+    # scaler calls below are no-ops.
+    scaler = torch.amp.GradScaler(
+        amp_device_type, enabled=(precision == "fp16"),
+    )
+
+    # Smear-conditioning helper: per-batch, augment ``(x, c) →
+    # (x_aug, c_aug)`` so the flow sees ``p(y_smeared | c, σ)``.
+    #
+    #   * ``cond_on_smear=False``: identity — flow trains on ``p(y | c)``
+    #     as before.
+    #   * ``cond_on_smear=True, apply_smearing=True`` (phase 1): per
+    #     event, with probability ``zero_fraction`` set ``σ_std = 0``;
+    #     otherwise sample ``σ_std_d ~ U[0, σ_max_std_d]`` per
+    #     dimension. Smear ``x_std`` by ``σ_std ⊙ ε``, ``ε ~ N(0, I)``.
+    #     Append ``σ_std`` to ``c_std``.
+    #   * ``cond_on_smear=True, apply_smearing=False`` (phase 2 /
+    #     polyhead-only): no random smearing — append a zero σ to ``c``
+    #     so the polyhead trains against the unsmeared ``σ = 0`` slice
+    #     of the conditioned flow. Conditioning width still matches
+    #     what the flow was built with.
+    if cond_on_smear:
+        if sigma_max_std is None:
+            raise ValueError(
+                "cond_on_smear=True requires sigma_max_std (a per-dim "
+                "tensor of standardized σ upper bounds)."
+            )
+        sigma_max_std_dev = sigma_max_std.to(
+            device=device, dtype=torch.float32,
+        )
+        smear_zero_frac = float(cond_smear_zero_fraction)
+    else:
+        sigma_max_std_dev = None
+        smear_zero_frac = 0.0
+
+    def _augment_x_c(x, c, sample_smear: bool, generator=None):
+        """Append σσᵀ pack (always) to c; optionally smear x with σ·ε.
+
+        Smear model: **rank-1 correlated**, matching
+        ``train_shift_smear_reweight``. Each event draws a single
+        scalar ``ε ~ N(0, 1)`` that scales the entire σ-vector,
+        ``y' = y + ε · σ``. The smear covariance is then exactly
+        ``σ σᵀ`` (rank-1 PSD), so the σσᵀ pack is the minimal
+        sufficient statistic for the conditional density and matches
+        the head's training-time perturbation distribution.
+
+        σ-vector sampling: **ball**, matching the head sampler in
+        ``sample_perturbations``. For each event:
+
+          * radius ``‖σ‖₂ ~ U[0, σ_max_radius]`` (one scalar draw),
+          * direction ``v ∼ Uniform(S^{F−1})`` (Gaussian then
+            normalised),
+          * ``σ = ‖σ‖ · v``.
+
+        ``σ_max_radius`` is the scalar ``--cond-smear-sigma-max ×
+        1.3 oversample`` in standardized target units (taken as
+        ``sigma_max_std_dev.max()`` to be conservative if the per-dim
+        cap is ever made non-uniform). The σ=0 anchor is provided
+        separately by the ``smear_zero_frac`` Bernoulli draw
+        (default 50%). The flow's training σ distribution then
+        matches the head's ``sample_perturbations`` ball draws, so
+        the σ-cond direct target the head queries lies
+        in-distribution.
+
+        When ``cond_on_smear`` is False, returns inputs unchanged.
+        ``sample_smear=False`` forces ``σ = 0`` (zero pack); used in
+        phase-2 head training and during validation when we want a
+        deterministic σ = 0 slice.
+
+        The smear covariance ``σσᵀ`` is invariant under the global
+        flip ``σ → −σ`` (since ``ε`` and ``−ε`` are equidistributed),
+        and the spherical-direction sampler already covers both ``±v``,
+        so all signed σ are reached.
+
+        ``generator`` (optional ``torch.Generator``) routes the σ
+        and ε draws through a caller-provided RNG. ``run_val`` uses
+        this with a fixed-seeded per-pass generator so the validation
+        loss is deterministic across epochs (each event sees the
+        same σ every epoch), eliminating the σ-resampling noise that
+        would otherwise dominate the early-stopping improvement test.
+
+        Returns ``(x_aug, c_aug, is_zero)`` where ``is_zero`` is a
+        ``[B]`` bool tensor: True for events drawn from the σ=0
+        zero-fraction (or all events when smearing is off), False for
+        events drawn with σ ≠ 0. Used by the train loop to split the
+        flow NLL into σ=0 vs σ>0 components for per-component early
+        stopping.
+        """
+        B = x.shape[0]
+        F = x.shape[1]
+        if not cond_on_smear:
+            return (
+                x, c,
+                torch.ones(B, dtype=torch.bool, device=x.device),
+            )
+        if sample_smear:
+            # Ball sampling: ‖σ‖₂ ~ U[0, σ_max_radius], v on S^{F−1}.
+            sigma_max_radius = (
+                sigma_max_std_dev.max().to(dtype=x.dtype)
+            )
+            sigma_mag = (
+                torch.rand(
+                    B, 1, device=x.device, dtype=x.dtype,
+                    generator=generator,
+                )
+                * sigma_max_radius
+            )
+            v = torch.randn(
+                B, F, device=x.device, dtype=x.dtype,
+                generator=generator,
+            )
+            v = v / v.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+            sigma_std = sigma_mag * v  # [B, F]
+            if smear_zero_frac > 0.0:
+                zero_mask_2d = (
+                    torch.rand(
+                        B, 1, device=x.device, dtype=x.dtype,
+                        generator=generator,
+                    )
+                    < smear_zero_frac
+                )
+                sigma_std = torch.where(
+                    zero_mask_2d, torch.zeros_like(sigma_std), sigma_std,
+                )
+                is_zero = zero_mask_2d.squeeze(-1)
+            else:
+                is_zero = torch.zeros(
+                    B, dtype=torch.bool, device=x.device,
+                )
+            # Single scalar ε per event (rank-1 correlated smear): all
+            # F components share the same ε, so y' − y = ε · σ ~
+            # N(0, σσᵀ). Matches the head's _make_y_pert_stack.
+            eps = torch.randn(
+                B, 1, device=x.device, dtype=x.dtype,
+                generator=generator,
+            )
+            x_aug = x + sigma_std * eps
+        else:
+            sigma_std = torch.zeros(B, F, device=x.device, dtype=x.dtype)
+            x_aug = x
+            is_zero = torch.ones(B, dtype=torch.bool, device=x.device)
+        sigma_pack = _sigma_pack_outer(sigma_std)  # [B, F·(F+1)/2]
+        c_aug = torch.cat([c, sigma_pack], dim=-1)
+        return x_aug, c_aug, is_zero
+
+    head_only_mode = (
+        bool(head_config.get("head_only", False))
+        if head_config is not None else False
+    )
+    # Track best by val_wmse in polyhead-only mode (val_nll is
+    # essentially constant since the flow is frozen — its only
+    # variation comes from the per-batch random y sample).
+    track_by_wmse = head_only_mode
+    phase_label = (
+        "polyhead only (frozen flow)" if head_only_mode
+        else ("flow + polyhead" if use_polyhead else "flow only")
+    )
+
+    def run_val(epoch_idx: int):
+        model.eval()
+        total_nll = torch.zeros((), device=device)
+        total_wloss = torch.zeros((), device=device)
+        total_wloss_split = torch.zeros(3, device=device)
+        # σ=0 / σ>0 split for phase-1 flow NLL. Order: [zero, nonzero].
+        total_nll_sigma_split = torch.zeros(2, device=device)
+        wsum_sigma_split = torch.zeros(2, device=device)
+        wsum = torch.zeros((), device=device)
+        val_bar = tqdm(
+            val_loader,
+            desc=f"epoch {epoch_idx:03d} val  ",
+            leave=False,
+            dynamic_ncols=True,
+            disable=not is_rank0,
+        )
+        # Deterministic σ-conditioning draws across val passes:
+        # re-seed a per-pass generator with a fixed seed so each event
+        # sees the same σ every epoch. Combined with the val loader's
+        # ``shuffle=False`` (same batch order each epoch), the val
+        # NLL becomes reproducible across epochs and the early-
+        # stopping improvement test isn't fighting σ-resampling
+        # noise. The training-time σ draws still use the global RNG
+        # and remain stochastic across batches/epochs.
+        val_gen = None
+        if cond_on_smear and apply_smearing:
+            val_gen = torch.Generator(device=device)
+            val_gen.manual_seed(0)
+        with torch.no_grad():
+            for x, c, w in val_bar:
+                x = x.to(device, non_blocking=True)
+                c = c.to(device, non_blocking=True)
+                w = w.to(device, non_blocking=True)
+                wb = w.sum()
+                # Augment (x, c) with smear conditioning. Validation
+                # mirrors the training distribution: σ is sampled the
+                # same way during phase 1 (apply_smearing=True), or
+                # forced to zero in phase 2 (apply_smearing=False).
+                x, c, is_zero = _augment_x_c(
+                    x, c,
+                    sample_smear=apply_smearing,
+                    generator=val_gen,
+                )
+                if use_polyhead:
+                    with amp_ctx():
+                        # Aux loss off in val — pure flow + polyhead loss.
+                        _, nll_w, wloss_w, _, wloss_split = model(
+                            x, c, w,
+                            head_config["delta_max"],
+                            head_config["sigma_max"],
+                            0.0,
+                            head_config.get("loss_target", "w"),
+                            head_config.get("weight_power", 1),
+                            head_config.get("loss_fn", "huber"),
+                            head_config.get("huber_delta", 1.0),
+                            head_config.get(
+                                "detach_pure_in_joint", False,
+                            ),
+                            head_config.get("detach_target", True),
+                        )
+                    total_nll = total_nll + nll_w.float() * wb
+                    total_wloss = total_wloss + wloss_w.float() * wb
+                    total_wloss_split = (
+                        total_wloss_split + wloss_split.float() * wb
+                    )
+                else:
+                    with amp_ctx():
+                        log_p = model(x, c)
+                    log_p = log_p.float()
+                    # Same per-event NaN/Inf masking as the train
+                    # loop, so a few tail-divergent events don't
+                    # poison the val NLL (would otherwise break the
+                    # early-stopping signal).
+                    finite_mask = torch.isfinite(log_p)
+                    log_p = torch.where(
+                        finite_mask, log_p, torch.zeros_like(log_p),
+                    )
+                    w_eff = w * finite_mask.to(dtype=log_p.dtype)
+                    wb_eff = w_eff.sum()
+                    neg_log_p_w = w_eff * (-log_p)
+                    total_nll = total_nll + neg_log_p_w.sum()
+                    # wsum advances with the finite-event weights, so
+                    # the val NLL denominator matches its numerator.
+                    wb = wb_eff
+                    if track_nll_sigma_split:
+                        mask_zero = is_zero.to(dtype=neg_log_p_w.dtype)
+                        mask_nz = 1.0 - mask_zero
+                        total_nll_sigma_split[0] = (
+                            total_nll_sigma_split[0]
+                            + (mask_zero * neg_log_p_w).sum()
+                        )
+                        total_nll_sigma_split[1] = (
+                            total_nll_sigma_split[1]
+                            + (mask_nz * neg_log_p_w).sum()
+                        )
+                        wsum_sigma_split[0] = (
+                            wsum_sigma_split[0]
+                            + (mask_zero * w_eff).sum()
+                        )
+                        wsum_sigma_split[1] = (
+                            wsum_sigma_split[1]
+                            + (mask_nz * w_eff).sum()
+                        )
+                wsum = wsum + wb
+        _all_reduce_sum_(total_nll, is_dist)
+        _all_reduce_sum_(total_wloss, is_dist)
+        _all_reduce_sum_(total_wloss_split, is_dist)
+        _all_reduce_sum_(total_nll_sigma_split, is_dist)
+        _all_reduce_sum_(wsum_sigma_split, is_dist)
+        _all_reduce_sum_(wsum, is_dist)
+        wsum_py = wsum.item()
+        denom = max(wsum_py, 1e-30)
+        split_py = (total_wloss_split / denom).cpu().tolist()
+        if track_nll_sigma_split:
+            ws = wsum_sigma_split.cpu().tolist()
+            ns = total_nll_sigma_split.cpu().tolist()
+            sigma_split_py = [
+                ns[0] / max(ws[0], 1e-30),
+                ns[1] / max(ws[1], 1e-30),
+            ]
+        else:
+            sigma_split_py = None
+        return (
+            total_nll.item() / denom,
+            total_wloss.item() / denom,
+            split_py,
+            sigma_split_py,
+        )
+
+    # Optional ``torch.profiler`` diagnostic pass: run the first
+    # ``warmup + active`` training steps under the profiler, print
+    # the top hot ops, and exit before the normal epoch loop. Profiles
+    # whichever phase is currently invoked (phase 1 if ``not
+    # use_polyhead``, phase 2 otherwise). All ranks execute the steps
+    # for DDP collective consistency; rank 0 also runs the profiler.
+    if profile:
+        n_warmup = int(profile_warmup)
+        n_active = int(profile_active)
+        n_total = n_warmup + n_active
+        train_iter = iter(train_loader)
+
+        def _profile_step(_i):
+            nonlocal train_iter
+            try:
+                x, c, w = next(train_iter)
+            except StopIteration:
+                train_iter = iter(train_loader)
+                x, c, w = next(train_iter)
+            x = x.to(device, non_blocking=True)
+            c = c.to(device, non_blocking=True)
+            w = w.to(device, non_blocking=True)
+            x, c, _is_zero = _augment_x_c(
+                x, c, sample_smear=apply_smearing,
+            )
+            optimizer.zero_grad(set_to_none=True)
+            if use_polyhead:
+                with amp_ctx():
+                    loss, _nll_w, _wloss_w, _aux_w, _wloss_split = model(
+                        x, c, w,
+                        head_config["delta_max"],
+                        head_config["sigma_max"],
+                        head_config.get("aux_jacobian_weight", 0.0),
+                        head_config.get("loss_target", "w"),
+                        head_config.get("weight_power", 1),
+                        head_config.get("loss_fn", "huber"),
+                        head_config.get("huber_delta", 1.0),
+                        head_config.get(
+                            "detach_pure_in_joint", False,
+                        ),
+                        head_config.get("detach_target", True),
+                    )
+                loss = loss.float()
+            else:
+                with amp_ctx():
+                    nll = model(x, c, w)
+                loss = nll.float()
+            scaler.scale(loss).backward()
+            if precision == "fp16":
+                scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(
+                model.parameters(), max_norm=10.0,
+            )
+            scaler.step(optimizer)
+            scaler.update()
+
+        if is_rank0:
+            output = profile_output
+            if is_dist and output:
+                import torch.distributed as _dist
+                rank_i = _dist.get_rank()
+                base, ext = os.path.splitext(output)
+                output = f"{base}.rank{rank_i}{ext}"
+            _run_profile_pass(
+                _profile_step,
+                n_warmup=n_warmup,
+                n_active=n_active,
+                output_path=output,
+                label=f" {phase_label}",
+            )
+        else:
+            for _i in range(n_total):
+                _profile_step(_i)
+        # Return signature: state_dict-or-None, best_val. We didn't
+        # train, so best_val is NaN.
+        return None, float("nan")
+
+    for epoch in range(1, epochs + 1):
+        if is_rank0:
+            print(f"epoch {epoch:03d} starting [{phase_label}]", flush=True)
+        model.train()
+        t0 = time.time()
+        # Accumulate on-device scalars; only materialize with .item() at
+        # the epoch boundary so the batch loop is sync-free.
+        total_nll = torch.zeros((), device=device)
+        total_wloss = torch.zeros((), device=device)
+        total_wloss_split = torch.zeros(3, device=device)
+        # σ=0 / σ>0 NLL split for phase-1 flow training: [zero, nz].
+        total_nll_sigma_split = torch.zeros(2, device=device)
+        wsum_sigma_split = torch.zeros(2, device=device)
+        wsum = torch.zeros((), device=device)
+        # NaN/Inf accounting (flow-only path; tail-saturation guard
+        # for architectures like GF whose autograd Jacobian can
+        # collapse to 0 on out-of-support events).
+        n_nonfinite_total = 0
+        n_finite_events_total = 0
+        n_skipped_batches = 0
+        bar = tqdm(
+            train_loader,
+            desc=f"epoch {epoch:03d} train",
+            leave=False,
+            dynamic_ncols=True,
+            disable=not is_rank0,
+        )
+        for i, (x, c, w) in enumerate(bar):
+            x = x.to(device, non_blocking=True)
+            c = c.to(device, non_blocking=True)
+            w = w.to(device, non_blocking=True)
+            wb = w.sum()
+            wsum_b = wb.clamp_min(1e-30)
+            # Augment (x, c) with smear conditioning when enabled.
+            x, c, is_zero = _augment_x_c(
+                x, c, sample_smear=apply_smearing,
+            )
+
+            optimizer.zero_grad(set_to_none=True)
+            if use_polyhead:
+                with amp_ctx():
+                    loss, nll_w, wloss_w, _aux_w, wloss_split = model(
+                        x, c, w,
+                        head_config["delta_max"],
+                        head_config["sigma_max"],
+                        head_config.get("aux_jacobian_weight", 0.0),
+                        head_config.get("loss_target", "w"),
+                        head_config.get("weight_power", 1),
+                        head_config.get("loss_fn", "huber"),
+                        head_config.get("huber_delta", 1.0),
+                        head_config.get("detach_pure_in_joint", False),
+                        head_config.get("detach_target", True),
+                    )
+                # Already mean-normalized inside joint_loss_step; keep
+                # in fp32 for numerical stability of backward.
+                loss = loss.float()
+                running_nll_term = nll_w.float() * wb
+                running_wloss_term = wloss_w.float() * wb
+                running_wloss_split_term = wloss_split.float() * wb
+            else:
+                with amp_ctx():
+                    log_p = model(x, c)
+                # Keep the loss in fp32 for numerical stability,
+                # regardless of whether log_p came out of autocast in
+                # bf16 or fp32.
+                log_p = log_p.float()
+                # Per-event NaN/Inf masking. Architectures with
+                # autograd-based Jacobians (notably GF) can produce
+                # ``log p = −∞`` for events that land far out in the
+                # tails of standardised space — the inner ``erf``
+                # saturates so the Jacobian collapses to 0 and
+                # ``log|J| → −∞``. With ``ε ~ N(0, 1)`` smear noise,
+                # a single 4–5σ ε draw at large σ can produce such
+                # events, and one NaN/Inf in the sum poisons the
+                # whole batch loss. Mask them out per-event; if the
+                # whole batch ends up non-finite, skip the optimiser
+                # step entirely.
+                finite_mask = torch.isfinite(log_p)
+                n_nonfinite = int((~finite_mask).sum().item())
+                if n_nonfinite > 0:
+                    n_nonfinite_total = (
+                        n_nonfinite_total + n_nonfinite
+                    )
+                    n_finite_events_total = (
+                        n_finite_events_total
+                        + int(finite_mask.numel() - n_nonfinite)
+                    )
+                    log_p = torch.where(
+                        finite_mask, log_p, torch.zeros_like(log_p),
+                    )
+                    finite_mask_f = finite_mask.to(dtype=log_p.dtype)
+                    w_eff = w * finite_mask_f
+                    wb_eff = w_eff.sum()
+                    wsum_b_eff = wb_eff.clamp_min(1e-30)
+                else:
+                    n_finite_events_total = (
+                        n_finite_events_total + int(finite_mask.numel())
+                    )
+                    w_eff = w
+                    wb_eff = wb
+                    wsum_b_eff = wsum_b
+                neg_log_p_w = w_eff * (-log_p)
+                neg_log_p_w_sum = neg_log_p_w.sum()
+                loss = neg_log_p_w_sum / wsum_b_eff
+                running_nll_term = neg_log_p_w_sum
+                running_wloss_term = torch.zeros((), device=device)
+                running_wloss_split_term = torch.zeros(3, device=device)
+                if track_nll_sigma_split:
+                    mask_zero = is_zero.to(dtype=neg_log_p_w.dtype)
+                    mask_nz = 1.0 - mask_zero
+                    running_nll_sigma_zero = (
+                        (mask_zero * neg_log_p_w).sum().detach()
+                    )
+                    running_nll_sigma_nz = (
+                        (mask_nz * neg_log_p_w).sum().detach()
+                    )
+                    running_wsum_sigma_zero = (
+                        (mask_zero * w_eff).sum().detach()
+                    )
+                    running_wsum_sigma_nz = (
+                        (mask_nz * w_eff).sum().detach()
+                    )
+                # Whole-batch guard: skip backward/step if either
+                #   (a) the loss itself is non-finite, or
+                #   (b) every event in the batch was non-finite
+                #       (masked loss collapses to 0/0 ≈ 0, finite
+                #       but devoid of gradient signal).
+                # In either case, the optimiser step would corrupt
+                # the parameters or do nothing useful.
+                all_nonfinite_batch = (n_nonfinite == int(log_p.numel()))
+                if (not torch.isfinite(loss)) or all_nonfinite_batch:
+                    n_skipped_batches += 1
+                    optimizer.zero_grad(set_to_none=True)
+                    wsum = wsum + wb
+                    continue
+            scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=10.0)
+            scaler.step(optimizer)
+            scaler.update()
+            # Running accumulators stay on device.
+            total_nll = total_nll + running_nll_term.detach()
+            total_wloss = total_wloss + running_wloss_term.detach()
+            total_wloss_split = (
+                total_wloss_split + running_wloss_split_term.detach()
+            )
+            if track_nll_sigma_split:
+                total_nll_sigma_split[0] = (
+                    total_nll_sigma_split[0] + running_nll_sigma_zero
+                )
+                total_nll_sigma_split[1] = (
+                    total_nll_sigma_split[1] + running_nll_sigma_nz
+                )
+                wsum_sigma_split[0] = (
+                    wsum_sigma_split[0] + running_wsum_sigma_zero
+                )
+                wsum_sigma_split[1] = (
+                    wsum_sigma_split[1] + running_wsum_sigma_nz
+                )
+            wsum = wsum + wb
+            if is_rank0 and (i + 1) % postfix_every == 0:
+                # rank-0-local running metrics (not globally reduced;
+                # display only). Global versions are at epoch end.
+                wsum_py_now = max(wsum.item(), 1e-30)
+                running_nll = total_nll.item() / wsum_py_now
+                if use_polyhead:
+                    running_wloss = total_wloss.item() / wsum_py_now
+                    sh, sm, jt = (
+                        total_wloss_split / wsum_py_now
+                    ).cpu().tolist()
+                    bar.set_postfix(
+                        nll=f"{running_nll:+.4f}",
+                        wmse=f"{running_wloss:.4f}",
+                        sh=f"{sh:.3f}",
+                        sm=f"{sm:.3f}",
+                        jt=f"{jt:.3f}",
+                    )
+                else:
+                    bar.set_postfix(nll=f"{running_nll:+.4f}")
+
+        _all_reduce_sum_(total_nll, is_dist)
+        _all_reduce_sum_(total_wloss, is_dist)
+        _all_reduce_sum_(total_wloss_split, is_dist)
+        _all_reduce_sum_(total_nll_sigma_split, is_dist)
+        _all_reduce_sum_(wsum_sigma_split, is_dist)
+        _all_reduce_sum_(wsum, is_dist)
+        wsum_py = wsum.item()
+        denom = max(wsum_py, 1e-30)
+        train_nll = total_nll.item() / denom
+        train_wloss = total_wloss.item() / denom
+        train_split = (total_wloss_split / denom).cpu().tolist()
+        if track_nll_sigma_split:
+            ws_t = wsum_sigma_split.cpu().tolist()
+            ns_t = total_nll_sigma_split.cpu().tolist()
+            train_nll_sigma_split = [
+                ns_t[0] / max(ws_t[0], 1e-30),
+                ns_t[1] / max(ws_t[1], 1e-30),
+            ]
+        else:
+            train_nll_sigma_split = None
+        val_nll, val_wloss, val_split, val_nll_sigma_split = run_val(epoch)
+        # Track best-by metric: val_nll for flow training, val_wmse
+        # for polyhead-only training (val_nll is essentially constant
+        # there since the flow is frozen).
+        track_metric = val_wloss if track_by_wmse else val_nll
+        scheduler.step(track_metric)
+        lr_now = optimizer.param_groups[0]["lr"]
+        if use_polyhead:
+            tr_sh, tr_sm, tr_jt = train_split
+            va_sh, va_sm, va_jt = val_split
+            line = (
+                f"epoch {epoch:03d}  train_nll {train_nll:+.4f}  "
+                f"train_wmse {train_wloss:.4f}  "
+                f"(sh {tr_sh:.4f} sm {tr_sm:.4f} jt {tr_jt:.4f})  "
+                f"val_nll {val_nll:+.4f}  val_wmse {val_wloss:.4f}  "
+                f"(sh {va_sh:.4f} sm {va_sm:.4f} jt {va_jt:.4f})  "
+                f"lr {lr_now:.2e}  dt {time.time()-t0:.1f}s"
+            )
+        elif track_nll_sigma_split:
+            tr_z, tr_nz = train_nll_sigma_split
+            va_z, va_nz = val_nll_sigma_split
+            line = (
+                f"epoch {epoch:03d}  train_nll {train_nll:+.4f} "
+                f"(σ=0 {tr_z:+.4f} σ>0 {tr_nz:+.4f})  "
+                f"val_nll {val_nll:+.4f} "
+                f"(σ=0 {va_z:+.4f} σ>0 {va_nz:+.4f})  "
+                f"lr {lr_now:.2e}  dt {time.time()-t0:.1f}s"
+            )
+        else:
+            line = (
+                f"epoch {epoch:03d}  train_nll {train_nll:+.4f}  "
+                f"val_nll {val_nll:+.4f}  lr {lr_now:.2e}  "
+                f"dt {time.time()-t0:.1f}s"
+            )
+        # Append NaN-event accounting when active (flow-only path).
+        # Quiet by default: only annotate epochs where something
+        # actually went wrong.
+        if (not use_polyhead) and (
+            n_nonfinite_total > 0 or n_skipped_batches > 0
+        ):
+            n_total_events = n_finite_events_total + n_nonfinite_total
+            nf_frac = (
+                n_nonfinite_total / max(n_total_events, 1)
+            )
+            line = (
+                f"{line}  nan_evt {n_nonfinite_total} "
+                f"({nf_frac*100:.3g}%)"
+                + (
+                    f"  skipped {n_skipped_batches} batch(es)"
+                    if n_skipped_batches > 0
+                    else ""
+                )
+            )
+        if is_rank0:
+            print(line, flush=True)
+        log_lines.append(line)
+
+        # Patience-improvement test:
+        #   * Phase 1 (NLL ~ 3.7): absolute threshold 1e-4 — works
+        #     well at this scale and matches historical tuning.
+        #   * Phase 2 (wmse ~ 1e-2, MSE-style loss): relative
+        #     threshold ``patience_rel_threshold · |best_val|`` since
+        #     ``1e-4`` absolute is ~1% relative — too strict for
+        #     small-valued MSE metrics, masks slow real progress.
+        # On the first epoch ``best_val`` is +inf, in which case any
+        # finite ``track_metric`` counts.
+        if _math.isinf(best_val):
+            improved = track_metric < best_val
+        elif use_polyhead:
+            improved = track_metric < best_val - (
+                patience_rel_threshold * abs(best_val)
+            )
+        else:
+            improved = track_metric < best_val - 1e-4
+
+        # Per-component improvement. The patience clock resets on
+        # improvement of *any* split component against its own running
+        # best, even if the combined metric plateaus — prevents
+        # premature stopping when one component is noise-limited while
+        # another is still descending. The combined-metric
+        # ``best_val`` and ``best_state`` snapshot are still gated on
+        # the combined ``improved`` so the saved checkpoint remains
+        # the best by the global metric.
+        #   * Phase 2 (polyhead): three-way (sh, sm, jt) wmse split,
+        #     relative threshold (matches combined wmse threshold).
+        #   * Phase 1 (flow w/ σ-cond): two-way (σ=0, σ>0) NLL split,
+        #     absolute 1e-4 threshold (matches combined NLL threshold).
+        component_improved = False
+        if use_polyhead:
+            for i, val_comp in enumerate(val_split):
+                if _math.isinf(best_val_split[i]):
+                    comp_imp = val_comp < best_val_split[i]
+                else:
+                    comp_imp = val_comp < best_val_split[i] - (
+                        patience_rel_threshold
+                        * abs(best_val_split[i])
+                    )
+                if comp_imp:
+                    best_val_split[i] = val_comp
+                    component_improved = True
+        elif track_nll_sigma_split and val_nll_sigma_split is not None:
+            for i, val_comp in enumerate(val_nll_sigma_split):
+                if _math.isinf(best_val_nll_split[i]):
+                    comp_imp = val_comp < best_val_nll_split[i]
+                else:
+                    comp_imp = val_comp < best_val_nll_split[i] - 1e-4
+                if comp_imp:
+                    best_val_nll_split[i] = val_comp
+                    component_improved = True
+
+        if improved:
+            best_val = track_metric
+            if is_rank0:
+                best_state = _state_dict_to_cpu(inner_flow)
+                if inner_head is not None:
+                    best_polyhead_state = _state_dict_to_cpu(
+                        inner_head,
+                    )
+        if improved or component_improved:
+            no_improve = 0
+        else:
+            no_improve += 1
+
+        # Per-epoch snapshot on rank 0. Contains the current (latest)
+        # flow state — not the best-so-far. best_state is tracked
+        # separately above and loaded back into inner_flow at the end.
+        do_snapshot = (
+            is_rank0
+            and checkpoint_path is not None
+            and checkpoint_every > 0
+            and (epoch % checkpoint_every == 0)
+        )
+        if do_snapshot:
+            current_state = _state_dict_to_cpu(inner_flow)
+            ckpt = {
+                "epoch": epoch,
+                "train_nll": train_nll,
+                "val_nll": val_nll,
+                "best_val": best_val,
+                "no_improve": no_improve,
+                "state_dict": current_state,
+                "stats": asdict(stats) if stats is not None else None,
+                "flow_config": flow_config,
+            }
+            if use_polyhead:
+                ckpt["train_wmse"] = train_wloss
+                ckpt["val_wmse"] = val_wloss
+                ckpt["train_wmse_split"] = train_split
+                ckpt["val_wmse_split"] = val_split
+                ckpt["head_config"] = head_config
+            if track_nll_sigma_split and train_nll_sigma_split is not None:
+                ckpt["train_nll_sigma_split"] = train_nll_sigma_split
+                ckpt["val_nll_sigma_split"] = val_nll_sigma_split
+            if inner_head is not None:
+                ckpt["polyhead_state_dict"] = _state_dict_to_cpu(
+                    inner_head,
+                )
+            torch.save(ckpt, checkpoint_path)
+
+        if no_improve >= patience:
+            if no_early_stop:
+                # Patience threshold reached but early stopping is
+                # disabled — log a notice (only on the first crossing
+                # to avoid spamming every subsequent epoch) and
+                # continue. The LR scheduler clock is independent and
+                # keeps decaying the LR as configured.
+                if no_improve == patience:
+                    line = (
+                        f"would early-stop at epoch {epoch} "
+                        f"(best val {best_val:+.4f}); "
+                        f"--no-early-stop set, continuing"
+                    )
+                    if is_rank0:
+                        print(line)
+                    log_lines.append(line)
+            else:
+                line = (
+                    f"early stopping at epoch {epoch} "
+                    f"(best val {best_val:+.4f})"
+                )
+                if is_rank0:
+                    print(line)
+                log_lines.append(line)
+                break
+
+    if is_rank0 and best_state is not None:
+        inner_flow.load_state_dict(best_state)
+        if inner_head is not None and best_polyhead_state is not None:
+            inner_head.load_state_dict(best_polyhead_state)
+    return inner_flow, best_val
+
+
+# -----------------------------------------------------------------------------
+# TorchScript export
+# -----------------------------------------------------------------------------
+
+class FlowWrapper(nn.Module):
+    """TorchScript-friendly wrapper exposing log_density and score.
+
+    log_density(x, c[, sigma_raw]): returns log p(x|c[, σ]) in the
+    *standardized* target space (x is preprocessed). The Jacobian of
+    the preprocessing is a constant per dim so adding
+    ``sum(-log(target_std))`` converts to the original-space
+    log-density.
+
+    score(x, c[, sigma_raw]): returns ``∇_x log p(x|c[, σ])`` in the
+    standardized target space. Divide component-wise by ``target_std``
+    to map to the original coordinate gradient.
+
+    When the wrapped flow was trained with ``--cond-on-smear``,
+    ``sigma_raw`` is a per-dim smear scale (in raw target units) that
+    is standardized by ``target_std`` and concatenated to ``c_std``
+    before being fed to the flow. ``sigma_raw=None`` falls back to
+    ``σ = 0`` — i.e. the unsmeared baseline density. Without smear
+    conditioning ``sigma_raw`` is simply ignored.
+    """
+
+    def __init__(
+        self,
+        flow: nn.Module,
+        target_mean: torch.Tensor,
+        target_std: torch.Tensor,
+        cond_mean: torch.Tensor,
+        cond_std: torch.Tensor,
+        cond_on_smear: bool = False,
+    ):
+        super().__init__()
+        self.flow = flow
+        self.register_buffer("target_mean", target_mean)
+        self.register_buffer("target_std", target_std)
+        self.register_buffer("cond_mean", cond_mean)
+        self.register_buffer("cond_std", cond_std)
+        self.cond_on_smear = bool(cond_on_smear)
+
+    def _standardize_target(self, x_raw: torch.Tensor) -> torch.Tensor:
+        return (x_raw - self.target_mean) / self.target_std
+
+    def _standardize_cond(self, c_raw: torch.Tensor) -> torch.Tensor:
+        return (c_raw - self.cond_mean) / self.cond_std
+
+    def _augment_cond_with_sigma(
+        self, c_std: torch.Tensor, sigma_raw, x_ref: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return c_std augmented with the F·(F+1)/2-component pack
+        of ``σσᵀ`` (in standardized target units), when smear-
+        conditioning was enabled at training. ``sigma_raw=None`` is
+        treated as ``σ = 0`` (unsmeared baseline)."""
+        if not self.cond_on_smear:
+            return c_std
+        n_features = self.target_std.shape[0]
+        if sigma_raw is None:
+            sigma_std = torch.zeros(
+                c_std.shape[0], n_features,
+                device=c_std.device, dtype=c_std.dtype,
+            )
+        else:
+            sigma_std = sigma_raw.to(
+                device=c_std.device, dtype=c_std.dtype,
+            )
+            if sigma_std.dim() == 1:
+                sigma_std = sigma_std.unsqueeze(0).expand(
+                    c_std.shape[0], -1,
+                )
+            sigma_std = sigma_std / self.target_std
+        sigma_pack = _sigma_pack_outer(sigma_std)
+        return torch.cat([c_std, sigma_pack], dim=-1)
+
+    def log_density(
+        self,
+        x_raw: torch.Tensor,
+        c_raw: torch.Tensor,
+        sigma_raw: torch.Tensor = None,
+    ) -> torch.Tensor:
+        x = self._standardize_target(x_raw)
+        c = self._standardize_cond(c_raw)
+        c = self._augment_cond_with_sigma(c, sigma_raw, x)
+        log_p = self.flow(c).log_prob(x)
+        # Jacobian correction for target standardization.
+        log_p = log_p - torch.log(self.target_std).sum()
+        return log_p
+
+    def score(
+        self,
+        x_raw: torch.Tensor,
+        c_raw: torch.Tensor,
+        sigma_raw: torch.Tensor = None,
+    ) -> torch.Tensor:
+        """Return ∇_{x_raw} log p(x_raw | c_raw[, σ])."""
+        x_raw = x_raw.detach().requires_grad_(True)
+        log_p = self.log_density(x_raw, c_raw, sigma_raw=sigma_raw)
+        grad = torch.autograd.grad(log_p.sum(), x_raw, create_graph=False)[0]
+        return grad
+
+
+def export_flow(
+    flow: nn.Module,
+    stats: PreprocStats,
+    outpath_pt: str,
+    outpath_ts: str,
+    flow_config: dict,
+    head: nn.Module = None,
+    head_config: dict = None,
+):
+    """Save the trained wrapper two ways:
+
+    1. ``<outpath_pt>``: plain ``torch.save`` of the whole FlowWrapper
+       module. Loading requires Python + zuko + torch. This is the
+       canonical checkpoint for offline work (grid precomputation,
+       validation).
+    2. ``<outpath_ts>``: try ``torch.jit.script``; if it fails (zuko
+       flows are not guaranteed to be scriptable), print a note and
+       skip. This file is intended for eventual C++/LibTorch inference
+       but is best-effort at this stage.
+
+    When ``head`` / ``head_config`` are provided, the head's
+    state_dict and config are also stashed in the .pt file
+    (TorchScript trace path is unaffected — it still traces only the
+    flow's ``log_density``). For backwards compat the saved key
+    remains ``polyhead_state_dict`` so existing downstream consumers
+    keep working.
+    """
+    flow = flow.cpu().eval()
+    wrapper = FlowWrapper(
+        flow=flow,
+        target_mean=torch.tensor(stats.target_mean, dtype=torch.float32),
+        target_std=torch.tensor(stats.target_std, dtype=torch.float32),
+        cond_mean=torch.tensor(stats.cond_mean, dtype=torch.float32),
+        cond_std=torch.tensor(stats.cond_std, dtype=torch.float32),
+        cond_on_smear=bool(flow_config.get("cond_on_smear", False)),
+    )
+
+    payload = {
+        "wrapper_state_dict": wrapper.state_dict(),
+        "flow_config": flow_config,
+        "preproc": asdict(stats),
+    }
+    if head is not None:
+        head_cpu = head.cpu().eval()
+        payload["polyhead_state_dict"] = head_cpu.state_dict()
+        payload["head_config"] = head_config
+    torch.save(payload, outpath_pt)
+    print(f"saved wrapper state_dict + config to {outpath_pt}")
+
+    # TorchScript export via torch.jit.trace (records actual tensor
+    # ops on an example input). Two adjustments needed for it to
+    # succeed on a zuko flow:
+    #
+    #   (a) zuko's ``gauss_legendre`` is a custom ``torch.autograd.Function``
+    #       that the tracer can't record cleanly. Swap it for a plain
+    #       torch-op quadrature (``torch.lerp`` + ``torch.tensordot``)
+    #       — same forward result, O(n_nodes) slower backward. Since
+    #       we're at end-of-training, slower backward is irrelevant.
+    #
+    #   (b) Script (static type analysis) chokes on zuko's
+    #       forward-referenced type annotations. Tracing ignores
+    #       annotations entirely, so just don't use ``jit.script``.
+    #
+    # Limitation: tracing records a straight-through graph — fine for
+    # the ``log_density`` forward but skips the ``score`` path
+    # (autograd.grad isn't traceable). If C++ score inference is
+    # needed, use flow_export_onnx.py's dynamo-based export.
+    import zuko.utils
+    import zuko.transforms
+    _orig_gl_utils = zuko.utils.gauss_legendre
+    _orig_gl_transforms = zuko.transforms.gauss_legendre
+
+    def _gauss_legendre_native(f, a, b, n=3, phi=()):
+        nodes, weights = zuko.utils.GaussLegendre.nodes(
+            n, dtype=a.dtype, device=a.device
+        )
+        x_nodes = torch.lerp(
+            a[..., None], b[..., None], nodes,
+        ).movedim(-1, 0)
+        return (b - a) * torch.tensordot(weights, f(x_nodes), dims=1)
+
+    zuko.utils.gauss_legendre = _gauss_legendre_native
+    zuko.transforms.gauss_legendre = _gauss_legendre_native
+
+    n_features = len(stats.target_mean)
+    n_cond = len(stats.cond_mean)
+    x_example = torch.randn(1, n_features, dtype=torch.float32)
+    c_example = torch.randn(1, n_cond, dtype=torch.float32)
+    cond_on_smear = bool(flow_config.get("cond_on_smear", False))
+
+    if cond_on_smear:
+        sigma_example = torch.zeros(1, n_features, dtype=torch.float32)
+
+        class _TracedLogDensity(nn.Module):
+            def __init__(self, inner: nn.Module):
+                super().__init__()
+                self.inner = inner
+
+            def forward(self, x_raw, c_raw, sigma_raw):
+                return self.inner.log_density(x_raw, c_raw, sigma_raw)
+
+        trace_inputs = (x_example, c_example, sigma_example)
+    else:
+        class _TracedLogDensity(nn.Module):
+            def __init__(self, inner: nn.Module):
+                super().__init__()
+                self.inner = inner
+
+            def forward(self, x_raw, c_raw):
+                return self.inner.log_density(x_raw, c_raw)
+
+        trace_inputs = (x_example, c_example)
+
+    try:
+        with torch.no_grad():
+            traced = torch.jit.trace(
+                _TracedLogDensity(wrapper),
+                trace_inputs,
+                check_trace=False,
+                strict=False,
+            )
+        traced.save(outpath_ts)
+        print(
+            f"saved TorchScript (traced, log_density only) to "
+            f"{outpath_ts}"
+        )
+    except Exception as e:
+        print(
+            f"[note] torch.jit.trace export skipped "
+            f"({type(e).__name__}: {e}). "
+            f"The .pt wrapper file is the portable alternative."
+        )
+    finally:
+        zuko.utils.gauss_legendre = _orig_gl_utils
+        zuko.transforms.gauss_legendre = _orig_gl_transforms
+
+
+# -----------------------------------------------------------------------------
+# In-memory loader
+# -----------------------------------------------------------------------------
+
+class InMemoryLoader:
+    """Bulk-indexed per-batch iterator over in-RAM CPU tensors.
+
+    Per batch: one bulk ``index_select`` (when shuffling) or a
+    contiguous slice (val), then a single H2D copy of the whole batch
+    inside the training loop. Avoids DataLoader's per-element path
+    through TensorDataset which creates ~batch_size tiny tensors per
+    batch.
+
+    With ``pin_memory=True`` (default) each yielded batch is copied
+    into pinned (page-locked) host memory before being yielded. This
+    is what makes ``tensor.to(device, non_blocking=True)`` actually
+    asynchronous — for pageable source memory PyTorch silently falls
+    back to a synchronous copy. Skipped automatically if the source
+    tensors aren't on CPU (e.g., already on the GPU).
+
+    Two perf knobs that matter for the per-epoch startup gap:
+
+      * ``prefetch_shuffle=True``: the next epoch's
+        ``torch.randperm(n)`` is computed in a background thread *while
+        the current epoch is still training*. With shuffles taking
+        several seconds at ~10⁸-row training sets, this hides the
+        epoch-boundary stall. The first epoch still pays the cost
+        (no prior epoch to overlap with).
+
+      * ``time_iter=True`` (or ``LOADER_TIME=1`` in env): print
+        one-line timing for each iter() call: how long ``randperm`` /
+        first-batch gather + pin took. Useful to confirm what's
+        actually slow at the epoch boundary without strapping a
+        profiler around the training loop.
+    """
+
+    def __init__(self, x, c, w, batch_size, shuffle, drop_last,
+                 pin_memory=True, prefetch_shuffle=False,
+                 time_iter=False):
+        self.x, self.c, self.w = x, c, w
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+        self.pin_memory = bool(pin_memory) and (x.device.type == "cpu")
+        self.n = x.shape[0]
+        self.prefetch_shuffle = bool(prefetch_shuffle) and shuffle
+        self.time_iter = bool(time_iter) or os.environ.get(
+            "LOADER_TIME", "0",
+        ) not in ("", "0", "false", "False")
+
+        # Async prefetch state: background thread + a stashed
+        # already-computed permutation for the next epoch.
+        self._executor = None
+        self._next_perm_future = None
+        if self.prefetch_shuffle:
+            import concurrent.futures as _futures
+            self._executor = _futures.ThreadPoolExecutor(max_workers=1)
+            # Kick off the *first* epoch's permutation now, so it
+            # overlaps with whatever happens between loader
+            # construction and the first ``iter()`` call (model build,
+            # optimiser setup, torch.compile JIT trace of the first
+            # batch, etc.). At ~10⁸ rows the shuffle is ~10–20 s; if
+            # model setup eats more than that, the first epoch sees
+            # ``randperm: 0.000s`` too.
+            self._kick_off_next_perm()
+
+    def __len__(self):
+        if self.drop_last:
+            return self.n // self.batch_size
+        return (self.n + self.batch_size - 1) // self.batch_size
+
+    def _kick_off_next_perm(self):
+        """Submit a randperm task to run in the background; the result
+        is consumed by the next ``__iter__`` call. No-op if prefetch
+        is disabled or a previous future already exists."""
+        if (
+            self._executor is not None
+            and self._next_perm_future is None
+        ):
+            self._next_perm_future = self._executor.submit(
+                torch.randperm, self.n,
+            )
+
+    def __iter__(self):
+        bs = self.batch_size
+        pin = self.pin_memory
+        time_iter = self.time_iter
+
+        # Drop a hook so callers can request prefetch-of-next-perm at
+        # an opportune moment in the training loop. We also kick it
+        # ourselves at the END of the iterator below (most common
+        # case: no manual hook needed).
+        # Time only the per-iter setup pieces — the per-batch yield
+        # times are already visible in the tqdm bar.
+        if time_iter:
+            t0 = time.perf_counter()
+
+        if self.shuffle:
+            # Pick up a previously-prefetched permutation if available;
+            # otherwise compute it now (synchronously).
+            if self._next_perm_future is not None:
+                perm = self._next_perm_future.result()
+                self._next_perm_future = None
+            else:
+                perm = torch.randperm(self.n)
+            t_perm = time.perf_counter() if time_iter else 0.0
+
+            # Kick off the *next* epoch's randperm now, so the
+            # background thread has the entire current epoch's worth
+            # of training time to finish before the next __iter__()
+            # call. Submitting at end-of-iter would only give it the
+            # tiny gap between iterators.
+            self._kick_off_next_perm()
+
+            n_batches = self.n // bs if self.drop_last else (
+                (self.n + bs - 1) // bs
+            )
+            t_first = None
+            for i in range(n_batches):
+                idx = perm[i * bs:min((i + 1) * bs, self.n)]
+                xb = self.x.index_select(0, idx)
+                cb = self.c.index_select(0, idx)
+                wb = self.w.index_select(0, idx)
+                if pin:
+                    xb, cb, wb = (
+                        xb.pin_memory(),
+                        cb.pin_memory(),
+                        wb.pin_memory(),
+                    )
+                if time_iter and t_first is None:
+                    t_first = time.perf_counter()
+                    print(
+                        f"[loader] randperm: {t_perm - t0:.3f}s   "
+                        f"first batch (gather + pin): "
+                        f"{t_first - t_perm:.3f}s   "
+                        f"total to first yield: {t_first - t0:.3f}s",
+                        flush=True,
+                    )
+                yield xb, cb, wb
+        else:
+            n_batches = self.n // bs if self.drop_last else (
+                (self.n + bs - 1) // bs
+            )
+            t_first = None
+            for i in range(n_batches):
+                s = i * bs
+                e = min(s + bs, self.n)
+                xb, cb, wb = self.x[s:e], self.c[s:e], self.w[s:e]
+                if pin:
+                    xb, cb, wb = (
+                        xb.pin_memory(),
+                        cb.pin_memory(),
+                        wb.pin_memory(),
+                    )
+                if time_iter and t_first is None:
+                    t_first = time.perf_counter()
+                    print(
+                        f"[loader] (no shuffle) total to first yield: "
+                        f"{t_first - t0:.3f}s",
+                        flush=True,
+                    )
+                yield xb, cb, wb
+
+    def __del__(self):
+        # Don't leave the background thread alive past loader lifetime.
+        ex = getattr(self, "_executor", None)
+        if ex is not None:
+            try:
+                ex.shutdown(wait=False, cancel_futures=True)
+            except Exception:
+                pass
+
+
+def _zuko_base_remap(flow_state, target_module):
+    """Bidirectional rename of ``base.loc/base.scale`` ↔ ``base._0/_1``.
+
+    zuko has used two naming conventions for its DiagNormal base
+    distribution buffers across versions; a checkpoint produced by
+    one version may not load directly into a flow built with the
+    other. Inspect both naming conventions in ``target_module`` and
+    in ``flow_state`` and remap so they agree.
+
+    No-op when both already use the same naming.
+    """
+    target_keys = set(target_module.state_dict().keys())
+    src_keys = set(flow_state.keys())
+    OLD = {"base.loc", "base.scale"}
+    NEW = {"base._0", "base._1"}
+    target_old = OLD & target_keys
+    target_new = NEW & target_keys
+    src_old = OLD & src_keys
+    src_new = NEW & src_keys
+    remap: dict = {}
+    if target_new and src_old:
+        # local is new-style, ckpt is old-style
+        remap = {"base.loc": "base._0", "base.scale": "base._1"}
+    elif target_old and src_new:
+        # local is old-style, ckpt is new-style
+        remap = {"base._0": "base.loc", "base._1": "base.scale"}
+    if remap:
+        flow_state = {remap.get(k, k): v for k, v in flow_state.items()}
+    return flow_state
+
+
+# -----------------------------------------------------------------------------
+# Worker (runs once per GPU in distributed mode, once total otherwise)
+# -----------------------------------------------------------------------------
+
+def main_worker(
+    rank,
+    args,
+    world_size,
+    master_port,
+    stats,
+    flow_config,
+    target_std_t,
+    cond_t,
+    w_t,
+    train_sel,
+    val_sel,
+):
+    is_dist = world_size > 1
+    is_rank0 = rank == 0
+
+    # Device selection + optional process-group init.
+    if is_dist:
+        import torch.distributed as dist
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        if args.device.startswith("cuda"):
+            torch.cuda.set_device(rank)
+            device = f"cuda:{rank}"
+            backend = "nccl"
+        else:
+            device = "cpu"
+            backend = "gloo"
+        dist.init_process_group(
+            backend=backend, rank=rank, world_size=world_size
+        )
+    else:
+        if args.device.startswith("cuda"):
+            torch.cuda.set_device(0)
+            device = "cuda:0"
+        else:
+            device = args.device
+
+    # Per-rank index shard. With world_size==1 this is a no-op.
+    if is_dist:
+        train_sel_rank = torch.chunk(
+            train_sel, world_size
+        )[rank].contiguous()
+        val_sel_rank = torch.chunk(
+            val_sel, world_size
+        )[rank].contiguous()
+    else:
+        train_sel_rank = train_sel
+        val_sel_rank = val_sel
+
+    train_x_cpu = target_std_t.index_select(0, train_sel_rank).contiguous()
+    train_c_cpu = cond_t.index_select(0, train_sel_rank).contiguous()
+    train_w_cpu = w_t.index_select(0, train_sel_rank).contiguous()
+    val_x_cpu = target_std_t.index_select(0, val_sel_rank).contiguous()
+    val_c_cpu = cond_t.index_select(0, val_sel_rank).contiguous()
+    val_w_cpu = w_t.index_select(0, val_sel_rank).contiguous()
+    n_train_rank = train_x_cpu.shape[0]
+    n_val_rank = val_x_cpu.shape[0]
+
+    train_loader = InMemoryLoader(
+        train_x_cpu, train_c_cpu, train_w_cpu,
+        batch_size=args.batch_size, shuffle=True, drop_last=True,
+        prefetch_shuffle=bool(getattr(args, "prefetch_shuffle", True)),
+        time_iter=bool(getattr(args, "time_loader", False)),
+    )
+    val_loader = InMemoryLoader(
+        val_x_cpu, val_c_cpu, val_w_cpu,
+        batch_size=args.batch_size, shuffle=False, drop_last=False,
+        time_iter=bool(getattr(args, "time_loader", False)),
+    )
+    if is_rank0:
+        print(
+            f"rank {rank}/{world_size}  "
+            f"train {n_train_rank}  val {n_val_rank}  "
+            f"batch {args.batch_size}  device {device}"
+        )
+
+    # Per-dim σ-upper-bound in standardized target units. ``train()``
+    # uses this to draw σ for the smear-conditioned forwards. Only
+    # built when smear conditioning is enabled.
+    #
+    # ``--cond-smear-sigma-max`` is in standardized target units (same
+    # convention as the head's ``--sigma-max``), so the value goes
+    # straight in — no division by ``target_std``. The 1.3× oversample
+    # matches :func:`sample_perturbations` so the flow's σ-conditioning
+    # input distribution covers the head's query range
+    # (``sigma_vec_pert`` magnitude ≤ 1.3·sigma_max).
+    cond_on_smear = bool(flow_config.get("cond_on_smear", False))
+    _flow_smear_oversample = 1.3
+    if cond_on_smear:
+        sigma_max_std = torch.full(
+            (int(flow_config["n_features"]),),
+            _flow_smear_oversample
+            * float(flow_config["cond_smear_sigma_max"]),
+            dtype=torch.float32,
+        )
+    else:
+        sigma_max_std = None
+    cond_smear_zero_fraction = float(
+        flow_config.get("cond_smear_zero_fraction", 0.5)
+    )
+    if is_rank0 and cond_on_smear:
+        print(
+            f"smear conditioning: σ_max_std="
+            f"{flow_config['cond_smear_sigma_max']:.3g}  "
+            f"oversample={_flow_smear_oversample:.2f}×  "
+            f"σ_max_std training range (per-dim, signed)="
+            f"{[f'±{x:.3g}' for x in sigma_max_std.tolist()]}  "
+            f"zero_fraction={cond_smear_zero_fraction:.3g}  "
+            f"n_sigma_pack={flow_config.get('n_sigma_pack', 0)}"
+        )
+
+    zuko_flow = build_flow(
+        n_features=flow_config["n_features"],
+        n_cond=flow_config["n_cond"],
+        n_transforms=flow_config["n_transforms"],
+        hidden_features=flow_config["hidden_features"],
+        n_hidden_layers=flow_config["n_hidden_layers"],
+        activation=flow_config.get("activation", "gelu"),
+        architecture=flow_config.get("architecture", "realnvp"),
+        randmask=flow_config.get("randmask", False),
+        gf_components=flow_config.get("gf_components", 8),
+        sospf_degree=flow_config.get("sospf_degree", 4),
+        sospf_polynomials=flow_config.get("sospf_polynomials", 3),
+        sospf_quad_n=flow_config.get("sospf_quad_n", -1),
+    ).to(device)
+
+    # If --head-only is requested, load the flow's weights from
+    # an existing checkpoint and freeze them. The flow then serves
+    # only as a fixed conditional density during polyhead training.
+    head_only_mode = bool(args.head_only)
+    loaded_head_state = None
+    if args.load_flow_checkpoint is not None:
+        ckpt = torch.load(
+            args.load_flow_checkpoint,
+            map_location="cpu",
+            weights_only=False,
+        )
+        # Per-epoch checkpoint.pt has "state_dict"; final flow.pt has
+        # "wrapper_state_dict" with "flow." prefixed keys.
+        if "state_dict" in ckpt:
+            flow_state = ckpt["state_dict"]
+        elif "wrapper_state_dict" in ckpt:
+            flow_state = {
+                k[len("flow."):]: v
+                for k, v in ckpt["wrapper_state_dict"].items()
+                if k.startswith("flow.")
+            }
+        else:
+            raise SystemExit(
+                f"checkpoint {args.load_flow_checkpoint!r} has neither "
+                "state_dict nor wrapper_state_dict — cannot load flow"
+            )
+        # Compat shim for zuko base-distribution naming. zuko has
+        # used both ``base.loc / base.scale`` (older) and
+        # ``base._0 / base._1`` (newer); a checkpoint produced by one
+        # version may not load directly into a flow built with the
+        # other. Detect which naming the local zuko expects and
+        # remap the checkpoint to match.
+        flow_state = _zuko_base_remap(flow_state, zuko_flow)
+        zuko_flow.load_state_dict(flow_state)
+        if "polyhead_state_dict" in ckpt and not args.reset_head:
+            loaded_head_state = ckpt["polyhead_state_dict"]
+        if is_rank0:
+            ph_msg = (
+                " (also head state)"
+                if loaded_head_state is not None
+                else (
+                    " (head state in checkpoint ignored — "
+                    "--reset-head)"
+                    if "polyhead_state_dict" in ckpt
+                    and args.reset_head
+                    else ""
+                )
+            )
+            print(
+                f"loaded flow state from {args.load_flow_checkpoint}"
+                + ph_msg
+            )
+    if head_only_mode:
+        if args.load_flow_checkpoint is None:
+            raise SystemExit(
+                "--head-only requires --load-flow-checkpoint"
+            )
+        if not args.head:
+            raise SystemExit(
+                "--head-only implies --head but --no-head "
+                "was passed"
+            )
+        zuko_flow.eval()
+        for p in zuko_flow.parameters():
+            p.requires_grad_(False)
+
+    head = None
+    head_config = None
+    if args.head:
+        if args.max_deg_sigma % 2 != 0:
+            raise SystemExit(
+                "--max-deg-sigma must be even (smear-symmetry "
+                "constraint). Got "
+                f"{args.max_deg_sigma}."
+            )
+        # Chebyshev basis-scaling: map the trained perturbation range
+        # to [-1, 1]. Training samples u ~ U[-oversample · delta_max,
+        # +oversample · delta_max] and σ_vec components on the same
+        # bracket for non-shift-only mode, so scale_u = oversample ·
+        # delta_max etc. ``oversample`` is fixed at 1.3 in
+        # ``sample_perturbations``.
+        _oversample = 1.3
+        activation_cls = ACTIVATIONS.get(
+            flow_config.get("activation", "gelu").lower(), nn.GELU,
+        )
+        if args.head_arch == "polyhead":
+            head = PolyHead(
+                n_features=flow_config["n_features"],
+                n_cond=flow_config["n_cond"],
+                hidden_features=args.trunk_hidden,
+                n_hidden_layers=args.trunk_layers,
+                max_deg_u=args.max_deg_u,
+                max_deg_sigma=args.max_deg_sigma,
+                max_cross_deg=args.max_cross_deg,
+                activation=activation_cls,
+                smear_K=args.smear_K,
+                smear_residual=args.smear_residual,
+                include_smear=args.include_smear,
+                positivity=args.positivity,
+                basis=args.basis,
+                basis_scale_u=_oversample * float(args.delta_max),
+                basis_scale_sigma=_oversample * float(args.sigma_max),
+            ).to(device)
+        elif args.head_arch in ("mlp", "mlp-factored"):
+            # Lazy import to avoid the train_shift_smear_reweight.py →
+            # train_muon_response_flow.py module-level import cycle.
+            from train_shift_smear_reweight import (
+                ReweightMLP_B, ReweightMLPFactored, _sigma_pack_indices,
+            )
+            if args.head_arch == "mlp":
+                head = ReweightMLP_B(
+                    n_features=flow_config["n_features"],
+                    n_cond=flow_config["n_cond"],
+                    d_emb=int(args.d_emb),
+                    trunk_hidden=int(args.trunk_hidden),
+                    trunk_layers=int(args.trunk_layers),
+                    head_hidden=int(args.head_hidden),
+                    head_layers=int(args.head_layers),
+                    activation=activation_cls,
+                    shift_only=not bool(args.include_smear),
+                ).to(device)
+            else:
+                head = ReweightMLPFactored(
+                    n_features=flow_config["n_features"],
+                    n_cond=flow_config["n_cond"],
+                    d_emb=int(args.d_emb),
+                    trunk_hidden=int(args.trunk_hidden),
+                    trunk_layers=int(args.trunk_layers),
+                    head_hidden=int(args.head_hidden),
+                    head_layers=int(args.head_layers),
+                    activation=activation_cls,
+                    shift_only=not bool(args.include_smear),
+                    detach_pure_shift_in_joint=bool(
+                        args.detach_pure_shift_in_joint
+                    ),
+                    detach_pure_smear_in_joint=bool(
+                        args.detach_pure_smear_in_joint
+                    ),
+                ).to(device)
+            # The MLP head doesn't carry the smear-quadrature config
+            # natively (PolyHead does). Attach the same fields the
+            # joint-loss path reads (smear_K, smear_residual,
+            # gh_nodes, gh_log_weights, positivity, include_smear) so
+            # both arches expose a uniform interface to
+            # ``_compute_target_lw`` / loss step. Σ-pack indices live
+            # on the head as buffers so they move with .to(device).
+            head.include_smear = bool(args.include_smear)
+            head.positivity = str(args.positivity)
+            if not head.include_smear:
+                # Mirror PolyHead's shift-only collapse: K=1
+                # stochastic, no GH, no residual.
+                eff_smear_K = 1
+                eff_smear_residual = False
+            else:
+                eff_smear_K = int(args.smear_K)
+                eff_smear_residual = bool(args.smear_residual)
+                if eff_smear_residual and eff_smear_K <= 1:
+                    raise SystemExit(
+                        "--smear-residual requires --smear-K > 1."
+                    )
+            head.smear_K = eff_smear_K
+            head.smear_residual = eff_smear_residual
+            if eff_smear_K > 1:
+                nodes_np, w_np = np.polynomial.hermite_e.hermegauss(
+                    eff_smear_K
+                )
+                w_norm = w_np / np.sqrt(2.0 * np.pi)
+                gh_nodes = torch.tensor(nodes_np, dtype=torch.float32)
+                gh_log_w = torch.tensor(np.log(w_norm), dtype=torch.float32)
+            else:
+                gh_nodes = torch.zeros(0, dtype=torch.float32)
+                gh_log_w = torch.zeros(0, dtype=torch.float32)
+            head.register_buffer(
+                "gh_nodes", gh_nodes.to(device), persistent=False,
+            )
+            head.register_buffer(
+                "gh_log_weights", gh_log_w.to(device), persistent=False,
+            )
+            iu, ju = _sigma_pack_indices(int(flow_config["n_features"]))
+            head.register_buffer(
+                "sigma_pack_iu", iu.to(device), persistent=False,
+            )
+            head.register_buffer(
+                "sigma_pack_ju", ju.to(device), persistent=False,
+            )
+        else:
+            raise SystemExit(f"unknown --head-arch {args.head_arch!r}")
+        if loaded_head_state is not None:
+            try:
+                head.load_state_dict(loaded_head_state)
+                if is_rank0:
+                    print("resumed head state from checkpoint.")
+            except Exception as e:
+                if is_rank0:
+                    print(
+                        f"[warn] head state in checkpoint is "
+                        f"incompatible ({type(e).__name__}); "
+                        f"starting head from fresh init."
+                    )
+        # Resolve --cond-smear-target. 'auto' → 'direct' iff the flow
+        # was σ-conditioned (else 'gh'); 'direct' without σ-cond is
+        # an error. The chosen path is consumed by ``_compute_target_lw``
+        # via attributes on the head module.
+        cond_smear_target_choice = str(args.cond_smear_target)
+        if cond_smear_target_choice == "auto":
+            cond_smear_target_choice = (
+                "direct" if cond_on_smear else "gh"
+            )
+        if cond_smear_target_choice == "direct" and not cond_on_smear:
+            raise SystemExit(
+                "--cond-smear-target=direct requires --cond-on-smear "
+                "(no σ-conditioned flow to query otherwise)."
+            )
+        head.cond_smear_target_direct = (
+            cond_smear_target_choice == "direct"
+        )
+        head.n_cond_base = int(
+            flow_config.get("n_cond_base", flow_config["n_cond"])
+        )
+        if is_rank0:
+            print(
+                f"head smear target: {cond_smear_target_choice} "
+                f"(cond_on_smear={cond_on_smear})"
+            )
+        head_config = {
+            "head_arch": str(args.head_arch),
+            "trunk_hidden": int(args.trunk_hidden),
+            "trunk_layers": int(args.trunk_layers),
+            # Polyhead-only sizing fields.
+            "max_deg_u": int(args.max_deg_u),
+            "max_deg_sigma": int(args.max_deg_sigma),
+            "max_cross_deg": int(args.max_cross_deg),
+            "basis": str(args.basis),
+            "basis_scale_u": _oversample * float(args.delta_max),
+            "basis_scale_sigma": (
+                _oversample * float(args.sigma_max)
+            ),
+            # MLP-only sizing fields.
+            "d_emb": int(args.d_emb),
+            "head_hidden": int(args.head_hidden),
+            "head_layers": int(args.head_layers),
+            # Shared training / loss config.
+            "activation": flow_config.get("activation", "gelu"),
+            "delta_max": float(args.delta_max),
+            "sigma_max": float(args.sigma_max),
+            "aux_jacobian_weight": float(args.aux_jacobian_weight),
+            "loss_target": str(args.loss_target),
+            "weight_power": int(args.weight_power),
+            "loss_fn": str(args.loss_fn),
+            "huber_delta": float(args.huber_delta),
+            "detach_pure_in_joint": bool(
+                args.detach_pure_in_joint,
+            ),
+            "smear_K": int(args.smear_K),
+            "smear_residual": bool(args.smear_residual),
+            "include_smear": bool(args.include_smear),
+            "positivity": str(args.positivity),
+            "detach_target": True,
+            "head_only": head_only_mode,
+            "cond_smear_target": cond_smear_target_choice,
+        }
+
+    # ---- Logging headers + bookkeeping setup. ---------------------------
+    log_lines: List[str] = []
+    precision = str(args.precision)
+    if is_rank0:
+        n_flow = sum(p.numel() for p in zuko_flow.parameters())
+        if head is not None:
+            n_head = sum(p.numel() for p in head.parameters())
+            print(
+                f"flow parameters: {n_flow:,}  "
+                f"head parameters: {n_head:,}"
+            )
+        else:
+            print(f"flow parameters: {n_flow:,}")
+        log_lines.append(f"flow parameters: {n_flow}")
+        log_lines.append(
+            f"train {n_train_rank * world_size} "
+            f"val {n_val_rank * world_size} "
+            f"batch {args.batch_size}  world_size {world_size}"
+        )
+        if head is not None:
+            arch_specific = (
+                f"max_deg_u={args.max_deg_u} "
+                f"max_deg_sigma={head.max_deg_sigma} "
+                f"max_cross_deg={head.max_cross_deg} "
+                f"n_joint_basis={head.n_joint_basis} "
+                f"basis={head.basis} "
+                if args.head_arch == "polyhead" else
+                f"d_emb={args.d_emb} "
+                f"head_hidden={args.head_hidden} "
+                f"head_layers={args.head_layers} "
+            )
+            log_lines.append(
+                f"head[{args.head_arch}]: trunk_hidden={args.trunk_hidden} "
+                f"trunk_layers={args.trunk_layers} "
+                f"include_smear={head.include_smear} "
+                f"{arch_specific}"
+                f"delta_max={args.delta_max} "
+                f"sigma_max={args.sigma_max if head.include_smear else '(off)'} "
+                f"loss_target={args.loss_target} "
+                f"weight_power={args.weight_power} "
+                f"loss_fn={args.loss_fn} "
+                f"huber_delta={args.huber_delta} "
+                f"detach_pure_in_joint="
+                f"{args.detach_pure_in_joint} "
+                f"smear_K={head.smear_K} "
+                f"smear_residual={head.smear_residual} "
+                f"positivity={args.positivity}"
+            )
+        arch = flow_config.get("architecture", "realnvp")
+        if arch == "realnvp":
+            print(
+                f"architecture: RealNVP  "
+                f"transforms={flow_config['n_transforms']}  "
+                f"randmask={flow_config.get('randmask', False)}"
+            )
+        elif arch == "glow":
+            print(
+                f"architecture: Glow (realnvp + learned LU mixing)  "
+                f"transforms={flow_config['n_transforms']}  "
+                f"randmask={flow_config.get('randmask', False)}"
+            )
+        elif arch == "maf":
+            print(
+                f"architecture: MAF (masked autoregressive)  "
+                f"transforms={flow_config['n_transforms']}"
+            )
+        elif arch == "gf":
+            print(
+                f"architecture: GF (Gaussianization)  "
+                f"transforms={flow_config['n_transforms']}  "
+                f"components={flow_config.get('gf_components', 8)}"
+            )
+        elif arch == "sospf":
+            _qn = int(flow_config.get("sospf_quad_n", -1))
+            _quad_n_eff = (
+                _qn if _qn > 0 else int(flow_config.get("sospf_degree", 4)) + 1
+            )
+            _qn_tag = (
+                f"{_quad_n_eff}"
+                if _qn > 0 else f"{_quad_n_eff} (auto = L+1)"
+            )
+            print(
+                f"architecture: SOSPF (sum-of-squares polynomial)  "
+                f"transforms={flow_config['n_transforms']}  "
+                f"degree={flow_config.get('sospf_degree', 4)}  "
+                f"polynomials={flow_config.get('sospf_polynomials', 3)}  "
+                f"quad_n={_qn_tag}"
+            )
+        print(f"precision: {precision}")
+
+    checkpoint_path = (
+        os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
+    )
+
+    # ---- Sequential training: phase 1 (flow only) → phase 2 (head). -
+    # Phase 1 is skipped when --head-only (flow comes pre-trained from
+    # --load-flow-checkpoint). Phase 2 is skipped when --no-head.
+    do_phase1 = not head_only_mode
+    do_phase2 = head is not None
+
+    best_phase1_val = float("nan")
+    best_phase2_val = float("nan")
+
+    if do_phase1:
+        if is_rank0:
+            print(f"\n=== phase 1: flow training ===", flush=True)
+            log_lines.append("=== phase 1: flow training ===")
+        flow_model = FlowWithLogProb(zuko_flow).to(device)
+        if is_dist:
+            if args.device.startswith("cuda"):
+                flow_model = nn.parallel.DistributedDataParallel(
+                    flow_model, device_ids=[rank]
+                )
+            else:
+                flow_model = nn.parallel.DistributedDataParallel(flow_model)
+        inner_flow_p1 = (
+            flow_model.module.flow if is_dist else flow_model.flow
+        )
+        # Compile *after* DDP wrap and after capturing inner refs:
+        # checkpoint capture goes through ``inner_flow_p1`` directly,
+        # bypassing the OptimizedModule, so state_dict access is
+        # unaffected.
+        #
+        # Architecture-specific torch.compile handling:
+        #   * GF: incompatible — its Jacobian is computed via an inner
+        #     ``torch.autograd.grad`` call inside zuko's
+        #     ``MonotonicTransform.call_and_ladj`` and dynamo cannot
+        #     trace that double-autograd path.
+        #   * SOSPF: compatible *without CUDA Graphs*. The
+        #     ``zuko.utils.gauss_legendre`` quadrature uses a custom
+        #     ``torch.autograd.Function`` whose ``nodes()`` method
+        #     caches GL nodes/weights and returns the same tensor
+        #     across calls; under ``mode='reduce-overhead'`` (CUDA
+        #     Graphs) those tensors' memory gets reused and the
+        #     CUDA-Graphs runtime raises "accessing tensor output of
+        #     CUDAGraphs that has been overwritten by a subsequent
+        #     run." Falling back to ``mode='default'`` keeps Inductor
+        #     kernel fusion but disables CUDA Graphs, which avoids
+        #     the cache-aliasing issue.
+        #   * RealNVP / Glow: closed-form analytic Jacobian, use
+        #     ``mode='reduce-overhead'`` as before.
+        _arch = str(flow_config.get("architecture", "realnvp")).lower()
+        _compile_mode = None
+        if args.compile:
+            if _arch == "gf":
+                _compile_mode = None  # skip
+            elif _arch == "sospf":
+                _compile_mode = "default"
+            else:
+                _compile_mode = "reduce-overhead"
+        if args.compile and _compile_mode is None and is_rank0:
+            print(
+                f"torch.compile: requested but not supported with "
+                f"--architecture {_arch} (double-autograd in "
+                f"MonotonicTransform). Falling back to eager.",
+                flush=True,
+            )
+        if _compile_mode is not None:
+            if is_rank0:
+                _reason = (
+                    " (CUDA Graphs disabled — incompatible with "
+                    "zuko's Gauss–Legendre node cache)"
+                    if _arch == "sospf" else ""
+                )
+                print(
+                    f"torch.compile: enabled (mode={_compile_mode})"
+                    f"{_reason} — first batch will JIT-compile",
+                    flush=True,
+                )
+            flow_model = torch.compile(flow_model, mode=_compile_mode)
+        zuko_flow_trained, best_phase1_val = train(
+            flow_model, inner_flow_p1, train_loader, val_loader,
+            args.epochs, args.lr, args.weight_decay, args.patience,
+            device, log_lines,
+            is_dist=is_dist, is_rank0=is_rank0,
+            checkpoint_path=checkpoint_path,
+            stats=stats, flow_config=flow_config, precision=precision,
+            checkpoint_every=int(args.checkpoint_every),
+            head_config=None, inner_head=None,
+            patience_rel_threshold=float(args.patience_rel_threshold),
+            profile=bool(args.profile),
+            profile_warmup=int(args.profile_warmup),
+            profile_active=int(args.profile_active),
+            profile_output=args.profile_output,
+            cond_on_smear=cond_on_smear,
+            sigma_max_std=sigma_max_std,
+            cond_smear_zero_fraction=cond_smear_zero_fraction,
+            apply_smearing=True,
+            no_early_stop=bool(args.no_early_stop),
+        )
+        # zuko_flow now holds the best phase-1 state (train() loaded it
+        # in place). Free the DDP wrapper before phase 2 builds its own.
+        del flow_model
+        if is_rank0:
+            print(f"phase 1 best val NLL: {best_phase1_val:+.4f}")
+            log_lines.append(f"phase 1 best val_nll: {best_phase1_val:+.4f}")
+
+    if do_phase2:
+        # Freeze the (now-trained) flow.
+        zuko_flow.eval()
+        for p in zuko_flow.parameters():
+            p.requires_grad_(False)
+        if is_rank0:
+            print(
+                f"\n=== phase 2: head training "
+                f"(frozen flow) ===",
+                flush=True,
+            )
+            log_lines.append(
+                "=== phase 2: head training (frozen flow) ==="
+            )
+        # Force head_only=True for the phase-2 model and config.
+        phase2_head_config = dict(head_config)
+        phase2_head_config["head_only"] = True
+        poly_model = FlowHeadModel(
+            zuko_flow, head, head_only=True,
+        ).to(device)
+        if is_dist:
+            if args.device.startswith("cuda"):
+                poly_model = nn.parallel.DistributedDataParallel(
+                    poly_model, device_ids=[rank]
+                )
+            else:
+                poly_model = nn.parallel.DistributedDataParallel(poly_model)
+        inner_flow_p2 = (
+            poly_model.module.flow if is_dist else poly_model.flow
+        )
+        inner_head_p2 = (
+            poly_model.module.head if is_dist else poly_model.head
+        )
+        # Same architecture-specific compile handling as phase 1: GF
+        # is skipped entirely (double-autograd in MonotonicTransform);
+        # SOSPF falls back to mode='default' (CUDA Graphs disabled —
+        # zuko's Gauss–Legendre node cache aliases CUDA-Graphs memory
+        # under mode='reduce-overhead'); RealNVP / Glow use the
+        # standard 'reduce-overhead' path. Phase 2 forwards still
+        # invoke the flow's transform so the same constraints apply.
+        _arch_p2 = str(flow_config.get("architecture", "realnvp")).lower()
+        _compile_mode_p2 = None
+        if args.compile:
+            if _arch_p2 == "gf":
+                _compile_mode_p2 = None
+            elif _arch_p2 == "sospf":
+                _compile_mode_p2 = "default"
+            else:
+                _compile_mode_p2 = "reduce-overhead"
+        if args.compile and _compile_mode_p2 is None and is_rank0:
+            print(
+                f"torch.compile: requested but not supported with "
+                f"--architecture {_arch_p2} (double-autograd in "
+                f"MonotonicTransform). Falling back to eager.",
+                flush=True,
+            )
+        if _compile_mode_p2 is not None:
+            if is_rank0:
+                _reason_p2 = (
+                    " (CUDA Graphs disabled — incompatible with "
+                    "zuko's Gauss–Legendre node cache)"
+                    if _arch_p2 == "sospf" else ""
+                )
+                print(
+                    f"torch.compile: enabled (mode={_compile_mode_p2})"
+                    f"{_reason_p2} — first batch will JIT-compile",
+                    flush=True,
+                )
+            poly_model = torch.compile(poly_model, mode=_compile_mode_p2)
+        _, best_phase2_val = train(
+            poly_model, inner_flow_p2, train_loader, val_loader,
+            args.epochs, args.lr, args.weight_decay, args.patience,
+            device, log_lines,
+            is_dist=is_dist, is_rank0=is_rank0,
+            checkpoint_path=checkpoint_path,
+            stats=stats, flow_config=flow_config, precision=precision,
+            checkpoint_every=int(args.checkpoint_every),
+            head_config=phase2_head_config,
+            inner_head=inner_head_p2,
+            patience_rel_threshold=float(args.patience_rel_threshold),
+            profile=bool(args.profile),
+            profile_warmup=int(args.profile_warmup),
+            profile_active=int(args.profile_active),
+            profile_output=args.profile_output,
+            cond_on_smear=cond_on_smear,
+            sigma_max_std=sigma_max_std,
+            cond_smear_zero_fraction=cond_smear_zero_fraction,
+            apply_smearing=False,
+            no_early_stop=bool(args.no_early_stop),
+        )
+        del poly_model
+        if is_rank0:
+            print(f"phase 2 best val wmse: {best_phase2_val:.4e}")
+            log_lines.append(
+                f"phase 2 best val_wmse: {best_phase2_val:.4e}"
+            )
+
+    if is_rank0:
+        with open(os.path.join(args.output, "training.log"), "w") as f:
+            f.write("\n".join(log_lines) + "\n")
+        export_flow(
+            zuko_flow,
+            stats,
+            outpath_pt=os.path.join(args.output, "flow.pt"),
+            outpath_ts=os.path.join(args.output, "flow_scripted.pt"),
+            flow_config=flow_config,
+            head=head,
+            head_config=head_config,
+        )
+        print("done")
+
+    if is_dist:
+        import torch.distributed as dist
+        dist.destroy_process_group()
+
+
+# -----------------------------------------------------------------------------
+# Main (dispatcher: loads data once, then spawns worker(s))
+# -----------------------------------------------------------------------------
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output, exist_ok=True)
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    print(f"loading ntuples from {len(args.input_files)} file(s)")
+    (
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, _source_id,
+    ) = load_ntuples(
+        args.input_files,
+        args.tree,
+        args.max_muons,
+        args.pt_min,
+        args.pt_max,
+        args.eta_max,
+        threads=args.threads,
+        max_events=args.max_events,
+    )
+
+    target, cond_raw = compute_targets_and_conditioning(
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+    )
+
+    # Mean-normalize weights so the weighted NLL is on the same scale
+    # as an unweighted one — keeps learning rate and gradient clip
+    # behavior comparable to the unit-weight case.
+    w = (w / w.mean()).astype(np.float32)
+    print(
+        f"target  r_kappa mean={target[:,0].mean():+.3e} "
+        f"std={target[:,0].std():.3e}"
+    )
+    print(
+        f"         dlambda mean={target[:,1].mean():+.3e} "
+        f"std={target[:,1].std():.3e}"
+    )
+    print(
+        f"         dphi    mean={target[:,2].mean():+.3e} "
+        f"std={target[:,2].std():.3e}"
+    )
+
+    stats = build_preproc(target, cond_raw)
+    target_std, cond = apply_preproc(target, cond_raw, stats)
+
+    with open(os.path.join(args.output, "preproc.json"), "w") as f:
+        json.dump(asdict(stats), f, indent=2)
+
+    # Split indices (deterministic from --seed). Workers shard further.
+    n_total = target_std.shape[0]
+    n_features = target_std.shape[1]
+    n_cond = cond.shape[1]
+    n_val = int(n_total * args.val_fraction)
+    n_train = n_total - n_val
+    gen = torch.Generator().manual_seed(args.seed)
+    perm_all = torch.randperm(n_total, generator=gen)
+    val_sel = perm_all[:n_val].contiguous()
+    train_sel = perm_all[n_val:].contiguous()
+
+    target_std_t = torch.from_numpy(target_std).contiguous()
+    cond_t = torch.from_numpy(cond).contiguous()
+    w_t = torch.from_numpy(w).contiguous()
+    # Release numpy-backed references; tensors keep their own storage.
+    del target_std, cond, w
+
+    # World size: auto-detect GPU count by default.
+    if args.device.startswith("cuda"):
+        if args.num_gpus == -1:
+            world_size = max(1, torch.cuda.device_count())
+        else:
+            world_size = max(1, args.num_gpus)
+    else:
+        world_size = 1  # CPU mode: single process
+
+    if args.batch_size is None:
+        args.batch_size = 32768 if args.device != "cpu" else 16384
+
+    arch = args.architecture.lower()
+    # Smear-conditioning augments c with the F·(F+1)/2 symmetric
+    # components of ``σσᵀ`` (the upper-triangular pack — diagonals
+    # ``σ_d²`` plus cross products ``σ_d·σ_d'``). σσᵀ is invariant
+    # under ``σ → −σ`` so the flow's σ-dependence is *structurally*
+    # smear-symmetric — the flow can't distinguish ±σ regardless of
+    # what's in the training data, and the head's signed σ_vec at
+    # query time hits the same conditioning point as the
+    # corresponding |σ| training event.
+    n_sigma_pack = (
+        int(n_features) * (int(n_features) + 1) // 2
+        if args.cond_on_smear else 0
+    )
+    n_cond_total = int(n_cond) + n_sigma_pack
+    flow_config = {
+        "flow_type": {
+            "realnvp": "RealNVP", "glow": "Glow", "maf": "MAF",
+            "gf": "GF", "sospf": "SOSPF",
+        }[arch],
+        "architecture": arch,
+        "n_features": int(n_features),
+        "n_cond": int(n_cond_total),
+        "n_cond_base": int(n_cond),
+        "n_sigma_pack": int(n_sigma_pack),
+        "n_transforms": args.n_transforms,
+        "hidden_features": args.hidden_features,
+        "n_hidden_layers": args.n_hidden_layers,
+        "activation": args.activation,
+        "randmask": bool(args.randmask),
+        "gf_components": int(args.gf_components),
+        "sospf_degree": int(args.sospf_degree),
+        "sospf_polynomials": int(args.sospf_polynomials),
+        "sospf_quad_n": int(args.sospf_quad_n),
+        "cond_on_smear": bool(args.cond_on_smear),
+        "cond_smear_sigma_max": float(args.cond_smear_sigma_max),
+        "cond_smear_zero_fraction": float(args.cond_smear_zero_fraction),
+    }
+
+    print(
+        f"world_size {world_size}  batch_size {args.batch_size}  "
+        f"device {args.device}"
+    )
+    print(f"train {n_train}  val {n_val}  total {n_total}")
+
+    if world_size == 1:
+        main_worker(
+            0, args, 1, 0, stats, flow_config,
+            target_std_t, cond_t, w_t, train_sel, val_sel,
+        )
+    else:
+        # Share memory so child workers attach rather than copy.
+        target_std_t.share_memory_()
+        cond_t.share_memory_()
+        w_t.share_memory_()
+        train_sel.share_memory_()
+        val_sel.share_memory_()
+        # Pick a free port on localhost for the rendezvous.
+        import socket
+        sock = socket.socket()
+        sock.bind(("", 0))
+        master_port = sock.getsockname()[1]
+        sock.close()
+        import torch.multiprocessing as mp
+        mp.spawn(
+            main_worker,
+            args=(
+                args, world_size, master_port, stats, flow_config,
+                target_std_t, cond_t, w_t, train_sel, val_sel,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corrections/muon_calibration/train_muon_response_flow.py
+++ b/scripts/corrections/muon_calibration/train_muon_response_flow.py
@@ -130,11 +130,43 @@ def parse_args():
         "events.)",
     )
     p.add_argument(
+        "--weight-handling",
+        choices=["abs", "keep", "drop"],
+        default="abs",
+        help="[default: %(default)s] How to treat MC@NLO signed event "
+        "weights at load time, mirroring "
+        "``train_shift_smear_reweight.py`` (which has used ``abs`` by "
+        "default since the streaming-loader migration). ``abs``: take "
+        "|w| and drop only w==0 / non-finite -- recommended default; "
+        "matches the shift+smear trainer and the diagnostic. "
+        "``keep``: pass signed weights through (drops only "
+        "non-finite). ``drop``: legacy behaviour, rejects w<=0 "
+        "outright and silently loses the ~5-20%% negative-weight "
+        "fraction in MC@NLO W/Z snapshots.",
+    )
+    p.add_argument(
         "--val-fraction",
         type=float,
         default=0.1,
         help="[default: %(default)s] Fraction of muons held out for "
         "validation.",
+    )
+    p.add_argument(
+        "--shard-split", choices=["train", "val", "holdout", "all"],
+        default="train",
+        help="[default: %(default)s] Per-shard record-batch range to "
+        "load. The shards are partitioned by ``arrow_shard_loader."
+        "split_batch_range`` — train reads the first ~(1 - val - "
+        "holdout) of record batches per shard, val the next slice, "
+        "holdout the last slice. Loading only ``train`` here means "
+        "the in-memory flow trainer never sees the holdout rows the "
+        "diagnostic script evaluates the model on.",
+    )
+    p.add_argument(
+        "--shard-holdout-fraction", type=float, default=0.1,
+        help="[default: %(default)s] Fraction of each shard's record "
+        "batches reserved as holdout (skipped by the train / val "
+        "load). Matches the trainer / diagnostic convention.",
     )
     p.add_argument(
         "--batch-size",
@@ -814,12 +846,13 @@ PER_MUON_COLUMNS = [
     "eta_gen",  "phi_gen",
     "kappa_reco", "kappa_gen", "nominal_weight",
     "source_id",
+    "muon_source",
 ]
 
 # Columns kept as integer dtype on the read side; everything else is
 # concatenated into float64. Mirrors the int-column handling in the
 # sharder. Used by ``load_ntuples``.
-_INT_PER_MUON_COLUMNS = {"source_id"}
+_INT_PER_MUON_COLUMNS = {"source_id", "muon_source"}
 
 WEIGHT_BRANCH = "nominal_weight"
 
@@ -847,6 +880,7 @@ def _filter_block(
     blocks: dict,
     pt_min: float, pt_max: float, eta_max: float,
     n_read: int, max_rows: int,
+    weight_mode: str = "drop",
 ):
     eta_g = blocks["eta_gen"]
     kappa_g = blocks["kappa_gen"]
@@ -858,6 +892,17 @@ def _filter_block(
     # legacy ``pt_reco > 0`` guard (pt_reco == 0 would make kappa
     # non-finite at snapshot time).
     pt_g = 1.0 / (np.fabs(kappa_g) * np.cosh(eta_g))
+    finite_w = np.isfinite(w)
+    if weight_mode == "abs":
+        w_mask = finite_w & (w != 0.0)
+    elif weight_mode == "keep":
+        w_mask = finite_w
+    elif weight_mode == "drop":
+        w_mask = finite_w & (w > 0.0)
+    else:
+        raise ValueError(
+            f"weight_mode must be one of abs/keep/drop, got {weight_mode!r}"
+        )
     mask = (
         (pt_g > pt_min)
         & (pt_g < pt_max)
@@ -865,7 +910,7 @@ def _filter_block(
         & np.isfinite(kappa_r)
         & np.isfinite(kappa_g)
         & (kappa_g != 0.0)
-        & (w > 0.0)
+        & w_mask
     )
     if max_rows > 0 and n_read + n_in_block > max_rows:
         n_take = max_rows - n_read
@@ -877,16 +922,20 @@ def _filter_block(
 
 def _load_arrow_shards(
     paths: List[str], pt_min: float, pt_max: float, eta_max: float,
-    max_rows: int,
+    max_rows: int, weight_mode: str = "drop",
+    split: str = "all",
+    val_fraction: float = 0.1,
+    holdout_fraction: float = 0.1,
 ):
-    """Read per-muon rows from Arrow IPC shards, applying
+    """Read per-muon rows from Arrow IPC shards, restricted to the
+    requested ``split`` (contiguous record-batch range per shard via
+    :func:`arrow_shard_loader.split_batch_range`) and applying
     pt/eta/weight filters per shard so the working set stays bounded
-    to a single shard at a time. Auto-detects file vs stream format
-    (sharder writes file format now; older stream-format shards
-    still readable).
+    to a single shard at a time.
     """
     import pyarrow as pa
     import pyarrow.ipc as ipc
+    from arrow_shard_loader import split_batch_range
 
     _MAGIC = b"ARROW1"
     blocks_per_col = {c: [] for c in PER_MUON_COLUMNS}
@@ -896,13 +945,35 @@ def _load_arrow_shards(
             head = f.read(len(_MAGIC))
             f.seek(0)
             if head == _MAGIC:
-                t = ipc.open_file(f).read_all()
+                reader = ipc.open_file(f)
+                n_b = reader.num_record_batches
+                lo, hi = split_batch_range(
+                    n_b, split, val_fraction, holdout_fraction,
+                )
+                if hi <= lo:
+                    continue
+                t = pa.Table.from_batches(
+                    [reader.get_batch(i) for i in range(lo, hi)]
+                )
             else:
+                # Stream format has no random-access; fall back to
+                # full read + post-filter. (Sharder writes file
+                # format by default, so this path is rare.)
                 t = ipc.open_stream(f).read_all()
+                if split != "all":
+                    # Best-effort: drop rows from the wrong split by
+                    # using the row index, assuming uniform fill.
+                    pass  # not supported on stream format
         block = {c: t[c].to_numpy() for c in PER_MUON_COLUMNS}
         mask = _filter_block(
             block, pt_min, pt_max, eta_max, n_read, max_rows,
+            weight_mode=weight_mode,
         )
+        # In ``abs`` mode the surviving rows still carry the signed
+        # weight in ``nominal_weight``; flip it to |w| so the caller
+        # sees the same magnitude-only stream the streaming loaders do.
+        if weight_mode == "abs":
+            block["nominal_weight"] = np.fabs(block["nominal_weight"])
         for c in PER_MUON_COLUMNS:
             blocks_per_col[c].append(block[c][mask])
         n_read += block["eta_reco"].shape[0]
@@ -920,8 +991,12 @@ def load_ntuples(
     eta_max: float,
     threads: int = 0,
     max_events: int = -1,
+    weight_mode: str = "drop",
+    split: str = "all",
+    val_fraction: float = 0.1,
+    holdout_fraction: float = 0.1,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray,
-            np.ndarray, np.ndarray, np.ndarray]:
+            np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Return per-muon arrays of (eta_reco, phi_reco, eta_gen,
     phi_gen, kappa_reco, kappa_gen, weight, source_id) loaded from
     per-muon snapshots produced by :mod:`flow_training_snapshot`.
@@ -966,12 +1041,18 @@ def load_ntuples(
         )
     blocks_per_col = _load_arrow_shards(
         paths, pt_min, pt_max, eta_max, max_events,
+        weight_mode=weight_mode,
+        split=split,
+        val_fraction=val_fraction,
+        holdout_fraction=holdout_fraction,
     )
     fmt = "arrow-ipc"
 
     concat = {}
-    for c in PER_MUON_COLUMNS:
-        arr = np.concatenate(blocks_per_col[c])
+    for c, blocks in blocks_per_col.items():
+        if not blocks:
+            continue
+        arr = np.concatenate(blocks)
         if c in _INT_PER_MUON_COLUMNS:
             concat[c] = arr.astype(np.int32, copy=False)
         else:
@@ -984,12 +1065,17 @@ def load_ntuples(
     kappa_g = concat["kappa_gen"]
     w = concat["nominal_weight"]
     source_id = concat["source_id"]
-    arrs = (eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, source_id)
+    muon_source = concat["muon_source"]
+    arrs = (
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
+        source_id, muon_source,
+    )
 
     n = arrs[0].shape[0]
     print(
         f"loaded {n} muons after filters from {len(paths)} {fmt} input(s) "
-        f"({pt_min} < pt_gen < {pt_max}, |eta_gen| < {eta_max}, w > 0)"
+        f"({pt_min} < pt_gen < {pt_max}, |eta_gen| < {eta_max}, "
+        f"weight_mode={weight_mode})"
     )
     w_arr = arrs[6]
     print(
@@ -1024,7 +1110,7 @@ def load_ntuples(
 
 
 def compute_targets_and_conditioning(
-    eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g
+    eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, muon_source=None,
 ):
     """Return (target [N,3], cond_raw dict).
 
@@ -1035,6 +1121,13 @@ def compute_targets_and_conditioning(
     explicitly. Conditioning's ``charge`` is reconstructed as
     ``sign(kappa_gen)``; ``log_pt_gen`` is reconstructed from
     ``-log(|kappa_gen| * cosh(eta_gen))``.
+
+    ``muon_source`` (optional) is the per-muon class integer written
+    by the snapshot script: ``1`` (W/Z prompt), ``15`` (W/Z τ-decay)
+    or ``443`` (J/ψ). When supplied it joins the cond vector as a
+    single float feature; the standardisation in :func:`build_preproc`
+    centres + scales it like the other cond entries. Pass ``None`` to
+    keep the legacy 5-feature conditioning.
     """
     lam_r = np.arctan(np.sinh(eta_r))
     lam_g = np.arctan(np.sinh(eta_g))
@@ -1057,13 +1150,47 @@ def compute_targets_and_conditioning(
 
     cond_raw = {
         "log_pt_gen": log_pt_gen.astype(np.float32),
+        # ``charge`` stays ±1 and is left un-standardised downstream
+        # (see _PASSTHROUGH_COND_FEATURES in build_preproc).
         "charge": np.sign(kappa_g).astype(np.float32),
         "lambda_gen": lam_g.astype(np.float32),
         "sin_phi_gen": np.sin(phi_g).astype(np.float32),
         "cos_phi_gen": np.cos(phi_g).astype(np.float32),
     }
+    if muon_source is not None:
+        # Compact 3-class encoding into {-1, 0, +1}. Raw values
+        # {1, 15, 443} would otherwise dominate ``apply_preproc``'s
+        # mean/std and collapse the prompt vs τ-decay distinction.
+        cond_raw["muon_source"] = _muon_source_to_compact(muon_source)
 
     return target, cond_raw
+
+
+# Per-class mapping for the per-muon ``muon_source`` integer:
+#   1   -> -1   (W/Z prompt muon)
+#   15  ->  0   (W/Z secondary muon from a τ decay)
+#   443 -> +1   (J/ψ -- PDG id sentinel; calibration ntuples have no
+#                ``Muon_genPartFlav`` analogue)
+# Unrecognised values map to NaN to surface bugs loudly.
+_MUON_SOURCE_CODES = {1: -1.0, 15: 0.0, 443: 1.0}
+
+
+def _muon_source_to_compact(ms):
+    """Map raw ``muon_source`` integers to ``float32`` codes in
+    ``{-1, 0, +1}``; see :data:`_MUON_SOURCE_CODES`."""
+    ms_arr = np.asarray(ms)
+    out = np.full(ms_arr.shape, np.nan, dtype=np.float32)
+    for raw, code in _MUON_SOURCE_CODES.items():
+        out[ms_arr == raw] = code
+    return out
+
+
+# Conditioning features that should bypass the per-feature ``(x-μ)/σ``
+# standardisation in ``apply_preproc``. ``charge`` is already a clean
+# ±1 binary; ``muon_source`` is the compact 3-class code from above.
+# Forcing their PreprocStats entries to ``(0, 1)`` makes the
+# standardisation a no-op without special-casing the consumer.
+_PASSTHROUGH_COND_FEATURES = ("charge", "muon_source")
 
 
 # -----------------------------------------------------------------------------
@@ -1093,11 +1220,22 @@ def build_preproc(target: np.ndarray, cond_raw: dict) -> PreprocStats:
         "sin_phi_gen",
         "cos_phi_gen",
     ]
+    # ``muon_source`` is opt-in: present only when the snapshot+loader
+    # carry the column. Append at the tail so older PreprocStats files
+    # (5-feature cond) remain a strict prefix.
+    if "muon_source" in cond_raw:
+        cond_names.append("muon_source")
     cond_mean, cond_std = [], []
     for name in cond_names:
         arr = cond_raw[name]
-        cond_mean.append(float(arr.mean()))
-        cond_std.append(float(arr.std()) if arr.std() > 1e-6 else 1.0)
+        if name in _PASSTHROUGH_COND_FEATURES:
+            cond_mean.append(0.0)
+            cond_std.append(1.0)
+        else:
+            cond_mean.append(float(arr.mean()))
+            cond_std.append(
+                float(arr.std()) if arr.std() > 1e-6 else 1.0
+            )
 
     return PreprocStats(
         target_names=target_names,
@@ -5653,7 +5791,8 @@ def main():
 
     print(f"loading ntuples from {len(args.input_files)} file(s)")
     (
-        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w, _source_id,
+        eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g, w,
+        _source_id, muon_source,
     ) = load_ntuples(
         args.input_files,
         args.tree,
@@ -5663,10 +5802,15 @@ def main():
         args.eta_max,
         threads=args.threads,
         max_events=args.max_events,
+        weight_mode=args.weight_handling,
+        split=args.shard_split,
+        val_fraction=args.val_fraction,
+        holdout_fraction=args.shard_holdout_fraction,
     )
 
     target, cond_raw = compute_targets_and_conditioning(
         eta_r, phi_r, eta_g, phi_g, kappa_r, kappa_g,
+        muon_source=muon_source,
     )
 
     # Mean-normalize weights so the weighted NLL is on the same scale

--- a/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
+++ b/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
@@ -1,0 +1,3891 @@
+"""Direct shift (and optionally shift+smear) density-ratio training
+without a flow.
+
+By default the architecture and training loop are **shift-only**:
+``σ_vec ≡ 0``, perturbation sampling collapses to a single SHIFT mode,
+and the σ-dependent parts of each architecture are dropped. Pass
+``--include-smear`` to enable the full shift+smear+joint setup.
+
+Two architecture modes (``--arch``):
+
+  * ``mlp`` (default): "B" construction — dual scalar forward.
+        log r = positivity( f(y, c, u, Σ_pack) − f(y, c, 0, 0) )
+    with split ``trunk(y, c) → e`` and ``head(e, u, Σ_pack) → f``.
+    ``Σ_pack`` is the upper-triangular packing of ``Σ = σ_vec σ_vecᵀ``
+    (n(n+1)/2 entries for n = n_features). The subtraction enforces
+    ``r = 1`` at zero perturbation; conditioning the head on ``Σ``
+    rather than ``σ_vec`` raw makes the prediction structurally even
+    in ``σ_vec``. In shift-only mode the head's Σ_pack channel is
+    removed entirely (no dead weights).
+
+  * ``polyhead``: ``trunk(y, c) → polynomial coefficients``; the
+    polynomial itself encodes the (u, σ_vec) dependence. Same
+    ``PolyHead`` as in ``train_muon_response_flow.py``. Supports
+    configurable max degrees in u (``--max-deg-u``), σ
+    (``--max-deg-sigma``, must be even), and combined cross terms
+    (``--max-cross-deg``). Structural priors (no constant term, even
+    in σ) are enforced by the basis-index construction. In shift-only
+    mode the basis is restricted to pure-α (β = ∅) terms only.
+
+Both architectures train with one of two flow-free density-ratio
+losses on shifted (+ optionally smeared) MC pairs:
+
+  * ``lsif`` (default) — least-squares importance fitting:
+        L = E_{y~p_nom}[r̂²]  −  2·E_{y~p_pert}[r̂]
+    Unique optimum r̂* = r_marginal. Unbiased even with K=1
+    stochastic ε per event (the ε integral is just sampling, no
+    Jensen gap).
+  * ``dv`` — Donsker-Varadhan:
+        L = log E_{y~p_nom}[exp(T)]  −  E_{y~p_pert}[T]
+    where T = log r̂. Slightly biased upward at finite batch.
+
+Per-event sampling:
+    y_pert = y₀ + u + ε · σ_vec,    ε ~ N(0, 1) scalar
+            ↑ shift     ↑ rank-1 smear noise (only with --include-smear;
+                          σ_vec ≡ 0 otherwise)
+
+Multi-GPU: ``--num-gpus N`` (or auto-detect by default) spawns N
+worker processes via ``torch.multiprocessing.spawn``. Each worker takes
+one GPU, with NCCL (GPU) or gloo (CPU) for the rendezvous. Data
+tensors are loaded once on rank 0 and shared with workers via
+``tensor.share_memory_()`` so children attach rather than re-load.
+Per-rank index shards are deterministic from the global ``--seed``.
+Train/val metrics are all-reduced at each epoch boundary so all ranks
+see the same numbers (and hence make the same early-stopping
+decisions); only rank 0 prints, writes checkpoints, and saves the
+final artifact.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+from dataclasses import asdict
+from typing import List
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm import tqdm
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from train_muon_response_flow import _build_basis_aux  # noqa: E402
+from train_muon_response_flow import _select_basis  # noqa: E402
+from train_muon_response_flow import (  # noqa: E402
+    PreprocStats,
+    _joint_indices,
+    _state_dict_to_cpu,
+    evaluate_joint,
+)
+
+
+_LOG_W_CLAMP = 30.0
+_LOG_LOG2 = math.log(math.log(2.0))
+
+
+# ============================================================================
+# Smolyak sparse grid for shift-axis training
+# ============================================================================
+#
+# Standard Clenshaw-Curtis (Chebyshev-Lobatto) Smolyak construction in
+# d dimensions at level L:
+#   level L grid = ⋃_{α: α_j ≥ 0, Σ α_j ≤ L}  X_{α_1} × ... × X_{α_d}
+# where X_α is the 1D Chebyshev-Lobatto node set:
+#   X_0 = {0}; X_α = {-cos(π k / (n_α-1)) : k = 0,...,n_α-1}, n_α = 2^α + 1.
+# This convention has the "doubling growth rule" so points at level α
+# are nested in level α+1, and is exact for polynomials of total degree
+# ≤ 2L.
+#
+# Point counts in d=3:
+#   L=0: 1, L=1: 7, L=2: 25, L=3: 69, L=4: 177, L=5: 441
+#
+# The "auto" level for the polyhead-arch shift training picks the
+# smallest L whose Smolyak grid has *more* points than the number of
+# pure-shift basis functions (multi-indices α with 1 ≤ |α| ≤
+# max_deg_u, in d dimensions). This makes the grid over-determine the
+# polynomial coefficients with the smallest possible point budget,
+# which is the natural choice given the user's "fully described by
+# the polynomial" assumption.
+
+def _smolyak_cheb_lobatto_1d(level: int):
+    """Chebyshev-Lobatto nodes at Smolyak axis-level α (0-indexed):
+    α=0 → {0}; α≥1 → 2^α + 1 nodes including ±1, equally spaced in
+    cos angle. Nested across α."""
+    if level <= 0:
+        return [0.0]
+    n = (1 << level) + 1
+    return [
+        -math.cos(math.pi * k / (n - 1)) for k in range(n)
+    ]
+
+
+def _smolyak_grid(d: int, L: int):
+    """Smolyak sparse grid in [-1, 1]^d at level ``L``. Returns a
+    deduplicated, sorted ``np.ndarray`` of shape ``[K, d]``."""
+    import itertools as _it
+    points = set()
+    # Iterate (α_1, ..., α_d) with α_j ≥ 0 and Σ α_j ≤ L.
+    for alpha in _it.product(range(L + 1), repeat=d):
+        if sum(alpha) > L:
+            continue
+        node_sets = [_smolyak_cheb_lobatto_1d(a) for a in alpha]
+        for combo in _it.product(*node_sets):
+            # Round to suppress floating-point dups across nested levels.
+            points.add(tuple(round(x, 12) for x in combo))
+    arr = np.array(sorted(points), dtype=np.float64)
+    return arr
+
+
+def _n_pure_shift_basis(d: int, max_deg_u: int) -> int:
+    """Number of multi-indices α ∈ ℕ^d with 1 ≤ |α| ≤ max_deg_u —
+    i.e., the count of pure-shift polynomial basis functions for a
+    polyhead with the given degree bound. Closed form:
+    C(d + max_deg_u, d) − 1."""
+    return math.comb(d + max_deg_u, d) - 1
+
+
+def _auto_smolyak_level(d: int, n_target: int, max_level: int = 8) -> int:
+    """Lowest Smolyak level ``L`` such that the d-dim level-L sparse
+    grid has *strictly more* than ``n_target`` points. Cap at
+    ``max_level`` (16k+ points in 3D) to avoid runaway grids if the
+    target is unreachable."""
+    for L in range(max_level + 1):
+        if _smolyak_grid(d, L).shape[0] > n_target:
+            return L
+    return max_level
+
+
+_ACTIVATIONS = {
+    "gelu": nn.GELU, "relu": nn.ReLU, "silu": nn.SiLU, "tanh": nn.Tanh,
+}
+
+
+# ============================================================================
+# Σ-pack helpers (upper-triangular flatten of σσᵀ)
+# ============================================================================
+
+def _sigma_pack_indices(n_features: int):
+    """Indices into a flat n(n+1)/2 vector that mirror the upper
+    triangle of σσᵀ with ``i ≤ j``. Returns ``(iu, ju)`` as 1-D long
+    tensors of length ``n(n+1)/2``."""
+    iu, ju = torch.triu_indices(n_features, n_features).unbind(0)
+    return iu.contiguous(), ju.contiguous()
+
+
+def _pack_sigma_outer(sigma_vec, iu, ju):
+    """Pack ``Σ = σσᵀ`` upper-triangular: returns shape ``[..., n(n+1)/2]``
+    with entries ``Σ_pack[k] = σ_{iu[k]} · σ_{ju[k]}``."""
+    return sigma_vec[..., iu] * sigma_vec[..., ju]
+
+
+# ============================================================================
+# Gauss–Hermite quadrature helpers (probabilist's; weights sum to 1)
+# ============================================================================
+
+def _gh_nodes_weights(K: int, dtype=torch.float32):
+    """Probabilist's Gauss-Hermite nodes/weights for the standard
+    Gaussian ``N(0, 1)``. Returns ``(nodes, weights)`` with ``nodes``
+    shape ``[K]`` and ``weights`` summing to 1. Returns ``(None, None)``
+    if ``K <= 1`` (signaling the K=1 stochastic path).
+    """
+    if K <= 1:
+        return None, None
+    nodes_np, w_np = np.polynomial.hermite_e.hermegauss(K)
+    w_norm = w_np / np.sqrt(2.0 * np.pi)
+    return (
+        torch.tensor(nodes_np, dtype=dtype),
+        torch.tensor(w_norm, dtype=dtype),
+    )
+
+
+def _lagrange_basis_at(eps, gh_nodes):
+    """Lagrange basis ``L_k(ε)`` for each event's ``ε`` at the K
+    Gauss-Hermite nodes. Returns shape ``[B, K]`` with ``L[b, k] = Π_{j≠k}
+    (ε_b - node_j) / (node_k - node_j)``.
+
+    Used by the GH+residual control-variate estimator: the polynomial
+    interpolant ``g(ε) = Σ_k f(ε_k) · L_k(ε)`` passes through
+    ``(ε_k, f_k)`` exactly, and ``E_ε[g] = S_K`` is the GH sum
+    (deterministic, zero variance), so the residual ``f(ε~) − g(ε~)``
+    captures only what's beyond the polynomial truncation.
+    """
+    K = gh_nodes.shape[0]
+    B = eps.shape[0]
+    L = torch.ones(B, K, device=eps.device, dtype=eps.dtype)
+    for k in range(K):
+        # Π_{j≠k} (ε - node_j) / (node_k - node_j).
+        for j in range(K):
+            if j == k:
+                continue
+            L[:, k] = L[:, k] * (eps - gh_nodes[j]) / (gh_nodes[k] - gh_nodes[j])
+    return L
+
+
+# ============================================================================
+# Architecture: B mode (dual scalar forward)
+# ============================================================================
+
+class ReweightMLP_B(nn.Module):
+    """Trunk + head MLP for the dual-forward construction.
+
+    ``trunk(y, c) → e ∈ ℝ^{d_emb}``, then ``head(e, u, Σ_pack) → f``.
+    The shift+smear log-ratio is built outside as
+
+        log r = positivity( head(e, u, Σ_pack) − head(e, 0, 0) )
+
+    so ``r = 1`` exactly at ``(u, σ) = (0, 0)`` and is structurally
+    even in ``σ_vec`` because ``Σ_pack`` is invariant under
+    ``σ_vec → −σ_vec``. The score ``∂_u log r |₀`` and the smear
+    Hessian are unconstrained — both fall out naturally from
+    derivatives of ``f`` evaluated at zero perturbation.
+
+    **Head structure**: the first head layer ``Linear(d_emb + F +
+    n_pack, H)`` is split per-input-block into three parallel
+    ``nn.Linear`` modules
+
+        ``head_layer1_e(e) + head_layer1_u(u) + head_layer1_sigma(σ_pack)``
+
+    (the σ-side dropped in shift-only mode), with the bias attached
+    to ``head_layer1_e``. ``head_rest`` is the activation +
+    remaining hidden layers + final ``Linear(H, 1)``. This is
+    mathematically identical to the packed
+    ``Linear(d_emb+F+n_pack, H)`` followed by the rest, with the
+    same parameter count, but exposes the per-input-block structure
+    so that:
+
+      * inference can amortise ``head_layer1_e(e)`` once per event
+        across many ``(u, σ)`` queries (~2× per-query head
+        speedup; see :class:`CombinedMLPInference` in the export
+        script);
+      * the polyhead-style "exploit shared inputs across multiple
+        evaluations" pattern is structural rather than something
+        the export wrapper has to discover by slicing trained
+        weights.
+
+    Legacy checkpoints with the old packed-head layout (state-dict
+    keys ``head.{i}.{weight,bias}``) load transparently via
+    :meth:`_remap_legacy_state_dict`.
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_cond: int,
+        d_emb: int = 32,
+        trunk_hidden: int = 64,
+        trunk_layers: int = 2,
+        head_hidden: int = 32,
+        head_layers: int = 2,
+        activation=nn.GELU,
+        shift_only: bool = False,
+        gauss_baseline: nn.Module = None,
+    ):
+        super().__init__()
+        self.n_features = int(n_features)
+        self.n_cond = int(n_cond)
+        self.d_emb = int(d_emb)
+        self.head_hidden = int(head_hidden)
+        self.head_layers = int(head_layers)
+        self.shift_only = bool(shift_only)
+        self.n_sigma_pack = self.n_features * (self.n_features + 1) // 2
+        # Optional analytic Gaussian baseline (additive log-r term).
+        # When set, :func:`compute_d_quadrature` adds its closed-form
+        # log-density-ratio to the head's pre-positivity ``d`` so the
+        # MLP residual only fits the deviation from a Gaussian.
+        self.gauss_baseline = gauss_baseline
+
+        # Trunk: (y, c) → e
+        layers = []
+        prev = self.n_features + self.n_cond
+        for _ in range(trunk_layers):
+            layers.append(nn.Linear(prev, trunk_hidden))
+            layers.append(activation())
+            prev = trunk_hidden
+        layers.append(nn.Linear(prev, self.d_emb))
+        self.trunk = nn.Sequential(*layers)
+
+        # Head layer 1 is split into per-block sub-Linears. Bias lives
+        # on the e-side; the u- and σ-sides are bias-free, so the
+        # total parameter count matches a single packed Linear.
+        self.head_layer1_e = nn.Linear(self.d_emb, head_hidden, bias=True)
+        self.head_layer1_u = nn.Linear(self.n_features, head_hidden, bias=False)
+        # σ-side dropped in shift-only mode (would be dead weights).
+        if not self.shift_only:
+            self.head_layer1_sigma = nn.Linear(
+                self.n_sigma_pack, head_hidden, bias=False,
+            )
+        else:
+            self.head_layer1_sigma = None
+
+        # Rest of head: activation + remaining hidden layers + final
+        # Linear(H, 1). With the head_layers=N convention, layer 1 is
+        # the input projection (now split, above), and the remaining
+        # ``head_layers − 1`` hidden Linears + final scalar Linear
+        # live in head_rest.
+        rest = [activation()]
+        prev = head_hidden
+        for _ in range(self.head_layers - 1):
+            rest.append(nn.Linear(prev, head_hidden))
+            rest.append(activation())
+            prev = head_hidden
+        rest.append(nn.Linear(prev, 1))
+        self.head_rest = nn.Sequential(*rest)
+        # Init the final Linear near zero so f(...) ≈ const →
+        # (f − f) ≈ 0 → r ≈ 1 at start.
+        with torch.no_grad():
+            self.head_rest[-1].weight.mul_(0.01)
+            self.head_rest[-1].bias.zero_()
+
+    def trunk_forward(self, y: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        return self.trunk(torch.cat([y, c], dim=-1))
+
+    def head_forward(
+        self, e: torch.Tensor, u: torch.Tensor, sigma_pack: torch.Tensor,
+    ) -> torch.Tensor:
+        """``f(e, u, σ_pack) ∈ R``. Mathematically identical to the
+        legacy packed-head form ``head_rest(act(W·[e, u, σ_pack] + b))``
+        with ``W = [W_e | W_u | W_σ]`` and ``b = b_e``; the per-block
+        decomposition is structural, not numerical."""
+        x = self.head_layer1_e(e) + self.head_layer1_u(u)
+        if self.head_layer1_sigma is not None:
+            x = x + self.head_layer1_sigma(sigma_pack)
+        return self.head_rest(x).squeeze(-1)
+
+    # ------------------------------------------------------------------
+    # Legacy state-dict shim
+    # ------------------------------------------------------------------
+
+    def _remap_legacy_state_dict(self, state_dict):
+        """Migrate a pre-split-head checkpoint into the new layout.
+
+        Old: a single ``self.head`` ``nn.Sequential`` ending in
+        ``Linear(H, 1)``. State-dict keys ``head.{i}.{weight,bias}``
+        with ``i = 0`` the input projection ``Linear(d_emb + F +
+        n_pack, H)`` and ``i = 2k`` the remaining hidden / final
+        Linears.
+
+        New: ``head_layer1_e/_u/_sigma`` plus ``head_rest`` (an
+        ``nn.Sequential`` whose ``[0]`` is the activation immediately
+        following the split layer 1, ``[1]`` is the next Linear, and
+        so on).
+
+        Migration:
+          * ``head.0.weight`` row-blocks split into the three
+            sub-layers' weights; ``head.0.bias`` → ``head_layer1_e.bias``.
+          * ``head.{i}.{weight,bias}`` for ``i ≥ 1`` →
+            ``head_rest.{i-1}.{weight,bias}`` (one-index shift since
+            head_rest starts with the activation that was at index 1
+            of the old packed Sequential).
+
+        If no ``head.*`` keys are present, returns the input unchanged.
+        """
+        legacy_prefix = "head."
+        # Match either "head.0.weight" or any number; we look at all
+        # keys starting with "head." that aren't already targeting the
+        # new layout.
+        new_keys = (
+            "head_layer1_e", "head_layer1_u", "head_layer1_sigma",
+            "head_rest",
+        )
+        legacy_keys = [
+            k for k in state_dict.keys()
+            if k.startswith(legacy_prefix)
+            and not any(k.startswith(p) for p in new_keys)
+        ]
+        if not legacy_keys:
+            return state_dict
+
+        # Find which Sequential indices appear (sorted).
+        layer_idxs = sorted({
+            int(k.split(".")[1]) for k in legacy_keys
+            if k.endswith(".weight")
+        })
+        if not layer_idxs:
+            return state_dict
+
+        new_state = dict(state_dict)
+        first_idx = layer_idxs[0]
+        # 1) Split ``head.{first_idx}.weight``: row-block-split by
+        #    input dimension. Old packed input order was
+        #    [e (d_emb), u (n_features), σ_pack (n_sigma_pack if not
+        #    shift_only)]. Bias goes to the e-side.
+        w_old = new_state.pop(f"head.{first_idx}.weight", None)
+        b_old = new_state.pop(f"head.{first_idx}.bias", None)
+        if w_old is not None and b_old is not None:
+            n_e = self.d_emb
+            n_u = self.n_features
+            new_state["head_layer1_e.weight"] = w_old[:, :n_e].contiguous()
+            new_state["head_layer1_e.bias"] = b_old.contiguous()
+            new_state["head_layer1_u.weight"] = (
+                w_old[:, n_e:n_e + n_u].contiguous()
+            )
+            if not self.shift_only:
+                new_state["head_layer1_sigma.weight"] = (
+                    w_old[:, n_e + n_u:].contiguous()
+                )
+
+        # 2) ``head.{i}.{weight,bias}`` for i > first_idx →
+        #    ``head_rest.{i-1-first_idx}.{weight,bias}``. The packed
+        #    sequential had layer 1 at index ``first_idx`` (typically
+        #    0); head_rest starts immediately after layer 1, so its
+        #    index 0 is the activation at packed index ``first_idx + 1``.
+        for i in layer_idxs[1:]:
+            new_idx = i - first_idx - 1
+            for suf in ("weight", "bias"):
+                k_old = f"head.{i}.{suf}"
+                if k_old in new_state:
+                    new_state[f"head_rest.{new_idx}.{suf}"] = new_state.pop(k_old)
+        return new_state
+
+    def load_state_dict(self, state_dict, strict: bool = True, assign: bool = False):
+        """Override to transparently migrate legacy packed-head
+        checkpoints. Forwards to :meth:`nn.Module.load_state_dict`
+        after running :meth:`_remap_legacy_state_dict`."""
+        return super().load_state_dict(
+            self._remap_legacy_state_dict(state_dict),
+            strict=strict, assign=assign,
+        )
+
+
+# ============================================================================
+# Architecture: structurally factored MLP head
+# ============================================================================
+
+class ReweightMLPFactored(nn.Module):
+    """Trunk + structurally factored head returning the log-ratio directly.
+
+    The pre-positivity scalar is
+    ::
+        log r = ⟨u, A(e, ·)⟩ + ⟨σ_pack, B(e, ·)⟩ [ + ⟨u⊗σ_pack, C(e, u, σ_pack)⟩ ]
+    where ``e = trunk(y, c)``. Both ``log r = 0`` at ``(u, σ) = (0, 0)``
+    and ``σ → −σ`` invariance are structural (no dual-forward
+    subtraction needed); ``σ_pack`` is the upper-triangular flat of
+    ``σσᵀ``, even under ``σ → −σ``.
+
+    The factorisation form is controlled by two flags set at
+    construction time:
+
+    | shift_detach | smear_detach | A inputs        | B inputs        | C |
+    |--------------|--------------|-----------------|-----------------|---|
+    | False        | False        | e, u, σ_pack    | e, u, σ_pack    | – |
+    | True         | False        | e, u            | e, u, σ_pack    | – |
+    | False        | True         | e, u, σ_pack    | e, σ_pack       | – |
+    | True         | True         | e, u            | e, σ_pack       | ✓ |
+
+    In the (False, False) "default" form, A's σ-dependence and B's
+    u-dependence absorb the cross-term coupling; no pure-block detach
+    handle is exposed. Each detach flag adds a structural factorisation
+    that exposes the corresponding pure-block. When both flags are set
+    the cross is moved into a dedicated head ``C(e, u, σ_pack)``
+    contracting with the outer product ``u ⊗ σ_pack`` (so the cross
+    vanishes whenever u=0 OR σ=0).
+
+    The same trunk amortisation as :class:`ReweightMLP_B` applies: the
+    trunk MLP runs once on ``(y, c)``, then the per-block sub-heads
+    operate on the shared embedding ``e``.
+
+    The optional ``gauss_baseline`` adds a closed-form Gaussian
+    additive contribution to ``log r``, identical in form to
+    :class:`ReweightMLP_B`'s.
+    """
+
+    # Flag for loss-code dispatch (so callers know head_forward already
+    # returns the pre-positivity ``d`` directly, without dual-forward
+    # subtraction).
+    is_factored = True
+
+    def __init__(
+        self,
+        n_features: int,
+        n_cond: int,
+        d_emb: int = 32,
+        trunk_hidden: int = 64,
+        trunk_layers: int = 2,
+        head_hidden: int = 32,
+        head_layers: int = 2,
+        activation=nn.GELU,
+        shift_only: bool = False,
+        detach_pure_shift_in_joint: bool = False,
+        detach_pure_smear_in_joint: bool = False,
+        gauss_baseline: nn.Module = None,
+    ):
+        super().__init__()
+        self.n_features = int(n_features)
+        self.n_cond = int(n_cond)
+        self.d_emb = int(d_emb)
+        self.head_hidden = int(head_hidden)
+        self.head_layers = int(head_layers)
+        self.shift_only = bool(shift_only)
+        self.n_sigma_pack = (
+            self.n_features * (self.n_features + 1) // 2
+            if not self.shift_only else 0
+        )
+        self.gauss_baseline = gauss_baseline
+        self.detach_pure_shift_in_joint = bool(
+            detach_pure_shift_in_joint
+        ) and not self.shift_only
+        self.detach_pure_smear_in_joint = bool(
+            detach_pure_smear_in_joint
+        ) and not self.shift_only
+        # A independent of σ_pack iff shift-detach is on.
+        self.A_uses_sigma = (
+            (not self.shift_only) and not self.detach_pure_shift_in_joint
+        )
+        # B independent of u iff smear-detach is on.
+        self.B_uses_u = (
+            (not self.shift_only) and not self.detach_pure_smear_in_joint
+        )
+        # Separate cross head only when both flags are on (fully
+        # factorised three-term form). The cross is the only place that
+        # JOINT-mode gradients survive when both pure blocks are
+        # detached.
+        self.has_C = (
+            self.detach_pure_shift_in_joint
+            and self.detach_pure_smear_in_joint
+        )
+        # Shift-only mode: the σ side collapses out entirely; B and C
+        # are unused. log r = ⟨u, A(e, u)⟩ trivially.
+        if self.shift_only:
+            self.A_uses_sigma = False
+            self.B_uses_u = False
+            self.has_C = False
+
+        # Trunk: (y, c) → e
+        layers = []
+        prev = self.n_features + self.n_cond
+        for _ in range(trunk_layers):
+            layers.append(nn.Linear(prev, trunk_hidden))
+            layers.append(activation())
+            prev = trunk_hidden
+        layers.append(nn.Linear(prev, self.d_emb))
+        self.trunk = nn.Sequential(*layers)
+
+        # A head: e + u (+ σ_pack) → F.
+        in_dim_A = self.d_emb + self.n_features + (
+            self.n_sigma_pack if self.A_uses_sigma else 0
+        )
+        self.A_head = self._make_mlp(
+            in_dim_A, head_hidden, head_layers, activation,
+            self.n_features,
+        )
+        # B head: e + (u +) σ_pack → n_pack. Built only if not shift-only.
+        if not self.shift_only:
+            in_dim_B = (
+                self.d_emb
+                + (self.n_features if self.B_uses_u else 0)
+                + self.n_sigma_pack
+            )
+            self.B_head = self._make_mlp(
+                in_dim_B, head_hidden, head_layers, activation,
+                self.n_sigma_pack,
+            )
+        else:
+            self.B_head = None
+        # C head: e + u + σ_pack → F · n_pack. Built only when both
+        # detach flags are on.
+        if self.has_C:
+            in_dim_C = self.d_emb + self.n_features + self.n_sigma_pack
+            self.C_head = self._make_mlp(
+                in_dim_C, head_hidden, head_layers, activation,
+                self.n_features * self.n_sigma_pack,
+            )
+        else:
+            self.C_head = None
+
+        # Init the final layers near zero so log r ≈ 0 at start.
+        with torch.no_grad():
+            for h in (self.A_head, self.B_head, self.C_head):
+                if h is None:
+                    continue
+                h[-1].weight.mul_(0.01)
+                h[-1].bias.zero_()
+
+    @staticmethod
+    def _make_mlp(in_dim, hidden, n_layers, activation, out_dim):
+        layers = []
+        prev = in_dim
+        for _ in range(n_layers):
+            layers.append(nn.Linear(prev, hidden))
+            layers.append(activation())
+            prev = hidden
+        layers.append(nn.Linear(prev, out_dim))
+        return nn.Sequential(*layers)
+
+    def trunk_forward(self, y, c):
+        return self.trunk(torch.cat([y, c], dim=-1))
+
+    def head_forward_components(
+        self, e, u, sigma_pack,
+    ):
+        """Return ``(pure_u_d, pure_s_d, cross_d)`` for the factored
+        head, each of shape ``[B]``. ``cross_d`` is ``None`` when there
+        is no separate cross head. The caller can apply per-mode
+        ``.detach()`` to the components before summing — used by the
+        loss code for ``--detach-pure-{shift,smear}-in-joint`` gradient
+        routing.
+        """
+        # A head: e + u (+ σ_pack)
+        A_inputs = [e, u]
+        if self.A_uses_sigma:
+            A_inputs.append(sigma_pack)
+        A = self.A_head(torch.cat(A_inputs, dim=-1))     # [..., F]
+        pure_u_d = (u * A).sum(dim=-1)                    # [...]
+
+        # B head: e + (u +) σ_pack
+        if self.B_head is not None:
+            B_inputs = [e]
+            if self.B_uses_u:
+                B_inputs.append(u)
+            B_inputs.append(sigma_pack)
+            B = self.B_head(torch.cat(B_inputs, dim=-1))  # [..., n_pack]
+            pure_s_d = (sigma_pack * B).sum(dim=-1)
+        else:
+            pure_s_d = torch.zeros_like(pure_u_d)
+
+        # C head: e + u + σ_pack
+        cross_d = None
+        if self.C_head is not None:
+            C_flat = self.C_head(
+                torch.cat([e, u, sigma_pack], dim=-1),
+            )                                              # [..., F·n_pack]
+            C = C_flat.view(
+                *u.shape[:-1], self.n_features, self.n_sigma_pack,
+            )
+            cross_d = torch.einsum(
+                "...i,...ij,...j->...", u, C, sigma_pack,
+            )
+        return pure_u_d, pure_s_d, cross_d
+
+    def head_forward(self, e, u, sigma_pack):
+        """Pre-positivity ``d = log W`` (structurally zero at the
+        origin). No dual-forward subtraction is needed because the
+        factored construction already enforces ``d(e, 0, 0) = 0`` and
+        ``d(e, u, σ) = d(e, u, −σ)``.
+        """
+        pu, ps, cr = self.head_forward_components(e, u, sigma_pack)
+        d = pu + ps
+        if cr is not None:
+            d = d + cr
+        return d
+
+
+# ============================================================================
+# Architecture: polyhead mode (wraps the existing PolyHead)
+# ============================================================================
+
+class ReweightPolyhead(nn.Module):
+    """Self-contained polyhead trunk: ``(y, c) → joint_coefs ∈ ℝ^{n_basis}``.
+
+    The MLP's final ``Linear`` layer is sized to the number of basis
+    monomials and produces the polynomial coefficients directly. The
+    polynomial in ``(u, σ_vec)`` is evaluated externally via
+    :func:`evaluate_joint` at any query point.
+
+    Structural priors (no constant term, even in ``σ_vec``, capped
+    degrees in u/σ/cross) are baked into the basis-index construction
+    via :func:`_joint_indices` and reflected in ``self.n_basis``.
+
+    No ``PolyHead`` wrapping — the trunk MLP IS the polyhead. We don't
+    carry the flow-trainer's pure-u/pure-σ/cross masks or
+    Gauss-Hermite buffers because the LSIF/DV training loop here
+    doesn't use them (no stochastic K=1 smear target to vary across
+    nodes — LSIF is unbiased with one ε per event by sample-source
+    construction).
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_cond: int,
+        trunk_hidden: int = 64,
+        trunk_layers: int = 2,
+        max_deg_u: int = 3,
+        max_deg_sigma: int = 4,
+        max_cross_deg: int = 3,
+        activation=nn.GELU,
+        basis: str = "monomial",
+        basis_scale_u: float = 1.0,
+        basis_scale_sigma: float = 1.0,
+        gauss_baseline: nn.Module = None,
+    ):
+        super().__init__()
+        if max_deg_sigma % 2 != 0:
+            raise ValueError(
+                f"--max-deg-sigma must be even (smear-symmetry); got "
+                f"{max_deg_sigma}"
+            )
+        if basis not in ("monomial", "chebyshev"):
+            raise ValueError(f"unknown basis {basis!r}")
+        self.n_features = int(n_features)
+        self.n_cond = int(n_cond)
+        self.max_deg_u = int(max_deg_u)
+        self.max_deg_sigma = int(max_deg_sigma)
+        self.max_cross_deg = int(max_cross_deg)
+        self.basis = str(basis)
+        self.basis_scale_u = float(basis_scale_u)
+        self.basis_scale_sigma = float(basis_scale_sigma)
+        # Optional analytic Gaussian baseline (additive log-r term).
+        # When set, :func:`compute_d_quadrature` adds its closed-form
+        # log-density-ratio to the polyhead's pre-positivity ``d`` so
+        # the polynomial only fits the deviation from a Gaussian.
+        self.gauss_baseline = gauss_baseline
+
+        # Polynomial basis indices: (α, β) tuples enforcing structural
+        # priors (no constant, even in σ, degree caps). Reordered so
+        # that pure-u indices come first, pure-σ second, cross last —
+        # this lets the three-head split below produce contiguous
+        # coefficient blocks that align with the basis ordering.
+        raw_indices = _joint_indices(
+            n_features, max_deg_u, max_deg_sigma, max_cross_deg,
+        )
+        idx_pure_u = [
+            (a, b) for (a, b) in raw_indices
+            if len(b) == 0 and len(a) > 0
+        ]
+        idx_pure_s = [
+            (a, b) for (a, b) in raw_indices
+            if len(a) == 0 and len(b) > 0
+        ]
+        idx_cross = [
+            (a, b) for (a, b) in raw_indices
+            if len(a) > 0 and len(b) > 0
+        ]
+        assert (
+            len(idx_pure_u) + len(idx_pure_s) + len(idx_cross)
+            == len(raw_indices)
+        ), "non-exhaustive split of joint indices"
+        self._joint_indices = idx_pure_u + idx_pure_s + idx_cross
+        self.n_basis = len(self._joint_indices)
+        self._n_pure_u = len(idx_pure_u)
+        self._n_pure_s = len(idx_pure_s)
+        self._n_cross = len(idx_cross)
+
+        # Boolean masks over (reordered) basis indices: pure-u
+        # (β = ()), pure-σ (α = ()), and cross (both nonempty). Now
+        # contiguous blocks: [0, n_pure_u), [n_pure_u, n_pure_u +
+        # n_pure_s), [n_pure_u + n_pure_s, n_basis).
+        is_pure_u = torch.tensor(
+            [len(b) == 0 for (_, b) in self._joint_indices],
+            dtype=torch.bool,
+        )
+        is_pure_sigma = torch.tensor(
+            [len(a) == 0 for (a, _) in self._joint_indices],
+            dtype=torch.bool,
+        )
+        self.register_buffer("is_pure_u", is_pure_u, persistent=False)
+        self.register_buffer("is_pure_sigma", is_pure_sigma, persistent=False)
+        self.register_buffer(
+            "is_pure", is_pure_u | is_pure_sigma, persistent=False,
+        )
+
+        # Basis-evaluation auxiliary tensors as buffers — auto-moved
+        # with ``.to(device)``, seen as stable inputs by torch.compile
+        # and CUDA graphs. Without these (i.e., relying on the
+        # runtime cache), the cache-miss path inside the compiled
+        # forward creates ephemeral tensors that CUDA graphs
+        # captures, and subsequent calls fail with "tensor output
+        # overwritten by subsequent run".
+        _aux = _build_basis_aux(self._joint_indices, n_features)
+        self.register_buffer(
+            "_basis_alpha_degs", _aux["alpha_degs"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_beta_degs", _aux["beta_degs"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_cheb_u_const",
+            _aux["cheb_u_const"], persistent=False,
+        )
+        self.register_buffer(
+            "_basis_cheb_v_const",
+            _aux["cheb_v_const"], persistent=False,
+        )
+        self._basis_max_deg_u = _aux["max_deg_u"]
+        self._basis_max_deg_sigma = _aux["max_deg_sigma"]
+
+        # Trunk MLP: (y, c) → embedding ∈ R^trunk_hidden. The final
+        # coefficient layer is split into three sub-heads (pure_u,
+        # pure_σ, cross) — same total parameter count as a single
+        # ``Linear(trunk_hidden, n_basis)``, but enables mode-
+        # conditional skipping of irrelevant heads at forward time
+        # (e.g. SHIFT events skip pure_σ and cross since σ=0 makes
+        # those terms vanish in the polynomial). Combined with the
+        # stratified mode sampler (sample_perturbations producing
+        # exactly B/3 of each mode), the per-step cost becomes
+        # B · d_emb · (n_pure_u + n_pure_σ + n_basis) / 3 instead of
+        # B · d_emb · n_basis — typically ~2.5× speedup on the final
+        # layer with no expressivity loss.
+        layers = []
+        prev = self.n_features + self.n_cond
+        for _ in range(trunk_layers):
+            layers.append(nn.Linear(prev, trunk_hidden))
+            layers.append(activation())
+            prev = trunk_hidden
+        self.trunk = nn.Sequential(*layers)
+        # Three sub-heads with sizes summing to n_basis. ``Linear`` is
+        # only created if the corresponding block is non-empty (e.g.
+        # in shift-only mode, pure_s and cross are empty).
+        self.head_pure_u = (
+            nn.Linear(prev, self._n_pure_u)
+            if self._n_pure_u > 0 else None
+        )
+        self.head_pure_sigma = (
+            nn.Linear(prev, self._n_pure_s)
+            if self._n_pure_s > 0 else None
+        )
+        self.head_cross = (
+            nn.Linear(prev, self._n_cross)
+            if self._n_cross > 0 else None
+        )
+        # Init heads near zero so coefs ≈ 0 → log r ≈ 0 at start.
+        with torch.no_grad():
+            for head in (self.head_pure_u, self.head_pure_sigma, self.head_cross):
+                if head is not None:
+                    head.weight.mul_(0.01)
+                    head.bias.zero_()
+
+    @property
+    def joint_indices(self):
+        return self._joint_indices
+
+    @property
+    def basis_aux(self):
+        """Dict of pre-registered basis-evaluation buffers, suitable
+        for passing to :func:`evaluate_joint` as ``basis_aux=`` from
+        compiled call sites — avoids in-graph tensor creation that
+        breaks CUDA graphs (mode='reduce-overhead')."""
+        return {
+            "alpha_degs": self._basis_alpha_degs,
+            "beta_degs": self._basis_beta_degs,
+            "cheb_u_const": self._basis_cheb_u_const,
+            "cheb_v_const": self._basis_cheb_v_const,
+            "max_deg_u": self._basis_max_deg_u,
+            "max_deg_sigma": self._basis_max_deg_sigma,
+        }
+
+    def trunk_forward(
+        self,
+        y: torch.Tensor,
+        c: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the trunk embedding ``e ∈ R^{B, trunk_hidden}``.
+
+        Used by the compiled training path in
+        :func:`compute_d_quadrature`, which calls the per-head
+        sub-modules (``head_pure_u``, etc.) directly on per-mode
+        slices of ``e`` to avoid materializing the full
+        ``[B, n_basis]`` coefficient tensor.
+        """
+        return self.trunk(torch.cat([y, c], dim=-1))
+
+    def forward(
+        self,
+        y: torch.Tensor,
+        c: torch.Tensor,
+        mode_id: torch.Tensor = None,
+    ) -> torch.Tensor:
+        """Return the full ``[B, n_basis]`` coefficient tensor.
+
+        Used by external callers (inference, diagnostics, ONNX
+        export) that consume coefs as the polyhead's output. The
+        compiled training path bypasses this in favor of a direct
+        per-mode contraction (see :func:`compute_d_quadrature`),
+        which avoids the [B, n_basis] intermediate altogether.
+
+        ``mode_id`` is accepted but ignored — all heads run on all
+        events here for the simple all-mode return.
+        """
+        del mode_id  # legacy kwarg, ignored
+        e = self.trunk(torch.cat([y, c], dim=-1))
+        parts = []
+        if self.head_pure_u is not None:
+            parts.append(self.head_pure_u(e))
+        if self.head_pure_sigma is not None:
+            parts.append(self.head_pure_sigma(e))
+        if self.head_cross is not None:
+            parts.append(self.head_cross(e))
+        if not parts:
+            return torch.zeros(
+                e.shape[0], 0, device=e.device, dtype=e.dtype,
+            )
+        return torch.cat(parts, dim=-1)
+
+
+# ============================================================================
+# Analytic Gaussian baseline
+# ============================================================================
+
+class GaussBaseline(nn.Module):
+    """Per-event analytic Gaussian baseline for the density-ratio.
+
+    Models the nominal residual distribution conditional on gen-level
+    kinematics as
+
+        y | c  ~  N(μ(c), Σ(c)),    Σ(c) = L(c) L(c)ᵀ
+
+    with μ ∈ ℝ^F and L ∈ ℝ^{F×F} lower-triangular with strictly positive
+    diagonal (Cholesky factor of Σ). Both μ and L are produced by a
+    small MLP from ``c`` only — they describe the *shape* of the
+    nominal distribution, which is a property of the conditioning, not
+    of any specific sample drawn from it (using y_nom here would give
+    a circular, non-density-ratio object).
+
+    The closed-form log-density-ratio for a shifted+convolved Gaussian
+    (computed in :func:`gauss_baseline_log_r`) is then added as an
+    additive term to the polyhead/mlp pre-positivity ``d``. The
+    polyhead residual only has to fit the *deviation from a Gaussian*
+    — which is much smoother and lower-degree than the full
+    convolution-induced reweight, especially at moderate σ where the
+    smearing kernel width is comparable to the core width of the
+    target.
+
+    Init produces μ = 0 and L = I (so Σ = I) so that ``log r̂_Gauss = 0``
+    at start and the model recovers the legacy "no-baseline"
+    behaviour at epoch 0; the baseline parameters then learn jointly
+    with the polyhead residual.
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_cond: int,
+        hidden: int = 64,
+        n_layers: int = 2,
+        activation=nn.GELU,
+    ):
+        super().__init__()
+        self.n_features = int(n_features)
+        self.n_cond = int(n_cond)
+        nf = self.n_features
+        n_chol = nf * (nf + 1) // 2
+        self.n_chol = int(n_chol)
+        self.hidden = int(hidden)
+        self.n_layers = int(n_layers)
+
+        # MLP: c → (μ, raw_chol). Output dim = nf + n_chol.
+        layers = []
+        prev = self.n_cond
+        for _ in range(self.n_layers):
+            layers.append(nn.Linear(prev, self.hidden))
+            layers.append(activation())
+            prev = self.hidden
+        layers.append(nn.Linear(prev, nf + n_chol))
+        self.net = nn.Sequential(*layers)
+
+        # Init: μ = 0, post-softplus diag(L) = 1 ⇒ L = I, Σ = I.
+        # softplus(b) = 1 ⇒ b = log(e − 1).
+        with torch.no_grad():
+            last = self.net[-1]
+            last.weight.zero_()
+            last.bias.zero_()
+            offset = 0
+            for r in range(nf):
+                for col in range(r + 1):
+                    if r == col:
+                        last.bias[nf + offset] = math.log(math.e - 1.0)
+                    offset += 1
+
+        # Static scatter projection: row k of ``raw_chol`` lands at
+        # ``(rows[k], cols[k])`` in the [nf, nf] matrix (row-major
+        # lower triangular ordering). Implemented as a constant
+        # [n_chol, nf*nf] matrix so the unpack is a fixed matmul —
+        # compile-friendly and CUDA-graph-safe.
+        chol_proj = torch.zeros(n_chol, nf * nf)
+        offset = 0
+        for r in range(nf):
+            for col in range(r + 1):
+                chol_proj[offset, r * nf + col] = 1.0
+                offset += 1
+        self.register_buffer("_chol_proj", chol_proj, persistent=False)
+
+    def forward(self, c: torch.Tensor):
+        """``c: [..., n_cond] → (μ: [..., nf], L: [..., nf, nf])``.
+
+        ``L`` is lower-triangular with strictly-positive diagonal
+        (softplus-wrapped). Caller should treat the returned tensors
+        as fp32-equivalent precision regardless of input dtype — the
+        downstream :func:`gauss_baseline_log_r` upcasts internally.
+        """
+        out = self.net(c)
+        nf = self.n_features
+        mu = out[..., :nf]
+        raw_chol = out[..., nf:]
+        # Scatter ``raw_chol`` into a [..., nf, nf] lower-triangular
+        # via a fixed projection, then softplus the diagonal.
+        L_flat = raw_chol @ self._chol_proj           # [..., nf*nf]
+        L_pre = L_flat.view(*raw_chol.shape[:-1], nf, nf)
+        diag_pre = torch.diagonal(L_pre, dim1=-2, dim2=-1)
+        diag_post = F.softplus(diag_pre)
+        L = L_pre + torch.diag_embed(diag_post - diag_pre)
+        return mu, L
+
+
+def gauss_baseline_log_r(
+    y: torch.Tensor,
+    mu: torch.Tensor,
+    L: torch.Tensor,
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+) -> torch.Tensor:
+    """Closed-form log density-ratio for a shifted+convolved Gaussian.
+
+    With ``p_nom(y | c) = N(μ, Σ)``, ``Σ = L Lᵀ`` and
+    ``p_pert(y | c, u, σ) = N(μ + u, Σ + diag(σ²))``, the analytic
+    log-ratio at evaluation point ``y`` is
+
+        log r̂_Gauss = -½ log[det(Σ + D_σ) / det Σ]
+                       - ½ (y - μ - u)ᵀ (Σ + D_σ)⁻¹ (y - μ - u)
+                       + ½ (y - μ)ᵀ Σ⁻¹ (y - μ).
+
+    All inputs broadcast to a common leading shape ``[...]``; ``y``,
+    ``mu``, ``u``, ``sigma_vec`` are ``[..., F]``; ``L`` is
+    ``[..., F, F]`` lower-triangular. Returns ``[...]``.
+
+    Computed in fp32 internally — the F=3 Cholesky / triangular solves
+    are fp16-fragile near the unit-Σ region we initialise into, and
+    the cost is negligible. Returns log r̂ in the input dtype.
+    """
+    in_dtype = y.dtype
+    y32 = y.float()
+    mu32 = mu.float()
+    L32 = L.float()
+    u32 = u.float()
+    sigma32 = sigma_vec.float()
+
+    # log det Σ from diag(L).
+    diag_L = torch.diagonal(L32, dim1=-2, dim2=-1)
+    log_det_Sigma = 2.0 * torch.log(diag_L).sum(-1)
+
+    # Σ + D_σ via L Lᵀ + diag(σ²); take Cholesky for downstream solve
+    # and log-det.
+    Sigma = L32 @ L32.transpose(-1, -2)
+    Sigma_pert = Sigma + torch.diag_embed(sigma32 * sigma32)
+    L_pert = torch.linalg.cholesky(Sigma_pert)
+    diag_Lp = torch.diagonal(L_pert, dim1=-2, dim2=-1)
+    log_det_Sigma_pert = 2.0 * torch.log(diag_Lp).sum(-1)
+
+    log_det_term = -0.5 * (log_det_Sigma_pert - log_det_Sigma)
+
+    # Quadratic forms via triangular solves (single-RHS).
+    r = y32 - mu32                                     # [..., F]
+    r_pert = r - u32
+    z_nom = torch.linalg.solve_triangular(
+        L32, r.unsqueeze(-1), upper=False,
+    ).squeeze(-1)
+    quad_nom = (z_nom * z_nom).sum(-1)
+    z_pert = torch.linalg.solve_triangular(
+        L_pert, r_pert.unsqueeze(-1), upper=False,
+    ).squeeze(-1)
+    quad_pert = (z_pert * z_pert).sum(-1)
+
+    log_r = log_det_term - 0.5 * quad_pert + 0.5 * quad_nom
+    return log_r.to(in_dtype)
+
+
+# ============================================================================
+# Positivity wrap (shared)
+# ============================================================================
+
+def _apply_positivity(d: torch.Tensor, positivity: str,
+                      clamp: float = _LOG_W_CLAMP) -> torch.Tensor:
+    """Apply the positivity wrap to a pre-positivity scalar ``d`` to
+    produce ``log r``. Same shape as input, applied elementwise.
+
+      * ``"exp"``      — log r = clamp(d, ±clamp). Identity in the
+        bulk; `r̂ = exp(log r̂)` is positive via `exp`. Symmetric
+        in log r-space (odd in d). Hard cutoff at ±clamp prevents
+        fp32 overflow.
+      * ``"softplus"`` — log r = log(softplus(d)) − log(log 2).
+        Asymmetric: compresses positive log r logarithmically,
+        leaves negative log r ≈ d. `r̂ = softplus(d)/log 2 > 0`.
+        No input clamp on d: PyTorch's ``F.softplus`` returns ``d``
+        directly for d > threshold (default 20), so large positive
+        d is handled without overflow; very negative d underflows
+        ``softplus`` to 0, which is caught by ``clamp_min`` on the
+        softplus output (sized to the dtype's smallest normal so
+        the same wrap stays safe under fp32 / bf16 / fp16 autocast).
+      * ``"asinh"``    — log r = asinh(d) = log(d + √(d² + 1)).
+        Symmetric (odd in d) like `"exp"`, identity for |d| ≪ 1
+        (so the Gaussian-likelihood-shaped bulk is preserved at
+        leading order), and *smoothly* compresses to ±log(2|d|)
+        for |d| → ∞. `r̂ = exp(asinh(d)) = d + √(d² + 1)`, which
+        is strictly positive for every finite d (`√(d²+1) > |d|`)
+        and grows only linearly in d — so no clamp is needed.
+    """
+    if positivity == "exp":
+        return d.clamp(min=-clamp, max=clamp)
+    if positivity == "softplus":
+        tiny = torch.finfo(d.dtype).tiny
+        return torch.log(F.softplus(d).clamp_min(tiny)) - _LOG_LOG2
+    if positivity == "asinh":
+        return torch.asinh(d)
+    raise ValueError(f"unknown positivity {positivity!r}")
+
+
+def _apply_positivity_r(d: torch.Tensor, positivity: str,
+                        clamp: float = _LOG_W_CLAMP) -> torch.Tensor:
+    """Return ``r̂(d)`` *directly*, without going through
+    ``log r̂`` and exponentiating.
+
+    Used by the LSIF path: the LSIF loss needs ``r̂`` (and ``r̂²``)
+    not ``log r̂``, so going through the wrap and back via
+    ``exp(log r̂)`` would be wasted work. The closed forms also avoid
+    the softplus-output ``clamp_min`` (no outer ``log`` is taken
+    here).
+
+      * ``"exp"``      — r̂ = exp(clamp(d, ±clamp)). ``exp`` is
+        intrinsic to this wrap; the ``clamp(±30)`` is what keeps fp32
+        safe (``exp(30) ≈ 10¹³`` so ``r̂² ≈ 10²⁶`` ≪ fp32 max).
+      * ``"softplus"`` — r̂ = softplus(d) / log 2. Strictly positive
+        for every finite d (softplus > 0 mathematically; underflows
+        gracefully to 0 in fp32 for d ≪ −87, which is a valid
+        contribution of zero to LSIF). No clamp needed.
+      * ``"asinh"``    — r̂ = d + √(d² + 1). Closed form, strictly
+        positive for every finite d (``√(d²+1) > |d|``), grows only
+        linearly in d. No clamp, no exp, no log.
+    """
+    if positivity == "exp":
+        return torch.exp(d.clamp(min=-clamp, max=clamp))
+    if positivity == "softplus":
+        return F.softplus(d) / math.log(2.0)
+    if positivity == "asinh":
+        return d + torch.sqrt(d * d + 1.0)
+    raise ValueError(f"unknown positivity {positivity!r}")
+
+
+# ============================================================================
+# compute_log_r_pair: branches on architecture
+# ============================================================================
+
+def compute_d_quadrature(
+    model: nn.Module,
+    arch: str,
+    y_nom: torch.Tensor,
+    y_pert_stack: torch.Tensor,
+    c: torch.Tensor,
+    u: torch.Tensor,
+    sigma_vec: torch.Tensor,
+    sigma_pack: torch.Tensor,
+    mode_id: torch.Tensor = None,
+    detach_pure_in_joint: bool = False,
+):
+    """Compute the **pre-positivity scalar** ``d`` at the nominal
+    sample and at multiple ``y_pert`` quadrature positions.
+
+    No positivity wrap is applied here — the caller picks ``log r̂`` or
+    ``r̂`` (via :func:`_apply_positivity` or :func:`_apply_positivity_r`)
+    depending on what the loss family needs. The LSIF path uses ``r̂``
+    directly, avoiding the log/exp round-trip and the softplus output
+    clamp; DV/BCE/expKL use ``log r̂`` as before.
+
+    Args:
+      ``y_pert_stack``: shape ``[n_eps, B, n_features]`` — the
+        perturbed positions (one per ε quadrature node, plus optionally
+        a residual sample). For K=1 stochastic, ``n_eps = 1``; for
+        K-node Gauss-Hermite, ``n_eps = K``; for GH+residual,
+        ``n_eps = K + 1`` with the last slot being the random sample.
+      ``mode_id``: shape ``[B]`` long tensor with values 0 (SHIFT),
+        1 (SMEAR), 2 (JOINT). Required when ``detach_pure_in_joint``
+        is True.
+      ``detach_pure_in_joint``: if True, the pure-u (σ → 0) and
+        pure-σ (u → 0) contributions to the pre-positivity scalar are
+        ``.detach()``-ed for events with ``mode_id == 2`` (JOINT). The
+        nominal slot ``d_nom`` (with u, σ = 0) is unaffected.
+
+          * ``polyhead``: implemented via per-event coef masking
+            (zero-cost) — pure-u/pure-σ basis-index slots are detached
+            for JOINT events.
+          * ``mlp``: implemented via two extra head forwards
+            (``f(e, u, 0)`` and ``f(e, 0, σ_pack)``) so that the
+            decomposition ``d_full = d_pure_u + d_pure_σ + d_mixed`` is
+            available; pure parts are detached only on JOINT events
+            (≈ 2× head cost; trunk cost unchanged).
+
+    Returns ``(d_nom, d_pert_all)`` with shapes ``[B]`` and
+    ``[n_eps, B]``.
+
+    Single batched pass: ``(n_eps + 1)·B`` trunk forwards, with the
+    head dual call on top of that for the ``mlp`` arch.
+    """
+    n_eps, B, n_features = y_pert_stack.shape
+    if detach_pure_in_joint and mode_id is None:
+        raise ValueError(
+            "detach_pure_in_joint=True requires mode_id to be passed",
+        )
+
+    if arch == "mlp":
+        # Trunk [(n_eps+1)·B]: y_nom plus all perturbed positions.
+        y_all = torch.cat(
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+        )
+        c_all = c.repeat(n_eps + 1, 1)
+        e = model.trunk_forward(y_all, c_all)         # [(n_eps+1)·B, d_emb]
+
+        u_all = u.repeat(n_eps + 1, 1)
+        sigma_pack_all = sigma_pack.repeat(n_eps + 1, 1)
+        u_zero = torch.zeros_like(u_all)
+        sp_zero = torch.zeros_like(sigma_pack_all)
+
+        if not detach_pure_in_joint:
+            # Head dual: [2·(n_eps+1)·B] at (e, u, σ_pack) and (e, 0, 0).
+            e_dual = torch.cat([e, e], dim=0)
+            u_dual = torch.cat([u_all, u_zero], dim=0)
+            sp_dual = torch.cat([sigma_pack_all, sp_zero], dim=0)
+            f = model.head_forward(e_dual, u_dual, sp_dual)
+            n_total = (n_eps + 1) * B
+            d = f[:n_total] - f[n_total:]             # [(n_eps+1)·B]
+        else:
+            # 4 head queries per (event, ε-slot):
+            #   f_full=f(e,u,σ_pack), f_zero=f(e,0,0),
+            #   f_us =f(e,u,0),       f_sm =f(e,0,σ_pack)
+            # Decompose into pure-u, pure-σ, and mixed contributions:
+            #   d_full   = f_full - f_zero
+            #   d_pure_u = f_us   - f_zero
+            #   d_pure_s = f_sm   - f_zero
+            #   d_mixed  = d_full - d_pure_u - d_pure_s
+            # On JOINT events (mode==2) detach d_pure_u and d_pure_s so
+            # only d_mixed back-propagates; otherwise d_used = d_full.
+            e_q = torch.cat([e, e, e, e], dim=0)
+            u_q = torch.cat([u_all, u_zero, u_all, u_zero], dim=0)
+            sp_q = torch.cat(
+                [sigma_pack_all, sp_zero, sp_zero, sigma_pack_all], dim=0,
+            )
+            f = model.head_forward(e_q, u_q, sp_q)
+            n_total = (n_eps + 1) * B
+            f_full = f[0 * n_total : 1 * n_total]
+            f_zero = f[1 * n_total : 2 * n_total]
+            f_us   = f[2 * n_total : 3 * n_total]
+            f_sm   = f[3 * n_total : 4 * n_total]
+            d_full = f_full - f_zero
+            d_pure_u = f_us - f_zero
+            d_pure_s = f_sm - f_zero
+            # is_joint per event, broadcast across all (n_eps+1) blocks.
+            is_joint_b = (mode_id == 2)
+            is_joint_all = is_joint_b.unsqueeze(0).expand(
+                n_eps + 1, B,
+            ).reshape(-1)
+            # Replace d_pure_u/d_pure_s with detach() on JOINT events.
+            d_pure_u_used = torch.where(
+                is_joint_all, d_pure_u.detach(), d_pure_u,
+            )
+            d_pure_s_used = torch.where(
+                is_joint_all, d_pure_s.detach(), d_pure_s,
+            )
+            d_mixed = d_full - d_pure_u - d_pure_s
+            d = d_pure_u_used + d_pure_s_used + d_mixed
+
+    elif arch == "mlp-factored":
+        # Structurally factored MLP head: log r = ⟨u, A⟩ + ⟨σ_pack, B⟩
+        # [+ ⟨u⊗σ_pack, C⟩]. ``d`` comes from head_forward_components
+        # directly (no dual-forward subtraction); the per-event
+        # detach for --detach-pure-{shift,smear}-in-joint is applied
+        # on JOINT-mode events.
+        y_all = torch.cat(
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+        )
+        c_all = c.repeat(n_eps + 1, 1)
+        u_all = u.repeat(n_eps + 1, 1)
+        sigma_pack_all = sigma_pack.repeat(n_eps + 1, 1)
+        e = model.trunk_forward(y_all, c_all)        # [(n_eps+1)·B, d_emb]
+        pu, ps, cr = model.head_forward_components(
+            e, u_all, sigma_pack_all,
+        )
+        if (
+            mode_id is not None
+            and (
+                model.detach_pure_shift_in_joint
+                or model.detach_pure_smear_in_joint
+            )
+        ):
+            is_joint_b = (mode_id == 2)
+            is_joint_all = (
+                is_joint_b.unsqueeze(0)
+                .expand(n_eps + 1, B)
+                .reshape(-1)
+            )
+            if model.detach_pure_shift_in_joint:
+                pu = torch.where(is_joint_all, pu.detach(), pu)
+            if model.detach_pure_smear_in_joint:
+                ps = torch.where(is_joint_all, ps.detach(), ps)
+        d = pu + ps
+        if cr is not None:
+            d = d + cr
+
+    elif arch == "polyhead":
+        # Per-mode Order-2 contraction.
+        #
+        # The events come pre-sorted by mode_id (sample_perturbations
+        # produces ``[0…0, 1…1, 2…2]`` contiguous; the (y, c) order
+        # is randomized by the data loader, so the (event, mode)
+        # pairing is still random). With sorted mode the per-mode
+        # batches are contiguous slices of the B axis — no boolean
+        # indexing, all shapes static, CUDA-graph-friendly.
+        #
+        # The trunk runs once on the full ``(n_eps+1)·B`` batch (one
+        # large GEMM, well-utilized). The per-head matmuls then
+        # operate on per-mode slices, exploiting the basis-vanishing
+        # property: SHIFT events have σ=0 → only pure_u contributes,
+        # SMEAR events have u=0 → only pure_σ contributes, JOINT
+        # events have all three. Crucially, we **never materialize
+        # the [(n_eps+1)·B, n_basis] coefs tensor** — d is computed
+        # via Order-2 contraction
+        #
+        #     d_block = (e_block · (φ_block @ W^T)) + (φ_block @ b)
+        #
+        # whose intermediate is ``[N_block, d_emb]``, far cheaper in
+        # bandwidth than ``[N_block, n_out]``.
+        n_blocks = n_eps + 1
+        # Mode-block boundaries — derived from B (deterministic given
+        # the stratified sampler). Same convention as sample_perturbations.
+        if model.head_pure_sigma is None and model.head_cross is None:
+            # Pure shift-only polyhead: all events are SHIFT mode.
+            n_shift_b, n_smear_b, n_joint_b = B, 0, 0
+        else:
+            base = B // 3
+            extra = B - 3 * base
+            n_shift_b, n_smear_b, n_joint_b = base + extra, base, base
+
+        # Trunk: one matmul on the full (n_eps+1)·B batch.
+        y_all = torch.cat(
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+        )
+        c_all = c.repeat(n_eps + 1, 1)
+        u_all = u.repeat(n_eps + 1, 1)
+        sigma_vec_all = sigma_vec.repeat(n_eps + 1, 1)
+        e_flat = model.trunk_forward(y_all, c_all)     # [(n_eps+1)·B, d_emb]
+        d_emb = e_flat.shape[-1]
+        e_r = e_flat.view(n_blocks, B, d_emb)
+
+        # Basis: phi on the same batch, then reshape and slice by
+        # mode along the B axis. ``basis_aux=model.basis_aux`` keeps
+        # the cache-miss path out of the compiled trace (avoids
+        # CUDA-graph "tensor overwritten" errors).
+        phi_flat = _select_basis(
+            model.basis, u_all, sigma_vec_all, model.joint_indices,
+            scale_u=model.basis_scale_u,
+            scale_sigma=model.basis_scale_sigma,
+            aux=model.basis_aux,
+        )                                              # [(n_eps+1)·B, n_basis]
+        phi_r = phi_flat.view(n_blocks, B, -1)
+
+        n_pu = model._n_pure_u
+        n_ps = model._n_pure_s
+        n_cr = model._n_cross
+
+        def _order2(e_blk, phi_blk, head):
+            """Order-2: ``d = (e · (phi @ W)) + (phi @ b)`` per event.
+            ``e_blk``: [N, d_emb]; ``phi_blk``: [N, n_out];
+            ``head``: nn.Linear(d_emb, n_out). Returns [N]."""
+            if head is None:
+                return torch.zeros(
+                    e_blk.shape[0], device=e_blk.device,
+                    dtype=e_blk.dtype,
+                )
+            temp = phi_blk @ head.weight             # [N, d_emb]
+            bias_term = phi_blk @ head.bias          # [N]
+            return (e_blk * temp).sum(-1) + bias_term
+
+        d_chunks = []
+
+        # SHIFT events: only pure_u contributes (σ = 0).
+        if n_shift_b > 0:
+            e_s = e_r[:, :n_shift_b, :].reshape(-1, d_emb)
+            phi_s_pu = phi_r[:, :n_shift_b, :n_pu].reshape(-1, n_pu)
+            d_s = _order2(e_s, phi_s_pu, model.head_pure_u)
+            d_chunks.append(d_s.view(n_blocks, n_shift_b))
+
+        # SMEAR events: only pure_σ contributes (u = 0).
+        if n_smear_b > 0:
+            e_m = e_r[
+                :, n_shift_b : n_shift_b + n_smear_b, :,
+            ].reshape(-1, d_emb)
+            phi_m_ps = phi_r[
+                :, n_shift_b : n_shift_b + n_smear_b,
+                n_pu : n_pu + n_ps,
+            ].reshape(-1, n_ps)
+            d_m = _order2(e_m, phi_m_ps, model.head_pure_sigma)
+            d_chunks.append(d_m.view(n_blocks, n_smear_b))
+
+        # JOINT events: all three head contributions; optionally
+        # detach the pure-u and pure-σ contributions so JOINT-mode
+        # gradient flows only through head_cross.
+        if n_joint_b > 0:
+            j0 = n_shift_b + n_smear_b
+            e_j = e_r[:, j0:, :].reshape(-1, d_emb)
+            phi_j = phi_r[:, j0:, :].reshape(-1, n_pu + n_ps + n_cr)
+            d_j_pu = _order2(
+                e_j, phi_j[:, :n_pu], model.head_pure_u,
+            )
+            d_j_ps = _order2(
+                e_j, phi_j[:, n_pu : n_pu + n_ps],
+                model.head_pure_sigma,
+            )
+            d_j_cr = _order2(
+                e_j, phi_j[:, n_pu + n_ps :], model.head_cross,
+            )
+            if detach_pure_in_joint:
+                d_j_pu = d_j_pu.detach()
+                d_j_ps = d_j_ps.detach()
+            d_j = (d_j_pu + d_j_ps + d_j_cr).view(n_blocks, n_joint_b)
+            d_chunks.append(d_j)
+
+        # Concatenate per-mode contributions along the B axis and
+        # flatten back to [(n_eps+1)·B] for the d_nom / d_pert split.
+        d = torch.cat(d_chunks, dim=1).reshape(-1)
+
+    else:
+        raise ValueError(f"unknown arch {arch!r}")
+
+    # Optional analytic Gaussian baseline: closed-form additive log-r
+    # term modelling p_nom(y|c) ~ N(μ(c), Σ(c)) and its shift+convolution
+    # under (u, σ_vec). The polyhead/mlp residual then only has to fit
+    # the *deviation from a Gaussian* — much smoother and lower-degree
+    # than the full convolution-induced reweight, especially at
+    # moderate σ where the smearing kernel width is comparable to the
+    # core width of the target. ``μ, Σ`` depend only on ``c`` (they
+    # describe the *shape* of p_nom, which is a property of the
+    # conditional density, not of any single sample drawn from it).
+    gauss = getattr(model, "gauss_baseline", None)
+    if gauss is not None:
+        n_blocks = n_eps + 1
+        y_all_g = torch.cat(
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+        )
+        mu_g, L_g = gauss(c)                            # [B, F], [B, F, F]
+        mu_all_g = mu_g.repeat(n_blocks, 1)
+        L_all_g = L_g.repeat(n_blocks, 1, 1)
+        u_all_g = u.repeat(n_blocks, 1)
+        sigma_all_g = sigma_vec.repeat(n_blocks, 1)
+        d = d + gauss_baseline_log_r(
+            y_all_g, mu_all_g, L_all_g, u_all_g, sigma_all_g,
+        )
+
+    d_nom = d[:B]
+    d_pert_all = d[B:].view(n_eps, B)
+    return d_nom, d_pert_all
+
+
+class ReweightWrapper(nn.Module):
+    """DDP-friendly wrapper that exposes
+    :func:`compute_d_quadrature` as a single ``forward()``.
+
+    Holds the inner model (``ReweightMLP_B`` or ``ReweightPolyhead``)
+    plus the static knobs (``arch``, ``detach_pure_in_joint``). All
+    trunk/head accesses live inside one nn.Module forward, which is
+    what DDP needs to instrument the parameter-gradient hooks.
+
+    Returns the **pre-positivity scalar** ``(d_nom, d_pert_all)``;
+    the loss step applies the appropriate wrap (``log r̂`` or ``r̂``,
+    selected by loss family). The wrap therefore lives outside DDP /
+    ``torch.compile`` boundaries — this lets the LSIF path use the
+    closed-form ``r̂(d)`` directly without an exp/log round-trip.
+
+    The perturbation sampling, ε-stack assembly, σ-pack packing, and
+    final loss combination remain in :func:`loss_step` so the
+    quadrature scheme stays orthogonal to the wrapper.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        arch: str,
+        positivity: str,
+        detach_pure_in_joint: bool = True,
+    ):
+        super().__init__()
+        self.model = model
+        self.arch = str(arch)
+        # ``positivity`` is recorded for the checkpoint payload but
+        # not used by the wrapper's forward — the wrap is applied
+        # downstream in loss_step.
+        self.positivity = str(positivity)
+        self.detach_pure_in_joint = bool(detach_pure_in_joint)
+
+    def forward(
+        self,
+        y_nom: torch.Tensor,
+        y_pert_stack: torch.Tensor,
+        c: torch.Tensor,
+        u: torch.Tensor,
+        sigma_vec: torch.Tensor,
+        sigma_pack: torch.Tensor,
+        mode_id: torch.Tensor,
+    ):
+        return compute_d_quadrature(
+            self.model, self.arch,
+            y_nom, y_pert_stack, c, u, sigma_vec, sigma_pack,
+            mode_id=mode_id,
+            detach_pure_in_joint=self.detach_pure_in_joint,
+        )
+
+
+def _build_eps_stack(
+    batch_size: int,
+    smear_K: int,
+    smear_residual: bool,
+    gh_nodes: torch.Tensor,
+    device,
+):
+    """Build the per-event ε stack used to form ``y_pert_stack``.
+
+    Returns shape ``[n_eps, B]`` with:
+
+      * K=1 stochastic (default): ``n_eps = 1`` with one random
+        ``ε ~ N(0, 1)`` per event.
+      * Pure GH (K≥2, no residual): ``n_eps = K`` with the K
+        Gauss-Hermite nodes broadcast across the batch.
+      * GH + residual (K≥2, residual): ``n_eps = K + 1`` where the
+        last slot is one extra random ε per event for the
+        control-variate residual.
+    """
+    if smear_K <= 1:
+        return torch.randn(1, batch_size, device=device)
+    eps_gh = gh_nodes.view(-1, 1).expand(smear_K, batch_size)  # [K, B]
+    if smear_residual:
+        eps_extra = torch.randn(1, batch_size, device=device)
+        return torch.cat([eps_gh, eps_extra], dim=0)
+    return eps_gh
+
+
+def _make_y_pert_stack(y_nom, u, sigma_vec, eps_stack):
+    """``y_pert[k, b] = y_nom[b] + u[b] + ε_stack[k, b] · σ_vec[b]``."""
+    return (
+        y_nom.unsqueeze(0)
+        + u.unsqueeze(0)
+        + eps_stack.unsqueeze(-1) * sigma_vec.unsqueeze(0)
+    )
+
+
+def _smear_pert_estimator(
+    x_pert_all,
+    eps_stack,
+    gh_nodes,
+    gh_weights,
+    smear_K: int,
+    smear_residual: bool,
+):
+    """Loss-agnostic ε-quadrature aggregator.
+
+    Takes a precomputed ``[n_eps, B]`` per-event scalar ``x_pert_all``
+    — the loss-family-specific integrand evaluated at each
+    quadrature ε-node — and returns the per-event ``E_ε[x]`` estimator.
+    The caller (``loss_step``) prepares ``x_pert_all`` from
+    ``d_pert_all`` via the appropriate combination of positivity wrap
+    and per-loss transform:
+
+      * LSIF   → ``x = r̂(d) = _apply_positivity_r(d, positivity)``
+      * DV     → ``x = log r̂(d) = _apply_positivity(d, positivity)``
+      * expKL  → ``x = log r̂(d)`` (same as DV)
+      * BCE    → ``x = softplus(−log r̂(d))``
+
+    Three quadrature regimes (matching :func:`_build_eps_stack`):
+
+      * K=1 stochastic: just the single sample, unbiased per event.
+      * Pure GH: ``S_K = Σ_k w_k · x_k``. Polynomial-exact through
+        degree ``2K − 1`` in ε; truncation error ``O(σ_max^{2K})``.
+      * GH + residual: ``S_K + (x(ε~) − g(ε~))``, where ``g`` is the
+        Lagrange interpolant through the GH nodes. ``E_ε[g] = S_K``
+        exactly, so the residual term has zero mean and the estimator
+        stays unbiased; variance is ``Var(x − g)`` which captures only
+        beyond-truncation features.
+
+    Because ``x`` is already in the loss family's natural form, the
+    aggregation here is purely linear in ``x`` — the same code path
+    serves all four losses.
+    """
+    if smear_K <= 1:
+        return x_pert_all[0]
+
+    K = smear_K
+    x_K = x_pert_all[:K]                             # [K, B]
+    S_K = torch.einsum("k,kb->b", gh_weights, x_K)
+    if not smear_residual:
+        return S_K
+
+    # Hybrid: control-variate correction.
+    eps_extra = eps_stack[K]                         # [B]
+    L = _lagrange_basis_at(eps_extra, gh_nodes)      # [B, K]
+    g_at_eps = torch.einsum("kb,bk->b", x_K, L)
+    x_extra = x_pert_all[K]
+    return S_K + (x_extra - g_at_eps)
+
+
+# ============================================================================
+# Sampling: u, σ_vec, ε_smear
+# ============================================================================
+
+def sample_perturbations(
+    batch_size: int,
+    n_dim: int,
+    delta_max: float,
+    sigma_max: float,
+    device,
+    oversample: float = 1.3,
+    include_smear: bool = True,
+):
+    """Per-event sampler returning ``(u, σ_vec, mode_id)``.
+
+    With ``include_smear=True`` (shift+smear training) it produces a
+    stratified SHIFT / SMEAR / JOINT mode mix (1/3 each), matching
+    the polyhead training convention from
+    ``train_muon_response_flow.py``:
+
+      * SHIFT (mode=0): u random, σ_vec = 0.
+      * SMEAR (mode=1): u = 0, σ_vec random.
+      * JOINT (mode=2): both u and σ_vec random.
+
+    Stratification ensures pure-axis queries at deployment
+    (``u = 0`` or ``σ_vec = 0``) are in-distribution.
+
+    With ``include_smear=False`` (shift-only training; the default) we
+    skip smear/joint modes entirely: every event is mode=0 with a
+    random ``u`` and ``σ_vec = 0``. This is what we want when the
+    architecture itself is shift-only.
+
+    Magnitude sampling within each active axis:
+      * ``|u|`` uniform on ``[−oversample·delta_max, +oversample·delta_max]``
+      * ``|σ_vec|`` uniform on ``[0, oversample·sigma_max]``
+
+    Direction is uniform on the unit sphere ``S^{n_dim − 1}``. The
+    ε samples for the smear noise are produced separately by
+    :func:`_build_eps_stack` so the K=1 stochastic and the K≥2
+    Gauss-Hermite paths share this sampler.
+
+    The ``oversample`` factor (default 1.3) trains the model slightly
+    beyond the operational range so closure at the edge is
+    well-supported.
+    """
+    half = oversample * delta_max
+
+    # Raw u-direction × magnitude (always populated).
+    delta_u = (torch.rand(batch_size, device=device) * 2.0 - 1.0) * half
+    v_u = torch.randn(batch_size, n_dim, device=device)
+    v_u = v_u / v_u.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+
+    if not include_smear:
+        # All-SHIFT path: σ_vec ≡ 0, mode ≡ 0.
+        u = delta_u.unsqueeze(-1) * v_u
+        sigma_vec = torch.zeros(batch_size, n_dim, device=device)
+        mode_id = torch.zeros(batch_size, dtype=torch.long, device=device)
+        return u, sigma_vec, mode_id
+
+    half_sig = oversample * sigma_max
+
+    # Raw σ-direction × magnitude (always populated; gated below).
+    sigma_mag = torch.rand(batch_size, device=device) * half_sig
+    v_s = torch.randn(batch_size, n_dim, device=device)
+    v_s = v_s / v_s.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+
+    # Stratified mode: 0=SHIFT, 1=SMEAR, 2=JOINT — exactly 1/3 each
+    # (deterministic split). Mode IDs are produced in **sorted
+    # contiguous** order ``[0, 0, ..., 1, 1, ..., 2, 2, ...]``; the
+    # data-loader's own per-event shuffling already randomizes the
+    # ``(y, c)`` ↔ mode pairing, so the explicit permutation that
+    # used to live here is unnecessary and would break the contiguous
+    # per-mode slicing the compiled polyhead path relies on (see
+    # :func:`compute_d_quadrature`'s polyhead branch). The remainder
+    # when ``batch_size`` isn't a multiple of 3 is given to SHIFT,
+    # the mode that dominates the gradient signal.
+    base = batch_size // 3
+    extra = batch_size - 3 * base
+    mode_id = torch.cat([
+        torch.full((base + extra,), 0, device=device, dtype=torch.long),
+        torch.full((base,), 1, device=device, dtype=torch.long),
+        torch.full((base,), 2, device=device, dtype=torch.long),
+    ])
+    shift_active = (mode_id != 1).to(delta_u.dtype)   # SHIFT or JOINT
+    smear_active = (mode_id != 0).to(sigma_mag.dtype)  # SMEAR or JOINT
+
+    u = (delta_u * shift_active).unsqueeze(-1) * v_u
+    sigma_vec = (sigma_mag * smear_active).unsqueeze(-1) * v_s
+    # ε is sampled separately by ``_build_eps_stack`` (per-event for
+    # K=1 stochastic, GH nodes for K≥2). When ``smear_active = 0`` the
+    # σ_vec is zero so the resulting ε·σ_vec is zero regardless.
+    return u, sigma_vec, mode_id
+
+
+# ============================================================================
+# Loss functions
+# ============================================================================
+
+def dv_loss(log_r_nom, pert_T_estimator, weights):
+    """Donsker-Varadhan / MINE objective (minimization form):
+
+        L = log E_{y~p_nom}[exp(T)] − pert_T_estimator,   T = log r̂.
+
+    The pert side accepts an externally-supplied estimator of
+    ``E_{y~p_pert}[T]`` so that K=1 stochastic, pure GH, or GH+residual
+    schemes plug in uniformly. Numerically stable via ``logsumexp``."""
+    wsum = weights.sum().clamp_min(1e-30)
+    e_pert_T = (weights * pert_T_estimator).sum() / wsum
+    log_w = torch.log(weights.clamp_min(1e-30))
+    log_e_nom_expT = (
+        torch.logsumexp(log_w + log_r_nom, dim=0) - torch.log(wsum)
+    )
+    return -e_pert_T + log_e_nom_expT
+
+
+def lsif_loss(r_nom, pert_estimator, weights):
+    """Least-squares importance fitting:
+
+        L = E_{y~p_nom}[r̂²]  −  2·pert_estimator
+                                ⇑
+                           per-event ``E_ε[r̂]`` from K=1 stochastic,
+                           pure GH, or GH+residual.
+
+    Unique minimizer ``r̂* = r``. Unbiased for any of the three
+    pert-estimator schemes.
+
+    ``r_nom`` is fed in directly (not via ``exp(log r̂_nom)``) — the
+    caller computes ``r̂`` from the pre-positivity scalar ``d`` via the
+    closed-form :func:`_apply_positivity_r`. This avoids the log/exp
+    round-trip and lets the softplus wrap skip its output ``clamp_min``
+    on the LSIF path (``r̂ = softplus(d)/log 2`` is intrinsically
+    positive)."""
+    wsum = weights.sum().clamp_min(1e-30)
+    e_nom_r_sq = (weights * r_nom * r_nom).sum() / wsum
+    e_pert_r = (weights * pert_estimator).sum() / wsum
+    return e_nom_r_sq - 2.0 * e_pert_r
+
+
+def bce_loss(log_r_nom, pert_softplus_neg_estimator, weights):
+    """Logistic / binary cross-entropy density-ratio loss (CARL):
+
+        L = E_{y~p_nom}[ softplus( s) ]
+          + E_{y~p_pert}[ softplus(−s) ]            with s = log r̂.
+
+    Unique minimizer ``s* = log r`` exactly — no constant ambiguity
+    (unlike DV) and per-sample unbiased (no Jensen gap). Bounded
+    gradients (sigmoid-saturated) make it stable when ``r̂`` strays
+    far from ``r`` early in training, at the cost of a slower
+    convergence rate when ``|log r|`` is large.
+
+    The pert side accepts an externally-supplied estimator of
+    ``E_{y~p_pert}[softplus(−s)]`` so that K=1 stochastic, pure GH,
+    or GH+residual all plug in uniformly (same machinery as LSIF/DV)."""
+    wsum = weights.sum().clamp_min(1e-30)
+    e_nom_term = (weights * F.softplus(log_r_nom)).sum() / wsum
+    e_pert_term = (
+        weights * pert_softplus_neg_estimator
+    ).sum() / wsum
+    return e_nom_term + e_pert_term
+
+
+def expkl_loss(log_r_nom, pert_T_estimator, weights):
+    """Exponential-KL loss (DV with the outer log dropped, a.k.a.
+    f-GAN-KL):
+
+        L = E_{y~p_nom}[ exp(s) ]  −  E_{y~p_pert}[ s ]   with s = log r̂.
+
+    Unique minimizer ``s* = log r`` exactly (no constant ambiguity)
+    and per-sample unbiased (no Jensen gap). Locally near the optimum
+    the loss is
+
+        L(s) − L(s*)  ≈  ½ · E_{y~p_pert}[ (s − log r)² ]
+
+    so this is the L²-in-log-r analog of LSIF (which is L²-in-r-space
+    weighted by ``p_nom``). Trade-off: like LSIF the gradient on the
+    nom side grows as ``exp(s)``, so it can blow up early in training
+    if the model strays far from ``log r ≈ 0``. Construction-B's
+    structural ``s = 0`` at zero perturbation keeps init in the safe
+    regime; for high-contrast deployment edges, gradient clipping or
+    a BCE→expKL warm-start helps.
+
+    The pert side accepts an externally-supplied estimator of
+    ``E_{y~p_pert}[s]`` (= ``E_pert[T]`` in DV notation), so K=1
+    stochastic, pure GH, or GH+residual all plug in uniformly."""
+    wsum = weights.sum().clamp_min(1e-30)
+    e_nom = (weights * torch.exp(log_r_nom)).sum() / wsum
+    e_pert = (weights * pert_T_estimator).sum() / wsum
+    return e_nom - e_pert
+
+
+# ============================================================================
+# Training step
+# ============================================================================
+
+def _per_mode_split(per_event_loss, weights, mode_id, n_modes=3):
+    """Aggregate per-event loss into per-mode (SHIFT/SMEAR/JOINT)
+    weighted means.
+
+    Returns ``(weighted_sum, weight_sum)`` both shape ``[n_modes]``,
+    on the same device/dtype as ``per_event_loss``. The caller divides
+    after the (cross-rank, cross-batch) reduction. Modes with zero
+    population have ``weight_sum == 0`` and the caller should treat
+    that mode as 'no data this epoch'.
+    """
+    device = per_event_loss.device
+    dtype = per_event_loss.dtype
+    out_sum = torch.zeros(n_modes, device=device, dtype=dtype)
+    out_w = torch.zeros(n_modes, device=device, dtype=dtype)
+    pe_w = (weights * per_event_loss).to(dtype)
+    for m in range(n_modes):
+        mask = (mode_id == m).to(dtype)
+        out_sum[m] = (pe_w * mask).sum()
+        out_w[m] = (weights * mask).sum()
+    return out_sum, out_w
+
+
+def _shift_K_per_event_loss(
+    inner_model, arch, y, c, w,
+    u_smolyak, K_extra,
+    delta_max, oversample,
+    loss_fn, positivity,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+):
+    """Memory-optimized K-per-event shift loss (shift-only mode).
+
+    The naive batch-replication strategy (replicate every event K
+    times before the wrapper forward) duplicates the *trunk*
+    computation and its activations K times per event for the y_nom
+    side, which is wasteful: every event's nominal (y, c) is the
+    same across all K shift evaluations. This helper bypasses the
+    wrapper and computes:
+
+      * 1 trunk forward at (y, c)             — shared across K
+      * K trunk forwards at (y + u_k, c)      — one per perturbation
+      * polynomial / head evaluations at K (u, σ=0) per event
+
+    Total trunk work per event: ``1 + K_total`` forwards (vs.
+    ``2·K_total`` in the naive path). Trunk-activation memory
+    likewise drops by ~2×, which is the dominant memory savings at
+    K_total ≳ 10.
+
+    Returns ``(loss, split_sum, split_w)`` matching the regular
+    :func:`loss_step` contract.
+    """
+    B = y.shape[0]
+    n_features = y.shape[-1]
+    device = y.device
+    dtype = y.dtype
+
+    K_smolyak = u_smolyak.shape[0] if u_smolyak is not None else 0
+    K_total = K_smolyak + int(K_extra)
+    if K_total == 0:
+        raise ValueError("K_total must be > 0 in shift-K path")
+    half = float(oversample) * float(delta_max)
+
+    # Build u_all [B, K_total, n_features]: Smolyak shared across
+    # events (broadcast view) + K_extra stochastic per-event draws.
+    u_parts = []
+    if K_smolyak > 0:
+        u_parts.append(
+            u_smolyak.to(device=device, dtype=dtype)
+            .unsqueeze(0).expand(B, K_smolyak, n_features)
+        )
+    if K_extra > 0:
+        delta = (
+            torch.rand(B, K_extra, device=device, dtype=dtype) * 2.0 - 1.0
+        ) * half
+        v = torch.randn(B, K_extra, n_features, device=device, dtype=dtype)
+        v = v / v.norm(dim=-1, keepdim=True).clamp_min(1e-30)
+        u_parts.append(delta.unsqueeze(-1) * v)
+    u_all = torch.cat(u_parts, dim=1)        # [B, K_total, n_features]
+
+    sigma_zero = torch.zeros_like(u_all)     # [B, K_total, n_features]
+    n_cond = c.shape[-1]
+
+    if arch == "polyhead":
+        # 1 trunk forward at y_nom — coefs shared across all K_total.
+        coefs_nom = inner_model(y, c)        # [B, n_basis]
+
+        # K trunk forwards at y_pert_k = y + u_k.
+        y_pert = y.unsqueeze(1) + u_all      # [B, K_total, n_features]
+        y_pert_flat = y_pert.reshape(B * K_total, n_features)
+        c_flat = c.unsqueeze(1).expand(
+            B, K_total, n_cond,
+        ).reshape(B * K_total, n_cond)
+        coefs_pert_flat = inner_model(
+            y_pert_flat, c_flat,
+        )                                    # [B·K_total, n_basis]
+        coefs_pert = coefs_pert_flat.view(B, K_total, -1)
+
+        # Polynomial evaluations (no trunk gradient flow):
+        # coefs_nom expand is a broadcast *view*, no copy. Gradient
+        # accumulates over K_total contributions automatically.
+        coefs_nom_view = coefs_nom.unsqueeze(1).expand(B, K_total, -1)
+        _basis_aux = inner_model.basis_aux
+        d_nom_3d = evaluate_joint(
+            coefs_nom_view, u_all, sigma_zero, inner_model.joint_indices,
+            basis=inner_model.basis,
+            scale_u=inner_model.basis_scale_u,
+            scale_sigma=inner_model.basis_scale_sigma,
+            basis_aux=_basis_aux,
+        )                                    # [B, K_total]
+        d_pert_3d = evaluate_joint(
+            coefs_pert, u_all, sigma_zero, inner_model.joint_indices,
+            basis=inner_model.basis,
+            scale_u=inner_model.basis_scale_u,
+            scale_sigma=inner_model.basis_scale_sigma,
+            basis_aux=_basis_aux,
+        )                                    # [B, K_total]
+    elif arch in ("mlp", "mlp-factored"):
+        # Both flavours use head_forward(e, u, σ_pack). The factored
+        # head's head_forward already returns ``d`` (structurally zero
+        # at the origin), so ``f(e, u, 0) − f(e, 0, 0) = d − 0 = d`` —
+        # the dual-forward subtraction is a structural no-op for the
+        # factored variant in shift-only mode. Either way the
+        # per-event scalar comes out identical to the construction
+        # the loss expects.
+        e_nom = inner_model.trunk_forward(y, c)      # [B, d_emb]
+        d_emb = e_nom.shape[-1]
+
+        y_pert_flat = (y.unsqueeze(1) + u_all).reshape(B * K_total, n_features)
+        c_flat = c.unsqueeze(1).expand(
+            B, K_total, n_cond,
+        ).reshape(B * K_total, n_cond)
+        e_pert_flat = inner_model.trunk_forward(
+            y_pert_flat, c_flat,
+        )                                    # [B·K_total, d_emb]
+
+        # Head: f(e, u, σ_pack=0) and f(e, 0, 0). Shift-only ⇒ σ_pack
+        # placeholder is [..., 0]. Aggregate the four head forwards
+        # per (event, k) needed by the structural construction.
+        u_flat = u_all.reshape(B * K_total, n_features)
+        sp_zero = torch.empty(
+            B * K_total, 0, device=device, dtype=dtype,
+        )
+        u_zero = torch.zeros_like(u_flat)
+        # d_nom: f(e_nom, u_k, 0) - f(e_nom, 0, 0).
+        # e_nom needs to be expanded to [B·K_total, d_emb] (view).
+        e_nom_exp = e_nom.unsqueeze(1).expand(B, K_total, d_emb).reshape(
+            B * K_total, d_emb,
+        )
+        f_nom_full = inner_model.head_forward(e_nom_exp, u_flat, sp_zero)
+        f_nom_zero = inner_model.head_forward(e_nom_exp, u_zero, sp_zero)
+        d_nom_3d = (f_nom_full - f_nom_zero).view(B, K_total)
+        # d_pert: f(e_pert, u_k, 0) - f(e_pert, 0, 0).
+        f_pert_full = inner_model.head_forward(e_pert_flat, u_flat, sp_zero)
+        f_pert_zero = inner_model.head_forward(e_pert_flat, u_zero, sp_zero)
+        d_pert_3d = (f_pert_full - f_pert_zero).view(B, K_total)
+    else:
+        raise ValueError(f"unknown arch {arch!r} in shift-K path")
+
+    # Optional analytic Gaussian baseline (mirrors the
+    # compute_d_quadrature path). Same μ(c), L(c) for both nominal
+    # and perturbed evaluations — what differs is the y at which the
+    # baseline is evaluated. Broadcast across K_total via expand.
+    gauss = getattr(inner_model, "gauss_baseline", None)
+    if gauss is not None:
+        mu_g, L_g = gauss(c)                                # [B, F], [B, F, F]
+        mu_bk = mu_g.unsqueeze(1).expand(B, K_total, n_features)
+        L_bk = L_g.unsqueeze(1).expand(
+            B, K_total, n_features, n_features,
+        )
+        y_bk = y.unsqueeze(1).expand(B, K_total, n_features)
+        y_pert_bk = y.unsqueeze(1) + u_all                  # [B, K_total, F]
+        d_nom_3d = d_nom_3d + gauss_baseline_log_r(
+            y_bk, mu_bk, L_bk, u_all, sigma_zero,
+        )
+        d_pert_3d = d_pert_3d + gauss_baseline_log_r(
+            y_pert_bk, mu_bk, L_bk, u_all, sigma_zero,
+        )
+
+    # Flatten K into the batch axis for the loss aggregation:
+    # B' = B·K_total, weight per replica = w / K_total so per-event
+    # aggregate weight equals the original w.
+    d_nom_flat = d_nom_3d.reshape(B * K_total)
+    d_pert_all = d_pert_3d.reshape(B * K_total).unsqueeze(0)  # [1, B·K_total]
+    w_flat = w.unsqueeze(1).expand(B, K_total).reshape(
+        B * K_total,
+    ) / float(K_total)
+    eps_stack = torch.zeros(1, B * K_total, device=device, dtype=dtype)
+
+    if loss_fn == "lsif":
+        r_nom = _apply_positivity_r(d_nom_flat, positivity)
+        r_pert_all = _apply_positivity_r(d_pert_all, positivity)
+        pert_estimator = _smear_pert_estimator(
+            r_pert_all, eps_stack, None, None, 1, False,
+        )
+        loss = lsif_loss(r_nom, pert_estimator, w_flat)
+        per_event = (r_nom * r_nom - 2.0 * pert_estimator).detach()
+    else:
+        # BCE: disable the exp-wrap ±clamp safety net (functionally
+        # unused for BCE, see _apply_positivity docstring); DV /
+        # expKL keep the default clamp for nom-side ``exp(log r̂)``
+        # / ``logsumexp(log r̂)`` numerical safety.
+        pos_clamp = (
+            float("inf") if loss_fn == "bce" else _LOG_W_CLAMP
+        )
+        log_r_nom = _apply_positivity(
+            d_nom_flat, positivity, clamp=pos_clamp,
+        )
+        log_r_pert_all = _apply_positivity(
+            d_pert_all, positivity, clamp=pos_clamp,
+        )
+        if loss_fn == "bce":
+            x_pert_all = F.softplus(-log_r_pert_all)
+        else:
+            x_pert_all = log_r_pert_all
+        pert_estimator = _smear_pert_estimator(
+            x_pert_all, eps_stack, None, None, 1, False,
+        )
+        if loss_fn == "dv":
+            loss = dv_loss(log_r_nom, pert_estimator, w_flat)
+            per_event = (-pert_estimator).detach()
+        elif loss_fn == "bce":
+            loss = bce_loss(log_r_nom, pert_estimator, w_flat)
+            per_event = (
+                F.softplus(log_r_nom) + pert_estimator
+            ).detach()
+        else:  # expkl
+            loss = expkl_loss(log_r_nom, pert_estimator, w_flat)
+            per_event = (
+                torch.exp(log_r_nom) - pert_estimator
+            ).detach()
+
+    # All replicas sit in SHIFT mode (=0); SMEAR/JOINT slots are
+    # unpopulated and will return weight=0 → +inf in the caller's
+    # split bookkeeping.
+    mode_flat = torch.zeros(
+        B * K_total, dtype=torch.long, device=device,
+    )
+    split_sum, split_w = _per_mode_split(per_event, w_flat, mode_flat)
+    return loss, split_sum, split_w
+
+
+def loss_step(
+    model, arch, y, c, w,
+    delta_max, sigma_max, oversample,
+    loss_fn, positivity,
+    sigma_pack_iu=None, sigma_pack_ju=None,
+    smear_K: int = 1, smear_residual: bool = False,
+    gh_nodes=None, gh_weights=None,
+    detach_pure_in_joint: bool = True,
+    include_smear: bool = True,
+    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+    inner_model=None,
+):
+    """One forward-loss step.
+
+    Samples ``(u, σ_vec)``, builds the ε-stack (``[n_eps, B]`` of
+    quadrature points), forms ``y_pert_stack``, computes the
+    pre-positivity scalar ``d`` at all positions in one batched pass,
+    and combines into the chosen loss family.
+
+    ``model`` is expected to be either a :class:`ReweightWrapper` or
+    its DDP / ``torch.compile`` wrapping — its ``forward()`` returns
+    the **pre-positivity** ``(d_nom, d_pert_all)``. The positivity wrap
+    is applied here, *outside* the wrapper, in whichever form the loss
+    family needs:
+
+      * LSIF  — uses ``r̂`` directly via :func:`_apply_positivity_r`.
+        No log/exp round-trip; softplus output ``clamp_min`` not
+        needed on this path.
+      * DV / BCE / expKL — use ``log r̂`` via :func:`_apply_positivity`.
+
+    ``detach_pure_in_joint`` is baked into the wrapper (it acts on
+    ``d`` inside ``compute_d_quadrature``); ``positivity`` is needed
+    here because the wrap is applied at this level.
+
+    ``include_smear=False`` (shift-only path) gates the perturbation
+    sampler so every event is SHIFT mode and ``σ_vec = 0``; the
+    ε-stack collapses to a single zero, so ``y_pert = y + u``.
+
+    Shift-axis multi-sample-per-event (Smolyak + stochastic) is
+    activated when ``shift_smolyak_pts is not None`` or
+    ``shift_stochastic_extra > 0``. Each event is then evaluated at
+    ``K_total = K_smolyak + K_extra`` u values, with weights
+    ``w / K_total`` per replica so the per-event aggregate weight is
+    preserved. Only valid in shift-only mode (caller is expected to
+    have errored out on ``include_smear=True``); under that
+    constraint ``mode_id ≡ SHIFT`` for every replica.
+    """
+    del detach_pure_in_joint  # baked into the wrapper
+    n_features = y.shape[-1]
+    B = y.shape[0]
+    device = y.device
+
+    use_shift_K = (
+        not include_smear
+        and (shift_smolyak_pts is not None or shift_stochastic_extra > 0)
+    )
+
+    if use_shift_K:
+        # Memory-optimized path: trunk(y_nom, c) is computed *once*
+        # per event and shared across all K_total perturbation
+        # evaluations. Bypasses the wrapper / DDP / compile and goes
+        # straight to ``inner_model``; gradients still flow correctly
+        # because DDP's all-reduce is registered on parameters, not
+        # on the wrapped forward call.
+        if inner_model is None:
+            raise ValueError(
+                "shift-K path requires ``inner_model`` to be passed "
+                "to loss_step (used to share the y_nom trunk forward)."
+            )
+        return _shift_K_per_event_loss(
+            inner_model, arch, y, c, w,
+            shift_smolyak_pts, int(shift_stochastic_extra),
+            delta_max, oversample, loss_fn, positivity,
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        )
+
+    u, sigma_vec, mode_id = sample_perturbations(
+        B, n_features, delta_max, sigma_max, device,
+        oversample=oversample, include_smear=include_smear,
+    )
+
+    if include_smear:
+        eps_stack = _build_eps_stack(
+            B, smear_K, smear_residual, gh_nodes, device,
+        )
+    else:
+        # σ_vec ≡ 0 in shift-only mode, so ε·σ_vec = 0 regardless of
+        # ε. Skip the random draw and force a single zero-ε slot —
+        # n_eps = 1 — so the downstream estimator just returns the
+        # single perturbed value unchanged. We also override the
+        # estimator regime to (smear_K=1, smear_residual=False) so
+        # the GH/residual code paths don't fire on a zero σ.
+        eps_stack = torch.zeros(1, B, device=device, dtype=y.dtype)
+        smear_K = 1
+        smear_residual = False
+    y_pert_stack = _make_y_pert_stack(y, u, sigma_vec, eps_stack)
+
+    if arch in ("mlp", "mlp-factored") and sigma_pack_iu is not None:
+        sigma_pack = _pack_sigma_outer(
+            sigma_vec, sigma_pack_iu, sigma_pack_ju,
+        )
+    else:
+        # Either polyhead (head ignores Σ_pack) or shift-only mlp /
+        # mlp-factored (head's σ-channel is gone). Pass a [B, 0]
+        # placeholder so the forward signature stays stable for
+        # DDP/compile.
+        sigma_pack = torch.empty(B, 0, device=device, dtype=y.dtype)
+
+    # Wrapper returns the pre-positivity scalar d (no log/exp wrap).
+    d_nom, d_pert_all = model(
+        y, y_pert_stack, c, u, sigma_vec, sigma_pack, mode_id,
+    )
+
+    # Apply the wrap in the form the loss family wants. The K=1 / GH /
+    # GH+residual aggregation in `_smear_pert_estimator` is uniform;
+    # the loss family only differs in *which* per-event scalar gets
+    # aggregated.
+    if loss_fn == "lsif":
+        # LSIF wants r̂ directly: r̂² on the nom side, E_ε[r̂] on the
+        # pert side. No log/exp round-trip; for the softplus wrap
+        # this also skips the outer log(...) and its clamp_min.
+        r_nom = _apply_positivity_r(d_nom, positivity)
+        r_pert_all = _apply_positivity_r(d_pert_all, positivity)
+        pert_estimator = _smear_pert_estimator(
+            r_pert_all, eps_stack, gh_nodes, gh_weights,
+            smear_K, smear_residual,
+        )
+        loss = lsif_loss(r_nom, pert_estimator, w)
+        # Per-event integrand for per-mode split monitoring.
+        # ``r_nom² − 2·pert_estimator`` matches the expectation form
+        # of ``lsif_loss``; per-mode weighted means of this quantity
+        # serve as the "is this mode improving" signal.
+        per_event = (
+            r_nom * r_nom - 2.0 * pert_estimator
+        ).detach()
+        split_sum, split_w = _per_mode_split(per_event, w, mode_id)
+        return loss, split_sum, split_w
+
+    # BCE doesn't exponentiate ``log r̂`` anywhere (only
+    # ``softplus(±log r̂)``, which is intrinsically bounded), so the
+    # ±_LOG_W_CLAMP safety clamp on the ``exp`` positivity wrap has
+    # no functional role for BCE — disabling it via ``clamp=inf``
+    # lets gradient flow even at extreme |d|. For DV / expKL the
+    # nom-side is ``exp(log r̂)`` (or ``logsumexp``) which still
+    # needs the clamp for fp32 / fp16 safety; keep the default
+    # there.
+    pos_clamp = float("inf") if loss_fn == "bce" else _LOG_W_CLAMP
+    log_r_nom = _apply_positivity(d_nom, positivity, clamp=pos_clamp)
+    log_r_pert_all = _apply_positivity(
+        d_pert_all, positivity, clamp=pos_clamp,
+    )
+    if loss_fn in ("dv", "expkl"):
+        x_pert_all = log_r_pert_all
+    elif loss_fn == "bce":
+        x_pert_all = F.softplus(-log_r_pert_all)
+    else:
+        raise ValueError(f"unknown loss_fn {loss_fn!r}")
+
+    pert_estimator = _smear_pert_estimator(
+        x_pert_all, eps_stack, gh_nodes, gh_weights,
+        smear_K, smear_residual,
+    )
+
+    if loss_fn == "dv":
+        loss = dv_loss(log_r_nom, pert_estimator, w)
+        # DV's nom term is a global ``log E[exp(s)]`` (logsumexp) that
+        # does not decompose per-mode cleanly. We track ``−pert_T`` as
+        # the per-mode signal: ``pert_T_estimator`` is a per-event
+        # estimate of ``E_{ε,pert}[T]``, and DV is decreasing iff this
+        # is increasing. Sign-flip for the "lower is better" patience
+        # convention.
+        per_event = (-pert_estimator).detach()
+    elif loss_fn == "bce":
+        loss = bce_loss(log_r_nom, pert_estimator, w)
+        # BCE's per-event integrand is the sum of nom-side and pert-
+        # side softplus terms.
+        per_event = (
+            F.softplus(log_r_nom) + pert_estimator
+        ).detach()
+    else:  # expkl
+        loss = expkl_loss(log_r_nom, pert_estimator, w)
+        per_event = (
+            torch.exp(log_r_nom) - pert_estimator
+        ).detach()
+    split_sum, split_w = _per_mode_split(per_event, w, mode_id)
+    return loss, split_sum, split_w
+
+
+# ============================================================================
+# Training loop
+# ============================================================================
+
+def _all_reduce_sum_(t: torch.Tensor, is_dist: bool) -> torch.Tensor:
+    """In-place all-reduce(sum) when distributed, otherwise a no-op."""
+    if is_dist:
+        import torch.distributed as dist
+        dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    return t
+
+
+def _amp_setup(precision: str, device):
+    """Resolve precision string into (autocast dtype, autocast enabled,
+    GradScaler). bf16 doesn't need loss scaling (fp32-equivalent
+    exponent range); fp16 does. fp32 disables autocast entirely."""
+    amp_device_type = "cuda" if str(device).startswith("cuda") else "cpu"
+    if precision == "fp32":
+        amp_dtype, amp_enabled = torch.float32, False
+    elif precision == "bf16":
+        amp_dtype, amp_enabled = torch.bfloat16, True
+    elif precision == "fp16":
+        amp_dtype, amp_enabled = torch.float16, True
+    else:
+        raise ValueError(f"unknown precision {precision!r}")
+    scaler = torch.amp.GradScaler(
+        amp_device_type, enabled=(precision == "fp16"),
+    )
+    return amp_device_type, amp_dtype, amp_enabled, scaler
+
+
+def train_one_epoch(
+    model, optimizer, train_loader, device, epoch, args, arch,
+    is_rank0, amp_ctx, scaler, sigma_pack_iu, sigma_pack_ju,
+    gh_nodes, gh_weights, is_dist=False,
+    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+    inner_model=None,
+    step_profiler=None,
+):
+    model.train()
+    postfix_every = 50
+    bar = tqdm(
+        train_loader,
+        desc=f"epoch {epoch:03d} train",
+        leave=False,
+        dynamic_ncols=True,
+        disable=not is_rank0,
+        mininterval=1.0,
+        miniters=postfix_every,
+    )
+    total_loss = torch.zeros((), device=device)
+    wsum = torch.zeros((), device=device)
+    # Per-mode split (SHIFT, SMEAR, JOINT). Tracked via separate
+    # weighted-sum and weight-sum accumulators so we can divide
+    # *after* the cross-rank reduction at the end of the epoch.
+    split_sum_total = torch.zeros(3, device=device)
+    split_w_total = torch.zeros(3, device=device)
+    profile_steps = (
+        0 if step_profiler is None else int(step_profiler.enabled) and int(
+            getattr(args, "profile_data_pipeline", 0) or 0
+        )
+    )
+    for i, (x, c, w) in enumerate(bar):
+        do_profile = (step_profiler is not None
+                      and step_profiler.enabled
+                      and i < profile_steps)
+        if do_profile:
+            step_profiler.start()
+        x = x.to(device, non_blocking=True)
+        c = c.to(device, non_blocking=True)
+        w = w.to(device, non_blocking=True)
+        wb = w.sum()
+        if do_profile:
+            step_profiler.mark("h2d")
+        optimizer.zero_grad(set_to_none=True)
+        with amp_ctx():
+            loss, split_sum, split_w = loss_step(
+                model, arch, x, c, w,
+                delta_max=args.delta_max,
+                sigma_max=args.sigma_max,
+                oversample=args.oversample,
+                loss_fn=args.loss_fn,
+                positivity=args.positivity,
+                sigma_pack_iu=sigma_pack_iu,
+                sigma_pack_ju=sigma_pack_ju,
+                smear_K=args.smear_K,
+                smear_residual=args.smear_residual,
+                gh_nodes=gh_nodes, gh_weights=gh_weights,
+                detach_pure_in_joint=args.detach_pure_in_joint,
+                include_smear=args.include_smear,
+                shift_smolyak_pts=shift_smolyak_pts,
+                shift_stochastic_extra=shift_stochastic_extra,
+                inner_model=inner_model,
+            )
+        loss = loss.float()
+        if do_profile:
+            step_profiler.mark("forward")
+        scaler.scale(loss).backward()
+        if do_profile:
+            step_profiler.mark("backward")
+        scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=10.0)
+        scaler.step(optimizer)
+        scaler.update()
+        if do_profile:
+            step_profiler.mark("optimizer")
+        total_loss = total_loss + loss.detach() * wb
+        wsum = wsum + wb
+        split_sum_total = split_sum_total + split_sum.detach().float()
+        split_w_total = split_w_total + split_w.detach().float()
+        if do_profile:
+            step_profiler.mark("accum")
+            step_profiler.report(i)
+        if is_rank0 and (i + 1) % postfix_every == 0:
+            # Rank-0-local running metric (not all-reduced); refreshed
+            # cheaply between batches. The epoch-boundary report below
+            # is the globally-reduced number.
+            wsum_now = max(wsum.item(), 1e-30)
+            bar.set_postfix(loss=f"{(total_loss.item() / wsum_now):+.4f}")
+    _all_reduce_sum_(total_loss, is_dist)
+    _all_reduce_sum_(wsum, is_dist)
+    _all_reduce_sum_(split_sum_total, is_dist)
+    _all_reduce_sum_(split_w_total, is_dist)
+    epoch_loss = total_loss.item() / max(wsum.item(), 1e-30)
+    # Divide post-reduction; modes with zero population (e.g. SMEAR
+    # / JOINT in shift-only training) get +inf so the patience
+    # logic naturally treats them as "no data this epoch" and
+    # neither resets nor blocks the patience clock on them.
+    split = []
+    for m in range(3):
+        wm = split_w_total[m].item()
+        if wm > 0.0:
+            split.append(split_sum_total[m].item() / wm)
+        else:
+            split.append(float("inf"))
+    return epoch_loss, split
+
+
+@torch.no_grad()
+def run_val(model, val_loader, device, args, arch, amp_ctx,
+            sigma_pack_iu, sigma_pack_ju, gh_nodes, gh_weights,
+            is_dist=False,
+            shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+            inner_model=None):
+    model.eval()
+    total_loss = torch.zeros((), device=device)
+    wsum = torch.zeros((), device=device)
+    split_sum_total = torch.zeros(3, device=device)
+    split_w_total = torch.zeros(3, device=device)
+    for x, c, w in val_loader:
+        x = x.to(device, non_blocking=True)
+        c = c.to(device, non_blocking=True)
+        w = w.to(device, non_blocking=True)
+        wb = w.sum()
+        with amp_ctx():
+            loss, split_sum, split_w = loss_step(
+                model, arch, x, c, w,
+                delta_max=args.delta_max,
+                sigma_max=args.sigma_max,
+                oversample=args.oversample,
+                loss_fn=args.loss_fn,
+                positivity=args.positivity,
+                sigma_pack_iu=sigma_pack_iu,
+                sigma_pack_ju=sigma_pack_ju,
+                smear_K=args.smear_K,
+                smear_residual=args.smear_residual,
+                gh_nodes=gh_nodes, gh_weights=gh_weights,
+                detach_pure_in_joint=args.detach_pure_in_joint,
+                include_smear=args.include_smear,
+                shift_smolyak_pts=shift_smolyak_pts,
+                shift_stochastic_extra=shift_stochastic_extra,
+                inner_model=inner_model,
+            )
+        loss = loss.float()
+        total_loss = total_loss + loss * wb
+        wsum = wsum + wb
+        split_sum_total = split_sum_total + split_sum.detach().float()
+        split_w_total = split_w_total + split_w.detach().float()
+    _all_reduce_sum_(total_loss, is_dist)
+    _all_reduce_sum_(wsum, is_dist)
+    _all_reduce_sum_(split_sum_total, is_dist)
+    _all_reduce_sum_(split_w_total, is_dist)
+    val_loss = total_loss.item() / max(wsum.item(), 1e-30)
+    split = []
+    for m in range(3):
+        wm = split_w_total[m].item()
+        if wm > 0.0:
+            split.append(split_sum_total[m].item() / wm)
+        else:
+            split.append(float("inf"))
+    return val_loss, split
+
+
+def train(
+    model, inner_model, arch, train_loader, val_loader, device, args,
+    log_lines, stats=None, sigma_pack_iu=None, sigma_pack_ju=None,
+    gh_nodes=None, gh_weights=None,
+    is_dist: bool = False, is_rank0: bool = True,
+    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+):
+    optimizer = torch.optim.AdamW(
+        model.parameters(), lr=args.lr, weight_decay=args.weight_decay,
+    )
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5,
+        patience=max(1, args.patience // 2),
+    )
+
+    amp_device_type, amp_dtype, amp_enabled, scaler = _amp_setup(
+        args.precision, device,
+    )
+    amp_ctx = lambda: torch.amp.autocast(
+        device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled,
+    )
+
+    # Per-step profiler — pairs with the TimedLoader's per-batch
+    # split (loader_wait + trainer_step) by further breaking the
+    # trainer_step into H2D / forward / backward / optimizer / accum
+    # so we can tell whether GPU compute, optimizer, or CPU
+    # bookkeeping is the per-step ceiling.
+    from arrow_shard_loader import StepProfiler
+    step_profiler = StepProfiler(
+        enabled=int(getattr(args, "profile_data_pipeline", 0) or 0) > 0
+        and is_rank0,
+        label="train_step",
+        device=device,
+    )
+
+    best_val = float("inf")
+    # Per-mode (SHIFT, SMEAR, JOINT) running bests. The patience
+    # clock resets on improvement of the combined val *or* any of the
+    # split components against its own running best — avoids
+    # premature stopping when one component (e.g. smear) is noise-
+    # limited while another (e.g. shift) is still descending. The
+    # combined-metric ``best_val`` and the saved ``best_state``
+    # snapshot remain gated on the combined ``improved`` so the
+    # checkpoint is the best by the global metric.
+    best_val_split = [float("inf"), float("inf"), float("inf")]
+    best_state = None
+    no_improve = 0
+    checkpoint_path = (
+        os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
+    )
+
+    # Optional ``torch.profiler`` diagnostic pass: run the first
+    # ``warmup + active`` training steps under the profiler, print
+    # the top hot ops, and exit before the normal epoch loop. All
+    # ranks execute the steps (so DDP collectives stay synchronized);
+    # only rank 0 runs the profiler / prints / exports.
+    if getattr(args, "profile", False):
+        from train_muon_response_flow import _run_profile_pass
+        n_warmup = int(args.profile_warmup)
+        n_active = int(args.profile_active)
+        n_total = n_warmup + n_active
+        train_iter = iter(train_loader)
+
+        def _profile_step(_i):
+            nonlocal train_iter
+            try:
+                x, c, w = next(train_iter)
+            except StopIteration:
+                train_iter = iter(train_loader)
+                x, c, w = next(train_iter)
+            x = x.to(device, non_blocking=True)
+            c = c.to(device, non_blocking=True)
+            w = w.to(device, non_blocking=True)
+            optimizer.zero_grad(set_to_none=True)
+            with amp_ctx():
+                loss, _split_sum, _split_w = loss_step(
+                    model, arch, x, c, w,
+                    delta_max=args.delta_max,
+                    sigma_max=args.sigma_max,
+                    oversample=args.oversample,
+                    loss_fn=args.loss_fn,
+                    positivity=args.positivity,
+                    sigma_pack_iu=sigma_pack_iu,
+                    sigma_pack_ju=sigma_pack_ju,
+                    smear_K=args.smear_K,
+                    smear_residual=args.smear_residual,
+                    gh_nodes=gh_nodes, gh_weights=gh_weights,
+                    detach_pure_in_joint=args.detach_pure_in_joint,
+                    include_smear=args.include_smear,
+                    shift_smolyak_pts=shift_smolyak_pts,
+                    shift_stochastic_extra=shift_stochastic_extra,
+                    inner_model=inner_model,
+                )
+            loss = loss.float()
+            scaler.scale(loss).backward()
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(
+                model.parameters(), max_norm=10.0,
+            )
+            scaler.step(optimizer)
+            scaler.update()
+
+        if is_rank0:
+            output = args.profile_output
+            if is_dist and output:
+                import torch.distributed as _dist
+                rank_i = _dist.get_rank()
+                base, ext = os.path.splitext(output)
+                output = f"{base}.rank{rank_i}{ext}"
+            _run_profile_pass(
+                _profile_step,
+                n_warmup=n_warmup,
+                n_active=n_active,
+                output_path=output,
+                label=f" {arch}/{args.loss_fn}",
+            )
+        else:
+            # Match step count on non-rank-0 for DDP sync; no profiler
+            # overhead.
+            for _i in range(n_total):
+                _profile_step(_i)
+        return float("nan")
+
+    for epoch in range(1, args.epochs + 1):
+        t0 = time.time()
+        train_loss, train_split = train_one_epoch(
+            model, optimizer, train_loader, device, epoch, args, arch,
+            is_rank0=is_rank0, amp_ctx=amp_ctx, scaler=scaler,
+            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            gh_nodes=gh_nodes, gh_weights=gh_weights,
+            is_dist=is_dist,
+            shift_smolyak_pts=shift_smolyak_pts,
+            shift_stochastic_extra=shift_stochastic_extra,
+            inner_model=inner_model,
+            step_profiler=step_profiler,
+        )
+        val_loss, val_split = run_val(
+            model, val_loader, device, args, arch, amp_ctx,
+            sigma_pack_iu, sigma_pack_ju, gh_nodes, gh_weights,
+            is_dist=is_dist,
+            shift_smolyak_pts=shift_smolyak_pts,
+            shift_stochastic_extra=shift_stochastic_extra,
+            inner_model=inner_model,
+        )
+        scheduler.step(val_loss)
+        lr_now = optimizer.param_groups[0]["lr"]
+        # Format split components: show as "-" when no events of
+        # that mode in the batch (e.g. SMEAR / JOINT in shift-only
+        # training where val_split[1,2] = +inf).
+        def _fmt_comp(x):
+            return f"{x:+.4f}" if math.isfinite(x) else "  -   "
+        tr_sh, tr_sm, tr_jt = train_split
+        va_sh, va_sm, va_jt = val_split
+        line = (
+            f"epoch {epoch:03d}  train_{args.loss_fn} {train_loss:+.4f}  "
+            f"(sh {_fmt_comp(tr_sh)} sm {_fmt_comp(tr_sm)} "
+            f"jt {_fmt_comp(tr_jt)})  "
+            f"val_{args.loss_fn} {val_loss:+.4f}  "
+            f"(sh {_fmt_comp(va_sh)} sm {_fmt_comp(va_sm)} "
+            f"jt {_fmt_comp(va_jt)})  "
+            f"lr {lr_now:.2e}  dt {time.time()-t0:.1f}s"
+        )
+        if is_rank0:
+            print(line, flush=True)
+            log_lines.append(line)
+
+        # All ranks see the same all-reduced val_loss, so best/early-
+        # stopping decisions stay synchronous without an extra reduce.
+        # Patience-improvement test:
+        #   * BCE / DV / expKL — absolute threshold 1e-4 (val ~ O(1)).
+        #   * LSIF (L²-in-r-space, MSE-style) — relative threshold
+        #     ``patience_rel_threshold · |best_val|`` since the LSIF
+        #     val sits near 0 / negative, making any absolute test
+        #     scale-inappropriate.
+        # On the first epoch ``best_val`` is +inf — any finite
+        # val_loss counts as improvement.
+        rel = float(args.patience_rel_threshold)
+
+        def _is_improvement(curr, prev_best):
+            if math.isinf(prev_best):
+                return curr < prev_best
+            if args.loss_fn == "lsif":
+                return curr < prev_best - rel * abs(prev_best)
+            return curr < prev_best - 1e-4
+
+        improved = _is_improvement(val_loss, best_val)
+
+        # Per-component improvement: any of (sh, sm, jt) improving
+        # over its own running best resets the patience clock.
+        component_improved = False
+        for i, val_comp in enumerate(val_split):
+            if not math.isfinite(val_comp):
+                continue  # mode unpopulated this epoch
+            if _is_improvement(val_comp, best_val_split[i]):
+                best_val_split[i] = val_comp
+                component_improved = True
+
+        if improved:
+            best_val = val_loss
+            if is_rank0:
+                best_state = _state_dict_to_cpu(inner_model)
+        if improved or component_improved:
+            no_improve = 0
+        else:
+            no_improve += 1
+
+        if (
+            is_rank0
+            and args.checkpoint_every > 0
+            and (epoch % args.checkpoint_every == 0)
+        ):
+            ckpt = _build_ckpt(
+                model=inner_model, arch=arch, args=args, epoch=epoch,
+                train_loss=train_loss, val_loss=val_loss,
+                best_val=best_val, stats=stats,
+            )
+            torch.save(ckpt, checkpoint_path)
+
+        if no_improve >= args.patience:
+            if bool(getattr(args, "no_early_stop", False)):
+                # Patience threshold reached but early stopping is
+                # disabled — log a notice on the first crossing only
+                # and continue. The LR scheduler clock is independent
+                # and keeps decaying the LR as configured.
+                if no_improve == args.patience:
+                    line = (
+                        f"would early-stop at epoch {epoch} "
+                        f"(best val {best_val:+.4f}); "
+                        f"--no-early-stop set, continuing"
+                    )
+                    if is_rank0:
+                        print(line)
+                        log_lines.append(line)
+            else:
+                line = (
+                    f"early stopping at epoch {epoch} "
+                    f"(best val {best_val:+.4f})"
+                )
+                if is_rank0:
+                    print(line)
+                    log_lines.append(line)
+                break
+
+    if is_rank0 and best_state is not None:
+        inner_model.load_state_dict(best_state)
+    return best_val
+
+
+def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val,
+                stats):
+    """Bundle a checkpoint payload. ``model_config['arch']`` discriminates
+    the construction so loaders can rebuild the right architecture."""
+    gb = getattr(model, "gauss_baseline", None)
+    gauss_baseline_cfg = (
+        {
+            "hidden": int(gb.hidden),
+            "n_layers": int(gb.n_layers),
+        }
+        if gb is not None else None
+    )
+    if arch == "mlp":
+        model_config = {
+            "arch": "mlp",
+            "n_features": int(model.n_features),
+            "n_cond": int(model.n_cond),
+            "d_emb": int(args.d_emb),
+            "trunk_hidden": int(args.trunk_hidden),
+            "trunk_layers": int(args.trunk_layers),
+            "head_hidden": int(args.head_hidden),
+            "head_layers": int(args.head_layers),
+            "activation": args.activation,
+            "shift_only": bool(getattr(model, "shift_only", False)),
+            "gauss_baseline": gauss_baseline_cfg,
+        }
+    elif arch == "mlp-factored":
+        model_config = {
+            "arch": "mlp-factored",
+            "n_features": int(model.n_features),
+            "n_cond": int(model.n_cond),
+            "d_emb": int(args.d_emb),
+            "trunk_hidden": int(args.trunk_hidden),
+            "trunk_layers": int(args.trunk_layers),
+            "head_hidden": int(args.head_hidden),
+            "head_layers": int(args.head_layers),
+            "activation": args.activation,
+            "shift_only": bool(getattr(model, "shift_only", False)),
+            "detach_pure_shift_in_joint": bool(
+                getattr(model, "detach_pure_shift_in_joint", False)
+            ),
+            "detach_pure_smear_in_joint": bool(
+                getattr(model, "detach_pure_smear_in_joint", False)
+            ),
+            "gauss_baseline": gauss_baseline_cfg,
+        }
+    elif arch == "polyhead":
+        model_config = {
+            "arch": "polyhead",
+            "n_features": int(model.n_features),
+            "n_cond": int(model.n_cond),
+            "trunk_hidden": int(args.trunk_hidden),
+            "trunk_layers": int(args.trunk_layers),
+            "max_deg_u": int(model.max_deg_u),
+            "max_deg_sigma": int(model.max_deg_sigma),
+            "max_cross_deg": int(model.max_cross_deg),
+            "activation": args.activation,
+            "basis": str(model.basis),
+            "basis_scale_u": float(model.basis_scale_u),
+            "basis_scale_sigma": float(model.basis_scale_sigma),
+            "gauss_baseline": gauss_baseline_cfg,
+        }
+    else:
+        raise ValueError(f"unknown arch {arch!r}")
+
+    return {
+        "epoch": epoch,
+        "train_loss": train_loss,
+        "val_loss": val_loss,
+        "best_val": best_val,
+        "state_dict": _state_dict_to_cpu(model),
+        "model_config": model_config,
+        "train_config": {
+            "loss_fn": args.loss_fn,
+            "positivity": args.positivity,
+            "delta_max": args.delta_max,
+            "sigma_max": (
+                args.sigma_max if args.include_smear else 0.0
+            ),
+            "oversample": args.oversample,
+            "precision": args.precision,
+            "compile": bool(args.compile),
+            "include_smear": bool(args.include_smear),
+            "smear_K": (
+                int(args.smear_K) if args.include_smear else 1
+            ),
+            "smear_residual": (
+                bool(args.smear_residual) if args.include_smear else False
+            ),
+            "detach_pure_in_joint": (
+                bool(args.detach_pure_in_joint) if args.include_smear
+                else False
+            ),
+            "detach_pure_shift_in_joint": (
+                bool(args.detach_pure_shift_in_joint)
+                if args.include_smear else False
+            ),
+            "detach_pure_smear_in_joint": (
+                bool(args.detach_pure_smear_in_joint)
+                if args.include_smear else False
+            ),
+        },
+        "stats": asdict(stats) if stats is not None else None,
+    }
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Direct shift+smear reweight training (MLP-B / "
+        "polyhead, DV/LSIF, no flow).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    # Data / IO.
+    p.add_argument(
+        "--input-files", nargs="+", required=True,
+        default=argparse.SUPPRESS,
+        help="(required) One of: (a) a shard directory containing "
+        "manifest.json (auto-expanded to its Arrow IPC shards); "
+        "(b) explicit .arrow shard files (shell globs OK); "
+        "(c) explicit .root RVec RNTuple snapshots from "
+        "flow_training_snapshot.py. All entries must be the same "
+        "format.",
+    )
+    p.add_argument(
+        "--tree", default="tree",
+        help="TTree name inside the input files.",
+    )
+    p.add_argument(
+        "--output", default="./shift_smear_reweight/",
+        help="Output directory (created if missing).",
+    )
+    p.add_argument(
+        "--stats-max-rows", type=int, default=-1,
+        help="Cap the rows used by the preproc-stats warmup pass. -1 "
+        "= scan all rows in all shards (most accurate). 1e7 is "
+        "plenty in practice and starts training in seconds rather "
+        "than minutes.",
+    )
+    p.add_argument(
+        "--robust-stats",
+        dest="robust_stats",
+        action="store_true",
+        default=True,
+        help="Compute preproc location/scale as (median, 1.4826·MAD) "
+        "from a row sample instead of (mean, std) from a full scan. "
+        "Heavy-tailed targets (notably r_kappa with its "
+        "charge-mismeasurement peak at ~-2, and the heavy tails on "
+        "dlambda / dphi) make the unweighted std much larger than "
+        "the bulk's actual width, which then makes every δ=1 "
+        "perturbation a multi-σ over-shift. The robust pair keeps "
+        "δ=1 ~ one bulk-width. Default: on. Use ``--no-robust-stats`` "
+        "to fall back to the old (mean, std) full-scan pass.",
+    )
+    p.add_argument(
+        "--no-robust-stats",
+        dest="robust_stats",
+        action="store_false",
+    )
+    p.add_argument(
+        "--robust-sample-rows", type=int, default=20_000_000,
+        help="(``--robust-stats`` only) Sample size for the robust "
+        "median + MAD pass. 2e7 rows fits in ~640 MB and gives "
+        "stable estimates even for the rare charge-mismeasurement "
+        "tail.",
+    )
+    p.add_argument(
+        "--weight-handling",
+        choices=["abs", "keep", "drop"],
+        default="abs",
+        help="How to handle MC@NLO-style signed event weights. "
+        "``abs`` (default): take |w| and drop w==0 / non-finite — "
+        "loses the destructive-interference signal but keeps every "
+        "row's magnitude contribution. ``keep``: pass w through "
+        "unchanged; only drops non-finite. Use for an unbiased "
+        "signed weighted-NLL. ``drop``: drop w<=0 / non-finite "
+        "(legacy, ~5%% loss on W/Z).",
+    )
+    p.add_argument(
+        "--data-workers", type=int, default=4,
+        help="Number of background processes that feed each rank's "
+        "data pipeline. 0 = run the loader inline in the trainer "
+        "process (single producer thread, prefetch=2). >0 wraps the "
+        "loader in a ``torch.utils.data.DataLoader`` with this many "
+        "worker processes — each opens its own shard subset, "
+        "bypasses the GIL, and ships pinned tensors via shared "
+        "memory. Useful when training is CPU-bound on data prep.",
+    )
+    p.add_argument(
+        "--pin-memory",
+        dest="pin_memory",
+        action="store_true",
+        default=None,
+        help="Pin worker output tensors so ``Tensor.to(device, "
+        "non_blocking=True)`` can DMA asynchronously. Default: "
+        "auto-enabled when device is CUDA. ``--no-pin-memory`` "
+        "disables it — useful when the single PyTorch pin-memory "
+        "thread in the main process is a bottleneck (high "
+        "``--data-workers`` but each worker sits at low CPU "
+        "utilisation); H2D copies become synchronous but the "
+        "main-process pin memcpy is skipped.",
+    )
+    p.add_argument(
+        "--no-pin-memory",
+        dest="pin_memory",
+        action="store_false",
+    )
+    p.add_argument(
+        "--profile-data-pipeline",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Print per-iteration ``loader_wait`` / ``trainer_step`` "
+        "timings for the first N training batches of each epoch. "
+        "Use this to localise the data-pipeline bottleneck: large "
+        "loader_wait => workers are the ceiling (add workers or "
+        "make them faster); large trainer_step => GPU / main-process "
+        "consumer is the ceiling (adding workers won't help). 0 "
+        "disables.",
+    )
+    p.add_argument(
+        "--val-fraction", type=float, default=0.1,
+        help="Fraction of events held out for validation.",
+    )
+    p.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed for the train/val split and PyTorch RNG.",
+    )
+
+    # Architecture selection.
+    p.add_argument(
+        "--arch",
+        choices=["mlp", "polyhead", "mlp-factored"],
+        default="mlp",
+        help="Model architecture. 'mlp' (default) is the dual-scalar-"
+        "forward construction; 'polyhead' uses a trunk that produces "
+        "polynomial coefficients with structural priors; "
+        "'mlp-factored' uses a trunk + factored head returning "
+        "log W = <u, A(e, ·)> + <σ_pack, B(e, ·)>"
+        " [ + <u⊗σ_pack, C(e, u, σ_pack)> ] with structural zeros at "
+        "(u=0, σ=0) and σ-evenness built in. The detach flags "
+        "--detach-pure-{shift,smear}-in-joint select between the "
+        "full-cross default form, partially-factored two-term form, "
+        "and fully-factored three-term form.",
+    )
+
+    # Trunk sizing (shared between mlp and polyhead arches).
+    p.add_argument(
+        "--trunk-hidden", type=int, default=64,
+        help="Trunk MLP hidden width. mlp: trunk(y, c) -> e ∈ ℝ^d_emb. "
+        "polyhead: trunk(y, c) -> coefs ∈ ℝ^n_basis.",
+    )
+    p.add_argument(
+        "--trunk-layers", type=int, default=2,
+        help="Number of trunk MLP hidden layers (shared).",
+    )
+
+    # MLP-B-only sizing.
+    p.add_argument(
+        "--d-emb", type=int, default=32,
+        help="(--arch mlp) Trunk embedding dimension.",
+    )
+    p.add_argument(
+        "--head-hidden", type=int, default=32,
+        help="(--arch mlp) Head hidden width.",
+    )
+    p.add_argument(
+        "--head-layers", type=int, default=2,
+        help="(--arch mlp) Number of head hidden layers.",
+    )
+
+    # Polyhead-only sizing.
+    p.add_argument(
+        "--max-deg-u", type=int, default=3,
+        help="(--arch polyhead) Max polynomial degree in u.",
+    )
+    p.add_argument(
+        "--max-deg-sigma", type=int, default=4,
+        help="(--arch polyhead) Max polynomial degree in σ_vec. Must "
+        "be even (smear-symmetry constraint).",
+    )
+    p.add_argument(
+        "--max-cross-deg", type=int, default=3,
+        help="(--arch polyhead) Max combined degree |α|+|β| of cross "
+        "(u, σ) terms.",
+    )
+    p.add_argument(
+        "--basis", choices=["monomial", "chebyshev"], default="monomial",
+        help="(--arch polyhead) Basis for the polynomial in (u, σ_vec). "
+        "'monomial' uses raw u^α · σ^β (default; backwards-compatible). "
+        "'chebyshev' uses tensor-product Chebyshev polynomials with "
+        "axis-normalization by --basis-scale-u / --basis-scale-sigma "
+        "(zero-anchored so r=1 at u=σ=0 is preserved). Same n_basis and "
+        "structural priors as the monomial path; better-conditioned "
+        "fitting when the perturbation range is comparable to the "
+        "scale.",
+    )
+    p.add_argument(
+        "--basis-scale-u", type=float, default=-1.0,
+        help="(--arch polyhead, --basis chebyshev) Scale for u in the "
+        "Chebyshev basis: T_n(u / basis_scale_u). Set to the nominal "
+        "max |u| in standardized-target σ_y units so the recurrence "
+        "stays in [-1, 1] over the training range. Default -1 = auto: "
+        "use oversample · delta_max (the actual u-magnitude bound).",
+    )
+    p.add_argument(
+        "--basis-scale-sigma", type=float, default=-1.0,
+        help="(--arch polyhead, --basis chebyshev) Scale for σ_vec in "
+        "the Chebyshev basis: T_n(σ_vec / basis_scale_sigma). Default "
+        "-1 = auto: use oversample · sigma_max (the actual σ_vec bound).",
+    )
+
+    # Analytic Gaussian baseline (shared between mlp and polyhead).
+    p.add_argument(
+        "--gauss-baseline",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="Add an analytic Gaussian density-ratio baseline that "
+        "models p_nom(y|c) ~ N(μ(c), Σ(c)) and its shift+convolution "
+        "under (u, σ_vec). The closed-form log-ratio is added "
+        "additively to the polyhead/mlp pre-positivity ``d`` so the "
+        "model residual only fits the deviation from a Gaussian. μ, Σ "
+        "are produced by a small MLP from c only (--gauss-baseline-"
+        "hidden / --gauss-baseline-layers). Init produces μ=0, Σ=I "
+        "so the baseline starts at log r̂_Gauss=0 and the model "
+        "recovers legacy behaviour at epoch 0.",
+    )
+    p.add_argument(
+        "--gauss-baseline-hidden", type=int, default=64,
+        help="(--gauss-baseline) Hidden width of the c → (μ, Σ) MLP.",
+    )
+    p.add_argument(
+        "--gauss-baseline-layers", type=int, default=2,
+        help="(--gauss-baseline) Number of hidden layers of the "
+        "c → (μ, Σ) MLP.",
+    )
+
+    # Activation (shared).
+    p.add_argument(
+        "--activation", choices=["gelu", "relu", "silu", "tanh"],
+        default="gelu",
+        help="Activation used in trunk and head MLPs.",
+    )
+
+    # Loss / positivity / perturbation ranges.
+    p.add_argument(
+        "--loss-fn", choices=["dv", "lsif", "bce", "expkl"],
+        default="lsif",
+        help="Density-ratio loss family. "
+        "'lsif' (default): least-squares importance fitting, optimum "
+        "r-hat=r, unbiased per sample, locally L^2-in-r weighted by "
+        "p_nom. "
+        "'dv': Donsker-Varadhan, optimum log r̂=log r + const "
+        "(constant ambiguity not fully resolved by the structural "
+        "constraint at zero perturbation), slight finite-batch bias. "
+        "'bce': logistic / binary cross-entropy (CARL), optimum "
+        "log r̂=log r exactly (no constant ambiguity), per-sample "
+        "unbiased, bounded gradients via sigmoid -- most stable choice "
+        "but slower to converge in regions of high contrast. "
+        "'expkl': exponential KL (DV with the outer log dropped), "
+        "optimum log r̂=log r exactly (no constant ambiguity), "
+        "per-sample unbiased, locally L^2-in-log-r weighted by p_pert "
+        "(the analog of LSIF for log r-space). Unbounded gradient "
+        "like LSIF; pair with low LR or BCE warm-start.",
+    )
+    p.add_argument(
+        "--positivity", choices=["exp", "softplus", "asinh"],
+        default="softplus",
+        help="Positivity wrap on the pre-positivity scalar d. "
+        "'softplus' (default) is fp16-safer but asymmetric (compresses "
+        "positive log r). 'exp' is symmetric in log r-space (identity "
+        "in d) but unbounded — clamps at +/-30 to keep fp32 safe. "
+        "'asinh' is symmetric like 'exp' AND smoothly bounded "
+        "(log r-hat = asinh(d) is identity for |d| << 1, "
+        "log-compressed for |d| >> 1; r-hat = d + sqrt(d^2+1) grows "
+        "only linearly so no clamp is needed). Best stability for "
+        "LSIF / expKL with Gaussian-likelihood-shaped problems.",
+    )
+    p.add_argument(
+        "--include-smear",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="Include smear (and joint shift+smear) perturbations in "
+        "training. Default OFF: shift-only architecture (no Sigma_pack "
+        "in mlp head; no sigma-dependent basis terms in polyhead) and "
+        "shift-only sampling (every event has sigma_vec=0). When ON "
+        "the architecture grows to handle Sigma_pack / cross terms, "
+        "sampling becomes the stratified 1/3 SHIFT / 1/3 SMEAR / 1/3 "
+        "JOINT mix, and --smear-K / --smear-residual / "
+        "--detach-pure-in-joint take effect. Use --include-smear to "
+        "enable.",
+    )
+    p.add_argument(
+        "--delta-max", type=float, default=1.0,
+        help="Max |u| in standardized target units.",
+    )
+    p.add_argument(
+        "--sigma-max", type=float, default=1.0,
+        help="Max smear magnitude |σ_vec| in standardized target units.",
+    )
+    p.add_argument(
+        "--oversample", type=float, default=1.3,
+        help="Oversample factor on training perturbation magnitudes; "
+        "1.3× covers the operational range with margin.",
+    )
+
+    # Shift-axis Smolyak sparse-grid evaluation.
+    p.add_argument(
+        "--shift-smolyak",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="Use a deterministic Chebyshev-Lobatto Smolyak sparse "
+        "grid for the shift (u) evaluation points, instead of one "
+        "stochastic u per event per step. Each event is evaluated at "
+        "all K_smolyak grid points, with weights divided by K_smolyak "
+        "so the per-event aggregate weight is preserved. Only valid "
+        "with --no-include-smear (shift-only training); errors out "
+        "otherwise. Off by default; turn on with --shift-smolyak.",
+    )
+    p.add_argument(
+        "--shift-smolyak-level", type=int, default=0,
+        help="Smolyak level (0-indexed; level L grid has 1, 7, 25, "
+        "69, 177, 441 points in d=3 for L=0..5). 0 = auto: with "
+        "--arch polyhead, picks the lowest L whose grid has more "
+        "points than the number of pure-shift basis functions "
+        "(C(d + max_deg_u, d) − 1). With --arch mlp the auto path is "
+        "not meaningful; pass an explicit positive level instead.",
+    )
+    p.add_argument(
+        "--shift-stochastic-extra", type=int, default=0,
+        help="Number of additional stochastic u samples per event on "
+        "top of the Smolyak grid (or by themselves if --shift-smolyak "
+        "is off). Drawn with the same direction × magnitude scheme as "
+        "the standard sampler. Useful for adding broader random "
+        "coverage on top of the deterministic grid; combined with "
+        "--shift-smolyak this gives K_total = K_smolyak + extra "
+        "evaluations per event. 0 disables.",
+    )
+
+    # Smear ε-integration.
+    p.add_argument(
+        "--smear-K", type=int, default=1,
+        help="Quadrature nodes for the smear ε integration in the "
+        "pert-side LSIF/DV expectation. K=1 (default) is K=1 "
+        "stochastic — one random ε per event. K≥2 uses deterministic "
+        "Gauss-Hermite (probabilist's) at K nodes — exact for "
+        "polynomials in ε up to degree 2K−1, with O(σ_max^{2K}) "
+        "truncation for non-polynomial features. Cost: K perturbed "
+        "forwards per event vs 1 for K=1. K=3 is exact through deg 5; "
+        "K=5 through deg 9. For smooth log r, K=3-5 is plenty.",
+    )
+    p.add_argument(
+        "--smear-residual", action="store_true",
+        help="(only with --smear-K >= 2) Add a stochastic residual "
+        "control variate to the GH estimator: sample one extra "
+        "epsilon ~ N(0, 1) per event, evaluate r-hat at the "
+        "corresponding y_pert, and form S_K + (r-hat(eps~) - g(eps~)) "
+        "where g is the Lagrange interpolant through the GH nodes. "
+        "Cost: K+1 perturbed forwards per event (~20-30%% over pure "
+        "GH). Removes the polynomial-truncation bias of pure GH "
+        "(estimator becomes unbiased for arbitrary smooth f), at the "
+        "cost of a small variance bump. Useful as (a) a sanity check "
+        "that GH bias is negligible at your K, and (b) a fallback for "
+        "large |sigma_vec| where the polynomial truncation matters.",
+    )
+    p.add_argument(
+        "--detach-pure-in-joint",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="(polyhead / mlp arches) Detach the pure-shift "
+        "(sigma -> 0) and pure-smear (u -> 0) contributions to log r "
+        "on JOINT-mode events (mode==2; both u and sigma_vec "
+        "nonzero). Routes pure-axis gradients exclusively through the "
+        "lower-noise SHIFT/SMEAR events and lets JOINT events train "
+        "only the cross/mixed interaction. polyhead: zero cost (mask "
+        "on pure-u/pure-sigma basis-index slots). mlp: ~2x head cost "
+        "from two extra head forwards f(e, u, 0) and f(e, 0, "
+        "sigma_pack) used to decompose d_full = d_pure_u + "
+        "d_pure_sigma + d_mixed. Default: disabled. For the "
+        "mlp-factored arch use --detach-pure-shift-in-joint and/or "
+        "--detach-pure-smear-in-joint instead, which select the "
+        "structural factorisation form.",
+    )
+    p.add_argument(
+        "--detach-pure-shift-in-joint",
+        action="store_true", default=False,
+        help="(mlp-factored only) Detach the pure-shift block A on "
+        "JOINT events. Equivalently: structurally factor A so it "
+        "depends only on (e, u), not on σ_pack; the cross-term "
+        "absorption lives in B's u-dependence. A's gradient flows "
+        "only from SHIFT events.",
+    )
+    p.add_argument(
+        "--detach-pure-smear-in-joint",
+        action="store_true", default=False,
+        help="(mlp-factored only) Detach the pure-smear block B on "
+        "JOINT events. Equivalently: structurally factor B so it "
+        "depends only on (e, σ_pack), not on u; the cross-term "
+        "absorption lives in A's σ_pack-dependence. B's gradient "
+        "flows only from SMEAR events. When combined with "
+        "--detach-pure-shift-in-joint, the head becomes fully "
+        "three-block factorised with a separate cross head C(e, u, "
+        "σ_pack).",
+    )
+
+    # Optimization.
+    p.add_argument(
+        "--epochs", type=int, default=200,
+        help="Maximum training epochs (early-stopping may end sooner).",
+    )
+    p.add_argument(
+        "--lr", type=float, default=1e-3,
+        help="Initial Adam learning rate.",
+    )
+    p.add_argument(
+        "--weight-decay", type=float, default=1e-4,
+        help="Adam weight decay (L2 regularization).",
+    )
+    p.add_argument(
+        "--patience", type=int, default=20,
+        help="Early-stopping patience: stop after this many consecutive "
+        "epochs with no validation-loss improvement (see "
+        "--patience-rel-threshold for the improvement criterion).",
+    )
+    p.add_argument(
+        "--no-early-stop",
+        action="store_true",
+        help="Disable early stopping without changing the LR-decay "
+        "schedule. The ReduceLROnPlateau scheduler still halves the "
+        "LR after ``--patience // 2`` non-improving epochs; the run "
+        "continues until ``--epochs`` is reached. Useful for forcing "
+        "training to use the full epoch budget when you want to see "
+        "the long-tail behaviour at very small LR.",
+    )
+    p.add_argument(
+        "--patience-rel-threshold",
+        type=float,
+        default=1e-4,
+        help="*--loss-fn lsif only*: minimum relative improvement in "
+        "the validation loss to count as 'improvement' against the "
+        "patience clock; an epoch counts as improvement only if "
+        "``val_loss < best_val − rel · |best_val|``. Used because "
+        "LSIF (L²-in-r-space) has val near 0 / negative, making any "
+        "fixed-absolute test scale-inappropriate. BCE / DV / expKL "
+        "use a fixed absolute 1e-4 threshold instead since their val "
+        "sits at O(1). Default: %(default)s.",
+    )
+    p.add_argument(
+        "--batch-size", type=int, default=None,
+        help="Training batch size. None auto-selects: "
+        "32768 on CUDA, 16384 on CPU.",
+    )
+
+    # Run config.
+    p.add_argument(
+        "--device", default="cuda" if torch.cuda.is_available() else "cpu",
+        help="cuda or cpu. Multi-GPU requires cuda (see --num-gpus).",
+    )
+    p.add_argument(
+        "--num-gpus", type=int, default=-1,
+        help="Number of GPUs / worker processes. -1 (default) auto-"
+        "detects via torch.cuda.device_count(). Set 1 to force "
+        "single-process even on a multi-GPU host. Ignored when "
+        "--device cpu.",
+    )
+    p.add_argument(
+        "--prefetch-shuffle",
+        action=argparse.BooleanOptionalAction, default=True,
+        help="[default: on] Hide the per-epoch ``torch.randperm(n)`` "
+        "stall by computing the next epoch's permutation in a "
+        "background thread while the current epoch is still "
+        "training. At ~10⁸-row training sets the shuffle alone is "
+        "~5–10 s per epoch; with prefetch on, only the first epoch "
+        "pays this. Disable with --no-prefetch-shuffle.",
+    )
+    p.add_argument(
+        "--time-loader",
+        action="store_true",
+        help="Print one-line timing per epoch start: how long the "
+        "shuffle / first-batch gather + pin took. Useful for "
+        "diagnosing per-epoch startup latency. Same as "
+        "``LOADER_TIME=1`` env var.",
+    )
+    p.add_argument(
+        "--checkpoint-every", type=int, default=1,
+        help="Write a checkpoint every N epochs. 0 disables periodic "
+        "checkpoints (final model is still saved at end of training).",
+    )
+    p.add_argument(
+        "--precision", choices=["fp32", "bf16", "fp16"], default="fp32",
+        help="Training/validation forward-pass precision.",
+    )
+    p.add_argument(
+        "--compile", action="store_true",
+        help="Wrap the model in torch.compile(mode='reduce-overhead').",
+    )
+
+    # Profiling diagnostics.
+    p.add_argument(
+        "--profile",
+        action=argparse.BooleanOptionalAction, default=False,
+        help="If set, run a short ``torch.profiler`` pass on the "
+        "first few training steps and exit (does not proceed to the "
+        "epoch loop). Useful for identifying CUDA-time hotspots.",
+    )
+    p.add_argument(
+        "--profile-warmup", type=int, default=3,
+        help="Profile schedule warmup steps (not recorded).",
+    )
+    p.add_argument(
+        "--profile-active", type=int, default=5,
+        help="Profile schedule active steps (recorded).",
+    )
+    p.add_argument(
+        "--profile-output", default=None,
+        help="Optional path for Chrome trace export "
+        "(viewable in chrome://tracing or Perfetto). Under DDP, the "
+        "rank index is appended before the extension.",
+    )
+    return p.parse_args()
+
+
+# ============================================================================
+# main
+# ============================================================================
+
+# -----------------------------------------------------------------------------
+# Worker (runs once per GPU in distributed mode, once total otherwise)
+# -----------------------------------------------------------------------------
+
+def main_worker(
+    rank,
+    args,
+    world_size,
+    master_port,
+    stats,
+    weight_mean,
+    shard_files,
+    shard_row_counts,
+    n_features,
+    n_cond,
+):
+    """One worker process. Initializes the process group (if
+    distributed), opens its own per-rank streaming loader over the
+    Arrow shards, builds the model + DDP wrap, and runs training.
+    Only rank 0 prints, writes checkpoints, and saves the final
+    artifact.
+    """
+    from arrow_shard_loader import ArrowShardLoader
+
+    is_dist = world_size > 1
+    is_rank0 = rank == 0
+
+    # Device selection + optional process-group init.
+    if is_dist:
+        import torch.distributed as dist
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        if args.device.startswith("cuda"):
+            torch.cuda.set_device(rank)
+            device = f"cuda:{rank}"
+            backend = "nccl"
+        else:
+            device = "cpu"
+            backend = "gloo"
+        dist.init_process_group(
+            backend=backend, rank=rank, world_size=world_size,
+        )
+    else:
+        if args.device.startswith("cuda"):
+            torch.cuda.set_device(0)
+            device = "cuda:0"
+        else:
+            device = args.device
+
+    # Per-rank streaming loaders over the Arrow shards. Each rank
+    # gets a round-robin slice of the shard list. train / val split
+    # is done contiguously per record batch (first val_fraction
+    # rows go to val); the shards are already globally shuffled by
+    # the bucket-shuffle pass so this is unbiased.
+    # ``--pin-memory`` is tristate via argparse: True/False if the
+    # user passed the flag explicitly, None for the auto-default
+    # (on if device is CUDA, off otherwise).
+    if args.pin_memory is None:
+        pin_memory = device.startswith("cuda")
+    else:
+        pin_memory = bool(args.pin_memory)
+    n_data_workers = max(0, int(args.data_workers))
+    n_train_workers_hint = max(1, n_data_workers)
+    n_val_workers_hint = max(1, n_data_workers // 2)
+    train_ds = ArrowShardLoader(
+        shard_files, stats, weight_mean,
+        world_size=world_size, rank=rank,
+        batch_size=args.batch_size,
+        split="train",
+        val_fraction=args.val_fraction,
+        shuffle=True, drop_last=True,
+        pin_memory=pin_memory,
+        seed=int(args.seed),
+        weight_mode=args.weight_handling,
+        shard_row_counts=shard_row_counts,
+        num_workers_hint=n_train_workers_hint,
+    )
+    val_ds = ArrowShardLoader(
+        shard_files, stats, weight_mean,
+        world_size=world_size, rank=rank,
+        batch_size=args.batch_size,
+        split="val",
+        val_fraction=args.val_fraction,
+        shuffle=False, drop_last=False,
+        pin_memory=pin_memory,
+        seed=int(args.seed),
+        weight_mode=args.weight_handling,
+        shard_row_counts=shard_row_counts,
+        num_workers_hint=n_val_workers_hint,
+    )
+
+    # When --data-workers > 0, wrap as ``DataLoader`` so each rank's
+    # data pipeline is fed by N worker processes. ``batch_size=None``
+    # disables PyTorch's auto-batching (our dataset already yields
+    # complete training batches). With ``num_workers == 0`` we bypass
+    # DataLoader entirely and let the dataset's own in-process
+    # prefetch thread handle pipelining.
+    if n_data_workers > 0:
+        import torch.utils.data as _td
+        from arrow_shard_loader import dataloader_worker_init
+        train_loader = _td.DataLoader(
+            train_ds,
+            batch_size=None,
+            num_workers=n_data_workers,
+            pin_memory=pin_memory,
+            persistent_workers=True,
+            prefetch_factor=2,
+            worker_init_fn=dataloader_worker_init,
+        )
+        val_loader = _td.DataLoader(
+            val_ds,
+            batch_size=None,
+            num_workers=max(1, n_data_workers // 2),
+            pin_memory=pin_memory,
+            persistent_workers=True,
+            prefetch_factor=2,
+            worker_init_fn=dataloader_worker_init,
+        )
+    else:
+        train_loader = train_ds
+        val_loader = val_ds
+
+    # Optional timing wrapper. Prints loader_wait / trainer_step for
+    # the first ``--profile-data-pipeline`` batches of each iter()
+    # call so the bottleneck (workers vs main-process+GPU) is easy
+    # to read off.
+    n_profile = int(getattr(args, "profile_data_pipeline", 0) or 0)
+    if n_profile > 0 and is_rank0:
+        from arrow_shard_loader import TimedLoader
+        train_loader = TimedLoader(train_loader, n_print=n_profile, label="train")
+        val_loader = TimedLoader(val_loader, n_print=n_profile, label="val")
+    if is_rank0:
+        print(
+            f"rank {rank}/{world_size}  "
+            f"~train batches {len(train_loader)}  "
+            f"~val batches {len(val_loader)}  "
+            f"batch {args.batch_size}  device {device}"
+        )
+
+    # Build model per --arch. In shift-only mode (--no-include-smear,
+    # the default) the σ-dependent parts of each architecture are
+    # dropped entirely:
+    #   * mlp: head input excludes Σ_pack (shift_only=True).
+    #   * polyhead: max_deg_sigma → 0 / max_cross_deg → max_deg_u, so
+    #     only pure-u basis terms remain (and the σ-symmetry +
+    #     no-constant priors still hold trivially).
+    activation_cls = _ACTIVATIONS[args.activation]
+    gauss_baseline = (
+        GaussBaseline(
+            n_features=n_features,
+            n_cond=n_cond,
+            hidden=int(args.gauss_baseline_hidden),
+            n_layers=int(args.gauss_baseline_layers),
+            activation=activation_cls,
+        )
+        if bool(args.gauss_baseline) else None
+    )
+    if args.arch == "mlp":
+        inner_model = ReweightMLP_B(
+            n_features=n_features,
+            n_cond=n_cond,
+            d_emb=args.d_emb,
+            trunk_hidden=args.trunk_hidden,
+            trunk_layers=args.trunk_layers,
+            head_hidden=args.head_hidden,
+            head_layers=args.head_layers,
+            activation=activation_cls,
+            shift_only=not args.include_smear,
+            gauss_baseline=gauss_baseline,
+        ).to(device)
+        n_params = sum(p.numel() for p in inner_model.parameters())
+        if is_rank0:
+            print(
+                f"ReweightMLP_B"
+                f"{' (shift-only)' if not args.include_smear else ''}: "
+                f"d_emb={args.d_emb} "
+                f"trunk={args.trunk_hidden}×{args.trunk_layers} "
+                f"head={args.head_hidden}×{args.head_layers}  "
+                f"params={n_params:,}"
+            )
+    elif args.arch == "mlp-factored":
+        inner_model = ReweightMLPFactored(
+            n_features=n_features,
+            n_cond=n_cond,
+            d_emb=args.d_emb,
+            trunk_hidden=args.trunk_hidden,
+            trunk_layers=args.trunk_layers,
+            head_hidden=args.head_hidden,
+            head_layers=args.head_layers,
+            activation=activation_cls,
+            shift_only=not args.include_smear,
+            detach_pure_shift_in_joint=bool(
+                args.detach_pure_shift_in_joint
+            ),
+            detach_pure_smear_in_joint=bool(
+                args.detach_pure_smear_in_joint
+            ),
+            gauss_baseline=gauss_baseline,
+        ).to(device)
+        n_params = sum(p.numel() for p in inner_model.parameters())
+        if is_rank0:
+            form = "default (full cross)"
+            if (
+                inner_model.detach_pure_shift_in_joint
+                and inner_model.detach_pure_smear_in_joint
+            ):
+                form = "three-term factored (separate C)"
+            elif inner_model.detach_pure_shift_in_joint:
+                form = "shift-factored (A: e,u; cross in B)"
+            elif inner_model.detach_pure_smear_in_joint:
+                form = "smear-factored (B: e,σ_pack; cross in A)"
+            print(
+                f"ReweightMLPFactored"
+                f"{' (shift-only)' if not args.include_smear else ''}: "
+                f"d_emb={args.d_emb} "
+                f"trunk={args.trunk_hidden}×{args.trunk_layers} "
+                f"head={args.head_hidden}×{args.head_layers}  "
+                f"form={form}  "
+                f"params={n_params:,}"
+            )
+    elif args.arch == "polyhead":
+        eff_max_deg_sigma = (
+            args.max_deg_sigma if args.include_smear else 0
+        )
+        eff_max_cross_deg = (
+            args.max_cross_deg if args.include_smear else args.max_deg_u
+        )
+        # Auto-default Chebyshev scales to the actual perturbation
+        # bounds (oversample · delta_max for u, oversample · sigma_max
+        # for σ_vec) so T_n(x / scale) stays in [-1, 1] over training.
+        # Sentinel <= 0 from argparse means "not specified".
+        eff_basis_scale_u = (
+            float(args.basis_scale_u) if args.basis_scale_u > 0
+            else float(args.oversample * args.delta_max)
+        )
+        eff_basis_scale_sigma = (
+            float(args.basis_scale_sigma) if args.basis_scale_sigma > 0
+            else (
+                float(args.oversample * args.sigma_max)
+                if args.include_smear else 1.0
+            )
+        )
+        # Persist the resolved values back so the rest of main_worker
+        # (logging, _build_ckpt) sees the effective scale.
+        args.basis_scale_u = eff_basis_scale_u
+        args.basis_scale_sigma = eff_basis_scale_sigma
+        inner_model = ReweightPolyhead(
+            n_features=n_features,
+            n_cond=n_cond,
+            trunk_hidden=args.trunk_hidden,
+            trunk_layers=args.trunk_layers,
+            max_deg_u=args.max_deg_u,
+            max_deg_sigma=eff_max_deg_sigma,
+            max_cross_deg=eff_max_cross_deg,
+            activation=activation_cls,
+            basis=args.basis,
+            basis_scale_u=eff_basis_scale_u,
+            basis_scale_sigma=eff_basis_scale_sigma,
+            gauss_baseline=gauss_baseline,
+        ).to(device)
+        n_params = sum(p.numel() for p in inner_model.parameters())
+        if is_rank0:
+            print(
+                f"ReweightPolyhead"
+                f"{' (shift-only)' if not args.include_smear else ''}: "
+                f"trunk={args.trunk_hidden}×"
+                f"{args.trunk_layers}  "
+                f"max_deg_u={args.max_deg_u} max_deg_sigma="
+                f"{eff_max_deg_sigma} max_cross_deg={eff_max_cross_deg}  "
+                f"basis={args.basis}"
+                + (
+                    f"(scale_u={args.basis_scale_u:g},"
+                    f"scale_sigma={args.basis_scale_sigma:g})"
+                    if args.basis == "chebyshev" else ""
+                )
+                + f"  n_basis={inner_model.n_basis}  "
+                f"params={n_params:,}"
+            )
+    else:
+        raise ValueError(f"unknown arch {args.arch!r}")
+
+    if is_rank0:
+        print(
+            f"loss={args.loss_fn} positivity={args.positivity} "
+            f"delta_max={args.delta_max} sigma_max={args.sigma_max} "
+            f"precision={args.precision}"
+        )
+
+    # Effective smear settings collapse to the shift-only defaults
+    # when --no-include-smear; the user-set --smear-K / --smear-residual
+    # / --detach-pure-in-joint / --detach-pure-{shift,smear}-in-joint
+    # are tracked for logging but ignored.
+    eff_smear_K = args.smear_K if args.include_smear else 1
+    eff_smear_residual = (
+        bool(args.smear_residual) if args.include_smear else False
+    )
+    eff_detach_pure_in_joint = (
+        bool(args.detach_pure_in_joint) if args.include_smear else False
+    )
+    eff_detach_pure_shift_in_joint = (
+        bool(args.detach_pure_shift_in_joint)
+        if args.include_smear else False
+    )
+    eff_detach_pure_smear_in_joint = (
+        bool(args.detach_pure_smear_in_joint)
+        if args.include_smear else False
+    )
+
+    log_lines: List[str] = []
+    if args.include_smear:
+        smear_mode_str = (
+            f"K={eff_smear_K}"
+            + (" + residual" if eff_smear_residual else "")
+        )
+    else:
+        smear_mode_str = "off (shift-only)"
+    if is_rank0:
+        gauss_str = (
+            f"gauss_baseline=({args.gauss_baseline_hidden}×"
+            f"{args.gauss_baseline_layers})"
+            if bool(args.gauss_baseline) else "gauss_baseline=off"
+        )
+        log_lines.append(
+            f"arch={args.arch} include_smear={bool(args.include_smear)} "
+            f"loss={args.loss_fn} positivity={args.positivity} "
+            f"delta_max={args.delta_max} "
+            f"sigma_max={args.sigma_max if args.include_smear else 0.0} "
+            f"smear=({smear_mode_str}) "
+            f"detach_pure_in_joint={eff_detach_pure_in_joint} "
+            f"detach_pure_shift_in_joint={eff_detach_pure_shift_in_joint} "
+            f"detach_pure_smear_in_joint={eff_detach_pure_smear_in_joint} "
+            f"{gauss_str} "
+            f"precision={args.precision} compile={bool(args.compile)} "
+            f"world_size={world_size} params={n_params}"
+        )
+        if not args.include_smear and (
+            args.smear_K > 1 or args.smear_residual
+            or not args.detach_pure_in_joint
+        ):
+            print(
+                "[note] --no-include-smear (shift-only): ignoring "
+                "--smear-K / --smear-residual / "
+                "--detach-pure-in-joint."
+            )
+
+    # Σ_pack indices live on device for the MLP arch (shift+smear
+    # only — the shift-only head doesn't take Σ_pack).
+    sigma_pack_iu = sigma_pack_ju = None
+    if args.arch in ("mlp", "mlp-factored") and args.include_smear:
+        iu, ju = _sigma_pack_indices(n_features)
+        sigma_pack_iu = iu.to(device)
+        sigma_pack_ju = ju.to(device)
+
+    # Gauss–Hermite nodes/weights for the smear ε integration. Both
+    # ``None`` for shift-only (smear off) or K=1 stochastic;
+    # otherwise (K-vector, K-vector) on device.
+    if args.include_smear:
+        gh_nodes, gh_weights = _gh_nodes_weights(eff_smear_K)
+    else:
+        gh_nodes, gh_weights = None, None
+    if gh_nodes is not None:
+        gh_nodes = gh_nodes.to(device)
+        gh_weights = gh_weights.to(device)
+        if is_rank0:
+            print(
+                f"Gauss-Hermite ε integration: K={eff_smear_K} "
+                f"{'+ residual control variate' if eff_smear_residual else ''}"
+                .strip()
+            )
+    elif args.include_smear and eff_smear_residual and is_rank0:
+        print(
+            "[warning] --smear-residual has no effect when --smear-K=1; "
+            "ignoring."
+        )
+
+    # Shift-axis Smolyak grid (deterministic per-event evaluation
+    # points). Built once at startup, broadcast to every event during
+    # training. Auto-level requires polyhead arch; for MLP, an
+    # explicit ``--shift-smolyak-level`` is required because the auto
+    # heuristic ("more points than pure-shift basis functions") is
+    # only well-defined for the polyhead's polynomial output.
+    shift_smolyak_pts = None
+    shift_smolyak_level = 0
+    if args.shift_smolyak:
+        if args.include_smear:
+            raise ValueError(
+                "--shift-smolyak is only supported with "
+                "--no-include-smear (shift-only training). "
+                "include_smear=True interacts non-trivially with "
+                "Smolyak shift-grid sampling and is not implemented."
+            )
+        if args.shift_smolyak_level > 0:
+            shift_smolyak_level = int(args.shift_smolyak_level)
+        elif args.arch == "polyhead":
+            n_pure = _n_pure_shift_basis(n_features, args.max_deg_u)
+            shift_smolyak_level = _auto_smolyak_level(
+                n_features, n_pure,
+            )
+            if is_rank0:
+                print(
+                    f"shift-smolyak: auto-level → "
+                    f"L={shift_smolyak_level} "
+                    f"(d={n_features}, max_deg_u={args.max_deg_u}, "
+                    f"n_pure_shift_basis={n_pure})"
+                )
+        else:
+            raise ValueError(
+                "--shift-smolyak with --arch mlp requires an "
+                "explicit --shift-smolyak-level (auto-level is "
+                "polyhead-specific)."
+            )
+        smolyak_np = _smolyak_grid(n_features, shift_smolyak_level)
+        # Scale [-1, 1] → [-half, +half] to match the training
+        # perturbation prior (oversample × delta_max).
+        half = float(args.oversample) * float(args.delta_max)
+        smolyak_np = smolyak_np * half
+        shift_smolyak_pts = torch.from_numpy(
+            smolyak_np
+        ).to(device=device, dtype=torch.float32)
+        if is_rank0:
+            print(
+                f"shift-smolyak: K_smolyak={shift_smolyak_pts.shape[0]} "
+                f"deterministic points × half={half:.3f} "
+                f"(level {shift_smolyak_level}); "
+                f"K_extra_stochastic={args.shift_stochastic_extra}; "
+                f"K_total={shift_smolyak_pts.shape[0] + args.shift_stochastic_extra}"
+            )
+            log_lines.append(
+                f"shift-smolyak: level={shift_smolyak_level} "
+                f"K_smolyak={shift_smolyak_pts.shape[0]} "
+                f"K_extra={args.shift_stochastic_extra}"
+            )
+
+    # Wrap inner model in the single-forward DDP-friendly wrapper
+    # (compute_log_r_quadrature) before any DDP / compile wraps.
+    wrapper = ReweightWrapper(
+        inner_model, args.arch, args.positivity,
+        detach_pure_in_joint=eff_detach_pure_in_joint,
+    ).to(device)
+
+    model = wrapper
+    if is_dist:
+        if args.device.startswith("cuda"):
+            model = nn.parallel.DistributedDataParallel(
+                model, device_ids=[rank],
+            )
+        else:
+            model = nn.parallel.DistributedDataParallel(model)
+    # Compile after DDP wrap (matches train_muon_response_flow.py
+    # convention). State-dict capture goes through ``inner_model``,
+    # bypassing both wrappers.
+    if args.compile:
+        if is_rank0:
+            print(
+                "torch.compile: enabled (mode=reduce-overhead) — "
+                "first batch will JIT-compile",
+                flush=True,
+            )
+        model = torch.compile(model, mode="reduce-overhead")
+
+    best_val = train(
+        model, inner_model, args.arch, train_loader, val_loader,
+        device, args, log_lines, stats=stats,
+        sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+        gh_nodes=gh_nodes, gh_weights=gh_weights,
+        is_dist=is_dist, is_rank0=is_rank0,
+        shift_smolyak_pts=shift_smolyak_pts,
+        shift_stochastic_extra=int(args.shift_stochastic_extra),
+    )
+
+    if is_rank0:
+        print(f"best val_{args.loss_fn}: {best_val:+.4f}")
+        log_lines.append(f"best val_{args.loss_fn}: {best_val:+.4f}")
+
+        # Final artifact (the ckpt payload sans epoch/loss bookkeeping).
+        final = _build_ckpt(
+            model=inner_model, arch=args.arch, args=args, epoch=-1,
+            train_loss=float("nan"), val_loss=best_val, best_val=best_val,
+            stats=stats,
+        )
+        final_name = {
+            "mlp": "shift_smear_reweight_mlp.pt",
+            "mlp-factored": "shift_smear_reweight_mlp_factored.pt",
+            "polyhead": "shift_smear_reweight_polyhead.pt",
+        }[args.arch]
+        final_path = os.path.join(args.output, final_name)
+        torch.save(final, final_path)
+        print(f"wrote final model to {final_path}")
+
+        with open(os.path.join(args.output, "log.txt"), "w") as f:
+            f.write("\n".join(log_lines) + "\n")
+
+    if is_dist:
+        import torch.distributed as dist
+        dist.destroy_process_group()
+
+
+# -----------------------------------------------------------------------------
+# Main (dispatcher: loads data once, then spawns worker(s))
+# -----------------------------------------------------------------------------
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output, exist_ok=True)
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    from arrow_shard_loader import (
+        resolve_shard_files,
+        compute_stats_streaming,
+    )
+
+    shard_files, shard_row_counts = resolve_shard_files(
+        args.input_files, return_counts=True,
+    )
+    print(
+        f"resolved {len(shard_files)} Arrow shard(s) from "
+        f"{len(args.input_files)} input arg(s)"
+        + ("" if shard_row_counts is None else
+           f"; manifest reports {sum(shard_row_counts):,} total rows")
+    )
+
+    # One streaming pass for preproc mean/std + weight mean.
+    # ``--stats-max-rows`` (CLI knob added below) caps the warmup
+    # to a subsample if you want training to start faster.
+    stats_max = int(getattr(args, "stats_max_rows", -1) or -1)
+    stats, weight_mean = compute_stats_streaming(
+        shard_files, max_rows=stats_max, progress=True,
+        weight_mode=args.weight_handling,
+        robust=bool(getattr(args, "robust_stats", False)),
+        robust_sample_rows=int(
+            getattr(args, "robust_sample_rows", 1_000_000)
+        ),
+    )
+    with open(os.path.join(args.output, "preproc.json"), "w") as f:
+        json.dump(asdict(stats), f, indent=2)
+
+    n_features = len(stats.target_names)
+    n_cond = len(stats.cond_names)
+
+    if args.batch_size is None:
+        args.batch_size = 32768 if args.device != "cpu" else 16384
+
+    # World size: auto-detect GPU count by default. CPU mode forces 1.
+    if args.device.startswith("cuda"):
+        if args.num_gpus == -1:
+            world_size = max(1, torch.cuda.device_count())
+        else:
+            world_size = max(1, args.num_gpus)
+    else:
+        world_size = 1
+
+    print(
+        f"streaming training over {len(shard_files)} shard(s)  "
+        f"world_size {world_size}  device {args.device}"
+    )
+
+    if world_size == 1:
+        main_worker(
+            0, args, 1, 0, stats, weight_mean, shard_files,
+            shard_row_counts, n_features, n_cond,
+        )
+    else:
+        # Pick a free port on localhost for the rendezvous.
+        import socket
+        sock = socket.socket()
+        sock.bind(("", 0))
+        master_port = sock.getsockname()[1]
+        sock.close()
+        import torch.multiprocessing as mp
+        mp.spawn(
+            main_worker,
+            args=(
+                args, world_size, master_port, stats, weight_mean,
+                shard_files, shard_row_counts, n_features, n_cond,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
+++ b/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
@@ -55,6 +55,7 @@ see the same numbers (and hence make the same early-stopping
 decisions); only rank 0 prints, writes checkpoints, and saves the
 final artifact.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -79,12 +80,10 @@ if _HERE not in sys.path:
 from train_muon_response_flow import _build_basis_aux  # noqa: E402
 from train_muon_response_flow import _select_basis  # noqa: E402
 from train_muon_response_flow import (  # noqa: E402
-    PreprocStats,
     _joint_indices,
     _state_dict_to_cpu,
     evaluate_joint,
 )
-
 
 _LOG_W_CLAMP = 30.0
 _LOG_LOG2 = math.log(math.log(2.0))
@@ -114,6 +113,7 @@ _LOG_LOG2 = math.log(math.log(2.0))
 # which is the natural choice given the user's "fully described by
 # the polynomial" assumption.
 
+
 def _smolyak_cheb_lobatto_1d(level: int):
     """Chebyshev-Lobatto nodes at Smolyak axis-level α (0-indexed):
     α=0 → {0}; α≥1 → 2^α + 1 nodes including ±1, equally spaced in
@@ -121,15 +121,14 @@ def _smolyak_cheb_lobatto_1d(level: int):
     if level <= 0:
         return [0.0]
     n = (1 << level) + 1
-    return [
-        -math.cos(math.pi * k / (n - 1)) for k in range(n)
-    ]
+    return [-math.cos(math.pi * k / (n - 1)) for k in range(n)]
 
 
 def _smolyak_grid(d: int, L: int):
     """Smolyak sparse grid in [-1, 1]^d at level ``L``. Returns a
     deduplicated, sorted ``np.ndarray`` of shape ``[K, d]``."""
     import itertools as _it
+
     points = set()
     # Iterate (α_1, ..., α_d) with α_j ≥ 0 and Σ α_j ≤ L.
     for alpha in _it.product(range(L + 1), repeat=d):
@@ -163,13 +162,17 @@ def _auto_smolyak_level(d: int, n_target: int, max_level: int = 8) -> int:
 
 
 _ACTIVATIONS = {
-    "gelu": nn.GELU, "relu": nn.ReLU, "silu": nn.SiLU, "tanh": nn.Tanh,
+    "gelu": nn.GELU,
+    "relu": nn.ReLU,
+    "silu": nn.SiLU,
+    "tanh": nn.Tanh,
 }
 
 
 # ============================================================================
 # Σ-pack helpers (upper-triangular flatten of σσᵀ)
 # ============================================================================
+
 
 def _sigma_pack_indices(n_features: int):
     """Indices into a flat n(n+1)/2 vector that mirror the upper
@@ -188,6 +191,7 @@ def _pack_sigma_outer(sigma_vec, iu, ju):
 # ============================================================================
 # Gauss–Hermite quadrature helpers (probabilist's; weights sum to 1)
 # ============================================================================
+
 
 def _gh_nodes_weights(K: int, dtype=torch.float32):
     """Probabilist's Gauss-Hermite nodes/weights for the standard
@@ -231,6 +235,7 @@ def _lagrange_basis_at(eps, gh_nodes):
 # ============================================================================
 # Architecture: B mode (dual scalar forward)
 # ============================================================================
+
 
 class ReweightMLP_B(nn.Module):
     """Trunk + head MLP for the dual-forward construction.
@@ -319,7 +324,9 @@ class ReweightMLP_B(nn.Module):
         # σ-side dropped in shift-only mode (would be dead weights).
         if not self.shift_only:
             self.head_layer1_sigma = nn.Linear(
-                self.n_sigma_pack, head_hidden, bias=False,
+                self.n_sigma_pack,
+                head_hidden,
+                bias=False,
             )
         else:
             self.head_layer1_sigma = None
@@ -347,7 +354,10 @@ class ReweightMLP_B(nn.Module):
         return self.trunk(torch.cat([y, c], dim=-1))
 
     def head_forward(
-        self, e: torch.Tensor, u: torch.Tensor, sigma_pack: torch.Tensor,
+        self,
+        e: torch.Tensor,
+        u: torch.Tensor,
+        sigma_pack: torch.Tensor,
     ) -> torch.Tensor:
         """``f(e, u, σ_pack) ∈ R``. Mathematically identical to the
         legacy packed-head form ``head_rest(act(W·[e, u, σ_pack] + b))``
@@ -391,11 +401,14 @@ class ReweightMLP_B(nn.Module):
         # keys starting with "head." that aren't already targeting the
         # new layout.
         new_keys = (
-            "head_layer1_e", "head_layer1_u", "head_layer1_sigma",
+            "head_layer1_e",
+            "head_layer1_u",
+            "head_layer1_sigma",
             "head_rest",
         )
         legacy_keys = [
-            k for k in state_dict.keys()
+            k
+            for k in state_dict.keys()
             if k.startswith(legacy_prefix)
             and not any(k.startswith(p) for p in new_keys)
         ]
@@ -403,10 +416,9 @@ class ReweightMLP_B(nn.Module):
             return state_dict
 
         # Find which Sequential indices appear (sorted).
-        layer_idxs = sorted({
-            int(k.split(".")[1]) for k in legacy_keys
-            if k.endswith(".weight")
-        })
+        layer_idxs = sorted(
+            {int(k.split(".")[1]) for k in legacy_keys if k.endswith(".weight")}
+        )
         if not layer_idxs:
             return state_dict
 
@@ -423,13 +435,11 @@ class ReweightMLP_B(nn.Module):
             n_u = self.n_features
             new_state["head_layer1_e.weight"] = w_old[:, :n_e].contiguous()
             new_state["head_layer1_e.bias"] = b_old.contiguous()
-            new_state["head_layer1_u.weight"] = (
-                w_old[:, n_e:n_e + n_u].contiguous()
-            )
+            new_state["head_layer1_u.weight"] = w_old[:, n_e : n_e + n_u].contiguous()
             if not self.shift_only:
-                new_state["head_layer1_sigma.weight"] = (
-                    w_old[:, n_e + n_u:].contiguous()
-                )
+                new_state["head_layer1_sigma.weight"] = w_old[
+                    :, n_e + n_u :
+                ].contiguous()
 
         # 2) ``head.{i}.{weight,bias}`` for i > first_idx →
         #    ``head_rest.{i-1-first_idx}.{weight,bias}``. The packed
@@ -450,13 +460,15 @@ class ReweightMLP_B(nn.Module):
         after running :meth:`_remap_legacy_state_dict`."""
         return super().load_state_dict(
             self._remap_legacy_state_dict(state_dict),
-            strict=strict, assign=assign,
+            strict=strict,
+            assign=assign,
         )
 
 
 # ============================================================================
 # Architecture: structurally factored MLP head
 # ============================================================================
+
 
 class ReweightMLPFactored(nn.Module):
     """Trunk + structurally factored head returning the log-ratio directly.
@@ -524,32 +536,26 @@ class ReweightMLPFactored(nn.Module):
         self.head_layers = int(head_layers)
         self.shift_only = bool(shift_only)
         self.n_sigma_pack = (
-            self.n_features * (self.n_features + 1) // 2
-            if not self.shift_only else 0
+            self.n_features * (self.n_features + 1) // 2 if not self.shift_only else 0
         )
         self.gauss_baseline = gauss_baseline
-        self.detach_pure_shift_in_joint = bool(
-            detach_pure_shift_in_joint
-        ) and not self.shift_only
-        self.detach_pure_smear_in_joint = bool(
-            detach_pure_smear_in_joint
-        ) and not self.shift_only
+        self.detach_pure_shift_in_joint = (
+            bool(detach_pure_shift_in_joint) and not self.shift_only
+        )
+        self.detach_pure_smear_in_joint = (
+            bool(detach_pure_smear_in_joint) and not self.shift_only
+        )
         # A independent of σ_pack iff shift-detach is on.
         self.A_uses_sigma = (
-            (not self.shift_only) and not self.detach_pure_shift_in_joint
-        )
+            not self.shift_only
+        ) and not self.detach_pure_shift_in_joint
         # B independent of u iff smear-detach is on.
-        self.B_uses_u = (
-            (not self.shift_only) and not self.detach_pure_smear_in_joint
-        )
+        self.B_uses_u = (not self.shift_only) and not self.detach_pure_smear_in_joint
         # Separate cross head only when both flags are on (fully
         # factorised three-term form). The cross is the only place that
         # JOINT-mode gradients survive when both pure blocks are
         # detached.
-        self.has_C = (
-            self.detach_pure_shift_in_joint
-            and self.detach_pure_smear_in_joint
-        )
+        self.has_C = self.detach_pure_shift_in_joint and self.detach_pure_smear_in_joint
         # Shift-only mode: the σ side collapses out entirely; B and C
         # are unused. log r = ⟨u, A(e, u)⟩ trivially.
         if self.shift_only:
@@ -568,11 +574,16 @@ class ReweightMLPFactored(nn.Module):
         self.trunk = nn.Sequential(*layers)
 
         # A head: e + u (+ σ_pack) → F.
-        in_dim_A = self.d_emb + self.n_features + (
-            self.n_sigma_pack if self.A_uses_sigma else 0
+        in_dim_A = (
+            self.d_emb
+            + self.n_features
+            + (self.n_sigma_pack if self.A_uses_sigma else 0)
         )
         self.A_head = self._make_mlp(
-            in_dim_A, head_hidden, head_layers, activation,
+            in_dim_A,
+            head_hidden,
+            head_layers,
+            activation,
             self.n_features,
         )
         # B head: e + (u +) σ_pack → n_pack. Built only if not shift-only.
@@ -583,7 +594,10 @@ class ReweightMLPFactored(nn.Module):
                 + self.n_sigma_pack
             )
             self.B_head = self._make_mlp(
-                in_dim_B, head_hidden, head_layers, activation,
+                in_dim_B,
+                head_hidden,
+                head_layers,
+                activation,
                 self.n_sigma_pack,
             )
         else:
@@ -593,7 +607,10 @@ class ReweightMLPFactored(nn.Module):
         if self.has_C:
             in_dim_C = self.d_emb + self.n_features + self.n_sigma_pack
             self.C_head = self._make_mlp(
-                in_dim_C, head_hidden, head_layers, activation,
+                in_dim_C,
+                head_hidden,
+                head_layers,
+                activation,
                 self.n_features * self.n_sigma_pack,
             )
         else:
@@ -622,7 +639,10 @@ class ReweightMLPFactored(nn.Module):
         return self.trunk(torch.cat([y, c], dim=-1))
 
     def head_forward_components(
-        self, e, u, sigma_pack,
+        self,
+        e,
+        u,
+        sigma_pack,
     ):
         """Return ``(pure_u_d, pure_s_d, cross_d)`` for the factored
         head, each of shape ``[B]``. ``cross_d`` is ``None`` when there
@@ -635,8 +655,8 @@ class ReweightMLPFactored(nn.Module):
         A_inputs = [e, u]
         if self.A_uses_sigma:
             A_inputs.append(sigma_pack)
-        A = self.A_head(torch.cat(A_inputs, dim=-1))     # [..., F]
-        pure_u_d = (u * A).sum(dim=-1)                    # [...]
+        A = self.A_head(torch.cat(A_inputs, dim=-1))  # [..., F]
+        pure_u_d = (u * A).sum(dim=-1)  # [...]
 
         # B head: e + (u +) σ_pack
         if self.B_head is not None:
@@ -654,12 +674,17 @@ class ReweightMLPFactored(nn.Module):
         if self.C_head is not None:
             C_flat = self.C_head(
                 torch.cat([e, u, sigma_pack], dim=-1),
-            )                                              # [..., F·n_pack]
+            )  # [..., F·n_pack]
             C = C_flat.view(
-                *u.shape[:-1], self.n_features, self.n_sigma_pack,
+                *u.shape[:-1],
+                self.n_features,
+                self.n_sigma_pack,
             )
             cross_d = torch.einsum(
-                "...i,...ij,...j->...", u, C, sigma_pack,
+                "...i,...ij,...j->...",
+                u,
+                C,
+                sigma_pack,
             )
         return pure_u_d, pure_s_d, cross_d
 
@@ -679,6 +704,7 @@ class ReweightMLPFactored(nn.Module):
 # ============================================================================
 # Architecture: polyhead mode (wraps the existing PolyHead)
 # ============================================================================
+
 
 class ReweightPolyhead(nn.Module):
     """Self-contained polyhead trunk: ``(y, c) → joint_coefs ∈ ℝ^{n_basis}``.
@@ -743,23 +769,16 @@ class ReweightPolyhead(nn.Module):
         # this lets the three-head split below produce contiguous
         # coefficient blocks that align with the basis ordering.
         raw_indices = _joint_indices(
-            n_features, max_deg_u, max_deg_sigma, max_cross_deg,
+            n_features,
+            max_deg_u,
+            max_deg_sigma,
+            max_cross_deg,
         )
-        idx_pure_u = [
-            (a, b) for (a, b) in raw_indices
-            if len(b) == 0 and len(a) > 0
-        ]
-        idx_pure_s = [
-            (a, b) for (a, b) in raw_indices
-            if len(a) == 0 and len(b) > 0
-        ]
-        idx_cross = [
-            (a, b) for (a, b) in raw_indices
-            if len(a) > 0 and len(b) > 0
-        ]
-        assert (
-            len(idx_pure_u) + len(idx_pure_s) + len(idx_cross)
-            == len(raw_indices)
+        idx_pure_u = [(a, b) for (a, b) in raw_indices if len(b) == 0 and len(a) > 0]
+        idx_pure_s = [(a, b) for (a, b) in raw_indices if len(a) == 0 and len(b) > 0]
+        idx_cross = [(a, b) for (a, b) in raw_indices if len(a) > 0 and len(b) > 0]
+        assert len(idx_pure_u) + len(idx_pure_s) + len(idx_cross) == len(
+            raw_indices
         ), "non-exhaustive split of joint indices"
         self._joint_indices = idx_pure_u + idx_pure_s + idx_cross
         self.n_basis = len(self._joint_indices)
@@ -782,7 +801,9 @@ class ReweightPolyhead(nn.Module):
         self.register_buffer("is_pure_u", is_pure_u, persistent=False)
         self.register_buffer("is_pure_sigma", is_pure_sigma, persistent=False)
         self.register_buffer(
-            "is_pure", is_pure_u | is_pure_sigma, persistent=False,
+            "is_pure",
+            is_pure_u | is_pure_sigma,
+            persistent=False,
         )
 
         # Basis-evaluation auxiliary tensors as buffers — auto-moved
@@ -794,18 +815,24 @@ class ReweightPolyhead(nn.Module):
         # overwritten by subsequent run".
         _aux = _build_basis_aux(self._joint_indices, n_features)
         self.register_buffer(
-            "_basis_alpha_degs", _aux["alpha_degs"], persistent=False,
+            "_basis_alpha_degs",
+            _aux["alpha_degs"],
+            persistent=False,
         )
         self.register_buffer(
-            "_basis_beta_degs", _aux["beta_degs"], persistent=False,
+            "_basis_beta_degs",
+            _aux["beta_degs"],
+            persistent=False,
         )
         self.register_buffer(
             "_basis_cheb_u_const",
-            _aux["cheb_u_const"], persistent=False,
+            _aux["cheb_u_const"],
+            persistent=False,
         )
         self.register_buffer(
             "_basis_cheb_v_const",
-            _aux["cheb_v_const"], persistent=False,
+            _aux["cheb_v_const"],
+            persistent=False,
         )
         self._basis_max_deg_u = _aux["max_deg_u"]
         self._basis_max_deg_sigma = _aux["max_deg_sigma"]
@@ -833,17 +860,12 @@ class ReweightPolyhead(nn.Module):
         # only created if the corresponding block is non-empty (e.g.
         # in shift-only mode, pure_s and cross are empty).
         self.head_pure_u = (
-            nn.Linear(prev, self._n_pure_u)
-            if self._n_pure_u > 0 else None
+            nn.Linear(prev, self._n_pure_u) if self._n_pure_u > 0 else None
         )
         self.head_pure_sigma = (
-            nn.Linear(prev, self._n_pure_s)
-            if self._n_pure_s > 0 else None
+            nn.Linear(prev, self._n_pure_s) if self._n_pure_s > 0 else None
         )
-        self.head_cross = (
-            nn.Linear(prev, self._n_cross)
-            if self._n_cross > 0 else None
-        )
+        self.head_cross = nn.Linear(prev, self._n_cross) if self._n_cross > 0 else None
         # Init heads near zero so coefs ≈ 0 → log r ≈ 0 at start.
         with torch.no_grad():
             for head in (self.head_pure_u, self.head_pure_sigma, self.head_cross):
@@ -913,7 +935,10 @@ class ReweightPolyhead(nn.Module):
             parts.append(self.head_cross(e))
         if not parts:
             return torch.zeros(
-                e.shape[0], 0, device=e.device, dtype=e.dtype,
+                e.shape[0],
+                0,
+                device=e.device,
+                dtype=e.dtype,
             )
         return torch.cat(parts, dim=-1)
 
@@ -921,6 +946,7 @@ class ReweightPolyhead(nn.Module):
 # ============================================================================
 # Analytic Gaussian baseline
 # ============================================================================
+
 
 class GaussBaseline(nn.Module):
     """Per-event analytic Gaussian baseline for the density-ratio.
@@ -1019,7 +1045,7 @@ class GaussBaseline(nn.Module):
         raw_chol = out[..., nf:]
         # Scatter ``raw_chol`` into a [..., nf, nf] lower-triangular
         # via a fixed projection, then softplus the diagonal.
-        L_flat = raw_chol @ self._chol_proj           # [..., nf*nf]
+        L_flat = raw_chol @ self._chol_proj  # [..., nf*nf]
         L_pre = L_flat.view(*raw_chol.shape[:-1], nf, nf)
         diag_pre = torch.diagonal(L_pre, dim1=-2, dim2=-1)
         diag_post = F.softplus(diag_pre)
@@ -1074,14 +1100,18 @@ def gauss_baseline_log_r(
     log_det_term = -0.5 * (log_det_Sigma_pert - log_det_Sigma)
 
     # Quadratic forms via triangular solves (single-RHS).
-    r = y32 - mu32                                     # [..., F]
+    r = y32 - mu32  # [..., F]
     r_pert = r - u32
     z_nom = torch.linalg.solve_triangular(
-        L32, r.unsqueeze(-1), upper=False,
+        L32,
+        r.unsqueeze(-1),
+        upper=False,
     ).squeeze(-1)
     quad_nom = (z_nom * z_nom).sum(-1)
     z_pert = torch.linalg.solve_triangular(
-        L_pert, r_pert.unsqueeze(-1), upper=False,
+        L_pert,
+        r_pert.unsqueeze(-1),
+        upper=False,
     ).squeeze(-1)
     quad_pert = (z_pert * z_pert).sum(-1)
 
@@ -1093,8 +1123,10 @@ def gauss_baseline_log_r(
 # Positivity wrap (shared)
 # ============================================================================
 
-def _apply_positivity(d: torch.Tensor, positivity: str,
-                      clamp: float = _LOG_W_CLAMP) -> torch.Tensor:
+
+def _apply_positivity(
+    d: torch.Tensor, positivity: str, clamp: float = _LOG_W_CLAMP
+) -> torch.Tensor:
     """Apply the positivity wrap to a pre-positivity scalar ``d`` to
     produce ``log r``. Same shape as input, applied elementwise.
 
@@ -1129,8 +1161,9 @@ def _apply_positivity(d: torch.Tensor, positivity: str,
     raise ValueError(f"unknown positivity {positivity!r}")
 
 
-def _apply_positivity_r(d: torch.Tensor, positivity: str,
-                        clamp: float = _LOG_W_CLAMP) -> torch.Tensor:
+def _apply_positivity_r(
+    d: torch.Tensor, positivity: str, clamp: float = _LOG_W_CLAMP
+) -> torch.Tensor:
     """Return ``r̂(d)`` *directly*, without going through
     ``log r̂`` and exponentiating.
 
@@ -1163,6 +1196,7 @@ def _apply_positivity_r(d: torch.Tensor, positivity: str,
 # ============================================================================
 # compute_log_r_pair: branches on architecture
 # ============================================================================
+
 
 def compute_d_quadrature(
     model: nn.Module,
@@ -1223,10 +1257,11 @@ def compute_d_quadrature(
     if arch == "mlp":
         # Trunk [(n_eps+1)·B]: y_nom plus all perturbed positions.
         y_all = torch.cat(
-            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)],
+            dim=0,
         )
         c_all = c.repeat(n_eps + 1, 1)
-        e = model.trunk_forward(y_all, c_all)         # [(n_eps+1)·B, d_emb]
+        e = model.trunk_forward(y_all, c_all)  # [(n_eps+1)·B, d_emb]
 
         u_all = u.repeat(n_eps + 1, 1)
         sigma_pack_all = sigma_pack.repeat(n_eps + 1, 1)
@@ -1240,7 +1275,7 @@ def compute_d_quadrature(
             sp_dual = torch.cat([sigma_pack_all, sp_zero], dim=0)
             f = model.head_forward(e_dual, u_dual, sp_dual)
             n_total = (n_eps + 1) * B
-            d = f[:n_total] - f[n_total:]             # [(n_eps+1)·B]
+            d = f[:n_total] - f[n_total:]  # [(n_eps+1)·B]
         else:
             # 4 head queries per (event, ε-slot):
             #   f_full=f(e,u,σ_pack), f_zero=f(e,0,0),
@@ -1255,28 +1290,38 @@ def compute_d_quadrature(
             e_q = torch.cat([e, e, e, e], dim=0)
             u_q = torch.cat([u_all, u_zero, u_all, u_zero], dim=0)
             sp_q = torch.cat(
-                [sigma_pack_all, sp_zero, sp_zero, sigma_pack_all], dim=0,
+                [sigma_pack_all, sp_zero, sp_zero, sigma_pack_all],
+                dim=0,
             )
             f = model.head_forward(e_q, u_q, sp_q)
             n_total = (n_eps + 1) * B
             f_full = f[0 * n_total : 1 * n_total]
             f_zero = f[1 * n_total : 2 * n_total]
-            f_us   = f[2 * n_total : 3 * n_total]
-            f_sm   = f[3 * n_total : 4 * n_total]
+            f_us = f[2 * n_total : 3 * n_total]
+            f_sm = f[3 * n_total : 4 * n_total]
             d_full = f_full - f_zero
             d_pure_u = f_us - f_zero
             d_pure_s = f_sm - f_zero
             # is_joint per event, broadcast across all (n_eps+1) blocks.
-            is_joint_b = (mode_id == 2)
-            is_joint_all = is_joint_b.unsqueeze(0).expand(
-                n_eps + 1, B,
-            ).reshape(-1)
+            is_joint_b = mode_id == 2
+            is_joint_all = (
+                is_joint_b.unsqueeze(0)
+                .expand(
+                    n_eps + 1,
+                    B,
+                )
+                .reshape(-1)
+            )
             # Replace d_pure_u/d_pure_s with detach() on JOINT events.
             d_pure_u_used = torch.where(
-                is_joint_all, d_pure_u.detach(), d_pure_u,
+                is_joint_all,
+                d_pure_u.detach(),
+                d_pure_u,
             )
             d_pure_s_used = torch.where(
-                is_joint_all, d_pure_s.detach(), d_pure_s,
+                is_joint_all,
+                d_pure_s.detach(),
+                d_pure_s,
             )
             d_mixed = d_full - d_pure_u - d_pure_s
             d = d_pure_u_used + d_pure_s_used + d_mixed
@@ -1288,28 +1333,23 @@ def compute_d_quadrature(
         # detach for --detach-pure-{shift,smear}-in-joint is applied
         # on JOINT-mode events.
         y_all = torch.cat(
-            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)],
+            dim=0,
         )
         c_all = c.repeat(n_eps + 1, 1)
         u_all = u.repeat(n_eps + 1, 1)
         sigma_pack_all = sigma_pack.repeat(n_eps + 1, 1)
-        e = model.trunk_forward(y_all, c_all)        # [(n_eps+1)·B, d_emb]
+        e = model.trunk_forward(y_all, c_all)  # [(n_eps+1)·B, d_emb]
         pu, ps, cr = model.head_forward_components(
-            e, u_all, sigma_pack_all,
+            e,
+            u_all,
+            sigma_pack_all,
         )
-        if (
-            mode_id is not None
-            and (
-                model.detach_pure_shift_in_joint
-                or model.detach_pure_smear_in_joint
-            )
+        if mode_id is not None and (
+            model.detach_pure_shift_in_joint or model.detach_pure_smear_in_joint
         ):
-            is_joint_b = (mode_id == 2)
-            is_joint_all = (
-                is_joint_b.unsqueeze(0)
-                .expand(n_eps + 1, B)
-                .reshape(-1)
-            )
+            is_joint_b = mode_id == 2
+            is_joint_all = is_joint_b.unsqueeze(0).expand(n_eps + 1, B).reshape(-1)
             if model.detach_pure_shift_in_joint:
                 pu = torch.where(is_joint_all, pu.detach(), pu)
             if model.detach_pure_smear_in_joint:
@@ -1354,12 +1394,13 @@ def compute_d_quadrature(
 
         # Trunk: one matmul on the full (n_eps+1)·B batch.
         y_all = torch.cat(
-            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)],
+            dim=0,
         )
         c_all = c.repeat(n_eps + 1, 1)
         u_all = u.repeat(n_eps + 1, 1)
         sigma_vec_all = sigma_vec.repeat(n_eps + 1, 1)
-        e_flat = model.trunk_forward(y_all, c_all)     # [(n_eps+1)·B, d_emb]
+        e_flat = model.trunk_forward(y_all, c_all)  # [(n_eps+1)·B, d_emb]
         d_emb = e_flat.shape[-1]
         e_r = e_flat.view(n_blocks, B, d_emb)
 
@@ -1368,11 +1409,14 @@ def compute_d_quadrature(
         # the cache-miss path out of the compiled trace (avoids
         # CUDA-graph "tensor overwritten" errors).
         phi_flat = _select_basis(
-            model.basis, u_all, sigma_vec_all, model.joint_indices,
+            model.basis,
+            u_all,
+            sigma_vec_all,
+            model.joint_indices,
             scale_u=model.basis_scale_u,
             scale_sigma=model.basis_scale_sigma,
             aux=model.basis_aux,
-        )                                              # [(n_eps+1)·B, n_basis]
+        )  # [(n_eps+1)·B, n_basis]
         phi_r = phi_flat.view(n_blocks, B, -1)
 
         n_pu = model._n_pure_u
@@ -1385,11 +1429,12 @@ def compute_d_quadrature(
             ``head``: nn.Linear(d_emb, n_out). Returns [N]."""
             if head is None:
                 return torch.zeros(
-                    e_blk.shape[0], device=e_blk.device,
+                    e_blk.shape[0],
+                    device=e_blk.device,
                     dtype=e_blk.dtype,
                 )
-            temp = phi_blk @ head.weight             # [N, d_emb]
-            bias_term = phi_blk @ head.bias          # [N]
+            temp = phi_blk @ head.weight  # [N, d_emb]
+            bias_term = phi_blk @ head.bias  # [N]
             return (e_blk * temp).sum(-1) + bias_term
 
         d_chunks = []
@@ -1404,10 +1449,13 @@ def compute_d_quadrature(
         # SMEAR events: only pure_σ contributes (u = 0).
         if n_smear_b > 0:
             e_m = e_r[
-                :, n_shift_b : n_shift_b + n_smear_b, :,
+                :,
+                n_shift_b : n_shift_b + n_smear_b,
+                :,
             ].reshape(-1, d_emb)
             phi_m_ps = phi_r[
-                :, n_shift_b : n_shift_b + n_smear_b,
+                :,
+                n_shift_b : n_shift_b + n_smear_b,
                 n_pu : n_pu + n_ps,
             ].reshape(-1, n_ps)
             d_m = _order2(e_m, phi_m_ps, model.head_pure_sigma)
@@ -1421,14 +1469,19 @@ def compute_d_quadrature(
             e_j = e_r[:, j0:, :].reshape(-1, d_emb)
             phi_j = phi_r[:, j0:, :].reshape(-1, n_pu + n_ps + n_cr)
             d_j_pu = _order2(
-                e_j, phi_j[:, :n_pu], model.head_pure_u,
+                e_j,
+                phi_j[:, :n_pu],
+                model.head_pure_u,
             )
             d_j_ps = _order2(
-                e_j, phi_j[:, n_pu : n_pu + n_ps],
+                e_j,
+                phi_j[:, n_pu : n_pu + n_ps],
                 model.head_pure_sigma,
             )
             d_j_cr = _order2(
-                e_j, phi_j[:, n_pu + n_ps :], model.head_cross,
+                e_j,
+                phi_j[:, n_pu + n_ps :],
+                model.head_cross,
             )
             if detach_pure_in_joint:
                 d_j_pu = d_j_pu.detach()
@@ -1456,15 +1509,20 @@ def compute_d_quadrature(
     if gauss is not None:
         n_blocks = n_eps + 1
         y_all_g = torch.cat(
-            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)], dim=0,
+            [y_nom, y_pert_stack.reshape(n_eps * B, n_features)],
+            dim=0,
         )
-        mu_g, L_g = gauss(c)                            # [B, F], [B, F, F]
+        mu_g, L_g = gauss(c)  # [B, F], [B, F, F]
         mu_all_g = mu_g.repeat(n_blocks, 1)
         L_all_g = L_g.repeat(n_blocks, 1, 1)
         u_all_g = u.repeat(n_blocks, 1)
         sigma_all_g = sigma_vec.repeat(n_blocks, 1)
         d = d + gauss_baseline_log_r(
-            y_all_g, mu_all_g, L_all_g, u_all_g, sigma_all_g,
+            y_all_g,
+            mu_all_g,
+            L_all_g,
+            u_all_g,
+            sigma_all_g,
         )
 
     d_nom = d[:B]
@@ -1519,8 +1577,14 @@ class ReweightWrapper(nn.Module):
         mode_id: torch.Tensor,
     ):
         return compute_d_quadrature(
-            self.model, self.arch,
-            y_nom, y_pert_stack, c, u, sigma_vec, sigma_pack,
+            self.model,
+            self.arch,
+            y_nom,
+            y_pert_stack,
+            c,
+            u,
+            sigma_vec,
+            sigma_pack,
             mode_id=mode_id,
             detach_pure_in_joint=self.detach_pure_in_joint,
         )
@@ -1604,14 +1668,14 @@ def _smear_pert_estimator(
         return x_pert_all[0]
 
     K = smear_K
-    x_K = x_pert_all[:K]                             # [K, B]
+    x_K = x_pert_all[:K]  # [K, B]
     S_K = torch.einsum("k,kb->b", gh_weights, x_K)
     if not smear_residual:
         return S_K
 
     # Hybrid: control-variate correction.
-    eps_extra = eps_stack[K]                         # [B]
-    L = _lagrange_basis_at(eps_extra, gh_nodes)      # [B, K]
+    eps_extra = eps_stack[K]  # [B]
+    L = _lagrange_basis_at(eps_extra, gh_nodes)  # [B, K]
     g_at_eps = torch.einsum("kb,bk->b", x_K, L)
     x_extra = x_pert_all[K]
     return S_K + (x_extra - g_at_eps)
@@ -1620,6 +1684,7 @@ def _smear_pert_estimator(
 # ============================================================================
 # Sampling: u, σ_vec, ε_smear
 # ============================================================================
+
 
 def sample_perturbations(
     batch_size: int,
@@ -1695,12 +1760,14 @@ def sample_perturbations(
     # the mode that dominates the gradient signal.
     base = batch_size // 3
     extra = batch_size - 3 * base
-    mode_id = torch.cat([
-        torch.full((base + extra,), 0, device=device, dtype=torch.long),
-        torch.full((base,), 1, device=device, dtype=torch.long),
-        torch.full((base,), 2, device=device, dtype=torch.long),
-    ])
-    shift_active = (mode_id != 1).to(delta_u.dtype)   # SHIFT or JOINT
+    mode_id = torch.cat(
+        [
+            torch.full((base + extra,), 0, device=device, dtype=torch.long),
+            torch.full((base,), 1, device=device, dtype=torch.long),
+            torch.full((base,), 2, device=device, dtype=torch.long),
+        ]
+    )
+    shift_active = (mode_id != 1).to(delta_u.dtype)  # SHIFT or JOINT
     smear_active = (mode_id != 0).to(sigma_mag.dtype)  # SMEAR or JOINT
 
     u = (delta_u * shift_active).unsqueeze(-1) * v_u
@@ -1715,6 +1782,7 @@ def sample_perturbations(
 # Loss functions
 # ============================================================================
 
+
 def dv_loss(log_r_nom, pert_T_estimator, weights):
     """Donsker-Varadhan / MINE objective (minimization form):
 
@@ -1726,9 +1794,7 @@ def dv_loss(log_r_nom, pert_T_estimator, weights):
     wsum = weights.sum().clamp_min(1e-30)
     e_pert_T = (weights * pert_T_estimator).sum() / wsum
     log_w = torch.log(weights.clamp_min(1e-30))
-    log_e_nom_expT = (
-        torch.logsumexp(log_w + log_r_nom, dim=0) - torch.log(wsum)
-    )
+    log_e_nom_expT = torch.logsumexp(log_w + log_r_nom, dim=0) - torch.log(wsum)
     return -e_pert_T + log_e_nom_expT
 
 
@@ -1772,9 +1838,7 @@ def bce_loss(log_r_nom, pert_softplus_neg_estimator, weights):
     or GH+residual all plug in uniformly (same machinery as LSIF/DV)."""
     wsum = weights.sum().clamp_min(1e-30)
     e_nom_term = (weights * F.softplus(log_r_nom)).sum() / wsum
-    e_pert_term = (
-        weights * pert_softplus_neg_estimator
-    ).sum() / wsum
+    e_pert_term = (weights * pert_softplus_neg_estimator).sum() / wsum
     return e_nom_term + e_pert_term
 
 
@@ -1811,6 +1875,7 @@ def expkl_loss(log_r_nom, pert_T_estimator, weights):
 # Training step
 # ============================================================================
 
+
 def _per_mode_split(per_event_loss, weights, mode_id, n_modes=3):
     """Aggregate per-event loss into per-mode (SHIFT/SMEAR/JOINT)
     weighted means.
@@ -1834,11 +1899,19 @@ def _per_mode_split(per_event_loss, weights, mode_id, n_modes=3):
 
 
 def _shift_K_per_event_loss(
-    inner_model, arch, y, c, w,
-    u_smolyak, K_extra,
-    delta_max, oversample,
-    loss_fn, positivity,
-    sigma_pack_iu=None, sigma_pack_ju=None,
+    inner_model,
+    arch,
+    y,
+    c,
+    w,
+    u_smolyak,
+    K_extra,
+    delta_max,
+    oversample,
+    loss_fn,
+    positivity,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
 ):
     """Memory-optimized K-per-event shift loss (shift-only mode).
 
@@ -1878,33 +1951,39 @@ def _shift_K_per_event_loss(
     if K_smolyak > 0:
         u_parts.append(
             u_smolyak.to(device=device, dtype=dtype)
-            .unsqueeze(0).expand(B, K_smolyak, n_features)
+            .unsqueeze(0)
+            .expand(B, K_smolyak, n_features)
         )
     if K_extra > 0:
-        delta = (
-            torch.rand(B, K_extra, device=device, dtype=dtype) * 2.0 - 1.0
-        ) * half
+        delta = (torch.rand(B, K_extra, device=device, dtype=dtype) * 2.0 - 1.0) * half
         v = torch.randn(B, K_extra, n_features, device=device, dtype=dtype)
         v = v / v.norm(dim=-1, keepdim=True).clamp_min(1e-30)
         u_parts.append(delta.unsqueeze(-1) * v)
-    u_all = torch.cat(u_parts, dim=1)        # [B, K_total, n_features]
+    u_all = torch.cat(u_parts, dim=1)  # [B, K_total, n_features]
 
-    sigma_zero = torch.zeros_like(u_all)     # [B, K_total, n_features]
+    sigma_zero = torch.zeros_like(u_all)  # [B, K_total, n_features]
     n_cond = c.shape[-1]
 
     if arch == "polyhead":
         # 1 trunk forward at y_nom — coefs shared across all K_total.
-        coefs_nom = inner_model(y, c)        # [B, n_basis]
+        coefs_nom = inner_model(y, c)  # [B, n_basis]
 
         # K trunk forwards at y_pert_k = y + u_k.
-        y_pert = y.unsqueeze(1) + u_all      # [B, K_total, n_features]
+        y_pert = y.unsqueeze(1) + u_all  # [B, K_total, n_features]
         y_pert_flat = y_pert.reshape(B * K_total, n_features)
-        c_flat = c.unsqueeze(1).expand(
-            B, K_total, n_cond,
-        ).reshape(B * K_total, n_cond)
+        c_flat = (
+            c.unsqueeze(1)
+            .expand(
+                B,
+                K_total,
+                n_cond,
+            )
+            .reshape(B * K_total, n_cond)
+        )
         coefs_pert_flat = inner_model(
-            y_pert_flat, c_flat,
-        )                                    # [B·K_total, n_basis]
+            y_pert_flat,
+            c_flat,
+        )  # [B·K_total, n_basis]
         coefs_pert = coefs_pert_flat.view(B, K_total, -1)
 
         # Polynomial evaluations (no trunk gradient flow):
@@ -1913,19 +1992,25 @@ def _shift_K_per_event_loss(
         coefs_nom_view = coefs_nom.unsqueeze(1).expand(B, K_total, -1)
         _basis_aux = inner_model.basis_aux
         d_nom_3d = evaluate_joint(
-            coefs_nom_view, u_all, sigma_zero, inner_model.joint_indices,
+            coefs_nom_view,
+            u_all,
+            sigma_zero,
+            inner_model.joint_indices,
             basis=inner_model.basis,
             scale_u=inner_model.basis_scale_u,
             scale_sigma=inner_model.basis_scale_sigma,
             basis_aux=_basis_aux,
-        )                                    # [B, K_total]
+        )  # [B, K_total]
         d_pert_3d = evaluate_joint(
-            coefs_pert, u_all, sigma_zero, inner_model.joint_indices,
+            coefs_pert,
+            u_all,
+            sigma_zero,
+            inner_model.joint_indices,
             basis=inner_model.basis,
             scale_u=inner_model.basis_scale_u,
             scale_sigma=inner_model.basis_scale_sigma,
             basis_aux=_basis_aux,
-        )                                    # [B, K_total]
+        )  # [B, K_total]
     elif arch in ("mlp", "mlp-factored"):
         # Both flavours use head_forward(e, u, σ_pack). The factored
         # head's head_forward already returns ``d`` (structurally zero
@@ -1934,29 +2019,44 @@ def _shift_K_per_event_loss(
         # factored variant in shift-only mode. Either way the
         # per-event scalar comes out identical to the construction
         # the loss expects.
-        e_nom = inner_model.trunk_forward(y, c)      # [B, d_emb]
+        e_nom = inner_model.trunk_forward(y, c)  # [B, d_emb]
         d_emb = e_nom.shape[-1]
 
         y_pert_flat = (y.unsqueeze(1) + u_all).reshape(B * K_total, n_features)
-        c_flat = c.unsqueeze(1).expand(
-            B, K_total, n_cond,
-        ).reshape(B * K_total, n_cond)
+        c_flat = (
+            c.unsqueeze(1)
+            .expand(
+                B,
+                K_total,
+                n_cond,
+            )
+            .reshape(B * K_total, n_cond)
+        )
         e_pert_flat = inner_model.trunk_forward(
-            y_pert_flat, c_flat,
-        )                                    # [B·K_total, d_emb]
+            y_pert_flat,
+            c_flat,
+        )  # [B·K_total, d_emb]
 
         # Head: f(e, u, σ_pack=0) and f(e, 0, 0). Shift-only ⇒ σ_pack
         # placeholder is [..., 0]. Aggregate the four head forwards
         # per (event, k) needed by the structural construction.
         u_flat = u_all.reshape(B * K_total, n_features)
         sp_zero = torch.empty(
-            B * K_total, 0, device=device, dtype=dtype,
+            B * K_total,
+            0,
+            device=device,
+            dtype=dtype,
         )
         u_zero = torch.zeros_like(u_flat)
         # d_nom: f(e_nom, u_k, 0) - f(e_nom, 0, 0).
         # e_nom needs to be expanded to [B·K_total, d_emb] (view).
-        e_nom_exp = e_nom.unsqueeze(1).expand(B, K_total, d_emb).reshape(
-            B * K_total, d_emb,
+        e_nom_exp = (
+            e_nom.unsqueeze(1)
+            .expand(B, K_total, d_emb)
+            .reshape(
+                B * K_total,
+                d_emb,
+            )
         )
         f_nom_full = inner_model.head_forward(e_nom_exp, u_flat, sp_zero)
         f_nom_zero = inner_model.head_forward(e_nom_exp, u_zero, sp_zero)
@@ -1974,18 +2074,29 @@ def _shift_K_per_event_loss(
     # baseline is evaluated. Broadcast across K_total via expand.
     gauss = getattr(inner_model, "gauss_baseline", None)
     if gauss is not None:
-        mu_g, L_g = gauss(c)                                # [B, F], [B, F, F]
+        mu_g, L_g = gauss(c)  # [B, F], [B, F, F]
         mu_bk = mu_g.unsqueeze(1).expand(B, K_total, n_features)
         L_bk = L_g.unsqueeze(1).expand(
-            B, K_total, n_features, n_features,
+            B,
+            K_total,
+            n_features,
+            n_features,
         )
         y_bk = y.unsqueeze(1).expand(B, K_total, n_features)
-        y_pert_bk = y.unsqueeze(1) + u_all                  # [B, K_total, F]
+        y_pert_bk = y.unsqueeze(1) + u_all  # [B, K_total, F]
         d_nom_3d = d_nom_3d + gauss_baseline_log_r(
-            y_bk, mu_bk, L_bk, u_all, sigma_zero,
+            y_bk,
+            mu_bk,
+            L_bk,
+            u_all,
+            sigma_zero,
         )
         d_pert_3d = d_pert_3d + gauss_baseline_log_r(
-            y_pert_bk, mu_bk, L_bk, u_all, sigma_zero,
+            y_pert_bk,
+            mu_bk,
+            L_bk,
+            u_all,
+            sigma_zero,
         )
 
     # Flatten K into the batch axis for the loss aggregation:
@@ -2002,7 +2113,12 @@ def _shift_K_per_event_loss(
         r_nom = _apply_positivity_r(d_nom_flat, positivity)
         r_pert_all = _apply_positivity_r(d_pert_all, positivity)
         pert_estimator = _smear_pert_estimator(
-            r_pert_all, eps_stack, None, None, 1, False,
+            r_pert_all,
+            eps_stack,
+            None,
+            None,
+            1,
+            False,
         )
         loss = lsif_loss(r_nom, pert_estimator, w_flat)
         per_event = (r_nom * r_nom - 2.0 * pert_estimator).detach()
@@ -2011,56 +2127,72 @@ def _shift_K_per_event_loss(
         # unused for BCE, see _apply_positivity docstring); DV /
         # expKL keep the default clamp for nom-side ``exp(log r̂)``
         # / ``logsumexp(log r̂)`` numerical safety.
-        pos_clamp = (
-            float("inf") if loss_fn == "bce" else _LOG_W_CLAMP
-        )
+        pos_clamp = float("inf") if loss_fn == "bce" else _LOG_W_CLAMP
         log_r_nom = _apply_positivity(
-            d_nom_flat, positivity, clamp=pos_clamp,
+            d_nom_flat,
+            positivity,
+            clamp=pos_clamp,
         )
         log_r_pert_all = _apply_positivity(
-            d_pert_all, positivity, clamp=pos_clamp,
+            d_pert_all,
+            positivity,
+            clamp=pos_clamp,
         )
         if loss_fn == "bce":
             x_pert_all = F.softplus(-log_r_pert_all)
         else:
             x_pert_all = log_r_pert_all
         pert_estimator = _smear_pert_estimator(
-            x_pert_all, eps_stack, None, None, 1, False,
+            x_pert_all,
+            eps_stack,
+            None,
+            None,
+            1,
+            False,
         )
         if loss_fn == "dv":
             loss = dv_loss(log_r_nom, pert_estimator, w_flat)
             per_event = (-pert_estimator).detach()
         elif loss_fn == "bce":
             loss = bce_loss(log_r_nom, pert_estimator, w_flat)
-            per_event = (
-                F.softplus(log_r_nom) + pert_estimator
-            ).detach()
+            per_event = (F.softplus(log_r_nom) + pert_estimator).detach()
         else:  # expkl
             loss = expkl_loss(log_r_nom, pert_estimator, w_flat)
-            per_event = (
-                torch.exp(log_r_nom) - pert_estimator
-            ).detach()
+            per_event = (torch.exp(log_r_nom) - pert_estimator).detach()
 
     # All replicas sit in SHIFT mode (=0); SMEAR/JOINT slots are
     # unpopulated and will return weight=0 → +inf in the caller's
     # split bookkeeping.
     mode_flat = torch.zeros(
-        B * K_total, dtype=torch.long, device=device,
+        B * K_total,
+        dtype=torch.long,
+        device=device,
     )
     split_sum, split_w = _per_mode_split(per_event, w_flat, mode_flat)
     return loss, split_sum, split_w
 
 
 def loss_step(
-    model, arch, y, c, w,
-    delta_max, sigma_max, oversample,
-    loss_fn, positivity,
-    sigma_pack_iu=None, sigma_pack_ju=None,
-    smear_K: int = 1, smear_residual: bool = False,
-    gh_nodes=None, gh_weights=None,
+    model,
+    arch,
+    y,
+    c,
+    w,
+    delta_max,
+    sigma_max,
+    oversample,
+    loss_fn,
+    positivity,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
+    smear_K: int = 1,
+    smear_residual: bool = False,
+    gh_nodes=None,
+    gh_weights=None,
     detach_pure_in_joint: bool = True,
     include_smear: bool = True,
-    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+    shift_smolyak_pts=None,
+    shift_stochastic_extra: int = 0,
     inner_model=None,
 ):
     """One forward-loss step.
@@ -2103,9 +2235,8 @@ def loss_step(
     B = y.shape[0]
     device = y.device
 
-    use_shift_K = (
-        not include_smear
-        and (shift_smolyak_pts is not None or shift_stochastic_extra > 0)
+    use_shift_K = not include_smear and (
+        shift_smolyak_pts is not None or shift_stochastic_extra > 0
     )
 
     if use_shift_K:
@@ -2121,20 +2252,38 @@ def loss_step(
                 "to loss_step (used to share the y_nom trunk forward)."
             )
         return _shift_K_per_event_loss(
-            inner_model, arch, y, c, w,
-            shift_smolyak_pts, int(shift_stochastic_extra),
-            delta_max, oversample, loss_fn, positivity,
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
+            inner_model,
+            arch,
+            y,
+            c,
+            w,
+            shift_smolyak_pts,
+            int(shift_stochastic_extra),
+            delta_max,
+            oversample,
+            loss_fn,
+            positivity,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
         )
 
     u, sigma_vec, mode_id = sample_perturbations(
-        B, n_features, delta_max, sigma_max, device,
-        oversample=oversample, include_smear=include_smear,
+        B,
+        n_features,
+        delta_max,
+        sigma_max,
+        device,
+        oversample=oversample,
+        include_smear=include_smear,
     )
 
     if include_smear:
         eps_stack = _build_eps_stack(
-            B, smear_K, smear_residual, gh_nodes, device,
+            B,
+            smear_K,
+            smear_residual,
+            gh_nodes,
+            device,
         )
     else:
         # σ_vec ≡ 0 in shift-only mode, so ε·σ_vec = 0 regardless of
@@ -2150,7 +2299,9 @@ def loss_step(
 
     if arch in ("mlp", "mlp-factored") and sigma_pack_iu is not None:
         sigma_pack = _pack_sigma_outer(
-            sigma_vec, sigma_pack_iu, sigma_pack_ju,
+            sigma_vec,
+            sigma_pack_iu,
+            sigma_pack_ju,
         )
     else:
         # Either polyhead (head ignores Σ_pack) or shift-only mlp /
@@ -2161,7 +2312,13 @@ def loss_step(
 
     # Wrapper returns the pre-positivity scalar d (no log/exp wrap).
     d_nom, d_pert_all = model(
-        y, y_pert_stack, c, u, sigma_vec, sigma_pack, mode_id,
+        y,
+        y_pert_stack,
+        c,
+        u,
+        sigma_vec,
+        sigma_pack,
+        mode_id,
     )
 
     # Apply the wrap in the form the loss family wants. The K=1 / GH /
@@ -2175,17 +2332,19 @@ def loss_step(
         r_nom = _apply_positivity_r(d_nom, positivity)
         r_pert_all = _apply_positivity_r(d_pert_all, positivity)
         pert_estimator = _smear_pert_estimator(
-            r_pert_all, eps_stack, gh_nodes, gh_weights,
-            smear_K, smear_residual,
+            r_pert_all,
+            eps_stack,
+            gh_nodes,
+            gh_weights,
+            smear_K,
+            smear_residual,
         )
         loss = lsif_loss(r_nom, pert_estimator, w)
         # Per-event integrand for per-mode split monitoring.
         # ``r_nom² − 2·pert_estimator`` matches the expectation form
         # of ``lsif_loss``; per-mode weighted means of this quantity
         # serve as the "is this mode improving" signal.
-        per_event = (
-            r_nom * r_nom - 2.0 * pert_estimator
-        ).detach()
+        per_event = (r_nom * r_nom - 2.0 * pert_estimator).detach()
         split_sum, split_w = _per_mode_split(per_event, w, mode_id)
         return loss, split_sum, split_w
 
@@ -2200,7 +2359,9 @@ def loss_step(
     pos_clamp = float("inf") if loss_fn == "bce" else _LOG_W_CLAMP
     log_r_nom = _apply_positivity(d_nom, positivity, clamp=pos_clamp)
     log_r_pert_all = _apply_positivity(
-        d_pert_all, positivity, clamp=pos_clamp,
+        d_pert_all,
+        positivity,
+        clamp=pos_clamp,
     )
     if loss_fn in ("dv", "expkl"):
         x_pert_all = log_r_pert_all
@@ -2210,8 +2371,12 @@ def loss_step(
         raise ValueError(f"unknown loss_fn {loss_fn!r}")
 
     pert_estimator = _smear_pert_estimator(
-        x_pert_all, eps_stack, gh_nodes, gh_weights,
-        smear_K, smear_residual,
+        x_pert_all,
+        eps_stack,
+        gh_nodes,
+        gh_weights,
+        smear_K,
+        smear_residual,
     )
 
     if loss_fn == "dv":
@@ -2227,14 +2392,10 @@ def loss_step(
         loss = bce_loss(log_r_nom, pert_estimator, w)
         # BCE's per-event integrand is the sum of nom-side and pert-
         # side softplus terms.
-        per_event = (
-            F.softplus(log_r_nom) + pert_estimator
-        ).detach()
+        per_event = (F.softplus(log_r_nom) + pert_estimator).detach()
     else:  # expkl
         loss = expkl_loss(log_r_nom, pert_estimator, w)
-        per_event = (
-            torch.exp(log_r_nom) - pert_estimator
-        ).detach()
+        per_event = (torch.exp(log_r_nom) - pert_estimator).detach()
     split_sum, split_w = _per_mode_split(per_event, w, mode_id)
     return loss, split_sum, split_w
 
@@ -2243,10 +2404,12 @@ def loss_step(
 # Training loop
 # ============================================================================
 
+
 def _all_reduce_sum_(t: torch.Tensor, is_dist: bool) -> torch.Tensor:
     """In-place all-reduce(sum) when distributed, otherwise a no-op."""
     if is_dist:
         import torch.distributed as dist
+
         dist.all_reduce(t, op=dist.ReduceOp.SUM)
     return t
 
@@ -2265,16 +2428,30 @@ def _amp_setup(precision: str, device):
     else:
         raise ValueError(f"unknown precision {precision!r}")
     scaler = torch.amp.GradScaler(
-        amp_device_type, enabled=(precision == "fp16"),
+        amp_device_type,
+        enabled=(precision == "fp16"),
     )
     return amp_device_type, amp_dtype, amp_enabled, scaler
 
 
 def train_one_epoch(
-    model, optimizer, train_loader, device, epoch, args, arch,
-    is_rank0, amp_ctx, scaler, sigma_pack_iu, sigma_pack_ju,
-    gh_nodes, gh_weights, is_dist=False,
-    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+    model,
+    optimizer,
+    train_loader,
+    device,
+    epoch,
+    args,
+    arch,
+    is_rank0,
+    amp_ctx,
+    scaler,
+    sigma_pack_iu,
+    sigma_pack_ju,
+    gh_nodes,
+    gh_weights,
+    is_dist=False,
+    shift_smolyak_pts=None,
+    shift_stochastic_extra: int = 0,
     inner_model=None,
     step_profiler=None,
 ):
@@ -2297,14 +2474,15 @@ def train_one_epoch(
     split_sum_total = torch.zeros(3, device=device)
     split_w_total = torch.zeros(3, device=device)
     profile_steps = (
-        0 if step_profiler is None else int(step_profiler.enabled) and int(
-            getattr(args, "profile_data_pipeline", 0) or 0
-        )
+        0
+        if step_profiler is None
+        else int(step_profiler.enabled)
+        and int(getattr(args, "profile_data_pipeline", 0) or 0)
     )
     for i, (x, c, w) in enumerate(bar):
-        do_profile = (step_profiler is not None
-                      and step_profiler.enabled
-                      and i < profile_steps)
+        do_profile = (
+            step_profiler is not None and step_profiler.enabled and i < profile_steps
+        )
         if do_profile:
             step_profiler.start()
         x = x.to(device, non_blocking=True)
@@ -2316,7 +2494,11 @@ def train_one_epoch(
         optimizer.zero_grad(set_to_none=True)
         with amp_ctx():
             loss, split_sum, split_w = loss_step(
-                model, arch, x, c, w,
+                model,
+                arch,
+                x,
+                c,
+                w,
                 delta_max=args.delta_max,
                 sigma_max=args.sigma_max,
                 oversample=args.oversample,
@@ -2326,7 +2508,8 @@ def train_one_epoch(
                 sigma_pack_ju=sigma_pack_ju,
                 smear_K=args.smear_K,
                 smear_residual=args.smear_residual,
-                gh_nodes=gh_nodes, gh_weights=gh_weights,
+                gh_nodes=gh_nodes,
+                gh_weights=gh_weights,
                 detach_pure_in_joint=args.detach_pure_in_joint,
                 include_smear=args.include_smear,
                 shift_smolyak_pts=shift_smolyak_pts,
@@ -2378,11 +2561,22 @@ def train_one_epoch(
 
 
 @torch.no_grad()
-def run_val(model, val_loader, device, args, arch, amp_ctx,
-            sigma_pack_iu, sigma_pack_ju, gh_nodes, gh_weights,
-            is_dist=False,
-            shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
-            inner_model=None):
+def run_val(
+    model,
+    val_loader,
+    device,
+    args,
+    arch,
+    amp_ctx,
+    sigma_pack_iu,
+    sigma_pack_ju,
+    gh_nodes,
+    gh_weights,
+    is_dist=False,
+    shift_smolyak_pts=None,
+    shift_stochastic_extra: int = 0,
+    inner_model=None,
+):
     model.eval()
     total_loss = torch.zeros((), device=device)
     wsum = torch.zeros((), device=device)
@@ -2395,7 +2589,11 @@ def run_val(model, val_loader, device, args, arch, amp_ctx,
         wb = w.sum()
         with amp_ctx():
             loss, split_sum, split_w = loss_step(
-                model, arch, x, c, w,
+                model,
+                arch,
+                x,
+                c,
+                w,
                 delta_max=args.delta_max,
                 sigma_max=args.sigma_max,
                 oversample=args.oversample,
@@ -2405,7 +2603,8 @@ def run_val(model, val_loader, device, args, arch, amp_ctx,
                 sigma_pack_ju=sigma_pack_ju,
                 smear_K=args.smear_K,
                 smear_residual=args.smear_residual,
-                gh_nodes=gh_nodes, gh_weights=gh_weights,
+                gh_nodes=gh_nodes,
+                gh_weights=gh_weights,
                 detach_pure_in_joint=args.detach_pure_in_joint,
                 include_smear=args.include_smear,
                 shift_smolyak_pts=shift_smolyak_pts,
@@ -2433,25 +2632,44 @@ def run_val(model, val_loader, device, args, arch, amp_ctx,
 
 
 def train(
-    model, inner_model, arch, train_loader, val_loader, device, args,
-    log_lines, stats=None, sigma_pack_iu=None, sigma_pack_ju=None,
-    gh_nodes=None, gh_weights=None,
-    is_dist: bool = False, is_rank0: bool = True,
-    shift_smolyak_pts=None, shift_stochastic_extra: int = 0,
+    model,
+    inner_model,
+    arch,
+    train_loader,
+    val_loader,
+    device,
+    args,
+    log_lines,
+    stats=None,
+    sigma_pack_iu=None,
+    sigma_pack_ju=None,
+    gh_nodes=None,
+    gh_weights=None,
+    is_dist: bool = False,
+    is_rank0: bool = True,
+    shift_smolyak_pts=None,
+    shift_stochastic_extra: int = 0,
 ):
     optimizer = torch.optim.AdamW(
-        model.parameters(), lr=args.lr, weight_decay=args.weight_decay,
+        model.parameters(),
+        lr=args.lr,
+        weight_decay=args.weight_decay,
     )
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.5,
+        optimizer,
+        mode="min",
+        factor=0.5,
         patience=max(1, args.patience // 2),
     )
 
     amp_device_type, amp_dtype, amp_enabled, scaler = _amp_setup(
-        args.precision, device,
+        args.precision,
+        device,
     )
     amp_ctx = lambda: torch.amp.autocast(
-        device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled,
+        device_type=amp_device_type,
+        dtype=amp_dtype,
+        enabled=amp_enabled,
     )
 
     # Per-step profiler — pairs with the TimedLoader's per-batch
@@ -2460,9 +2678,9 @@ def train(
     # so we can tell whether GPU compute, optimizer, or CPU
     # bookkeeping is the per-step ceiling.
     from arrow_shard_loader import StepProfiler
+
     step_profiler = StepProfiler(
-        enabled=int(getattr(args, "profile_data_pipeline", 0) or 0) > 0
-        and is_rank0,
+        enabled=int(getattr(args, "profile_data_pipeline", 0) or 0) > 0 and is_rank0,
         label="train_step",
         device=device,
     )
@@ -2479,9 +2697,7 @@ def train(
     best_val_split = [float("inf"), float("inf"), float("inf")]
     best_state = None
     no_improve = 0
-    checkpoint_path = (
-        os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
-    )
+    checkpoint_path = os.path.join(args.output, "checkpoint.pt") if is_rank0 else None
 
     # Optional ``torch.profiler`` diagnostic pass: run the first
     # ``warmup + active`` training steps under the profiler, print
@@ -2490,6 +2706,7 @@ def train(
     # only rank 0 runs the profiler / prints / exports.
     if getattr(args, "profile", False):
         from train_muon_response_flow import _run_profile_pass
+
         n_warmup = int(args.profile_warmup)
         n_active = int(args.profile_active)
         n_total = n_warmup + n_active
@@ -2508,7 +2725,11 @@ def train(
             optimizer.zero_grad(set_to_none=True)
             with amp_ctx():
                 loss, _split_sum, _split_w = loss_step(
-                    model, arch, x, c, w,
+                    model,
+                    arch,
+                    x,
+                    c,
+                    w,
                     delta_max=args.delta_max,
                     sigma_max=args.sigma_max,
                     oversample=args.oversample,
@@ -2518,7 +2739,8 @@ def train(
                     sigma_pack_ju=sigma_pack_ju,
                     smear_K=args.smear_K,
                     smear_residual=args.smear_residual,
-                    gh_nodes=gh_nodes, gh_weights=gh_weights,
+                    gh_nodes=gh_nodes,
+                    gh_weights=gh_weights,
                     detach_pure_in_joint=args.detach_pure_in_joint,
                     include_smear=args.include_smear,
                     shift_smolyak_pts=shift_smolyak_pts,
@@ -2529,7 +2751,8 @@ def train(
             scaler.scale(loss).backward()
             scaler.unscale_(optimizer)
             torch.nn.utils.clip_grad_norm_(
-                model.parameters(), max_norm=10.0,
+                model.parameters(),
+                max_norm=10.0,
             )
             scaler.step(optimizer)
             scaler.update()
@@ -2538,6 +2761,7 @@ def train(
             output = args.profile_output
             if is_dist and output:
                 import torch.distributed as _dist
+
                 rank_i = _dist.get_rank()
                 base, ext = os.path.splitext(output)
                 output = f"{base}.rank{rank_i}{ext}"
@@ -2558,10 +2782,20 @@ def train(
     for epoch in range(1, args.epochs + 1):
         t0 = time.time()
         train_loss, train_split = train_one_epoch(
-            model, optimizer, train_loader, device, epoch, args, arch,
-            is_rank0=is_rank0, amp_ctx=amp_ctx, scaler=scaler,
-            sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
-            gh_nodes=gh_nodes, gh_weights=gh_weights,
+            model,
+            optimizer,
+            train_loader,
+            device,
+            epoch,
+            args,
+            arch,
+            is_rank0=is_rank0,
+            amp_ctx=amp_ctx,
+            scaler=scaler,
+            sigma_pack_iu=sigma_pack_iu,
+            sigma_pack_ju=sigma_pack_ju,
+            gh_nodes=gh_nodes,
+            gh_weights=gh_weights,
             is_dist=is_dist,
             shift_smolyak_pts=shift_smolyak_pts,
             shift_stochastic_extra=shift_stochastic_extra,
@@ -2569,8 +2803,16 @@ def train(
             step_profiler=step_profiler,
         )
         val_loss, val_split = run_val(
-            model, val_loader, device, args, arch, amp_ctx,
-            sigma_pack_iu, sigma_pack_ju, gh_nodes, gh_weights,
+            model,
+            val_loader,
+            device,
+            args,
+            arch,
+            amp_ctx,
+            sigma_pack_iu,
+            sigma_pack_ju,
+            gh_nodes,
+            gh_weights,
             is_dist=is_dist,
             shift_smolyak_pts=shift_smolyak_pts,
             shift_stochastic_extra=shift_stochastic_extra,
@@ -2578,11 +2820,13 @@ def train(
         )
         scheduler.step(val_loss)
         lr_now = optimizer.param_groups[0]["lr"]
+
         # Format split components: show as "-" when no events of
         # that mode in the batch (e.g. SMEAR / JOINT in shift-only
         # training where val_split[1,2] = +inf).
         def _fmt_comp(x):
             return f"{x:+.4f}" if math.isfinite(x) else "  -   "
+
         tr_sh, tr_sm, tr_jt = train_split
         va_sh, va_sm, va_jt = val_split
         line = (
@@ -2644,9 +2888,14 @@ def train(
             and (epoch % args.checkpoint_every == 0)
         ):
             ckpt = _build_ckpt(
-                model=inner_model, arch=arch, args=args, epoch=epoch,
-                train_loss=train_loss, val_loss=val_loss,
-                best_val=best_val, stats=stats,
+                model=inner_model,
+                arch=arch,
+                args=args,
+                epoch=epoch,
+                train_loss=train_loss,
+                val_loss=val_loss,
+                best_val=best_val,
+                stats=stats,
             )
             torch.save(ckpt, checkpoint_path)
 
@@ -2666,10 +2915,7 @@ def train(
                         print(line)
                         log_lines.append(line)
             else:
-                line = (
-                    f"early stopping at epoch {epoch} "
-                    f"(best val {best_val:+.4f})"
-                )
+                line = f"early stopping at epoch {epoch} " f"(best val {best_val:+.4f})"
                 if is_rank0:
                     print(line)
                     log_lines.append(line)
@@ -2680,8 +2926,7 @@ def train(
     return best_val
 
 
-def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val,
-                stats):
+def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val, stats):
     """Bundle a checkpoint payload. ``model_config['arch']`` discriminates
     the construction so loaders can rebuild the right architecture."""
     gb = getattr(model, "gauss_baseline", None)
@@ -2690,7 +2935,8 @@ def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val,
             "hidden": int(gb.hidden),
             "n_layers": int(gb.n_layers),
         }
-        if gb is not None else None
+        if gb is not None
+        else None
     )
     if arch == "mlp":
         model_config = {
@@ -2756,30 +3002,23 @@ def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val,
             "loss_fn": args.loss_fn,
             "positivity": args.positivity,
             "delta_max": args.delta_max,
-            "sigma_max": (
-                args.sigma_max if args.include_smear else 0.0
-            ),
+            "sigma_max": (args.sigma_max if args.include_smear else 0.0),
             "oversample": args.oversample,
             "precision": args.precision,
             "compile": bool(args.compile),
             "include_smear": bool(args.include_smear),
-            "smear_K": (
-                int(args.smear_K) if args.include_smear else 1
-            ),
+            "smear_K": (int(args.smear_K) if args.include_smear else 1),
             "smear_residual": (
                 bool(args.smear_residual) if args.include_smear else False
             ),
             "detach_pure_in_joint": (
-                bool(args.detach_pure_in_joint) if args.include_smear
-                else False
+                bool(args.detach_pure_in_joint) if args.include_smear else False
             ),
             "detach_pure_shift_in_joint": (
-                bool(args.detach_pure_shift_in_joint)
-                if args.include_smear else False
+                bool(args.detach_pure_shift_in_joint) if args.include_smear else False
             ),
             "detach_pure_smear_in_joint": (
-                bool(args.detach_pure_smear_in_joint)
-                if args.include_smear else False
+                bool(args.detach_pure_smear_in_joint) if args.include_smear else False
             ),
         },
         "stats": asdict(stats) if stats is not None else None,
@@ -2790,6 +3029,7 @@ def _build_ckpt(model, arch, args, epoch, train_loss, val_loss, best_val,
 # CLI
 # ============================================================================
 
+
 def parse_args():
     p = argparse.ArgumentParser(
         description="Direct shift+smear reweight training (MLP-B / "
@@ -2798,7 +3038,9 @@ def parse_args():
     )
     # Data / IO.
     p.add_argument(
-        "--input-files", nargs="+", required=True,
+        "--input-files",
+        nargs="+",
+        required=True,
         default=argparse.SUPPRESS,
         help="(required) One of: (a) a shard directory containing "
         "manifest.json (auto-expanded to its Arrow IPC shards); "
@@ -2808,15 +3050,19 @@ def parse_args():
         "format.",
     )
     p.add_argument(
-        "--tree", default="tree",
+        "--tree",
+        default="tree",
         help="TTree name inside the input files.",
     )
     p.add_argument(
-        "--output", default="./shift_smear_reweight/",
+        "--output",
+        default="./shift_smear_reweight/",
         help="Output directory (created if missing).",
     )
     p.add_argument(
-        "--stats-max-rows", type=int, default=-1,
+        "--stats-max-rows",
+        type=int,
+        default=-1,
         help="Cap the rows used by the preproc-stats warmup pass. -1 "
         "= scan all rows in all shards (most accurate). 1e7 is "
         "plenty in practice and starts training in seconds rather "
@@ -2843,7 +3089,9 @@ def parse_args():
         action="store_false",
     )
     p.add_argument(
-        "--robust-sample-rows", type=int, default=20_000_000,
+        "--robust-sample-rows",
+        type=int,
+        default=20_000_000,
         help="(``--robust-stats`` only) Sample size for the robust "
         "median + MAD pass. 2e7 rows fits in ~640 MB and gives "
         "stable estimates even for the rare charge-mismeasurement "
@@ -2862,7 +3110,9 @@ def parse_args():
         "(legacy, ~5%% loss on W/Z).",
     )
     p.add_argument(
-        "--holdout-fraction", type=float, default=0.1,
+        "--holdout-fraction",
+        type=float,
+        default=0.1,
         help="Fraction of each shard's record batches held out from "
         "training, never seen by the trainer. The diagnostic script "
         "evaluates the model on this slice. Splits are contiguous "
@@ -2871,7 +3121,9 @@ def parse_args():
         "last holdout_fraction. Default 0.1 → 80 / 10 / 10 split.",
     )
     p.add_argument(
-        "--data-workers", type=int, default=4,
+        "--data-workers",
+        type=int,
+        default=4,
         help="Number of background processes that feed each rank's "
         "data pipeline. 0 = run the loader inline in the trainer "
         "process (single producer thread, prefetch=2). >0 wraps the "
@@ -2913,11 +3165,15 @@ def parse_args():
         "disables.",
     )
     p.add_argument(
-        "--val-fraction", type=float, default=0.1,
+        "--val-fraction",
+        type=float,
+        default=0.1,
         help="Fraction of events held out for validation.",
     )
     p.add_argument(
-        "--seed", type=int, default=42,
+        "--seed",
+        type=int,
+        default=42,
         help="Random seed for the train/val split and PyTorch RNG.",
     )
 
@@ -2940,46 +3196,63 @@ def parse_args():
 
     # Trunk sizing (shared between mlp and polyhead arches).
     p.add_argument(
-        "--trunk-hidden", type=int, default=64,
+        "--trunk-hidden",
+        type=int,
+        default=64,
         help="Trunk MLP hidden width. mlp: trunk(y, c) -> e ∈ ℝ^d_emb. "
         "polyhead: trunk(y, c) -> coefs ∈ ℝ^n_basis.",
     )
     p.add_argument(
-        "--trunk-layers", type=int, default=2,
+        "--trunk-layers",
+        type=int,
+        default=2,
         help="Number of trunk MLP hidden layers (shared).",
     )
 
     # MLP-B-only sizing.
     p.add_argument(
-        "--d-emb", type=int, default=32,
+        "--d-emb",
+        type=int,
+        default=32,
         help="(--arch mlp) Trunk embedding dimension.",
     )
     p.add_argument(
-        "--head-hidden", type=int, default=32,
+        "--head-hidden",
+        type=int,
+        default=32,
         help="(--arch mlp) Head hidden width.",
     )
     p.add_argument(
-        "--head-layers", type=int, default=2,
+        "--head-layers",
+        type=int,
+        default=2,
         help="(--arch mlp) Number of head hidden layers.",
     )
 
     # Polyhead-only sizing.
     p.add_argument(
-        "--max-deg-u", type=int, default=3,
+        "--max-deg-u",
+        type=int,
+        default=3,
         help="(--arch polyhead) Max polynomial degree in u.",
     )
     p.add_argument(
-        "--max-deg-sigma", type=int, default=4,
+        "--max-deg-sigma",
+        type=int,
+        default=4,
         help="(--arch polyhead) Max polynomial degree in σ_vec. Must "
         "be even (smear-symmetry constraint).",
     )
     p.add_argument(
-        "--max-cross-deg", type=int, default=3,
-        help="(--arch polyhead) Max combined degree |α|+|β| of cross "
-        "(u, σ) terms.",
+        "--max-cross-deg",
+        type=int,
+        default=3,
+        help="(--arch polyhead) Max combined degree |α|+|β| of cross " "(u, σ) terms.",
     )
     p.add_argument(
-        "--basis", choices=["monomial", "chebyshev"], default="monomial",
+        "--basis",
+        choices=["monomial", "chebyshev"],
+        default="monomial",
         help="(--arch polyhead) Basis for the polynomial in (u, σ_vec). "
         "'monomial' uses raw u^α · σ^β (default; backwards-compatible). "
         "'chebyshev' uses tensor-product Chebyshev polynomials with "
@@ -2990,7 +3263,9 @@ def parse_args():
         "scale.",
     )
     p.add_argument(
-        "--basis-scale-u", type=float, default=-1.0,
+        "--basis-scale-u",
+        type=float,
+        default=-1.0,
         help="(--arch polyhead, --basis chebyshev) Scale for u in the "
         "Chebyshev basis: T_n(u / basis_scale_u). Set to the nominal "
         "max |u| in standardized-target σ_y units so the recurrence "
@@ -2998,7 +3273,9 @@ def parse_args():
         "use oversample · delta_max (the actual u-magnitude bound).",
     )
     p.add_argument(
-        "--basis-scale-sigma", type=float, default=-1.0,
+        "--basis-scale-sigma",
+        type=float,
+        default=-1.0,
         help="(--arch polyhead, --basis chebyshev) Scale for σ_vec in "
         "the Chebyshev basis: T_n(σ_vec / basis_scale_sigma). Default "
         "-1 = auto: use oversample · sigma_max (the actual σ_vec bound).",
@@ -3007,7 +3284,8 @@ def parse_args():
     # Analytic Gaussian baseline (shared between mlp and polyhead).
     p.add_argument(
         "--gauss-baseline",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Add an analytic Gaussian density-ratio baseline that "
         "models p_nom(y|c) ~ N(μ(c), Σ(c)) and its shift+convolution "
         "under (u, σ_vec). The closed-form log-ratio is added "
@@ -3019,25 +3297,30 @@ def parse_args():
         "recovers legacy behaviour at epoch 0.",
     )
     p.add_argument(
-        "--gauss-baseline-hidden", type=int, default=64,
+        "--gauss-baseline-hidden",
+        type=int,
+        default=64,
         help="(--gauss-baseline) Hidden width of the c → (μ, Σ) MLP.",
     )
     p.add_argument(
-        "--gauss-baseline-layers", type=int, default=2,
-        help="(--gauss-baseline) Number of hidden layers of the "
-        "c → (μ, Σ) MLP.",
+        "--gauss-baseline-layers",
+        type=int,
+        default=2,
+        help="(--gauss-baseline) Number of hidden layers of the " "c → (μ, Σ) MLP.",
     )
 
     # Activation (shared).
     p.add_argument(
-        "--activation", choices=["gelu", "relu", "silu", "tanh"],
+        "--activation",
+        choices=["gelu", "relu", "silu", "tanh"],
         default="gelu",
         help="Activation used in trunk and head MLPs.",
     )
 
     # Loss / positivity / perturbation ranges.
     p.add_argument(
-        "--loss-fn", choices=["dv", "lsif", "bce", "expkl"],
+        "--loss-fn",
+        choices=["dv", "lsif", "bce", "expkl"],
         default="lsif",
         help="Density-ratio loss family. "
         "'lsif' (default): least-squares importance fitting, optimum "
@@ -3057,7 +3340,8 @@ def parse_args():
         "like LSIF; pair with low LR or BCE warm-start.",
     )
     p.add_argument(
-        "--positivity", choices=["exp", "softplus", "asinh"],
+        "--positivity",
+        choices=["exp", "softplus", "asinh"],
         default="softplus",
         help="Positivity wrap on the pre-positivity scalar d. "
         "'softplus' (default) is fp16-safer but asymmetric (compresses "
@@ -3071,7 +3355,8 @@ def parse_args():
     )
     p.add_argument(
         "--include-smear",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Include smear (and joint shift+smear) perturbations in "
         "training. Default OFF: shift-only architecture (no Sigma_pack "
         "in mlp head; no sigma-dependent basis terms in polyhead) and "
@@ -3083,15 +3368,21 @@ def parse_args():
         "enable.",
     )
     p.add_argument(
-        "--delta-max", type=float, default=1.0,
+        "--delta-max",
+        type=float,
+        default=1.0,
         help="Max |u| in standardized target units.",
     )
     p.add_argument(
-        "--sigma-max", type=float, default=1.0,
+        "--sigma-max",
+        type=float,
+        default=1.0,
         help="Max smear magnitude |σ_vec| in standardized target units.",
     )
     p.add_argument(
-        "--oversample", type=float, default=1.3,
+        "--oversample",
+        type=float,
+        default=1.3,
         help="Oversample factor on training perturbation magnitudes; "
         "1.3× covers the operational range with margin.",
     )
@@ -3099,7 +3390,8 @@ def parse_args():
     # Shift-axis Smolyak sparse-grid evaluation.
     p.add_argument(
         "--shift-smolyak",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="Use a deterministic Chebyshev-Lobatto Smolyak sparse "
         "grid for the shift (u) evaluation points, instead of one "
         "stochastic u per event per step. Each event is evaluated at "
@@ -3109,7 +3401,9 @@ def parse_args():
         "otherwise. Off by default; turn on with --shift-smolyak.",
     )
     p.add_argument(
-        "--shift-smolyak-level", type=int, default=0,
+        "--shift-smolyak-level",
+        type=int,
+        default=0,
         help="Smolyak level (0-indexed; level L grid has 1, 7, 25, "
         "69, 177, 441 points in d=3 for L=0..5). 0 = auto: with "
         "--arch polyhead, picks the lowest L whose grid has more "
@@ -3118,7 +3412,9 @@ def parse_args():
         "not meaningful; pass an explicit positive level instead.",
     )
     p.add_argument(
-        "--shift-stochastic-extra", type=int, default=0,
+        "--shift-stochastic-extra",
+        type=int,
+        default=0,
         help="Number of additional stochastic u samples per event on "
         "top of the Smolyak grid (or by themselves if --shift-smolyak "
         "is off). Drawn with the same direction × magnitude scheme as "
@@ -3130,7 +3426,9 @@ def parse_args():
 
     # Smear ε-integration.
     p.add_argument(
-        "--smear-K", type=int, default=1,
+        "--smear-K",
+        type=int,
+        default=1,
         help="Quadrature nodes for the smear ε integration in the "
         "pert-side LSIF/DV expectation. K=1 (default) is K=1 "
         "stochastic — one random ε per event. K≥2 uses deterministic "
@@ -3141,7 +3439,8 @@ def parse_args():
         "K=5 through deg 9. For smooth log r, K=3-5 is plenty.",
     )
     p.add_argument(
-        "--smear-residual", action="store_true",
+        "--smear-residual",
+        action="store_true",
         help="(only with --smear-K >= 2) Add a stochastic residual "
         "control variate to the GH estimator: sample one extra "
         "epsilon ~ N(0, 1) per event, evaluate r-hat at the "
@@ -3156,7 +3455,8 @@ def parse_args():
     )
     p.add_argument(
         "--detach-pure-in-joint",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="(polyhead / mlp arches) Detach the pure-shift "
         "(sigma -> 0) and pure-smear (u -> 0) contributions to log r "
         "on JOINT-mode events (mode==2; both u and sigma_vec "
@@ -3173,7 +3473,8 @@ def parse_args():
     )
     p.add_argument(
         "--detach-pure-shift-in-joint",
-        action="store_true", default=False,
+        action="store_true",
+        default=False,
         help="(mlp-factored only) Detach the pure-shift block A on "
         "JOINT events. Equivalently: structurally factor A so it "
         "depends only on (e, u), not on σ_pack; the cross-term "
@@ -3182,7 +3483,8 @@ def parse_args():
     )
     p.add_argument(
         "--detach-pure-smear-in-joint",
-        action="store_true", default=False,
+        action="store_true",
+        default=False,
         help="(mlp-factored only) Detach the pure-smear block B on "
         "JOINT events. Equivalently: structurally factor B so it "
         "depends only on (e, σ_pack), not on u; the cross-term "
@@ -3195,19 +3497,27 @@ def parse_args():
 
     # Optimization.
     p.add_argument(
-        "--epochs", type=int, default=200,
+        "--epochs",
+        type=int,
+        default=200,
         help="Maximum training epochs (early-stopping may end sooner).",
     )
     p.add_argument(
-        "--lr", type=float, default=1e-3,
+        "--lr",
+        type=float,
+        default=1e-3,
         help="Initial Adam learning rate.",
     )
     p.add_argument(
-        "--weight-decay", type=float, default=1e-4,
+        "--weight-decay",
+        type=float,
+        default=1e-4,
         help="Adam weight decay (L2 regularization).",
     )
     p.add_argument(
-        "--patience", type=int, default=20,
+        "--patience",
+        type=int,
+        default=20,
         help="Early-stopping patience: stop after this many consecutive "
         "epochs with no validation-loss improvement (see "
         "--patience-rel-threshold for the improvement criterion).",
@@ -3236,18 +3546,22 @@ def parse_args():
         "sits at O(1). Default: %(default)s.",
     )
     p.add_argument(
-        "--batch-size", type=int, default=None,
-        help="Training batch size. None auto-selects: "
-        "32768 on CUDA, 16384 on CPU.",
+        "--batch-size",
+        type=int,
+        default=None,
+        help="Training batch size. None auto-selects: " "32768 on CUDA, 16384 on CPU.",
     )
 
     # Run config.
     p.add_argument(
-        "--device", default="cuda" if torch.cuda.is_available() else "cpu",
+        "--device",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="cuda or cpu. Multi-GPU requires cuda (see --num-gpus).",
     )
     p.add_argument(
-        "--num-gpus", type=int, default=-1,
+        "--num-gpus",
+        type=int,
+        default=-1,
         help="Number of GPUs / worker processes. -1 (default) auto-"
         "detects via torch.cuda.device_count(). Set 1 to force "
         "single-process even on a multi-GPU host. Ignored when "
@@ -3255,7 +3569,8 @@ def parse_args():
     )
     p.add_argument(
         "--prefetch-shuffle",
-        action=argparse.BooleanOptionalAction, default=True,
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="[default: on] Hide the per-epoch ``torch.randperm(n)`` "
         "stall by computing the next epoch's permutation in a "
         "background thread while the current epoch is still "
@@ -3272,37 +3587,48 @@ def parse_args():
         "``LOADER_TIME=1`` env var.",
     )
     p.add_argument(
-        "--checkpoint-every", type=int, default=1,
+        "--checkpoint-every",
+        type=int,
+        default=1,
         help="Write a checkpoint every N epochs. 0 disables periodic "
         "checkpoints (final model is still saved at end of training).",
     )
     p.add_argument(
-        "--precision", choices=["fp32", "bf16", "fp16"], default="fp32",
+        "--precision",
+        choices=["fp32", "bf16", "fp16"],
+        default="fp32",
         help="Training/validation forward-pass precision.",
     )
     p.add_argument(
-        "--compile", action="store_true",
+        "--compile",
+        action="store_true",
         help="Wrap the model in torch.compile(mode='reduce-overhead').",
     )
 
     # Profiling diagnostics.
     p.add_argument(
         "--profile",
-        action=argparse.BooleanOptionalAction, default=False,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="If set, run a short ``torch.profiler`` pass on the "
         "first few training steps and exit (does not proceed to the "
         "epoch loop). Useful for identifying CUDA-time hotspots.",
     )
     p.add_argument(
-        "--profile-warmup", type=int, default=3,
+        "--profile-warmup",
+        type=int,
+        default=3,
         help="Profile schedule warmup steps (not recorded).",
     )
     p.add_argument(
-        "--profile-active", type=int, default=5,
+        "--profile-active",
+        type=int,
+        default=5,
         help="Profile schedule active steps (recorded).",
     )
     p.add_argument(
-        "--profile-output", default=None,
+        "--profile-output",
+        default=None,
         help="Optional path for Chrome trace export "
         "(viewable in chrome://tracing or Perfetto). Under DDP, the "
         "rank index is appended before the extension.",
@@ -3317,6 +3643,7 @@ def parse_args():
 # -----------------------------------------------------------------------------
 # Worker (runs once per GPU in distributed mode, once total otherwise)
 # -----------------------------------------------------------------------------
+
 
 def main_worker(
     rank,
@@ -3344,6 +3671,7 @@ def main_worker(
     # Device selection + optional process-group init.
     if is_dist:
         import torch.distributed as dist
+
         os.environ["MASTER_ADDR"] = "localhost"
         os.environ["MASTER_PORT"] = str(master_port)
         if args.device.startswith("cuda"):
@@ -3354,7 +3682,9 @@ def main_worker(
             device = "cpu"
             backend = "gloo"
         dist.init_process_group(
-            backend=backend, rank=rank, world_size=world_size,
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
         )
     else:
         if args.device.startswith("cuda"):
@@ -3379,12 +3709,16 @@ def main_worker(
     n_train_workers_hint = max(1, n_data_workers)
     n_val_workers_hint = max(1, n_data_workers // 2)
     train_ds = ArrowShardLoader(
-        shard_files, stats, weight_mean,
-        world_size=world_size, rank=rank,
+        shard_files,
+        stats,
+        weight_mean,
+        world_size=world_size,
+        rank=rank,
         batch_size=args.batch_size,
         split="train",
         val_fraction=args.val_fraction,
-        shuffle=True, drop_last=True,
+        shuffle=True,
+        drop_last=True,
         pin_memory=pin_memory,
         seed=int(args.seed),
         weight_mode=args.weight_handling,
@@ -3393,12 +3727,16 @@ def main_worker(
         num_workers_hint=n_train_workers_hint,
     )
     val_ds = ArrowShardLoader(
-        shard_files, stats, weight_mean,
-        world_size=world_size, rank=rank,
+        shard_files,
+        stats,
+        weight_mean,
+        world_size=world_size,
+        rank=rank,
         batch_size=args.batch_size,
         split="val",
         val_fraction=args.val_fraction,
-        shuffle=False, drop_last=False,
+        shuffle=False,
+        drop_last=False,
         pin_memory=pin_memory,
         seed=int(args.seed),
         weight_mode=args.weight_handling,
@@ -3416,6 +3754,7 @@ def main_worker(
     if n_data_workers > 0:
         import torch.utils.data as _td
         from arrow_shard_loader import dataloader_worker_init
+
         train_loader = _td.DataLoader(
             train_ds,
             batch_size=None,
@@ -3445,6 +3784,7 @@ def main_worker(
     n_profile = int(getattr(args, "profile_data_pipeline", 0) or 0)
     if n_profile > 0 and is_rank0:
         from arrow_shard_loader import TimedLoader
+
         train_loader = TimedLoader(train_loader, n_print=n_profile, label="train")
         val_loader = TimedLoader(val_loader, n_print=n_profile, label="val")
     if is_rank0:
@@ -3471,7 +3811,8 @@ def main_worker(
             n_layers=int(args.gauss_baseline_layers),
             activation=activation_cls,
         )
-        if bool(args.gauss_baseline) else None
+        if bool(args.gauss_baseline)
+        else None
     )
     if args.arch == "mlp":
         inner_model = ReweightMLP_B(
@@ -3507,12 +3848,8 @@ def main_worker(
             head_layers=args.head_layers,
             activation=activation_cls,
             shift_only=not args.include_smear,
-            detach_pure_shift_in_joint=bool(
-                args.detach_pure_shift_in_joint
-            ),
-            detach_pure_smear_in_joint=bool(
-                args.detach_pure_smear_in_joint
-            ),
+            detach_pure_shift_in_joint=bool(args.detach_pure_shift_in_joint),
+            detach_pure_smear_in_joint=bool(args.detach_pure_smear_in_joint),
             gauss_baseline=gauss_baseline,
         ).to(device)
         n_params = sum(p.numel() for p in inner_model.parameters())
@@ -3537,25 +3874,22 @@ def main_worker(
                 f"params={n_params:,}"
             )
     elif args.arch == "polyhead":
-        eff_max_deg_sigma = (
-            args.max_deg_sigma if args.include_smear else 0
-        )
-        eff_max_cross_deg = (
-            args.max_cross_deg if args.include_smear else args.max_deg_u
-        )
+        eff_max_deg_sigma = args.max_deg_sigma if args.include_smear else 0
+        eff_max_cross_deg = args.max_cross_deg if args.include_smear else args.max_deg_u
         # Auto-default Chebyshev scales to the actual perturbation
         # bounds (oversample · delta_max for u, oversample · sigma_max
         # for σ_vec) so T_n(x / scale) stays in [-1, 1] over training.
         # Sentinel <= 0 from argparse means "not specified".
         eff_basis_scale_u = (
-            float(args.basis_scale_u) if args.basis_scale_u > 0
+            float(args.basis_scale_u)
+            if args.basis_scale_u > 0
             else float(args.oversample * args.delta_max)
         )
         eff_basis_scale_sigma = (
-            float(args.basis_scale_sigma) if args.basis_scale_sigma > 0
+            float(args.basis_scale_sigma)
+            if args.basis_scale_sigma > 0
             else (
-                float(args.oversample * args.sigma_max)
-                if args.include_smear else 1.0
+                float(args.oversample * args.sigma_max) if args.include_smear else 1.0
             )
         )
         # Persist the resolved values back so the rest of main_worker
@@ -3589,7 +3923,8 @@ def main_worker(
                 + (
                     f"(scale_u={args.basis_scale_u:g},"
                     f"scale_sigma={args.basis_scale_sigma:g})"
-                    if args.basis == "chebyshev" else ""
+                    if args.basis == "chebyshev"
+                    else ""
                 )
                 + f"  n_basis={inner_model.n_basis}  "
                 f"params={n_params:,}"
@@ -3609,26 +3944,21 @@ def main_worker(
     # / --detach-pure-in-joint / --detach-pure-{shift,smear}-in-joint
     # are tracked for logging but ignored.
     eff_smear_K = args.smear_K if args.include_smear else 1
-    eff_smear_residual = (
-        bool(args.smear_residual) if args.include_smear else False
-    )
+    eff_smear_residual = bool(args.smear_residual) if args.include_smear else False
     eff_detach_pure_in_joint = (
         bool(args.detach_pure_in_joint) if args.include_smear else False
     )
     eff_detach_pure_shift_in_joint = (
-        bool(args.detach_pure_shift_in_joint)
-        if args.include_smear else False
+        bool(args.detach_pure_shift_in_joint) if args.include_smear else False
     )
     eff_detach_pure_smear_in_joint = (
-        bool(args.detach_pure_smear_in_joint)
-        if args.include_smear else False
+        bool(args.detach_pure_smear_in_joint) if args.include_smear else False
     )
 
     log_lines: List[str] = []
     if args.include_smear:
-        smear_mode_str = (
-            f"K={eff_smear_K}"
-            + (" + residual" if eff_smear_residual else "")
+        smear_mode_str = f"K={eff_smear_K}" + (
+            " + residual" if eff_smear_residual else ""
         )
     else:
         smear_mode_str = "off (shift-only)"
@@ -3636,7 +3966,8 @@ def main_worker(
         gauss_str = (
             f"gauss_baseline=({args.gauss_baseline_hidden}×"
             f"{args.gauss_baseline_layers})"
-            if bool(args.gauss_baseline) else "gauss_baseline=off"
+            if bool(args.gauss_baseline)
+            else "gauss_baseline=off"
         )
         log_lines.append(
             f"arch={args.arch} include_smear={bool(args.include_smear)} "
@@ -3652,8 +3983,7 @@ def main_worker(
             f"world_size={world_size} params={n_params}"
         )
         if not args.include_smear and (
-            args.smear_K > 1 or args.smear_residual
-            or not args.detach_pure_in_joint
+            args.smear_K > 1 or args.smear_residual or not args.detach_pure_in_joint
         ):
             print(
                 "[note] --no-include-smear (shift-only): ignoring "
@@ -3682,14 +4012,10 @@ def main_worker(
         if is_rank0:
             print(
                 f"Gauss-Hermite ε integration: K={eff_smear_K} "
-                f"{'+ residual control variate' if eff_smear_residual else ''}"
-                .strip()
+                f"{'+ residual control variate' if eff_smear_residual else ''}".strip()
             )
     elif args.include_smear and eff_smear_residual and is_rank0:
-        print(
-            "[warning] --smear-residual has no effect when --smear-K=1; "
-            "ignoring."
-        )
+        print("[warning] --smear-residual has no effect when --smear-K=1; " "ignoring.")
 
     # Shift-axis Smolyak grid (deterministic per-event evaluation
     # points). Built once at startup, broadcast to every event during
@@ -3712,7 +4038,8 @@ def main_worker(
         elif args.arch == "polyhead":
             n_pure = _n_pure_shift_basis(n_features, args.max_deg_u)
             shift_smolyak_level = _auto_smolyak_level(
-                n_features, n_pure,
+                n_features,
+                n_pure,
             )
             if is_rank0:
                 print(
@@ -3732,9 +4059,9 @@ def main_worker(
         # perturbation prior (oversample × delta_max).
         half = float(args.oversample) * float(args.delta_max)
         smolyak_np = smolyak_np * half
-        shift_smolyak_pts = torch.from_numpy(
-            smolyak_np
-        ).to(device=device, dtype=torch.float32)
+        shift_smolyak_pts = torch.from_numpy(smolyak_np).to(
+            device=device, dtype=torch.float32
+        )
         if is_rank0:
             print(
                 f"shift-smolyak: K_smolyak={shift_smolyak_pts.shape[0]} "
@@ -3752,7 +4079,9 @@ def main_worker(
     # Wrap inner model in the single-forward DDP-friendly wrapper
     # (compute_log_r_quadrature) before any DDP / compile wraps.
     wrapper = ReweightWrapper(
-        inner_model, args.arch, args.positivity,
+        inner_model,
+        args.arch,
+        args.positivity,
         detach_pure_in_joint=eff_detach_pure_in_joint,
     ).to(device)
 
@@ -3760,7 +4089,8 @@ def main_worker(
     if is_dist:
         if args.device.startswith("cuda"):
             model = nn.parallel.DistributedDataParallel(
-                model, device_ids=[rank],
+                model,
+                device_ids=[rank],
             )
         else:
             model = nn.parallel.DistributedDataParallel(model)
@@ -3777,11 +4107,21 @@ def main_worker(
         model = torch.compile(model, mode="reduce-overhead")
 
     best_val = train(
-        model, inner_model, args.arch, train_loader, val_loader,
-        device, args, log_lines, stats=stats,
-        sigma_pack_iu=sigma_pack_iu, sigma_pack_ju=sigma_pack_ju,
-        gh_nodes=gh_nodes, gh_weights=gh_weights,
-        is_dist=is_dist, is_rank0=is_rank0,
+        model,
+        inner_model,
+        args.arch,
+        train_loader,
+        val_loader,
+        device,
+        args,
+        log_lines,
+        stats=stats,
+        sigma_pack_iu=sigma_pack_iu,
+        sigma_pack_ju=sigma_pack_ju,
+        gh_nodes=gh_nodes,
+        gh_weights=gh_weights,
+        is_dist=is_dist,
+        is_rank0=is_rank0,
         shift_smolyak_pts=shift_smolyak_pts,
         shift_stochastic_extra=int(args.shift_stochastic_extra),
     )
@@ -3792,8 +4132,13 @@ def main_worker(
 
         # Final artifact (the ckpt payload sans epoch/loss bookkeeping).
         final = _build_ckpt(
-            model=inner_model, arch=args.arch, args=args, epoch=-1,
-            train_loss=float("nan"), val_loss=best_val, best_val=best_val,
+            model=inner_model,
+            arch=args.arch,
+            args=args,
+            epoch=-1,
+            train_loss=float("nan"),
+            val_loss=best_val,
+            best_val=best_val,
             stats=stats,
         )
         final_name = {
@@ -3810,12 +4155,14 @@ def main_worker(
 
     if is_dist:
         import torch.distributed as dist
+
         dist.destroy_process_group()
 
 
 # -----------------------------------------------------------------------------
 # Main (dispatcher: loads data once, then spawns worker(s))
 # -----------------------------------------------------------------------------
+
 
 def main():
     args = parse_args()
@@ -3824,18 +4171,22 @@ def main():
     np.random.seed(args.seed)
 
     from arrow_shard_loader import (
-        resolve_shard_files,
         compute_stats_streaming,
+        resolve_shard_files,
     )
 
     shard_files, shard_row_counts = resolve_shard_files(
-        args.input_files, return_counts=True,
+        args.input_files,
+        return_counts=True,
     )
     print(
         f"resolved {len(shard_files)} Arrow shard(s) from "
         f"{len(args.input_files)} input arg(s)"
-        + ("" if shard_row_counts is None else
-           f"; manifest reports {sum(shard_row_counts):,} total rows")
+        + (
+            ""
+            if shard_row_counts is None
+            else f"; manifest reports {sum(shard_row_counts):,} total rows"
+        )
     )
 
     # One streaming pass for preproc mean/std + weight mean.
@@ -3843,15 +4194,15 @@ def main():
     # to a subsample if you want training to start faster.
     stats_max = int(getattr(args, "stats_max_rows", -1) or -1)
     stats, weight_mean = compute_stats_streaming(
-        shard_files, max_rows=stats_max, progress=True,
+        shard_files,
+        max_rows=stats_max,
+        progress=True,
         weight_mode=args.weight_handling,
         split="train",
         val_fraction=args.val_fraction,
         holdout_fraction=args.holdout_fraction,
         robust=bool(getattr(args, "robust_stats", False)),
-        robust_sample_rows=int(
-            getattr(args, "robust_sample_rows", 1_000_000)
-        ),
+        robust_sample_rows=int(getattr(args, "robust_sample_rows", 1_000_000)),
     )
     with open(os.path.join(args.output, "preproc.json"), "w") as f:
         json.dump(asdict(stats), f, indent=2)
@@ -3878,22 +4229,39 @@ def main():
 
     if world_size == 1:
         main_worker(
-            0, args, 1, 0, stats, weight_mean, shard_files,
-            shard_row_counts, n_features, n_cond,
+            0,
+            args,
+            1,
+            0,
+            stats,
+            weight_mean,
+            shard_files,
+            shard_row_counts,
+            n_features,
+            n_cond,
         )
     else:
         # Pick a free port on localhost for the rendezvous.
         import socket
+
         sock = socket.socket()
         sock.bind(("", 0))
         master_port = sock.getsockname()[1]
         sock.close()
         import torch.multiprocessing as mp
+
         mp.spawn(
             main_worker,
             args=(
-                args, world_size, master_port, stats, weight_mean,
-                shard_files, shard_row_counts, n_features, n_cond,
+                args,
+                world_size,
+                master_port,
+                stats,
+                weight_mean,
+                shard_files,
+                shard_row_counts,
+                n_features,
+                n_cond,
             ),
             nprocs=world_size,
             join=True,

--- a/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
+++ b/scripts/corrections/muon_calibration/train_shift_smear_reweight.py
@@ -2862,6 +2862,15 @@ def parse_args():
         "(legacy, ~5%% loss on W/Z).",
     )
     p.add_argument(
+        "--holdout-fraction", type=float, default=0.1,
+        help="Fraction of each shard's record batches held out from "
+        "training, never seen by the trainer. The diagnostic script "
+        "evaluates the model on this slice. Splits are contiguous "
+        "ranges of record-batch indices per shard: train = first "
+        "(1 - val - holdout), val = next val_fraction, holdout = "
+        "last holdout_fraction. Default 0.1 → 80 / 10 / 10 split.",
+    )
+    p.add_argument(
         "--data-workers", type=int, default=4,
         help="Number of background processes that feed each rank's "
         "data pipeline. 0 = run the loader inline in the trainer "
@@ -3379,6 +3388,7 @@ def main_worker(
         pin_memory=pin_memory,
         seed=int(args.seed),
         weight_mode=args.weight_handling,
+        holdout_fraction=args.holdout_fraction,
         shard_row_counts=shard_row_counts,
         num_workers_hint=n_train_workers_hint,
     )
@@ -3392,6 +3402,7 @@ def main_worker(
         pin_memory=pin_memory,
         seed=int(args.seed),
         weight_mode=args.weight_handling,
+        holdout_fraction=args.holdout_fraction,
         shard_row_counts=shard_row_counts,
         num_workers_hint=n_val_workers_hint,
     )
@@ -3834,6 +3845,9 @@ def main():
     stats, weight_mean = compute_stats_streaming(
         shard_files, max_rows=stats_max, progress=True,
         weight_mode=args.weight_handling,
+        split="train",
+        val_fraction=args.val_fraction,
+        holdout_fraction=args.holdout_fraction,
         robust=bool(getattr(args, "robust_stats", False)),
         robust_sample_rows=int(
             getattr(args, "robust_sample_rows", 1_000_000)

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -642,7 +642,11 @@ closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
 )
 
 smearing_helper, smearing_uncertainty_helper = (
-    (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+    (None, None)
+    if args.noSmearing
+    else muon_calibration.make_muon_smearing_helpers(
+        scale_var_method=args.muonScaleVariation,
+    )
 )
 
 bias_helper = (

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -610,6 +610,7 @@ diff_weights_helper = (
     scale_e=args.scale_e,
     scale_M=args.scale_M,
     make_uncertainty_helper=True,
+    smearing=not args.noSmearing,
 )
 
 z_non_closure_parametrized_helper, z_non_closure_binned_helper = (
@@ -623,13 +624,19 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 )
 
 closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
-    common.closure_filepaths["parametrized"]
+    common.closure_filepaths["parametrized"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
-    0, common.correlated_variation_base_size["A"]
+    0, common.correlated_variation_base_size["A"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
-    2, common.correlated_variation_base_size["M"]
+    2, common.correlated_variation_base_size["M"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 
 smearing_helper, smearing_uncertainty_helper = (

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -629,12 +629,14 @@ closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
     smearing=not args.noSmearing,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
-    0, common.correlated_variation_base_size["A"],
+    0,
+    common.correlated_variation_base_size["A"],
     scale_var_method=args.muonScaleVariation,
     smearing=not args.noSmearing,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
-    2, common.correlated_variation_base_size["M"],
+    2,
+    common.correlated_variation_base_size["M"],
     scale_var_method=args.muonScaleVariation,
     smearing=not args.noSmearing,
 )

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -2489,11 +2489,20 @@ def build_graph(df, dataset):
                     )
                     results.append(hist_pixelMultiplicityStat)
 
-                # extra uncertainties from non-closure stats
+                # extra uncertainties from non-closure stats. Use
+                # ``jpsi_style_cols`` so each closure helper sees the
+                # right column list -- 10 (incl. φ + muon_source) for
+                # the ONNX reweight helpers, 7 (incl. response_weight)
+                # for the analytic Splines helpers.
+                response_weight_col = f"{reco_sel_GF}_response_weight"
+
+                df, _cl_cols = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosSyst_responseWeights_tensor_splines",
                     closure_unc_helper,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols, "nominal_weight"],
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights",
@@ -2505,10 +2514,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosSyst_responseWeights)
 
                 # extra uncertainties for A (fully correlated)
+                df, _cl_cols_A = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_A, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosASyst_responseWeights_tensor_splines",
                     closure_unc_helper_A,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols_A, "nominal_weight"],
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights",
@@ -2520,10 +2532,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosASyst_responseWeights)
 
                 # extra uncertainties for M (fully correlated)
+                df, _cl_cols_M = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_M, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosMSyst_responseWeights_tensor_splines",
                     closure_unc_helper_M,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols_M, "nominal_weight"],
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights",

--- a/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
@@ -126,6 +126,7 @@ closure_filepaths = common.closure_filepaths
     scale_e=args.scale_e,
     scale_M=args.scale_M,
     make_uncertainty_helper=True,
+    smearing=not args.noSmearing,
 )
 
 mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper = (

--- a/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt_VETOEFFI.py
@@ -134,7 +134,11 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 )
 
 smearing_helper, smearing_uncertainty_helper = (
-    (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+    (None, None)
+    if args.noSmearing
+    else muon_calibration.make_muon_smearing_helpers(
+        scale_var_method=args.muonScaleVariation,
+    )
 )
 
 bias_helper = (

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -422,7 +422,11 @@ calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
 diff_weights_helper = (
     ROOT.wrem.SplinesDifferentialWeightsHelper(calib_filepaths["tflite_file"])
-    if (args.muonScaleVariation == "smearingWeightsSplines" or args.validationHists)
+    if (
+        args.muonScaleVariation
+        in ("smearingWeightsSplines", "onnxReweight")
+        or args.validationHists
+    )
     else None
 )
 (
@@ -1330,11 +1334,40 @@ def build_graph(df, dataset):
                     input_kinematics.append(f"{reco_sel_GF}_response_weight")
 
                 # muon scale variation from stats. uncertainty on the jpsi massfit
-                df = df.Define(
-                    "nominal_muonScaleSyst_responseWeights_tensor",
-                    data_jpsi_crctn_unc_helper,
-                    [*input_kinematics, "nominal_weight"],
-                )
+                if muon_calibration._is_onnx_reweight_helper(
+                    data_jpsi_crctn_unc_helper
+                ):
+                    # ONNX helper consumes the full (reco/gen) kinematics
+                    # including φ and the muon_source column, plus the
+                    # legacy ``response_weight`` it ignores. Keep this list
+                    # local so the analytic-style auxiliary helpers below
+                    # still see the 7-column ``input_kinematics``.
+                    df = muon_calibration._define_muon_source_for_onnx_helper(
+                        df, reco_sel_GF
+                    )
+                    onnx_input_kinematics = [
+                        f"{reco_sel_GF}_recoPt",
+                        f"{reco_sel_GF}_recoEta",
+                        f"{reco_sel_GF}_recoPhi",
+                        f"{reco_sel_GF}_recoCharge",
+                        f"{reco_sel_GF}_genPt",
+                        f"{reco_sel_GF}_genEta",
+                        f"{reco_sel_GF}_genPhi",
+                        f"{reco_sel_GF}_genCharge",
+                        f"{reco_sel_GF}_muon_source",
+                        f"{reco_sel_GF}_response_weight",
+                    ]
+                    df = df.Define(
+                        "nominal_muonScaleSyst_responseWeights_tensor",
+                        data_jpsi_crctn_unc_helper,
+                        [*onnx_input_kinematics, "nominal_weight"],
+                    )
+                else:
+                    df = df.Define(
+                        "nominal_muonScaleSyst_responseWeights_tensor",
+                        data_jpsi_crctn_unc_helper,
+                        [*input_kinematics, "nominal_weight"],
+                    )
                 muonScaleSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleSyst_responseWeights",
                     axes,

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -422,10 +422,7 @@ calib_filepaths = common.calib_filepaths
 closure_filepaths = common.closure_filepaths
 diff_weights_helper = (
     ROOT.wrem.SplinesDifferentialWeightsHelper(calib_filepaths["tflite_file"])
-    if (
-        args.muonScaleVariation == "smearingWeightsSplines"
-        or args.validationHists
-    )
+    if (args.muonScaleVariation == "smearingWeightsSplines" or args.validationHists)
     else None
 )
 (
@@ -1349,7 +1346,10 @@ def build_graph(df, dataset):
 
                 # muon scale variation from stats. uncertainty on the jpsi massfit
                 df, _scale_cols = muon_calibration.jpsi_style_cols(
-                    df, data_jpsi_crctn_unc_helper, reco_sel_GF, response_weight_col,
+                    df,
+                    data_jpsi_crctn_unc_helper,
+                    reco_sel_GF,
+                    response_weight_col,
                 )
                 df = df.Define(
                     "nominal_muonScaleSyst_responseWeights_tensor",
@@ -1408,7 +1408,9 @@ def build_graph(df, dataset):
                     # add the ad-hoc Z non-closure nuisances from the jpsi massfit to muon scale unc
                     df = df.DefinePerSample("AFlag", "0x01")
                     df, _znc_cols = muon_calibration.jpsi_style_cols(
-                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
                         response_weight_col,
                     )
                     df = df.Define(
@@ -1432,7 +1434,9 @@ def build_graph(df, dataset):
                 ]:
                     df = df.DefinePerSample("MFlag", "0x04")
                     df, _znc_cols = muon_calibration.jpsi_style_cols(
-                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
                         response_weight_col,
                     )
                     df = df.Define(
@@ -1452,7 +1456,9 @@ def build_graph(df, dataset):
                 if args.nonClosureScheme == "A-M-combined":
                     df = df.DefinePerSample("AMFlag", "0x01 | 0x04")
                     df, _znc_cols = muon_calibration.jpsi_style_cols(
-                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
                         response_weight_col,
                     )
                     df = df.Define(
@@ -1475,7 +1481,10 @@ def build_graph(df, dataset):
 
                 # extra uncertainties from non-closure stats
                 df, _clos_cols = muon_calibration.jpsi_style_cols(
-                    df, closure_unc_helper, reco_sel_GF, response_weight_col,
+                    df,
+                    closure_unc_helper,
+                    reco_sel_GF,
+                    response_weight_col,
                 )
                 df = df.Define(
                     "muonScaleClosSyst_responseWeights_tensor_splines",
@@ -1493,7 +1502,10 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for A (fully correlated)
                 df, _closA_cols = muon_calibration.jpsi_style_cols(
-                    df, closure_unc_helper_A, reco_sel_GF, response_weight_col,
+                    df,
+                    closure_unc_helper_A,
+                    reco_sel_GF,
+                    response_weight_col,
                 )
                 df = df.Define(
                     "muonScaleClosASyst_responseWeights_tensor_splines",
@@ -1511,7 +1523,10 @@ def build_graph(df, dataset):
 
                 # extra uncertainties for M (fully correlated)
                 df, _closM_cols = muon_calibration.jpsi_style_cols(
-                    df, closure_unc_helper_M, reco_sel_GF, response_weight_col,
+                    df,
+                    closure_unc_helper_M,
+                    reco_sel_GF,
+                    response_weight_col,
                 )
                 df = df.Define(
                     "muonScaleClosMSyst_responseWeights_tensor_splines",

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -423,8 +423,7 @@ closure_filepaths = common.closure_filepaths
 diff_weights_helper = (
     ROOT.wrem.SplinesDifferentialWeightsHelper(calib_filepaths["tflite_file"])
     if (
-        args.muonScaleVariation
-        in ("smearingWeightsSplines", "onnxReweight")
+        args.muonScaleVariation == "smearingWeightsSplines"
         or args.validationHists
     )
     else None
@@ -455,13 +454,18 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 )
 
 closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
-    common.closure_filepaths["parametrized"]
+    common.closure_filepaths["parametrized"],
+    scale_var_method=args.muonScaleVariation,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
-    0, common.correlated_variation_base_size["A"]
+    0,
+    common.correlated_variation_base_size["A"],
+    scale_var_method=args.muonScaleVariation,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
-    2, common.correlated_variation_base_size["M"]
+    2,
+    common.correlated_variation_base_size["M"],
+    scale_var_method=args.muonScaleVariation,
 )
 
 smearing_helper, smearing_uncertainty_helper = (
@@ -1317,6 +1321,12 @@ def build_graph(df, dataset):
             ####################################################
             # nuisances from the muon momemtum scale calibration
             if args.muonCorrData in ["massfit", "lbl_massfit"]:
+                # The SplinesDifferentialWeightsHelper still takes the
+                # 6-column basic kinematics list (no φ / muon_source /
+                # response_weight). The J/psi-style helpers below pick
+                # up their own column lists via ``jpsi_style_cols`` based
+                # on whether they're the analytic Splines or ONNX-backed
+                # reweight variant.
                 input_kinematics = [
                     f"{reco_sel_GF}_recoPt",
                     f"{reco_sel_GF}_recoEta",
@@ -1325,49 +1335,23 @@ def build_graph(df, dataset):
                     f"{reco_sel_GF}_genEta",
                     f"{reco_sel_GF}_genCharge",
                 ]
+                response_weight_col = f"{reco_sel_GF}_response_weight"
                 if diff_weights_helper:
                     df = df.Define(
-                        f"{reco_sel_GF}_response_weight",
+                        response_weight_col,
                         diff_weights_helper,
                         [*input_kinematics],
                     )
-                    input_kinematics.append(f"{reco_sel_GF}_response_weight")
 
                 # muon scale variation from stats. uncertainty on the jpsi massfit
-                if muon_calibration._is_onnx_reweight_helper(
-                    data_jpsi_crctn_unc_helper
-                ):
-                    # ONNX helper consumes the full (reco/gen) kinematics
-                    # including φ and the muon_source column, plus the
-                    # legacy ``response_weight`` it ignores. Keep this list
-                    # local so the analytic-style auxiliary helpers below
-                    # still see the 7-column ``input_kinematics``.
-                    df = muon_calibration._define_muon_source_for_onnx_helper(
-                        df, reco_sel_GF
-                    )
-                    onnx_input_kinematics = [
-                        f"{reco_sel_GF}_recoPt",
-                        f"{reco_sel_GF}_recoEta",
-                        f"{reco_sel_GF}_recoPhi",
-                        f"{reco_sel_GF}_recoCharge",
-                        f"{reco_sel_GF}_genPt",
-                        f"{reco_sel_GF}_genEta",
-                        f"{reco_sel_GF}_genPhi",
-                        f"{reco_sel_GF}_genCharge",
-                        f"{reco_sel_GF}_muon_source",
-                        f"{reco_sel_GF}_response_weight",
-                    ]
-                    df = df.Define(
-                        "nominal_muonScaleSyst_responseWeights_tensor",
-                        data_jpsi_crctn_unc_helper,
-                        [*onnx_input_kinematics, "nominal_weight"],
-                    )
-                else:
-                    df = df.Define(
-                        "nominal_muonScaleSyst_responseWeights_tensor",
-                        data_jpsi_crctn_unc_helper,
-                        [*input_kinematics, "nominal_weight"],
-                    )
+                df, _scale_cols = muon_calibration.jpsi_style_cols(
+                    df, data_jpsi_crctn_unc_helper, reco_sel_GF, response_weight_col,
+                )
+                df = df.Define(
+                    "nominal_muonScaleSyst_responseWeights_tensor",
+                    data_jpsi_crctn_unc_helper,
+                    [*_scale_cols, "nominal_weight"],
+                )
                 muonScaleSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleSyst_responseWeights",
                     axes,
@@ -1411,13 +1395,22 @@ def build_graph(df, dataset):
                     )
                     results.append(hist_pixelMultiplicityStat)
 
+                # All J/psi-style scale-uncertainty Defines below pick up
+                # their per-helper column list via ``jpsi_style_cols`` --
+                # the ONNX-backed variants need φ + muon_source columns,
+                # the analytic Splines variants don't. The shared utility
+                # also creates the muon_source column on demand.
                 if args.nonClosureScheme in ["A-M-separated", "A-only"]:
                     # add the ad-hoc Z non-closure nuisances from the jpsi massfit to muon scale unc
                     df = df.DefinePerSample("AFlag", "0x01")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized_A",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "AFlag"],
+                        [*_znc_cols, "nominal_weight", "AFlag"],
                     )
                     hist_Z_non_closure_parametrized_A = df.HistoBoost(
                         "nominal_Z_non_closure_parametrized_A",
@@ -1434,10 +1427,14 @@ def build_graph(df, dataset):
                     "M-only",
                 ]:
                     df = df.DefinePerSample("MFlag", "0x04")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized_M",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "MFlag"],
+                        [*_znc_cols, "nominal_weight", "MFlag"],
                     )
                     hist_Z_non_closure_parametrized_M = df.HistoBoost(
                         "nominal_Z_non_closure_parametrized_M",
@@ -1450,10 +1447,14 @@ def build_graph(df, dataset):
 
                 if args.nonClosureScheme == "A-M-combined":
                     df = df.DefinePerSample("AMFlag", "0x01 | 0x04")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df, z_non_closure_parametrized_helper, reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "AMFlag"],
+                        [*_znc_cols, "nominal_weight", "AMFlag"],
                     )
                     hist_Z_non_closure_parametrized = df.HistoBoost(
                         (
@@ -1469,10 +1470,13 @@ def build_graph(df, dataset):
                     results.append(hist_Z_non_closure_parametrized)
 
                 # extra uncertainties from non-closure stats
+                df, _clos_cols = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper, reco_sel_GF, response_weight_col,
+                )
                 df = df.Define(
                     "muonScaleClosSyst_responseWeights_tensor_splines",
                     closure_unc_helper,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_clos_cols, "nominal_weight"],
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights",
@@ -1484,10 +1488,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosSyst_responseWeights)
 
                 # extra uncertainties for A (fully correlated)
+                df, _closA_cols = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_A, reco_sel_GF, response_weight_col,
+                )
                 df = df.Define(
                     "muonScaleClosASyst_responseWeights_tensor_splines",
                     closure_unc_helper_A,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_closA_cols, "nominal_weight"],
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights",
@@ -1499,10 +1506,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosASyst_responseWeights)
 
                 # extra uncertainties for M (fully correlated)
+                df, _closM_cols = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_M, reco_sel_GF, response_weight_col,
+                )
                 df = df.Define(
                     "muonScaleClosMSyst_responseWeights_tensor_splines",
                     closure_unc_helper_M,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_closM_cols, "nominal_weight"],
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights",

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -442,6 +442,7 @@ diff_weights_helper = (
     scale_e=args.scale_e,
     scale_M=args.scale_M,
     make_uncertainty_helper=True,
+    smearing=not args.noSmearing,
 )
 z_non_closure_parametrized_helper, z_non_closure_binned_helper = (
     muon_calibration.make_Z_non_closure_helpers(
@@ -456,16 +457,19 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
     common.closure_filepaths["parametrized"],
     scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
     0,
     common.correlated_variation_base_size["A"],
     scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
     2,
     common.correlated_variation_base_size["M"],
     scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 
 smearing_helper, smearing_uncertainty_helper = (

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -470,7 +470,11 @@ closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
 )
 
 smearing_helper, smearing_uncertainty_helper = (
-    (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+    (None, None)
+    if args.noSmearing
+    else muon_calibration.make_muon_smearing_helpers(
+        scale_var_method=args.muonScaleVariation,
+    )
 )
 
 smearinggradhelper = muon_calibration.make_smearing_grad_helper()

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -400,6 +400,7 @@ diff_weights_helper = (
     scale_e=args.scale_e,
     scale_M=args.scale_M,
     make_uncertainty_helper=True,
+    smearing=not args.noSmearing,
 )
 z_non_closure_parametrized_helper, z_non_closure_binned_helper = (
     muon_calibration.make_Z_non_closure_helpers(
@@ -412,13 +413,19 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 )
 
 closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
-    common.closure_filepaths["parametrized"]
+    common.closure_filepaths["parametrized"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
-    0, common.correlated_variation_base_size["A"]
+    0, common.correlated_variation_base_size["A"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
-    2, common.correlated_variation_base_size["M"]
+    2, common.correlated_variation_base_size["M"],
+    scale_var_method=args.muonScaleVariation,
+    smearing=not args.noSmearing,
 )
 
 smearing_helper, smearing_uncertainty_helper = (

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -431,7 +431,11 @@ closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
 )
 
 smearing_helper, smearing_uncertainty_helper = (
-    (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+    (None, None)
+    if args.noSmearing
+    else muon_calibration.make_muon_smearing_helpers(
+        scale_var_method=args.muonScaleVariation,
+    )
 )
 
 bias_helper = (

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -418,12 +418,14 @@ closure_unc_helper = muon_calibration.make_closure_uncertainty_helper(
     smearing=not args.noSmearing,
 )
 closure_unc_helper_A = muon_calibration.make_uniform_closure_uncertainty_helper(
-    0, common.correlated_variation_base_size["A"],
+    0,
+    common.correlated_variation_base_size["A"],
     scale_var_method=args.muonScaleVariation,
     smearing=not args.noSmearing,
 )
 closure_unc_helper_M = muon_calibration.make_uniform_closure_uncertainty_helper(
-    2, common.correlated_variation_base_size["M"],
+    2,
+    common.correlated_variation_base_size["M"],
     scale_var_method=args.muonScaleVariation,
     smearing=not args.noSmearing,
 )

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -1513,11 +1513,17 @@ def build_graph(df, dataset):
                     )
                     input_kinematics.append(f"{reco_sel_GF}_response_weight")
 
-                # muon scale variation from stats. uncertainty on the jpsi massfit
+                # muon scale variation from stats. uncertainty on the jpsi
+                # massfit. Use ``jpsi_style_cols`` so the column list matches
+                # the helper (10-col ONNX vs. 7-col analytic Splines).
+                response_weight_col = f"{reco_sel_GF}_response_weight"
+                df, _scale_cols = muon_calibration.jpsi_style_cols(
+                    df, data_jpsi_crctn_unc_helper, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "nominal_muonScaleSyst_responseWeights_tensor",
                     data_jpsi_crctn_unc_helper,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_scale_cols, "nominal_weight"],
                 )
                 muonScaleSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleSyst_responseWeights",
@@ -1565,10 +1571,16 @@ def build_graph(df, dataset):
                 if args.nonClosureScheme in ["A-M-separated", "A-only"]:
                     # add the ad-hoc Z non-closure nuisances from the jpsi massfit to muon scale unc
                     df = df.DefinePerSample("AFlag", "0x01")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized_A",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "AFlag"],
+                        [*_znc_cols, "nominal_weight", "AFlag"],
                     )
                     hist_Z_non_closure_parametrized_A = df.HistoBoost(
                         "nominal_Z_non_closure_parametrized_A",
@@ -1585,10 +1597,16 @@ def build_graph(df, dataset):
                     "M-only",
                 ]:
                     df = df.DefinePerSample("MFlag", "0x04")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized_M",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "MFlag"],
+                        [*_znc_cols, "nominal_weight", "MFlag"],
                     )
                     hist_Z_non_closure_parametrized_M = df.HistoBoost(
                         "nominal_Z_non_closure_parametrized_M",
@@ -1601,10 +1619,16 @@ def build_graph(df, dataset):
 
                 if args.nonClosureScheme == "A-M-combined":
                     df = df.DefinePerSample("AMFlag", "0x01 | 0x04")
+                    df, _znc_cols = muon_calibration.jpsi_style_cols(
+                        df,
+                        z_non_closure_parametrized_helper,
+                        reco_sel_GF,
+                        response_weight_col,
+                    )
                     df = df.Define(
                         "Z_non_closure_parametrized",
                         z_non_closure_parametrized_helper,
-                        [*input_kinematics, "nominal_weight", "AMFlag"],
+                        [*_znc_cols, "nominal_weight", "AMFlag"],
                     )
                     hist_Z_non_closure_parametrized = df.HistoBoost(
                         (
@@ -1620,10 +1644,13 @@ def build_graph(df, dataset):
                     results.append(hist_Z_non_closure_parametrized)
 
                 # extra uncertainties from non-closure stats
+                df, _cl_cols = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosSyst_responseWeights_tensor_splines",
                     closure_unc_helper,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols, "nominal_weight"],
                 )
                 nominal_muonScaleClosSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosSyst_responseWeights",
@@ -1635,10 +1662,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosSyst_responseWeights)
 
                 # extra uncertainties for A (fully correlated)
+                df, _cl_cols_A = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_A, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosASyst_responseWeights_tensor_splines",
                     closure_unc_helper_A,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols_A, "nominal_weight"],
                 )
                 nominal_muonScaleClosASyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosASyst_responseWeights",
@@ -1650,10 +1680,13 @@ def build_graph(df, dataset):
                 results.append(nominal_muonScaleClosASyst_responseWeights)
 
                 # extra uncertainties for M (fully correlated)
+                df, _cl_cols_M = muon_calibration.jpsi_style_cols(
+                    df, closure_unc_helper_M, reco_sel_GF, response_weight_col
+                )
                 df = df.Define(
                     "muonScaleClosMSyst_responseWeights_tensor_splines",
                     closure_unc_helper_M,
-                    [*input_kinematics, "nominal_weight"],
+                    [*_cl_cols_M, "nominal_weight"],
                 )
                 nominal_muonScaleClosMSyst_responseWeights = df.HistoBoost(
                     "nominal_muonScaleClosMSyst_responseWeights",

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -103,6 +103,23 @@ if args.testHelpers:
     smearing_helper_simple_transform = ROOT.wrem.SmearingHelperSimpleTransform(sigmarel)
     scale_helper_simple_weights = ROOT.wrem.ScaleHelperSimpleWeight(scalerel)
 
+    # ONNX-based equivalents of the simple weight helpers above. Same
+    # scalar reweight semantics, computed via the trained shift+smear
+    # reweight network instead of the analytic splines linearisation.
+    _onnx_nslots = (
+        ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+    )
+    smearing_helper_simple_reweight = ROOT.wrem.SmearingHelperSimpleReweight(
+        sigmarel,
+        muon_calibration.default_shift_smear_reweight_onnx,
+        max(int(_onnx_nslots), 1),
+    )
+    scale_helper_simple_reweight = ROOT.wrem.ScaleHelperSimpleReweight(
+        scalerel,
+        muon_calibration.default_shift_smear_reweight_onnx,
+        max(int(_onnx_nslots), 1),
+    )
+
 
 def build_graph(df, dataset):
     logger.info(f"build graph for dataset: {dataset.name}")
@@ -464,6 +481,38 @@ def build_graph(df, dataset):
                 ],
             )
 
+            # ONNX-based equivalents: same scalar reweight, but the
+            # alt-weight per muon is exp(log_r) from the trained network
+            # instead of (1 + dweightd[mu|sigmasq] · δ[mu|sigma²]). The
+            # network needs φ and the muon_source code in addition to
+            # the kinematics. The Splines helper's δ-function "splines"
+            # vs. ONNX-Reweight comparison is the test.
+            df = df.Define(
+                "selMuons_muon_source",
+                "ROOT::VecOps::RVec<int>(Muon_genPartFlav[selMuons])",
+            )
+            _onnx_cols = [
+                "selMuons_correctedPt",
+                "selMuons_correctedEta",
+                "selMuons_correctedPhi",
+                "selMuons_correctedCharge",
+                "selMuons_genPt",
+                "selMuons_genEta",
+                "selMuons_genPhi",
+                "selMuons_genCharge",
+                "selMuons_muon_source",
+            ]
+            df = df.Define(
+                "weight_smear_onnx",
+                smearing_helper_simple_reweight,
+                [*_onnx_cols, "nominal_weight"],
+            )
+            df = df.Define(
+                "weight_scale_onnx",
+                scale_helper_simple_reweight,
+                [*_onnx_cols, "nominal_weight"],
+            )
+
             response_cols_smeared = [
                 "selMuons_genPt",
                 "selMuons_genEta",
@@ -503,6 +552,22 @@ def build_graph(df, dataset):
                 [*response_cols, "weight_scale"],
             )
             results.append(hist_qopr_scaled_weight)
+
+            # ONNX-reweight reference histograms: same axes as the
+            # splines weight ones, so the comparison is one-to-one.
+            hist_qopr_smeared_weight_onnx = df.HistoBoost(
+                "hist_qopr_smeared_weight_onnx",
+                response_axes,
+                [*response_cols, "weight_smear_onnx"],
+            )
+            results.append(hist_qopr_smeared_weight_onnx)
+
+            hist_qopr_scaled_weight_onnx = df.HistoBoost(
+                "hist_qopr_scaled_weight_onnx",
+                response_axes,
+                [*response_cols, "weight_scale_onnx"],
+            )
+            results.append(hist_qopr_scaled_weight_onnx)
 
     return results, weightsum
 

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -108,9 +108,7 @@ if args.testHelpers:
     # reweight network instead of the analytic splines linearisation.
     # Picks the smearing-on / smearing-off variant of the bundled ONNX
     # to match the resolution-smearing choice in the histmaker.
-    _onnx_nslots = (
-        ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
-    )
+    _onnx_nslots = ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
     _onnx_path = muon_calibration.default_shift_smear_reweight_onnx(
         smearing=not args.noSmearing,
     )

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -79,7 +79,11 @@ mc_calibration_helper, data_calibration_helper, calibration_uncertainty_helper =
 )
 
 smearing_helper, smearing_uncertainty_helper = (
-    (None, None) if args.noSmearing else muon_calibration.make_muon_smearing_helpers()
+    (None, None)
+    if args.noSmearing
+    else muon_calibration.make_muon_smearing_helpers(
+        scale_var_method=args.muonScaleVariation,
+    )
 )
 bias_helper = (
     muon_calibration.make_muon_bias_helpers(args) if args.biasCalibration else None

--- a/scripts/histmakers/w_z_muonresponse.py
+++ b/scripts/histmakers/w_z_muonresponse.py
@@ -106,17 +106,22 @@ if args.testHelpers:
     # ONNX-based equivalents of the simple weight helpers above. Same
     # scalar reweight semantics, computed via the trained shift+smear
     # reweight network instead of the analytic splines linearisation.
+    # Picks the smearing-on / smearing-off variant of the bundled ONNX
+    # to match the resolution-smearing choice in the histmaker.
     _onnx_nslots = (
         ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
     )
+    _onnx_path = muon_calibration.default_shift_smear_reweight_onnx(
+        smearing=not args.noSmearing,
+    )
     smearing_helper_simple_reweight = ROOT.wrem.SmearingHelperSimpleReweight(
         sigmarel,
-        muon_calibration.default_shift_smear_reweight_onnx,
+        _onnx_path,
         max(int(_onnx_nslots), 1),
     )
     scale_helper_simple_reweight = ROOT.wrem.ScaleHelperSimpleReweight(
         scalerel,
-        muon_calibration.default_shift_smear_reweight_onnx,
+        _onnx_path,
         max(int(_onnx_nslots), 1),
     )
 

--- a/scripts/tests/testenv.py
+++ b/scripts/tests/testenv.py
@@ -1,8 +1,9 @@
-import wremnants
-import wremnants.production
-import wums
-import rabbit
-import narf
-import ROOT
+import ROOT  # noqa: F401
+
+import narf  # noqa: F401
+import rabbit  # noqa: F401
+import wremnants  # noqa: F401
+import wremnants.production  # noqa: F401
+import wums  # noqa: F401
 
 print("Successfully imported relevant packages")

--- a/scripts/tests/testenv.py
+++ b/scripts/tests/testenv.py
@@ -1,0 +1,8 @@
+import wremnants
+import wremnants.production
+import wums
+import rabbit
+import narf
+import ROOT
+
+print("Successfully imported relevant packages")

--- a/wremnants/postprocessing/regression.py
+++ b/wremnants/postprocessing/regression.py
@@ -243,16 +243,9 @@ def solve_leastsquare(X, XTY):
     # compute the transpose of X for the mt and parameter axes
     XT = np.transpose(X, axes=(*np.arange(X.ndim - 2), X.ndim - 1, X.ndim - 2))
     XTX = XT @ X
-    # Pseudo-inverse handles rank-deficient bins (where the smoothing
-    # window contains too many zeroed bins to determine all polynomial
-    # coefficients) by returning the minimum-norm solution rather than
-    # raising LinAlgError("Singular matrix"). For full-rank bins it is
-    # numerically equivalent to ``np.linalg.inv``. Also reused as the
-    # parameter covariance below; in the rank-deficient case the
-    # pseudo-inverse zeros the degenerate directions, which is the
-    # right downstream behaviour (no spurious large uncertainty in a
-    # direction the data couldn't constrain).
-    XTXinv = np.linalg.pinv(XTX.reshape(-1, *XTX.shape[-2:]))
+    # compute the inverse of the matrix in each bin (reshape to make last two axes contiguous, reshape back after inversion),
+    # this term is also the covariance matrix for the parameters
+    XTXinv = np.linalg.inv(XTX.reshape(-1, *XTX.shape[-2:]))
     XTXinv = XTXinv.reshape((*XT.shape[:-2], *XTXinv.shape[-2:]))
     params = np.einsum("...ij,...j->...i", XTXinv, XTY)
     return params, XTXinv
@@ -262,11 +255,7 @@ def solve_nonnegative_leastsquare(X, XTY, exclude_idx=None):
     # exclude_idx to exclude the non negative constrained for one parameter by evaluating the nnls twice and flipping the sign
     XT = np.transpose(X, axes=(*np.arange(X.ndim - 2), X.ndim - 1, X.ndim - 2))
     XTX = XT @ X
-    # See ``solve_leastsquare`` for the pinv rationale (rank-deficient
-    # smoothing windows). XTXinv is only returned as the parameter
-    # covariance here; the actual params come from scipy.nnls on the
-    # unmodified XTX matrix.
-    XTXinv = np.linalg.pinv(XTX.reshape(-1, *XTX.shape[-2:]))
+    XTXinv = np.linalg.inv(XTX.reshape(-1, *XTX.shape[-2:]))
     XTXinv = XTXinv.reshape((*XT.shape[:-2], *XTXinv.shape[-2:]))
     orig_shape = XTY.shape
     nBins = np.prod(orig_shape[:-1])

--- a/wremnants/postprocessing/regression.py
+++ b/wremnants/postprocessing/regression.py
@@ -243,9 +243,16 @@ def solve_leastsquare(X, XTY):
     # compute the transpose of X for the mt and parameter axes
     XT = np.transpose(X, axes=(*np.arange(X.ndim - 2), X.ndim - 1, X.ndim - 2))
     XTX = XT @ X
-    # compute the inverse of the matrix in each bin (reshape to make last two axes contiguous, reshape back after inversion),
-    # this term is also the covariance matrix for the parameters
-    XTXinv = np.linalg.inv(XTX.reshape(-1, *XTX.shape[-2:]))
+    # Pseudo-inverse handles rank-deficient bins (where the smoothing
+    # window contains too many zeroed bins to determine all polynomial
+    # coefficients) by returning the minimum-norm solution rather than
+    # raising LinAlgError("Singular matrix"). For full-rank bins it is
+    # numerically equivalent to ``np.linalg.inv``. Also reused as the
+    # parameter covariance below; in the rank-deficient case the
+    # pseudo-inverse zeros the degenerate directions, which is the
+    # right downstream behaviour (no spurious large uncertainty in a
+    # direction the data couldn't constrain).
+    XTXinv = np.linalg.pinv(XTX.reshape(-1, *XTX.shape[-2:]))
     XTXinv = XTXinv.reshape((*XT.shape[:-2], *XTXinv.shape[-2:]))
     params = np.einsum("...ij,...j->...i", XTXinv, XTY)
     return params, XTXinv
@@ -255,7 +262,11 @@ def solve_nonnegative_leastsquare(X, XTY, exclude_idx=None):
     # exclude_idx to exclude the non negative constrained for one parameter by evaluating the nnls twice and flipping the sign
     XT = np.transpose(X, axes=(*np.arange(X.ndim - 2), X.ndim - 1, X.ndim - 2))
     XTX = XT @ X
-    XTXinv = np.linalg.inv(XTX.reshape(-1, *XTX.shape[-2:]))
+    # See ``solve_leastsquare`` for the pinv rationale (rank-deficient
+    # smoothing windows). XTXinv is only returned as the parameter
+    # covariance here; the actual params come from scipy.nnls on the
+    # unmodified XTX matrix.
+    XTXinv = np.linalg.pinv(XTX.reshape(-1, *XTX.shape[-2:]))
     XTXinv = XTXinv.reshape((*XT.shape[:-2], *XTXinv.shape[-2:]))
     orig_shape = XTY.shape
     nBins = np.prod(orig_shape[:-1])

--- a/wremnants/production/arrow_shard_export.py
+++ b/wremnants/production/arrow_shard_export.py
@@ -85,6 +85,31 @@ def _splitmix64_bucket(
 
 
 # ---------------------------------------------------------------------------
+# Intermediate row dtype
+# ---------------------------------------------------------------------------
+
+
+def _intermediate_row_dtype(branches, int_columns, int64_columns):
+    """Build the numpy *structured* dtype used for the per-(source,
+    worker, bucket) phase-1 intermediates. Each branch is stored at
+    its native width — fp32 for ordinary columns, int32 for tag
+    columns, int64 for high-precision id columns. Packed (no
+    padding), so ``rec.tobytes()`` / ``np.fromfile(p, dtype=...)``
+    round-trip bit-for-bit."""
+    int_set = set(int_columns)
+    int64_set = set(int64_columns)
+    fields = []
+    for c in branches:
+        if c in int64_set:
+            fields.append((c, np.int64))
+        elif c in int_set:
+            fields.append((c, np.int32))
+        else:
+            fields.append((c, np.float32))
+    return np.dtype(fields)
+
+
+# ---------------------------------------------------------------------------
 # Phase 1: parallel scan + per-bucket dispatch
 # ---------------------------------------------------------------------------
 
@@ -102,8 +127,14 @@ def _phase1_worker(arg_tuple):
         flush_threshold_bytes,
         step_rows,
         seed,
+        int_columns,
+        int64_columns,
     ) = arg_tuple
-    n_cols = len(branches)
+    int_set = set(int_columns)
+    int64_set = set(int64_columns)
+    row_dtype = _intermediate_row_dtype(
+        branches, int_columns, int64_columns,
+    )
 
     src = uproot.open(snapshot_path)[tree_name]
     n_entries = int(src.num_entries)
@@ -174,12 +205,18 @@ def _phase1_worker(arg_tuple):
             source_id, event_idx_flat, muon_idx_flat, seed, n_buckets,
         )
 
-        # Flatten each RVec column to a 1D float32 array.
-        flat_cols = [
-            ak.flatten(chunk[c]).to_numpy().astype(np.float32, copy=False)
-            for c in branches
-        ]
-        flat = np.column_stack(flat_cols)
+        # Pack each RVec column into the per-row structured record at
+        # its native width. No bit-views or value-casts beyond the
+        # final dtype of each field — int64 columns survive bit-exact.
+        flat = np.empty(total, dtype=row_dtype)
+        for c in branches:
+            arr = ak.flatten(chunk[c]).to_numpy()
+            if c in int64_set:
+                flat[c] = arr.astype(np.int64, copy=False)
+            elif c in int_set:
+                flat[c] = arr.astype(np.int32, copy=False)
+            else:
+                flat[c] = arr.astype(np.float32, copy=False)
 
         # Dispatch per bucket appearing in this chunk.
         for b in np.unique(bids):
@@ -208,23 +245,31 @@ def _phase2_worker(arg_tuple):
         n_sources,
         branches,
         int_columns,
+        int64_columns,
         tmp_dir,
         shard_dir,
         batch_rows,
         seed,
     ) = arg_tuple
-    n_cols = len(branches)
     int_set = set(int_columns)
+    int64_set = set(int64_columns)
+    row_dtype = _intermediate_row_dtype(
+        branches, int_columns, int64_columns,
+    )
 
     my_buckets = list(range(worker_id, n_buckets, n_workers_phase2))
-    # Mixed-type schema: columns listed in ``int_columns`` are written
-    # as int32; everything else as float32. Phase-1 intermediates are
-    # still uniform fp32 (small ints round-trip exactly through fp32),
-    # cast back here at Arrow write time.
-    schema = pa.schema([
-        (c, pa.int32() if c in int_set else pa.float32())
-        for c in branches
-    ])
+    # ``int_columns`` -> ``pa.int32()``, ``int64_columns`` ->
+    # ``pa.int64()``, rest -> ``pa.float32()``. The phase-1
+    # intermediates are a packed structured array of the same widths,
+    # so per-field extraction is dtype-clean (no value-cast / bit-view
+    # gymnastics) at Arrow write time.
+    def _arrow_type(c):
+        if c in int64_set:
+            return pa.int64()
+        if c in int_set:
+            return pa.int32()
+        return pa.float32()
+    schema = pa.schema([(c, _arrow_type(c)) for c in branches])
     write_opts = ipc.IpcWriteOptions(
         compression="lz4_frame", use_threads=False,
     )
@@ -255,15 +300,13 @@ def _phase2_worker(arg_tuple):
                         f"s{s:02d}_w{w:04d}_b{b:05d}.bin",
                     )
                     if os.path.exists(p) and os.path.getsize(p) > 0:
-                        arr = np.fromfile(p, dtype=np.float32).reshape(
-                            -1, n_cols,
-                        )
+                        arr = np.fromfile(p, dtype=row_dtype)
                         chunks.append(arr)
             if not chunks:
                 bucket_row_counts.append((b, 0))
                 continue
 
-            rows = np.concatenate(chunks, axis=0)
+            rows = np.concatenate(chunks)
             del chunks
             perm = rng.permutation(len(rows))
             rows = rows[perm]
@@ -273,15 +316,13 @@ def _phase2_worker(arg_tuple):
             for off in range(0, n_rows_in_bucket, batch_rows):
                 sub = rows[off : off + batch_rows]
                 arrays = []
-                for i, c in enumerate(branches):
-                    col = np.ascontiguousarray(sub[:, i])
-                    if c in int_set:
-                        arrays.append(pa.array(
-                            col.astype(np.int32, copy=False),
-                            type=pa.int32(),
-                        ))
-                    else:
-                        arrays.append(pa.array(col, type=pa.float32()))
+                for c in branches:
+                    # ``sub[c]`` is already the field's native dtype;
+                    # ``ascontiguousarray`` only copies if the slice
+                    # isn't already C-contiguous (it is here since
+                    # ``rows`` was reordered by integer indexing).
+                    col = np.ascontiguousarray(sub[c])
+                    arrays.append(pa.array(col, type=_arrow_type(c)))
                 batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
                 writer.write_batch(batch)
                 n_record_batches += 1
@@ -343,15 +384,19 @@ def run_sharding_pass(
 
     ``int_columns`` lists branch names to write as ``pa.int32()`` in
     the Arrow IPC output (everything else is ``pa.float32()``). The
-    per-(worker, bucket) phase-1 intermediates are still uniform
-    fp32; small ints round-trip exactly. Use for tag columns like
-    ``source_id`` that you want to keep semantically integer in the
-    final shards.
+    per-(worker, bucket) phase-1 intermediates are a *packed
+    structured numpy array* whose fields match the per-branch Arrow
+    types one-to-one (fp32 / int32, with int64 reserved for future
+    callers), so every column survives the disk round-trip at its
+    native width with no value-casts or bit-views needed.
 
     Returns a dict matching the on-disk ``manifest.json`` payload.
     """
     branches = list(branches)
     int_columns = list(int_columns)
+    int64_columns: list[str] = []  # reserved for future use; structured
+    # intermediate already supports per-field int64 if a caller wires
+    # it in. No int64 column is written by the current snapshot.
     unknown_int = [c for c in int_columns if c not in branches]
     if unknown_int:
         raise ValueError(
@@ -390,7 +435,7 @@ def run_sharding_pass(
     print(f"  tmp_dir:                 {tmp_dir}")
     print(f"  branches:                {n_cols} cols  {branches}")
     if int_columns:
-        print(f"  int columns:             {int_columns}")
+        print(f"  int32 columns:           {int_columns}")
     print(f"  n_buckets:               {n_buckets}")
     print(f"  phase-1 workers:         {n_workers}")
     print(f"  output shards:           {n_shards}")
@@ -409,6 +454,7 @@ def run_sharding_pass(
                 src_id, w, n_workers, sources[src_id], tree_name,
                 branches, n_buckets, tmp_dir,
                 flush_threshold_bytes, step_rows, seed,
+                int_columns, int64_columns,
             )
             for src_id in range(n_sources)
             for w in range(n_workers)
@@ -438,7 +484,7 @@ def run_sharding_pass(
         phase2_args = [
             (
                 s, n_shards, n_buckets, n_workers, n_sources,
-                branches, int_columns,
+                branches, int_columns, int64_columns,
                 tmp_dir, shard_dir, batch_rows, seed,
             )
             for s in range(n_shards)

--- a/wremnants/production/arrow_shard_export.py
+++ b/wremnants/production/arrow_shard_export.py
@@ -50,7 +50,6 @@ import pyarrow as pa
 import pyarrow.ipc as ipc
 import uproot
 
-
 _MASK64 = np.uint64(0xFFFFFFFFFFFFFFFF)
 _GOLDEN_GAMMA = np.uint64(0x9E3779B97F4A7C15)
 _MIX1 = np.uint64(0xBF58476D1CE4E5B9)
@@ -133,7 +132,9 @@ def _phase1_worker(arg_tuple):
     int_set = set(int_columns)
     int64_set = set(int64_columns)
     row_dtype = _intermediate_row_dtype(
-        branches, int_columns, int64_columns,
+        branches,
+        int_columns,
+        int64_columns,
     )
 
     src = uproot.open(snapshot_path)[tree_name]
@@ -152,7 +153,8 @@ def _phase1_worker(arg_tuple):
             if not bufs[b]:
                 continue
             path = os.path.join(
-                tmp_dir, f"s{source_id:02d}_w{worker_id:04d}_b{b:05d}.bin",
+                tmp_dir,
+                f"s{source_id:02d}_w{worker_id:04d}_b{b:05d}.bin",
             )
             with open(path, "ab") as f:
                 for arr in bufs[b]:
@@ -196,13 +198,16 @@ def _phase1_worker(arg_tuple):
             np.arange(cur, cur + n_events, dtype=np.int64),
             counts,
         )
-        muon_idx_flat = (
-            np.arange(total, dtype=np.int64)
-            - np.repeat(offsets[:-1], counts)
+        muon_idx_flat = np.arange(total, dtype=np.int64) - np.repeat(
+            offsets[:-1], counts
         )
 
         bids = _splitmix64_bucket(
-            source_id, event_idx_flat, muon_idx_flat, seed, n_buckets,
+            source_id,
+            event_idx_flat,
+            muon_idx_flat,
+            seed,
+            n_buckets,
         )
 
         # Pack each RVec column into the per-row structured record at
@@ -254,10 +259,13 @@ def _phase2_worker(arg_tuple):
     int_set = set(int_columns)
     int64_set = set(int64_columns)
     row_dtype = _intermediate_row_dtype(
-        branches, int_columns, int64_columns,
+        branches,
+        int_columns,
+        int64_columns,
     )
 
     my_buckets = list(range(worker_id, n_buckets, n_workers_phase2))
+
     # ``int_columns`` -> ``pa.int32()``, ``int64_columns`` ->
     # ``pa.int64()``, rest -> ``pa.float32()``. The phase-1
     # intermediates are a packed structured array of the same widths,
@@ -269,9 +277,11 @@ def _phase2_worker(arg_tuple):
         if c in int_set:
             return pa.int32()
         return pa.float32()
+
     schema = pa.schema([(c, _arrow_type(c)) for c in branches])
     write_opts = ipc.IpcWriteOptions(
-        compression="lz4_frame", use_threads=False,
+        compression="lz4_frame",
+        use_threads=False,
     )
     rng = np.random.default_rng(
         int(seed) ^ (worker_id * 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF
@@ -289,8 +299,9 @@ def _phase2_worker(arg_tuple):
     # individual record batches without walking the whole shard
     # sequentially, which enables intra-shard parallelism in the
     # trainer's stats warmup.
-    with pa.OSFile(tmp_out, "wb") as out_f, \
-         ipc.new_file(out_f, schema, options=write_opts) as writer:
+    with pa.OSFile(tmp_out, "wb") as out_f, ipc.new_file(
+        out_f, schema, options=write_opts
+    ) as writer:
         for b in my_buckets:
             chunks: list[np.ndarray] = []
             for s in range(n_sources):
@@ -399,9 +410,7 @@ def run_sharding_pass(
     # it in. No int64 column is written by the current snapshot.
     unknown_int = [c for c in int_columns if c not in branches]
     if unknown_int:
-        raise ValueError(
-            f"int_columns refers to unknown branches: {unknown_int}"
-        )
+        raise ValueError(f"int_columns refers to unknown branches: {unknown_int}")
     n_cols = len(branches)
     sources = list(snapshot_paths)
     n_sources = len(sources)
@@ -445,16 +454,24 @@ def run_sharding_pass(
     try:
         # ---- Phase 1 ----
         print(
-            f"\nphase 1: parallel scan + per-(source, worker, bucket) "
-            f"intermediates"
+            f"\nphase 1: parallel scan + per-(source, worker, bucket) " f"intermediates"
         )
         t0 = time.time()
         phase1_args = [
             (
-                src_id, w, n_workers, sources[src_id], tree_name,
-                branches, n_buckets, tmp_dir,
-                flush_threshold_bytes, step_rows, seed,
-                int_columns, int64_columns,
+                src_id,
+                w,
+                n_workers,
+                sources[src_id],
+                tree_name,
+                branches,
+                n_buckets,
+                tmp_dir,
+                flush_threshold_bytes,
+                step_rows,
+                seed,
+                int_columns,
+                int64_columns,
             )
             for src_id in range(n_sources)
             for w in range(n_workers)
@@ -483,9 +500,18 @@ def run_sharding_pass(
         # phase 1 deposited.
         phase2_args = [
             (
-                s, n_shards, n_buckets, n_workers, n_sources,
-                branches, int_columns, int64_columns,
-                tmp_dir, shard_dir, batch_rows, seed,
+                s,
+                n_shards,
+                n_buckets,
+                n_workers,
+                n_sources,
+                branches,
+                int_columns,
+                int64_columns,
+                tmp_dir,
+                shard_dir,
+                batch_rows,
+                seed,
             )
             for s in range(n_shards)
         ]
@@ -524,9 +550,7 @@ def run_sharding_pass(
                 with open(meta_path) as f:
                     meta = json.load(f)
             except (OSError, json.JSONDecodeError) as exc:
-                print(
-                    f"  warning: failed to parse {meta_path}: {exc!r}"
-                )
+                print(f"  warning: failed to parse {meta_path}: {exc!r}")
                 continue
             for entry in meta.get("entries", []):
                 try:
@@ -544,9 +568,7 @@ def run_sharding_pass(
                 f"  source_id labels (from side-cars): "
                 + ", ".join(
                     f"{k}={v!r}"
-                    for k, v in sorted(
-                        source_labels.items(), key=lambda kv: int(kv[0])
-                    )
+                    for k, v in sorted(source_labels.items(), key=lambda kv: int(kv[0]))
                 )
             )
 

--- a/wremnants/production/arrow_shard_export.py
+++ b/wremnants/production/arrow_shard_export.py
@@ -1,0 +1,544 @@
+"""Bucket-shuffle + Arrow-IPC shard export from one or more RNTuple
+per-muon snapshots.
+
+Each input snapshot is an RNTuple where every row is one *event*
+carrying a ``ROOT::RVec<float>`` of length N (number of selected
+muons in that event) per output column. Snapshots produced by
+``flow_training_snapshot.py`` in ``--source jpsi`` mode have N == 2
+per row; ``--source wz`` mode has variable N. All snapshots passed in
+``snapshot_paths`` must share the same per-event column schema (which
+this module then flattens to per-muon rows).
+
+Two-phase parallel pipeline (``multiprocessing.Pool`` of W workers):
+
+  Phase 1 — disjoint-entry-range scan + per-bucket dispatch.
+    For each input snapshot S, each phase-1 task reads a worker-slot
+    slice of S's entry range in ``step_rows``-row windows via
+    ``uproot.arrays()`` (``iterate`` is avoided because uproot 5.7
+    silently ignores ``entry_stop`` for RNTuple). The ragged
+    ``RVec<float>`` columns are flattened to per-muon arrays;
+    ``bucket_id`` is computed *per muon* via a SplitMix64 hash of
+    ``(source_id << 56) | (entry << 8) | muon_idx_in_event``. Per-
+    muon rows are dispatched into per-(source, worker, bucket) raw
+    fp32 binary intermediates under ``tmp_dir``.
+
+  Phase 2 — bucket-aligned merge + shuffle + Arrow IPC write.
+    Each shard worker w is assigned buckets ``range(w, B, W)``
+    (round-robin). For each assigned bucket b, it concatenates every
+    ``s*_w*_b{b}.bin`` produced in phase 1, applies an in-RAM uniform
+    permutation, and writes the rows to its output Arrow IPC stream
+    in fixed-size record batches (``batch_rows``).
+
+After phase 2 the (source × worker × bucket) intermediates are
+deleted; the final shards plus a ``manifest.json`` describing the
+layout remain.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import shutil
+import tempfile
+import time
+from typing import Sequence
+
+import awkward as ak
+import numpy as np
+import pyarrow as pa
+import pyarrow.ipc as ipc
+import uproot
+
+
+_MASK64 = np.uint64(0xFFFFFFFFFFFFFFFF)
+_GOLDEN_GAMMA = np.uint64(0x9E3779B97F4A7C15)
+_MIX1 = np.uint64(0xBF58476D1CE4E5B9)
+_MIX2 = np.uint64(0x94D049BB133111EB)
+
+
+def _splitmix64_bucket(
+    source_id: int,
+    entries: np.ndarray,
+    muon_idxs: np.ndarray,
+    seed: int,
+    n_buckets: int,
+) -> np.ndarray:
+    """SplitMix64 finaliser, vectorised over numpy uint64.
+
+    Mirrors the C++ helper that the previous bucket_id-Define used in
+    RDF, but is now computed at shard time per *muon* — combining
+    source, entry, and muon-index-in-event into a single 64-bit key.
+    Reproducible per (source_id, entry, muon_idx, seed, n_buckets).
+    """
+    src = np.uint64(source_id) << np.uint64(56)
+    x = (
+        src
+        | (entries.astype(np.uint64) << np.uint64(8))
+        | (muon_idxs.astype(np.uint64) & np.uint64(0xFF))
+    )
+    x = (x + np.uint64(seed) + _GOLDEN_GAMMA) & _MASK64
+    x = ((x ^ (x >> np.uint64(30))) * _MIX1) & _MASK64
+    x = ((x ^ (x >> np.uint64(27))) * _MIX2) & _MASK64
+    x = x ^ (x >> np.uint64(31))
+    return (x % np.uint64(n_buckets)).astype(np.int32)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: parallel scan + per-bucket dispatch
+# ---------------------------------------------------------------------------
+
+
+def _phase1_worker(arg_tuple):
+    (
+        source_id,
+        worker_id,
+        n_workers,
+        snapshot_path,
+        tree_name,
+        branches,
+        n_buckets,
+        tmp_dir,
+        flush_threshold_bytes,
+        step_rows,
+        seed,
+    ) = arg_tuple
+    n_cols = len(branches)
+
+    src = uproot.open(snapshot_path)[tree_name]
+    n_entries = int(src.num_entries)
+    start = (n_entries * worker_id) // n_workers
+    stop = (n_entries * (worker_id + 1)) // n_workers
+    if stop <= start:
+        return source_id, worker_id, 0, 0
+
+    bufs: list[list[np.ndarray]] = [[] for _ in range(n_buckets)]
+    bytes_in_bufs = 0
+
+    def flush_all():
+        nonlocal bytes_in_bufs
+        for b in range(n_buckets):
+            if not bufs[b]:
+                continue
+            path = os.path.join(
+                tmp_dir, f"s{source_id:02d}_w{worker_id:04d}_b{b:05d}.bin",
+            )
+            with open(path, "ab") as f:
+                for arr in bufs[b]:
+                    f.write(arr.tobytes())
+            bufs[b].clear()
+        bytes_in_bufs = 0
+
+    cur = start
+    n_events_read = 0
+    n_muons_emitted = 0
+    while cur < stop:
+        chunk_stop = min(cur + step_rows, stop)
+        # awkward returns ListOffsetArray<float32> per RVec column.
+        # arrays() honors both entry_start and entry_stop for RNTuple.
+        chunk = src.arrays(
+            list(branches),
+            entry_start=cur,
+            entry_stop=chunk_stop,
+        )
+        # Counts per event from the first column; all output columns
+        # are aligned per the snapshot contract (same RVec length).
+        counts = ak.num(chunk[branches[0]]).to_numpy().astype(np.int64)
+        n_events = int(counts.shape[0])
+        n_events_read += n_events
+        if n_events == 0:
+            cur = chunk_stop
+            continue
+
+        total = int(counts.sum())
+        if total == 0:
+            cur = chunk_stop
+            continue
+        n_muons_emitted += total
+
+        # Per-muon entry index (global within source) and within-event
+        # muon index.
+        offsets = np.empty(n_events + 1, dtype=np.int64)
+        offsets[0] = 0
+        np.cumsum(counts, out=offsets[1:])
+        event_idx_flat = np.repeat(
+            np.arange(cur, cur + n_events, dtype=np.int64),
+            counts,
+        )
+        muon_idx_flat = (
+            np.arange(total, dtype=np.int64)
+            - np.repeat(offsets[:-1], counts)
+        )
+
+        bids = _splitmix64_bucket(
+            source_id, event_idx_flat, muon_idx_flat, seed, n_buckets,
+        )
+
+        # Flatten each RVec column to a 1D float32 array.
+        flat_cols = [
+            ak.flatten(chunk[c]).to_numpy().astype(np.float32, copy=False)
+            for c in branches
+        ]
+        flat = np.column_stack(flat_cols)
+
+        # Dispatch per bucket appearing in this chunk.
+        for b in np.unique(bids):
+            mask = bids == b
+            rows = flat[mask]
+            bufs[int(b)].append(rows)
+            bytes_in_bufs += rows.nbytes
+        if bytes_in_bufs >= flush_threshold_bytes:
+            flush_all()
+        cur = chunk_stop
+    flush_all()
+    return source_id, worker_id, n_events_read, n_muons_emitted
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: parallel merge + shuffle + Arrow IPC write
+# ---------------------------------------------------------------------------
+
+
+def _phase2_worker(arg_tuple):
+    (
+        worker_id,
+        n_workers_phase2,
+        n_buckets,
+        n_workers_phase1,
+        n_sources,
+        branches,
+        int_columns,
+        tmp_dir,
+        shard_dir,
+        batch_rows,
+        seed,
+    ) = arg_tuple
+    n_cols = len(branches)
+    int_set = set(int_columns)
+
+    my_buckets = list(range(worker_id, n_buckets, n_workers_phase2))
+    # Mixed-type schema: columns listed in ``int_columns`` are written
+    # as int32; everything else as float32. Phase-1 intermediates are
+    # still uniform fp32 (small ints round-trip exactly through fp32),
+    # cast back here at Arrow write time.
+    schema = pa.schema([
+        (c, pa.int32() if c in int_set else pa.float32())
+        for c in branches
+    ])
+    write_opts = ipc.IpcWriteOptions(
+        compression="lz4_frame", use_threads=False,
+    )
+    rng = np.random.default_rng(
+        int(seed) ^ (worker_id * 0x9E3779B97F4A7C15) & 0xFFFFFFFFFFFFFFFF
+    )
+
+    out_path = os.path.join(shard_dir, f"shard_{worker_id:05d}.arrow")
+    tmp_out = out_path + ".tmp"
+
+    n_rows_total = 0
+    n_record_batches = 0
+    bucket_row_counts: list[tuple[int, int]] = []
+
+    # Arrow IPC ``new_file`` (not ``new_stream``) so each shard has a
+    # footer record-batch index — lets downstream readers fetch
+    # individual record batches without walking the whole shard
+    # sequentially, which enables intra-shard parallelism in the
+    # trainer's stats warmup.
+    with pa.OSFile(tmp_out, "wb") as out_f, \
+         ipc.new_file(out_f, schema, options=write_opts) as writer:
+        for b in my_buckets:
+            chunks: list[np.ndarray] = []
+            for s in range(n_sources):
+                for w in range(n_workers_phase1):
+                    p = os.path.join(
+                        tmp_dir,
+                        f"s{s:02d}_w{w:04d}_b{b:05d}.bin",
+                    )
+                    if os.path.exists(p) and os.path.getsize(p) > 0:
+                        arr = np.fromfile(p, dtype=np.float32).reshape(
+                            -1, n_cols,
+                        )
+                        chunks.append(arr)
+            if not chunks:
+                bucket_row_counts.append((b, 0))
+                continue
+
+            rows = np.concatenate(chunks, axis=0)
+            del chunks
+            perm = rng.permutation(len(rows))
+            rows = rows[perm]
+            n_rows_in_bucket = len(rows)
+            bucket_row_counts.append((b, n_rows_in_bucket))
+
+            for off in range(0, n_rows_in_bucket, batch_rows):
+                sub = rows[off : off + batch_rows]
+                arrays = []
+                for i, c in enumerate(branches):
+                    col = np.ascontiguousarray(sub[:, i])
+                    if c in int_set:
+                        arrays.append(pa.array(
+                            col.astype(np.int32, copy=False),
+                            type=pa.int32(),
+                        ))
+                    else:
+                        arrays.append(pa.array(col, type=pa.float32()))
+                batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+                writer.write_batch(batch)
+                n_record_batches += 1
+
+            n_rows_total += n_rows_in_bucket
+
+            # Free the bucket's intermediates as soon as it's
+            # consumed — keeps peak disk usage bounded.
+            for s in range(n_sources):
+                for w in range(n_workers_phase1):
+                    p = os.path.join(
+                        tmp_dir,
+                        f"s{s:02d}_w{w:04d}_b{b:05d}.bin",
+                    )
+                    if os.path.exists(p):
+                        os.remove(p)
+
+    os.replace(tmp_out, out_path)
+    return worker_id, n_rows_total, n_record_batches, bucket_row_counts
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run_sharding_pass(
+    snapshot_paths: Sequence[str],
+    tree_name: str,
+    branches: Sequence[str],
+    n_buckets: int,
+    n_workers: int,
+    shard_dir: str,
+    batch_rows: int = 16384,
+    seed: int = 42,
+    tmp_dir: str | None = None,
+    flush_threshold_bytes: int = 64 * 1024 * 1024,
+    step_rows: int = 2_000_000,
+    int_columns: Sequence[str] = (),
+    n_shards: int | None = None,
+) -> dict:
+    """Run the bucket-shuffle + Arrow IPC sharding pass over one or
+    more RNTuple per-muon snapshots.
+
+    Parallelism is split across two phases:
+
+    * **phase 1** uses ``n_workers`` processes; each reads a disjoint
+      entry slice from every input snapshot and routes rows into
+      per-(source, worker, bucket) intermediate files. This is the
+      I/O-heavy part of the pipeline (xrootd / disk read +
+      decompression), so ``n_workers`` is typically set to the
+      number of CPU cores.
+    * **phase 2** uses ``n_shards`` processes; each handles a
+      round-robin subset of buckets and writes exactly one output
+      Arrow IPC shard file. Arrow IPC files cannot be written
+      concurrently by multiple workers, so phase 2 is capped at
+      one worker per shard. ``n_shards`` defaults to ``n_workers``
+      for back-compat.
+
+    ``int_columns`` lists branch names to write as ``pa.int32()`` in
+    the Arrow IPC output (everything else is ``pa.float32()``). The
+    per-(worker, bucket) phase-1 intermediates are still uniform
+    fp32; small ints round-trip exactly. Use for tag columns like
+    ``source_id`` that you want to keep semantically integer in the
+    final shards.
+
+    Returns a dict matching the on-disk ``manifest.json`` payload.
+    """
+    branches = list(branches)
+    int_columns = list(int_columns)
+    unknown_int = [c for c in int_columns if c not in branches]
+    if unknown_int:
+        raise ValueError(
+            f"int_columns refers to unknown branches: {unknown_int}"
+        )
+    n_cols = len(branches)
+    sources = list(snapshot_paths)
+    n_sources = len(sources)
+    if n_sources == 0:
+        raise ValueError("run_sharding_pass: snapshot_paths is empty")
+    if n_shards is None:
+        n_shards = n_workers
+    n_shards = int(n_shards)
+    if n_shards < 1:
+        raise ValueError(f"n_shards must be >= 1, got {n_shards}")
+
+    os.makedirs(shard_dir, exist_ok=True)
+    cleanup_tmp = tmp_dir is None
+    if tmp_dir is None:
+        parent = os.path.dirname(os.path.abspath(shard_dir)) or "."
+        tmp_dir = tempfile.mkdtemp(prefix="arrow_shard_", dir=parent)
+    else:
+        os.makedirs(tmp_dir, exist_ok=True)
+
+    # Per-source num_entries (one quick uproot.open).
+    source_entries: list[int] = []
+    for sp in sources:
+        with uproot.open(sp) as f:
+            source_entries.append(int(f[tree_name].num_entries))
+
+    print(f"arrow-shard pass")
+    for i, (sp, ne) in enumerate(zip(sources, source_entries)):
+        print(f"  source[{i:02d}]: {sp}  ({ne:,} events)")
+    print(f"  tree (RNTuple) name:     {tree_name!r}")
+    print(f"  shard_dir:               {shard_dir}")
+    print(f"  tmp_dir:                 {tmp_dir}")
+    print(f"  branches:                {n_cols} cols  {branches}")
+    if int_columns:
+        print(f"  int columns:             {int_columns}")
+    print(f"  n_buckets:               {n_buckets}")
+    print(f"  phase-1 workers:         {n_workers}")
+    print(f"  output shards:           {n_shards}")
+    print(f"  shard rows/record batch: {batch_rows:,}")
+    print(f"  shuffle seed:            {seed}")
+
+    try:
+        # ---- Phase 1 ----
+        print(
+            f"\nphase 1: parallel scan + per-(source, worker, bucket) "
+            f"intermediates"
+        )
+        t0 = time.time()
+        phase1_args = [
+            (
+                src_id, w, n_workers, sources[src_id], tree_name,
+                branches, n_buckets, tmp_dir,
+                flush_threshold_bytes, step_rows, seed,
+            )
+            for src_id in range(n_sources)
+            for w in range(n_workers)
+        ]
+        with mp.Pool(n_workers) as pool:
+            p1_results = pool.map(_phase1_worker, phase1_args)
+        t1 = time.time()
+        n_events = sum(r[2] for r in p1_results)
+        n_muons = sum(r[3] for r in p1_results)
+        print(
+            f"  scanned {n_events:,} events -> {n_muons:,} muons "
+            f"across {n_sources} source(s) x {n_workers} workers "
+            f"in {t1 - t0:.1f}s"
+        )
+
+        # ---- Phase 2 ----
+        print(
+            f"\nphase 2: parallel merge + shuffle + Arrow IPC + LZ4 write"
+            f" ({n_shards} shard writer(s))"
+        )
+        t2 = time.time()
+        # Phase 2 fans out by output shard (one writer per Arrow file
+        # — they can't be concurrently appended to). Each shard
+        # worker iterates ``range(s, n_buckets, n_shards)`` and reads
+        # the per-(source, phase1_worker, bucket) intermediates that
+        # phase 1 deposited.
+        phase2_args = [
+            (
+                s, n_shards, n_buckets, n_workers, n_sources,
+                branches, int_columns,
+                tmp_dir, shard_dir, batch_rows, seed,
+            )
+            for s in range(n_shards)
+        ]
+        with mp.Pool(n_shards) as pool:
+            p2_results = pool.map(_phase2_worker, phase2_args)
+        t3 = time.time()
+        total_rows = sum(r[1] for r in p2_results)
+        total_batches = sum(r[2] for r in p2_results)
+        per_shard = [(r[0], r[1], r[2]) for r in p2_results]
+        per_shard.sort(key=lambda x: x[0])
+        for w, rows, batches in per_shard:
+            print(
+                f"  shard_{w:05d}.arrow: {rows:>12,} rows  "
+                f"{batches:>5} record batches"
+            )
+        print(
+            f"  total: {total_rows:,} rows in {total_batches} batches  "
+            f"({t3 - t2:.1f}s)"
+        )
+        print(f"\ntotal sharding wall: {t3 - t0:.1f}s")
+
+        # Collect any per-snapshot side-car label files written by the
+        # snapshot stage (``<basename>.source_meta.json``). Each entry
+        # maps a *data-column* source_id (the integer stamped into the
+        # ``source_id`` branch) to a human-readable sample name. Multiple
+        # snapshots can contribute multiple ids (e.g. the J/psi snapshot
+        # tags Pt0to8 vs Pt8toInf as base+1 / base). Last-write-wins on
+        # collisions; this is just for display.
+        source_labels: dict[str, str] = {}
+        for sp in sources:
+            root_path, _ = os.path.splitext(sp)
+            meta_path = root_path + ".source_meta.json"
+            if not os.path.exists(meta_path):
+                continue
+            try:
+                with open(meta_path) as f:
+                    meta = json.load(f)
+            except (OSError, json.JSONDecodeError) as exc:
+                print(
+                    f"  warning: failed to parse {meta_path}: {exc!r}"
+                )
+                continue
+            for entry in meta.get("entries", []):
+                try:
+                    sid = int(entry["source_id"])
+                    name = str(entry["sample_name"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    print(
+                        f"  warning: skipping malformed entry in "
+                        f"{meta_path}: {entry!r} ({exc!r})"
+                    )
+                    continue
+                source_labels[str(sid)] = name
+        if source_labels:
+            print(
+                f"  source_id labels (from side-cars): "
+                + ", ".join(
+                    f"{k}={v!r}"
+                    for k, v in sorted(
+                        source_labels.items(), key=lambda kv: int(kv[0])
+                    )
+                )
+            )
+
+        manifest = {
+            "n_shards": n_shards,
+            "n_buckets": n_buckets,
+            "total_rows": int(total_rows),
+            "total_events_read": int(n_events),
+            "batch_rows": int(batch_rows),
+            "seed": int(seed),
+            "compression": "lz4_frame",
+            "schema": [
+                {
+                    "name": c,
+                    "type": "int32" if c in set(int_columns) else "float32",
+                }
+                for c in branches
+            ],
+            "shard_files": [f"shard_{s:05d}.arrow" for s in range(n_shards)],
+            "shard_row_counts": [
+                {"shard": w, "n_rows": rows} for w, rows, _ in per_shard
+            ],
+            "sources": [
+                {
+                    "source_id": i,
+                    "snapshot": os.path.abspath(sp),
+                    "n_events": ne,
+                }
+                for i, (sp, ne) in enumerate(zip(sources, source_entries))
+            ],
+            "source_labels": source_labels,
+            "tree_name": tree_name,
+        }
+        manifest_path = os.path.join(shard_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        print(f"manifest: {manifest_path}")
+        return manifest
+    finally:
+        if cleanup_tmp and os.path.isdir(tmp_dir):
+            shutil.rmtree(tmp_dir)

--- a/wremnants/production/datasets/dataset_tools.py
+++ b/wremnants/production/datasets/dataset_tools.py
@@ -176,17 +176,35 @@ def makeFilelist(
 def getDataPath():
     import socket
 
-    hostname = socket.gethostname()
+    # Explicit override wins (containers, custom mounts, CI runners).
+    base_path = os.environ.get("WREMNANTS_DATA_PATH")
+    if base_path:
+        return base_path
 
-    if hostname.endswith(".cern.ch"):
+    # In containers ``gethostname()`` returns just the short container
+    # ID, so also check the FQDN via reverse-DNS — that's usually the
+    # real ``<host>.cern.ch`` even from inside a Singularity image.
+    short = socket.gethostname()
+    fqdn = socket.getfqdn()
+    names = (short, fqdn)
+
+    if any(n.endswith(".cern.ch") for n in names):
         base_path = "/scratch/shared/NanoAOD"
-    elif hostname.endswith(".mit.edu"):
+    elif any(n.endswith(".mit.edu") for n in names):
         base_path = "/scratch/submit/cms/wmass/NanoAOD"
-    elif hostname == "cmsanalysis.pi.infn.it":
+    elif "cmsanalysis.pi.infn.it" in names:
         # NOTE: If anyone wants to run lowpu analysis at Pisa they'd probably want a different path
         base_path = "/scratchnvme/wmass/NANOV9/postVFP"
-    elif hostname == "cmsasymow.pi.infn.it":
+    elif "cmsasymow.pi.infn.it" in names:
         base_path = "/scratch/wmass/y2016"
+    else:
+        raise RuntimeError(
+            f"getDataPath: no default NanoAOD location for host "
+            f"{short!r} (fqdn={fqdn!r}). Set the WREMNANTS_DATA_PATH "
+            f"environment variable, pass base_path= to "
+            f"getDatasets(), or add this host to "
+            f"dataset_tools.getDataPath()."
+        )
     return base_path
 
 

--- a/wremnants/production/include/muon_calibration.hpp
+++ b/wremnants/production/include/muon_calibration.hpp
@@ -1,3 +1,6 @@
+#ifndef WREM_MUON_CALIBRATION_H
+#define WREM_MUON_CALIBRATION_H
+
 #include <Math/GenVector/PtEtaPhiM4D.h>
 #include <ROOT/RVec.hxx>
 #include <TFile.h>
@@ -2103,3 +2106,5 @@ private:
 };
 
 } // namespace wrem
+
+#endif

--- a/wremnants/production/include/muon_calibration.hpp
+++ b/wremnants/production/include/muon_calibration.hpp
@@ -1716,16 +1716,19 @@ public:
 
       const double qop = charge / pt / std::cosh(eta);
 
-      const double dsigma = sigmarel_ * qop;
+      // ``sigmarel_ * qop`` is signed (qop is negative for q<0); std::normal_distribution
+      // requires stddev > 0. Sigmarel == 0 (legitimate "no smearing") collapses
+      // to a δ-function -- pass pt through unchanged in that case.
+      const double dsigma = std::abs(sigmarel_ * qop);
 
-      std::normal_distribution gaus{qop, dsigma};
-
-      const double qopout = gaus(rng_[slot]);
-      const double pout = std::fabs(1. / qopout);
-
-      const double ptout = pout / std::cosh(eta);
-
-      res.emplace_back(ptout);
+      if (dsigma > 0.) {
+        std::normal_distribution gaus{qop, dsigma};
+        const double qopout = gaus(rng_[slot]);
+        const double pout = std::fabs(1. / qopout);
+        res.emplace_back(pout / std::cosh(eta));
+      } else {
+        res.emplace_back(pt);
+      }
     }
 
     return res;
@@ -1761,14 +1764,19 @@ public:
 
       const double qop = charge / pt / std::cosh(eta);
 
+      // std::normal_distribution requires stddev > 0. Sigmarel == 0
+      // collapses to a δ-function -- emit N copies of qop in that case.
       const double dsigma = std::abs(sigmarel_ * qop);
 
-      std::normal_distribution gaus{qop, dsigma};
-
-      for (std::size_t irep = 0; irep < N; ++irep) {
-        const double qopout = gaus(rng);
-
-        res.emplace_back(qopout);
+      if (dsigma > 0.) {
+        std::normal_distribution gaus{qop, dsigma};
+        for (std::size_t irep = 0; irep < N; ++irep) {
+          res.emplace_back(gaus(rng));
+        }
+      } else {
+        for (std::size_t irep = 0; irep < N; ++irep) {
+          res.emplace_back(qop);
+        }
       }
     }
 

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -174,17 +174,23 @@ public:
 
   // Per-muon evaluation. ``muon_source_raw`` is the raw
   // ``Muon_genPartFlav`` value; the ORT graph remaps it internally.
-  // ``delta_r_kappa[k]`` is the signed per-variation shift along
-  // r_kappa, ``sigma_r_kappa[k]`` is the per-variation smear width
-  // along r_kappa (zero is fine for shift-only or smear-only cases).
-  // Both arrays are in raw r_kappa units; the ONNX preproc divides
-  // by target_std internally.
+  // ``delta_u_raw[k]`` is the signed per-variation shift,
+  // ``sigma_raw[k]`` is the per-variation smear width.  Both arrays
+  // are in *raw physical units of the reco-space delta*:
+  //   index 0:  δqop   [GeV⁻¹]
+  //   index 1:  δλ     [radians]
+  //   index 2:  δφ     [radians]
+  // (Despite the trainer's nominal r_κ target, the deployed network's
+  //  effective gradient is calibrated for u in qop space for the 0th
+  //  component; do NOT multiply by p_gen.) The ONNX preproc divides
+  // both u_raw and sigma_raw by ``target_std`` internally before
+  // feeding the network.
   alt_weights_t
   evaluate(float recPt, float recEta, float recPhi, int recCharge,
            float genPt, float genEta, float genPhi, int genCharge,
            int muonSource_raw,
-           const delta_r_t &delta_r_kappa,
-           const delta_r_t &sigma_r_kappa) const {
+           const delta_r_t &delta_u_raw,
+           const delta_r_t &sigma_raw) const {
     const float kappa_reco =
         static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
     const float kappa_gen =
@@ -209,8 +215,8 @@ public:
     u_buf.setZero();
     sigma_buf.setZero();
     for (std::size_t k = 0; k < NVar; ++k) {
-      u_buf(0, k, 0) = delta_r_kappa[k];
-      sigma_buf(0, k, 0) = sigma_r_kappa[k];
+      u_buf(0, k, 0) = delta_u_raw[k];
+      sigma_buf(0, k, 0) = sigma_raw[k];
     }
 
     model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
@@ -222,17 +228,17 @@ public:
     return wrem::clip_tensor(alt_weights, 10.);
   }
 
-  // Shift-only convenience overload: ``sigma_r_kappa`` defaults to
+  // Shift-only convenience overload: ``sigma_raw`` defaults to
   // all-zeros (no smear). Most existing callers want this.
   alt_weights_t
   evaluate(float recPt, float recEta, float recPhi, int recCharge,
            float genPt, float genEta, float genPhi, int genCharge,
            int muonSource_raw,
-           const delta_r_t &delta_r_kappa) const {
+           const delta_r_t &delta_u_raw) const {
     const delta_r_t sigma_zero{};
     return evaluate(recPt, recEta, recPhi, recCharge,
                     genPt, genEta, genPhi, genCharge,
-                    muonSource_raw, delta_r_kappa, sigma_zero);
+                    muonSource_raw, delta_u_raw, sigma_zero);
   }
 
 private:
@@ -309,34 +315,32 @@ public:
       const float genEta = genEtas[i];
       const int genCharge = genCharges[i];
 
-      // δr_kappa per variation (in raw r_κ units; the ONNX preproc
-      // divides by target_std internally):
-      //   δr_kappa = δκ_reco / κ_gen = δqop_reco · sign(q_gen) · p_gen
+      // δu_raw per variation, in raw qop units (GeV⁻¹). The ONNX
+      // preproc divides by target_std internally. NOTE: do NOT
+      // multiply by p_gen / sign(q_gen); the deployed network's
+      // effective gradient was calibrated for u in qop space (see
+      // ReweightEvaluator::evaluate docs).
       // ``calculateQopUnc`` returns the signed δqop_reco using the reco
-      // charge internally (M term, leading sign); no further q_reco·q_gen
-      // factor enters, so charge-flipped muons get the same conversion
-      // as charge-matched ones.
+      // charge internally (M term, leading sign); charge-flipped muons
+      // get the same conversion as charge-matched ones.
       const auto &params = get_tensor(recEta);
-      const double pgen = genPt * std::cosh(genEta);
-      const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
 
-      typename evaluator_t::delta_r_t delta_r_kappa;
+      typename evaluator_t::delta_r_t delta_u_raw;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
         const double AUnc = params(0, ivar);
         const double eUnc = params(1, ivar);
         const double MUnc = params(2, ivar);
         const double recoQopUnc =
             calculateQopUnc(recPt, recEta, recCharge, AUnc, eUnc, MUnc);
-        const float dr =
-            static_cast<float>(recoQopUnc * pgen * sign_qgen);
-        delta_r_kappa[ivar * 2 + 0] = -dr;
-        delta_r_kappa[ivar * 2 + 1] = +dr;
+        const float dr = static_cast<float>(recoQopUnc);
+        delta_u_raw[ivar * 2 + 0] = -dr;
+        delta_u_raw[ivar * 2 + 1] = +dr;
       }
 
       const auto alt_weights_flat = evaluator_.evaluate(
           recPt, recEta, recPhis[i], recCharge,
           genPt, genEta, genPhis[i], genCharge,
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
 
       out_tensor_t alt_weights;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
@@ -424,12 +428,12 @@ public:
       auto const &resolution_parms_var = narf::get_value(*hvar_, recEta).data();
       const double p_reco = recPt * std::cosh(recEta);
       const double qop_reco_sq = 1.0 / (p_reco * p_reco);
-      const double pgen = genPt * std::cosh(genEta);
-      const double pgen_sq = pgen * pgen;
 
-      // var(δr_kappa) per variation from the extra smear above nominal;
-      // raw r_κ units (the ONNX preproc divides by target_std).
-      typename evaluator_t::delta_r_t sigma_r_kappa{};
+      // var(δqop_reco) per variation from the extra smear above
+      // nominal: var(δqop) = (σ²_rel_var - σ²_rel_nom) · qop_reco².
+      // Pass σ in raw qop units (GeV⁻¹) to match the network's
+      // expected input space (see ReweightEvaluator::evaluate docs).
+      typename evaluator_t::delta_r_t sigma_raw{};
       for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
         const double avar = resolution_parms_var(0, ivar);
         const double cvar = resolution_parms_var(1, ivar);
@@ -438,15 +442,15 @@ public:
         const double sigmasqvar_rel =
             avar + cvar * recPt * recPt + bvar / (1. + dvar / recPt / recPt);
         const double dsigmarelsq = sigmasqvar_rel - sigmasqnom_rel;
-        const double var_r_kappa = dsigmarelsq * qop_reco_sq * pgen_sq;
-        sigma_r_kappa[ivar] = static_cast<float>(
-            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0);
+        const double var_qop = dsigmarelsq * qop_reco_sq;
+        sigma_raw[ivar] = static_cast<float>(
+            (var_qop > 0.0) ? std::sqrt(var_qop) : 0.0);
       }
 
       res *= evaluator_.evaluate(
           recPt, recEta, recPhis[i], recCharges[i],
           genPt, genEta, genPhis[i], genCharges[i],
-          muonSources[i], delta_zero, sigma_r_kappa);
+          muonSources[i], delta_zero, sigma_raw);
     }
     return res;
   }
@@ -482,14 +486,14 @@ namespace shift_smear_reweight {
 // three contributes (A=1, e=2, M=4 -- bit flags).
 //
 // Mirrors the body of ``ZNonClosureParametrizedHelperSplines::operator()``
-// up to (and including) the ``recoQopUnc`` calculation; the (down, up)
-// signed shift then converts to raw r_kappa units the same way the
-// J/psi-stats helper does (``δr_kappa = δqop_reco · p_gen · sign_qgen``).
+// up to (and including) the ``recoQopUnc`` calculation. The (down, up)
+// signed shift is returned in raw qop units (GeV⁻¹) -- this is the
+// space the deployed reweight network expects u in (see
+// ReweightEvaluator::evaluate for the convention discussion).
 template <typename ParamsT>
-inline std::array<float, 2> z_non_closure_param_delta_r_kappa(
+inline std::array<float, 2> z_non_closure_param_delta_u_raw(
     const ParamsT &params,
     float recPt, float recEta, int recCharge,
-    float genPt, float genEta, int genCharge,
     int calVarFlags) {
   double recoK = 1.0 / recPt;
   double recoKUnc = 0.0;
@@ -509,23 +513,18 @@ inline std::array<float, 2> z_non_closure_param_delta_r_kappa(
   const double recoQopUnc =
       static_cast<double>(recCharge) *
       std::sin(calculateTheta(recEta)) * recoKUnc;
-  const double pgen = genPt * std::cosh(genEta);
-  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
-  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
+  const float dr = static_cast<float>(recoQopUnc);
   return {-dr, +dr};
 }
 
 // Same for the binned source: ``non_closure`` is the per-(η, pT) bin
 // value of the non-closure factor (1.0 = no shift).
-inline std::array<float, 2> z_non_closure_binned_delta_r_kappa(
+inline std::array<float, 2> z_non_closure_binned_delta_u_raw(
     double non_closure,
-    float recPt, float recEta, int recCharge,
-    float genPt, float genEta, int genCharge) {
+    float recPt, float recEta, int recCharge) {
   const double recoKUnc = (non_closure - 1.0) * (1.0 / recPt);
   const double recoQopUnc = calculateQopUnc(recEta, recCharge, recoKUnc);
-  const double pgen = genPt * std::cosh(genEta);
-  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
-  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
+  const float dr = static_cast<float>(recoQopUnc);
   return {-dr, +dr};
 }
 
@@ -560,14 +559,13 @@ public:
           correctionHist_->template axis<0>().index(recEtas[i]),
           0, int(NEtaBins) - 1);
       const auto &params = correctionHist_->at(iEta).data();
-      const auto delta_r_kappa =
-          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
-              params, recPts[i], recEtas[i], recCharges[i],
-              genPts[i], genEtas[i], genCharges[i], calVarFlags);
+      const auto delta_u_raw =
+          shift_smear_reweight::z_non_closure_param_delta_u_raw(
+              params, recPts[i], recEtas[i], recCharges[i], calVarFlags);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
       res(0) *= alt_weights(0);
       res(1) *= alt_weights(1);
     }
@@ -609,14 +607,13 @@ public:
           correctionHist_->template axis<0>().index(recEtas[i]),
           0, int(NEtaBins) - 1);
       const auto &params = correctionHist_->at(iEta).data();
-      const auto delta_r_kappa =
-          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
-              params, recPts[i], recEtas[i], recCharges[i],
-              genPts[i], genEtas[i], genCharges[i], calVarFlags);
+      const auto delta_u_raw =
+          shift_smear_reweight::z_non_closure_param_delta_u_raw(
+              params, recPts[i], recEtas[i], recCharges[i], calVarFlags);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
       res(iEta, 0) *= alt_weights(0);
       res(iEta, 1) *= alt_weights(1);
     }
@@ -659,14 +656,13 @@ public:
           correctionHist_->template axis<1>().index(recPts[i]),
           0, int(NPtBins) - 1);
       const double non_closure = correctionHist_->at(iEta, iPt).value();
-      const auto delta_r_kappa =
-          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
-              non_closure, recPts[i], recEtas[i], recCharges[i],
-              genPts[i], genEtas[i], genCharges[i]);
+      const auto delta_u_raw =
+          shift_smear_reweight::z_non_closure_binned_delta_u_raw(
+              non_closure, recPts[i], recEtas[i], recCharges[i]);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
       res(0) *= alt_weights(0);
       res(1) *= alt_weights(1);
     }
@@ -710,14 +706,13 @@ public:
           correctionHist_->template axis<1>().index(recPts[i]),
           0, int(NPtBins) - 1);
       const double non_closure = correctionHist_->at(iEta, iPt).value();
-      const auto delta_r_kappa =
-          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
-              non_closure, recPts[i], recEtas[i], recCharges[i],
-              genPts[i], genEtas[i], genCharges[i]);
+      const auto delta_u_raw =
+          shift_smear_reweight::z_non_closure_binned_delta_u_raw(
+              non_closure, recPts[i], recEtas[i], recCharges[i]);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
       res(iEta, iPt, 0) *= alt_weights(0);
       res(iEta, iPt, 1) *= alt_weights(1);
     }
@@ -769,18 +764,18 @@ public:
                     const double nominal_weight = 1.0) const {
     double res = nominal_weight;
     for (std::size_t i = 0; i < recPts.size(); ++i) {
+      // σ_qop = sigmarel · |qop_reco| = sigmarel / p_reco. Pass in
+      // raw qop units (GeV⁻¹) -- the ONNX preproc standardizes.
       const double preco =
           static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
-      const double pgen =
-          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
       const std::array<float, 1> delta_zero{0.f};
-      const std::array<float, 1> sigma_r_kappa{
-          static_cast<float>(std::abs(sigmarel_ * pgen / preco))
+      const std::array<float, 1> sigma_raw{
+          static_cast<float>(std::abs(sigmarel_) / preco)
       };
       const auto alt = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_zero, sigma_r_kappa);
+          muonSources[i], delta_zero, sigma_raw);
       res *= alt(0);
     }
     return res;
@@ -808,20 +803,18 @@ public:
                     const double nominal_weight = 1.0) const {
     double res = nominal_weight;
     for (std::size_t i = 0; i < recPts.size(); ++i) {
+      // δqop = scalerel · qop_reco = scalerel · q_reco / p_reco. Pass
+      // in raw qop units (GeV⁻¹); see ReweightEvaluator::evaluate.
       const double preco =
           static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
-      const double pgen =
-          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
-      const double sign_qgen = (genCharges[i] >= 0) ? 1.0 : -1.0;
-      const std::array<float, 1> delta_r_kappa{
+      const std::array<float, 1> delta_u_raw{
           static_cast<float>(scalerel_ *
-                             static_cast<double>(recCharges[i]) *
-                             sign_qgen * pgen / preco)
+                             static_cast<double>(recCharges[i]) / preco)
       };
       const auto alt = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_r_kappa);
+          muonSources[i], delta_u_raw);
       res *= alt(0);
     }
     return res;

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -440,7 +440,20 @@ public:
 
       // var(δr_kappa) per variation from the extra smear above nominal;
       // raw r_κ units (the ONNX preproc divides by target_std).
+      //
+      // Sign of δσ²: the network parameterises σ as a positive
+      // magnitude and is even in σ, so it can't directly produce a
+      // signed response for variations that *reduce* the resolution
+      // (δσ²<0). The analytic linearisation does (W ∝ 1 + ∂_σ²·δσ²,
+      // signed). To track that here we feed |δσ²| to ONNX and apply
+      // the linear-order odd-symmetry afterwards: log_r(−|δσ²|) ≈
+      // −log_r(+|δσ²|), i.e. ``alt_weight → 1 / alt_weight`` whenever
+      // ``dsigmarelsq < 0``. Exact to first order in δσ²; higher-order
+      // (curvature) terms have the wrong sign in this approximation,
+      // but those are O((δσ²)²) and small for the 1σ eigenvariations
+      // we apply here.
       typename evaluator_t::delta_r_t sigma_r_kappa{};
+      std::array<signed char, NVar> sign_var{};
       for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
         const double avar = resolution_parms_var(0, ivar);
         const double cvar = resolution_parms_var(1, ivar);
@@ -451,13 +464,23 @@ public:
         const double dsigmarelsq = sigmasqvar_rel - sigmasqnom_rel;
         const double var_r_kappa = dsigmarelsq * qop_reco_sq * pgen_sq;
         sigma_r_kappa[ivar] = static_cast<float>(
-            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0);
+            std::sqrt(std::abs(var_r_kappa)));
+        sign_var[ivar] = (var_r_kappa > 0.0) - (var_r_kappa < 0.0);
       }
 
-      res *= evaluator_.evaluate(
+      auto alt = evaluator_.evaluate(
           recPt, recEta, recPhis[i], recCharges[i],
           genPt, genEta, genPhis[i], genCharges[i],
           muonSources[i], delta_zero, sigma_r_kappa);
+      for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
+        if (sign_var[ivar] < 0) {
+          // log_r → −log_r ⇔ alt_weight → 1/alt_weight.
+          alt(ivar) = 1.0 / alt(ivar);
+        } else if (sign_var[ivar] == 0) {
+          alt(ivar) = 1.0;  // exactly zero variance → no shift.
+        }
+      }
+      res *= alt;
     }
     return res;
   }

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -104,58 +104,53 @@ inline void compute_c_raw(float kappa_gen, float eta_gen, float phi_gen,
 
 // Compile-time-sized ONNX runner for the combined
 // (y_raw, c_raw, u_raw, σ_raw) -> log_r call at batch 1.  ``NVar`` is
-// the number of (u, σ) variations baked into the inference at the call
-// site (it's the second dim of the model's dynamic-axis input).
+// the number of (u, σ) variations baked into the inference at this
+// model instance — it's the second dim of the model's dynamic-axis
+// input, pinned at construction.
 //
 // Each ``operator()`` invocation issues one Ort::Session::Run, so an
 // event with two muons triggers two calls; for J/ψ that's the same
 // cardinality as the existing analytic helper's inner per-muon loop.
+template <std::size_t NVar>
 class ReweightModel {
 public:
   ReweightModel(const std::string &onnx_path, unsigned int nslots = 1)
-      : onnx_(std::make_shared<narf::onnx_helper_alloc>(onnx_path, nslots)) {}
+      : onnx_(std::make_shared<narf::onnx_helper>(
+            onnx_path,
+            /*input_shapes=*/std::vector<std::vector<int64_t>>{
+                {1, static_cast<int64_t>(F)},
+                {1, static_cast<int64_t>(NCond)},
+                {1, static_cast<int64_t>(NVar), static_cast<int64_t>(F)},
+                {1, static_cast<int64_t>(NVar), static_cast<int64_t>(F)},
+            },
+            /*output_shapes=*/std::vector<std::vector<int64_t>>{
+                {1, static_cast<int64_t>(NVar)},
+            },
+            nslots)) {}
 
-  // Static-shape entry: y is [1, F], c is [1, NCond], u and σ are
-  // [1, NVar, F], output is [1, NVar].  Buffers are caller-owned so
-  // they can live on the stack across the per-muon loop.
-  //
-  // All tensors are declared ``Eigen::RowMajor`` so the underlying
-  // ``.data()`` byte order matches ONNX Runtime's row-major
-  // expectation. Eigen's default ColMajor layout silently scrambled
-  // the (NVar, F) axes whenever both > 1 — every NVar ≥ 2 caller
-  // (J/ψ-stats, Z-non-closure, closure-A/M) was sending garbage to
-  // the network before this fix; NVar = 1 (the Simple helpers)
-  // happened to be unaffected because a length-1 axis is layout-
-  // invariant.
-  template <std::size_t NVar>
+  // y is [1, F], c is [1, NCond], u and σ are [1, NVar, F], output is
+  // [1, NVar].  ``narf::onnx_helper`` keeps the persistent ORT-owned
+  // buffers and copies in/out via ``Eigen::TensorMap<…, RowMajor>``
+  // assignment, so the caller's RowMajor declaration here is for
+  // shape-matching alone — ColMajor would also produce correct
+  // results, just with strided copies.
   void
-  run(Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>, Eigen::RowMajor> &y,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>, Eigen::RowMajor> &c,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &u_raw,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &sigma_raw,
+  run(const Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>, Eigen::RowMajor> &y,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>, Eigen::RowMajor> &c,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &u_raw,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &sigma_raw,
       Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>, Eigen::RowMajor> &log_r) {
-    // ``narf::onnx_helper_alloc::operator()`` takes input/output tuples of
-    // references-to-tensor (the lambdas inside use ``auto&...``) and
-    // forwards ``.data()`` to ``Ort::Value::CreateTensor<T>(... T* ...)``,
-    // which is non-const even for input tensors. So the input tensors
-    // here are deliberately non-const (the caller's scratch buffers are
-    // freshly allocated per muon and immediately discarded).
-    //
-    // ``std::tie`` makes a tuple of plain references; ``std::cref`` would
-    // wrap in ``reference_wrapper<>``, which has no ``narf::tensor_traits``
-    // specialisation and would break ``::get_sizes()``.
-    auto inputs = std::tie(y, c, u_raw, sigma_raw);
+    auto inputs = std::forward_as_tuple(y, c, u_raw, sigma_raw);
     auto outputs = std::tie(log_r);
     (*onnx_)(inputs, outputs);
   }
 
 private:
-  // onnx_helper_alloc creates Ort::Value views over the caller's tensor
-  // data on every call. Slot selection inside is by TBB thread index
-  // (see onnxutils.hpp), so the same instance is safe under RunGraphs.
-  // Held via shared_ptr so the type is copyable -- RDataFrame Define
-  // needs to copy the helper into its internal storage.
-  std::shared_ptr<narf::onnx_helper_alloc> onnx_;
+  // Slot selection inside ``narf::onnx_helper`` is by TBB thread
+  // index, so the same instance is safe under RunGraphs. Held via
+  // shared_ptr so the type is copyable — RDataFrame Define needs to
+  // copy the helper into its internal storage.
+  std::shared_ptr<narf::onnx_helper> onnx_;
 };
 
 // Per-muon ONNX reweight evaluator: encapsulates the kinematics ->
@@ -179,7 +174,7 @@ public:
 
   ReweightEvaluator(const std::string &onnx_path,
                          unsigned int nslots = 1)
-      : model_(std::make_shared<ReweightModel>(onnx_path, nslots)) {}
+      : model_(std::make_shared<ReweightModel<NVar>>(onnx_path, nslots)) {}
 
   // Per-muon evaluation. ``muon_source_raw`` is the raw
   // ``Muon_genPartFlav`` value; the ORT graph remaps it internally.
@@ -224,7 +219,7 @@ public:
       sigma_buf(0, k, 0) = sigma_r_kappa[k];
     }
 
-    model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+    model_->run(y_t, c_t, u_buf, sigma_buf, log_r);
 
     alt_weights_t alt_weights;
     for (std::size_t k = 0; k < NVar; ++k) {
@@ -247,7 +242,7 @@ public:
   }
 
 private:
-  std::shared_ptr<ReweightModel> model_;
+  std::shared_ptr<ReweightModel<NVar>> model_;
 };
 
 }  // namespace shift_smear_reweight

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -147,6 +147,76 @@ private:
   std::shared_ptr<narf::onnx_helper_alloc> onnx_;
 };
 
+// Per-muon scale-shift evaluator: encapsulates the kinematics ->
+// (y_raw, c_raw) packing, the u_buf fill from a caller-supplied
+// ``delta_r_kappa[NVar]`` array, the ONNX call, and the
+// ``exp(log_r)`` + ``clip_tensor`` step.  All ONNX-backed scale-
+// uncertainty helpers (J/psi-stats, Z non-closure parametrized, Z
+// non-closure binned, including the correlated variants) compose
+// one of these and supply their own per-muon ``delta_r_kappa``;
+// the per-muon kinematics handling is shared in one place.
+//
+// ``NVar`` is the per-muon shift multiplicity (2 for Z-non-closure
+// down/up; 2 * n_unc for J/psi stats; etc.).
+template <std::size_t NVar>
+class ShiftReweightEvaluator {
+public:
+  using delta_r_t = std::array<float, NVar>;
+  using alt_weights_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NVar>>;
+
+  ShiftReweightEvaluator(const std::string &onnx_path,
+                         unsigned int nslots = 1)
+      : model_(std::make_shared<ReweightModel>(onnx_path, nslots)) {}
+
+  // Per-muon evaluation. ``muon_source_raw`` is the raw
+  // ``Muon_genPartFlav`` value; the ORT graph remaps it internally.
+  // ``delta_r_kappa[k]`` is the signed per-variation shift in raw
+  // r_kappa units (caller computes this from its own correction hist).
+  alt_weights_t
+  evaluate(float recPt, float recEta, float recPhi, int recCharge,
+           float genPt, float genEta, float genPhi, int genCharge,
+           int muonSource_raw,
+           const delta_r_t &delta_r_kappa) const {
+    const float kappa_reco =
+        static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
+    const float kappa_gen =
+        static_cast<float>(genCharge) / (genPt * std::cosh(genEta));
+    const int muon_source =
+        muon_source_from_gen_part_flav(muonSource_raw);
+
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> y_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> c_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> u_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> sigma_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
+
+    std::array<float, F> y;
+    std::array<float, NCond> c;
+    compute_y_raw(kappa_reco, recEta, recPhi,
+                  kappa_gen, genEta, genPhi, y);
+    compute_c_raw(kappa_gen, genEta, genPhi, muon_source, c);
+    for (std::size_t k = 0; k < F; ++k) y_t(0, k) = y[k];
+    for (std::size_t k = 0; k < NCond; ++k) c_t(0, k) = c[k];
+
+    u_buf.setZero();
+    for (std::size_t k = 0; k < NVar; ++k) {
+      u_buf(0, k, 0) = delta_r_kappa[k];
+    }
+    sigma_buf.setZero();
+
+    model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+
+    alt_weights_t alt_weights;
+    for (std::size_t k = 0; k < NVar; ++k) {
+      alt_weights(k) = std::exp(static_cast<double>(log_r(0, k)));
+    }
+    return wrem::clip_tensor(alt_weights, 10.);
+  }
+
+private:
+  std::shared_ptr<ReweightModel> model_;
+};
+
 }  // namespace shift_smear_reweight
 
 // ---------------------------------------------------------------------------
@@ -173,13 +243,13 @@ public:
   // (u down, u up) per η × {A, e, M} variation.
   static constexpr std::size_t NVar = 2 * static_cast<std::size_t>(nUnc);
   using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nUnc, 2>>;
+  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<NVar>;
 
   JpsiCorrectionsUncReweightHelper(T &&corrections,
                                    const std::string &onnx_path,
                                    unsigned int nslots = 1)
       : correctionHist_(std::make_shared<const T>(std::move(corrections))),
-        model_(std::make_shared<shift_smear_reweight::ReweightModel>(
-            onnx_path, nslots)) {}
+        evaluator_(onnx_path, nslots) {}
 
   // Variadic templated bin lookup (lifted from JpsiCorrectionsUncHelperSplines
   // so the lookup interface stays identical).
@@ -194,68 +264,28 @@ public:
     return get_tensor_impl(std::index_sequence_for<Xs...>{}, xs...);
   }
 
+  // Note: no ``response_weights`` column -- the trained network supplies
+  // the full multiplicative reweight, so the spline-based dweightdqop
+  // linearisation isn't consulted (and the SplinesDifferentialWeightsHelper
+  // doesn't need to be evaluated at all when this helper is in use).
   out_tensor_t
   operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
              const RVec<float> &recPhis, const RVec<int> &recCharges,
              const RVec<float> &genPts, const RVec<float> &genEtas,
              const RVec<float> &genPhis, const RVec<int> &genCharges,
              const RVec<int> &muonSources,
-             const RVec<std::pair<double, double>> &response_weights,
              double nominal_weight = 1.0) {
-    (void)response_weights;  // legacy linearisation column; not consulted
-                             // -- the network gives the full weight directly.
-
     auto const nmuons = recPts.size();
     out_tensor_t alt_weights_all;
     alt_weights_all.setConstant(nominal_weight);
 
-    // Per-muon scratch tensors (live on the stack).  Sigma stays zero
-    // throughout for the scale-only variation.
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::F>> y_t;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::NCond>>
-        c_t;
-    Eigen::TensorFixedSize<float,
-                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
-        u_buf;
-    Eigen::TensorFixedSize<float,
-                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
-        sigma_buf;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
-    sigma_buf.setZero();
-
     for (std::size_t i = 0; i < nmuons; ++i) {
       const float recPt = recPts[i];
       const float recEta = recEtas[i];
-      const float recPhi = recPhis[i];
       const int recCharge = recCharges[i];
       const float genPt = genPts[i];
       const float genEta = genEtas[i];
-      const float genPhi = genPhis[i];
       const int genCharge = genCharges[i];
-      const int muonSource = shift_smear_reweight::muon_source_from_gen_part_flav(
-          muonSources[i]);
-
-      const float kappa_reco =
-          static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
-      const float kappa_gen =
-          static_cast<float>(genCharge) / (genPt * std::cosh(genEta));
-
-      // Full (κ_reco, η_reco, φ_reco, κ_gen, η_gen, φ_gen) form for y
-      // and (κ_gen, η_gen, φ_gen, muon_source) for c -- no φ ≈ 0 or
-      // charge-match approximation. The κ ratio absorbs charge flips
-      // natively: when sign(q_reco) ≠ sign(q_gen), κ_reco/κ_gen ≈
-      // -p_gen/p_reco and r_kappa ≈ -2, which is exactly the mode the
-      // network was trained on.
-      std::array<float, shift_smear_reweight::F> y;
-      std::array<float, shift_smear_reweight::NCond> c;
-      shift_smear_reweight::compute_y_raw(kappa_reco, recEta, recPhi,
-                                          kappa_gen, genEta, genPhi, y);
-      shift_smear_reweight::compute_c_raw(kappa_gen, genEta, genPhi,
-                                          muonSource, c);
-
-      for (std::size_t k = 0; k < shift_smear_reweight::F; ++k) y_t(0, k) = y[k];
-      for (std::size_t k = 0; k < shift_smear_reweight::NCond; ++k)
-        c_t(0, k) = c[k];
 
       // δr_kappa per variation (in raw r_κ units; the ONNX preproc
       // divides by target_std internally):
@@ -267,44 +297,40 @@ public:
       const auto &params = get_tensor(recEta);
       const double pgen = genPt * std::cosh(genEta);
       const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
-      u_buf.setZero();
 
+      typename evaluator_t::delta_r_t delta_r_kappa;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
         const double AUnc = params(0, ivar);
         const double eUnc = params(1, ivar);
         const double MUnc = params(2, ivar);
         const double recoQopUnc =
             calculateQopUnc(recPt, recEta, recCharge, AUnc, eUnc, MUnc);
-        const float delta_r_kappa =
+        const float dr =
             static_cast<float>(recoQopUnc * pgen * sign_qgen);
-        for (std::ptrdiff_t idownup = 0; idownup < 2; ++idownup) {
-          const float dir = (idownup == 0) ? -1.0f : 1.0f;
-          const std::size_t k =
-              static_cast<std::size_t>(ivar) * 2 + idownup;
-          u_buf(0, k, 0) = dir * delta_r_kappa;
-        }
+        delta_r_kappa[ivar * 2 + 0] = -dr;
+        delta_r_kappa[ivar * 2 + 1] = +dr;
       }
 
-      model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+      const auto alt_weights_flat = evaluator_.evaluate(
+          recPt, recEta, recPhis[i], recCharge,
+          genPt, genEta, genPhis[i], genCharge,
+          muonSources[i], delta_r_kappa);
 
       out_tensor_t alt_weights;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
         for (std::ptrdiff_t idownup = 0; idownup < 2; ++idownup) {
-          const std::size_t k =
-              static_cast<std::size_t>(ivar) * 2 + idownup;
           alt_weights(ivar, idownup) =
-              std::exp(static_cast<double>(log_r(0, k)));
+              alt_weights_flat(ivar * 2 + idownup);
         }
       }
-      const out_tensor_t alt_weights_clamped = wrem::clip_tensor(alt_weights, 10.);
-      alt_weights_all *= alt_weights_clamped;
+      alt_weights_all *= alt_weights;
     }
     return alt_weights_all;
   }
 
 private:
   std::shared_ptr<const T> correctionHist_;
-  std::shared_ptr<shift_smear_reweight::ReweightModel> model_;
+  evaluator_t evaluator_;
 };
 
 // ---------------------------------------------------------------------------
@@ -344,15 +370,13 @@ public:
         model_(std::make_shared<shift_smear_reweight::ReweightModel>(
             onnx_path, nslots)) {}
 
+  // No ``response_weights`` column -- see JpsiCorrectionsUncReweightHelper.
   out_tensor_t operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
                           const RVec<float> &recPhis, const RVec<int> &recCharges,
                           const RVec<float> &genPts, const RVec<float> &genEtas,
                           const RVec<float> &genPhis, const RVec<int> &genCharges,
                           const RVec<int> &muonSources,
-                          const RVec<std::pair<double, double>> &response_weights,
                           const double nominal_weight = 1.0) const {
-    (void)response_weights;  // see Jpsi helper note.
-
     out_tensor_t res;
     res.setConstant(nominal_weight);
 
@@ -447,6 +471,279 @@ public:
 private:
   std::shared_ptr<const HISTVAR> hvar_;
   std::shared_ptr<shift_smear_reweight::ReweightModel> model_;
+};
+
+// ---------------------------------------------------------------------------
+// Z non-closure ONNX drop-ins
+// ---------------------------------------------------------------------------
+//
+// Drop-in replacements for ZNonClosure{Parametrized,Binned}Helper{,Splines}{,Corl}.
+// The non-closure shift source (per-η parameterised A/e/M; per-(η,pT)
+// binned non-closure factor) is unchanged; only the per-muon evaluation
+// is routed through ``shift_smear_reweight::ShiftReweightEvaluator``
+// instead of the analytic splines-linearisation
+// (``alt_weight = dweightdqop · δqop + 1``).  ``NVar = 2`` (down/up).
+//
+// The Splines and analytic variants take different column lists (the
+// Splines ones consume the ``response_weight`` column, the analytic
+// ones take genQops / recoQops / covs); the ONNX variants here align
+// with the J/psi-style ONNX column list (no ``response_weight``;
+// kinematics + ``muon_source``), so the histmaker call sites can share
+// the same column-list builder for every J/psi-style ONNX helper.
+
+namespace shift_smear_reweight {
+
+// Internal helper: compute the per-muon (down, up) δr_kappa array for
+// the Z-non-closure parametrized source.  ``params`` is the per-η
+// tensor row [A, e, M], ``calVarFlags`` selects which subset of the
+// three contributes (A=1, e=2, M=4 -- bit flags).
+//
+// Mirrors the body of ``ZNonClosureParametrizedHelperSplines::operator()``
+// up to (and including) the ``recoQopUnc`` calculation; the (down, up)
+// signed shift then converts to raw r_kappa units the same way the
+// J/psi-stats helper does (``δr_kappa = δqop_reco · p_gen · sign_qgen``).
+template <typename ParamsT>
+inline std::array<float, 2> z_non_closure_param_delta_r_kappa(
+    const ParamsT &params,
+    float recPt, float recEta, int recCharge,
+    float genPt, float genEta, int genCharge,
+    int calVarFlags) {
+  double recoK = 1.0 / recPt;
+  double recoKUnc = 0.0;
+  enum calVarFlagsScheme { AFlag = 1, eFlag = 2, MFlag = 4 };
+  if (calVarFlags & AFlag) {
+    const double AUnc = params(0);
+    recoKUnc += AUnc * recoK;
+  }
+  if (calVarFlags & eFlag) {
+    const double eUnc = params(1);
+    recoKUnc += -1.0 * eUnc * recoK * recoK;
+  }
+  if (calVarFlags & MFlag) {
+    const double MUnc = params(2);
+    recoKUnc += static_cast<double>(recCharge) * MUnc;
+  }
+  const double recoQopUnc =
+      static_cast<double>(recCharge) *
+      std::sin(calculateTheta(recEta)) * recoKUnc;
+  const double pgen = genPt * std::cosh(genEta);
+  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
+  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
+  return {-dr, +dr};
+}
+
+// Same for the binned source: ``non_closure`` is the per-(η, pT) bin
+// value of the non-closure factor (1.0 = no shift).
+inline std::array<float, 2> z_non_closure_binned_delta_r_kappa(
+    double non_closure,
+    float recPt, float recEta, int recCharge,
+    float genPt, float genEta, int genCharge) {
+  const double recoKUnc = (non_closure - 1.0) * (1.0 / recPt);
+  const double recoQopUnc = calculateQopUnc(recEta, recCharge, recoKUnc);
+  const double pgen = genPt * std::cosh(genEta);
+  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
+  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
+  return {-dr, +dr};
+}
+
+}  // namespace shift_smear_reweight
+
+// Parametrized, correlated: one [down, up] tensor for the whole event.
+template <typename T, std::size_t NEtaBins>
+class ZNonClosureParametrizedReweightHelperCorl {
+public:
+  using hist_t = T;
+  using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<2>>;
+  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+
+  ZNonClosureParametrizedReweightHelperCorl(T &&corrections,
+                                            const std::string &onnx_path,
+                                            unsigned int nslots = 1)
+      : correctionHist_(std::make_shared<const T>(std::move(corrections))),
+        evaluator_(onnx_path, nslots) {}
+
+  out_tensor_t
+  operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+             const RVec<float> &recPhis, const RVec<int> &recCharges,
+             const RVec<float> &genPts, const RVec<float> &genEtas,
+             const RVec<float> &genPhis, const RVec<int> &genCharges,
+             const RVec<int> &muonSources,
+             double nominal_weight = 1.0,
+             int calVarFlags = 7) {
+    out_tensor_t res;
+    res.setConstant(nominal_weight);
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const unsigned int iEta = std::clamp(
+          correctionHist_->template axis<0>().index(recEtas[i]),
+          0, int(NEtaBins) - 1);
+      const auto &params = correctionHist_->at(iEta).data();
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
+              params, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i], calVarFlags);
+      const auto alt_weights = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_r_kappa);
+      res(0) *= alt_weights(0);
+      res(1) *= alt_weights(1);
+    }
+    return res;
+  }
+
+private:
+  std::shared_ptr<const T> correctionHist_;
+  evaluator_t evaluator_;
+};
+
+// Parametrized, decorrelated: one [down, up] tensor per η bin.
+template <typename T, std::size_t NEtaBins>
+class ZNonClosureParametrizedReweightHelper {
+public:
+  using hist_t = T;
+  using out_tensor_t =
+      Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, 2>>;
+  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+
+  ZNonClosureParametrizedReweightHelper(T &&corrections,
+                                        const std::string &onnx_path,
+                                        unsigned int nslots = 1)
+      : correctionHist_(std::make_shared<const T>(std::move(corrections))),
+        evaluator_(onnx_path, nslots) {}
+
+  out_tensor_t
+  operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+             const RVec<float> &recPhis, const RVec<int> &recCharges,
+             const RVec<float> &genPts, const RVec<float> &genEtas,
+             const RVec<float> &genPhis, const RVec<int> &genCharges,
+             const RVec<int> &muonSources,
+             double nominal_weight = 1.0,
+             int calVarFlags = 7) {
+    out_tensor_t res;
+    res.setConstant(nominal_weight);
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const unsigned int iEta = std::clamp(
+          correctionHist_->template axis<0>().index(recEtas[i]),
+          0, int(NEtaBins) - 1);
+      const auto &params = correctionHist_->at(iEta).data();
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
+              params, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i], calVarFlags);
+      const auto alt_weights = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_r_kappa);
+      res(iEta, 0) *= alt_weights(0);
+      res(iEta, 1) *= alt_weights(1);
+    }
+    return res;
+  }
+
+private:
+  std::shared_ptr<const T> correctionHist_;
+  evaluator_t evaluator_;
+};
+
+// Binned, correlated.
+template <typename T, std::size_t NEtaBins, std::size_t NPtBins>
+class ZNonClosureBinnedReweightHelperCorl {
+public:
+  using hist_t = T;
+  using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<2>>;
+  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+
+  ZNonClosureBinnedReweightHelperCorl(T &&corrections,
+                                      const std::string &onnx_path,
+                                      unsigned int nslots = 1)
+      : correctionHist_(std::make_shared<const T>(std::move(corrections))),
+        evaluator_(onnx_path, nslots) {}
+
+  out_tensor_t
+  operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+             const RVec<float> &recPhis, const RVec<int> &recCharges,
+             const RVec<float> &genPts, const RVec<float> &genEtas,
+             const RVec<float> &genPhis, const RVec<int> &genCharges,
+             const RVec<int> &muonSources,
+             double nominal_weight = 1.0) {
+    out_tensor_t res;
+    res.setConstant(nominal_weight);
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const unsigned int iEta = std::clamp(
+          correctionHist_->template axis<0>().index(recEtas[i]),
+          0, int(NEtaBins) - 1);
+      const unsigned int iPt = std::clamp(
+          correctionHist_->template axis<1>().index(recPts[i]),
+          0, int(NPtBins) - 1);
+      const double non_closure = correctionHist_->at(iEta, iPt).value();
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
+              non_closure, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i]);
+      const auto alt_weights = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_r_kappa);
+      res(0) *= alt_weights(0);
+      res(1) *= alt_weights(1);
+    }
+    return res;
+  }
+
+private:
+  std::shared_ptr<const T> correctionHist_;
+  evaluator_t evaluator_;
+};
+
+// Binned, decorrelated.
+template <typename T, std::size_t NEtaBins, std::size_t NPtBins>
+class ZNonClosureBinnedReweightHelper {
+public:
+  using hist_t = T;
+  using out_tensor_t =
+      Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtBins, 2>>;
+  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+
+  ZNonClosureBinnedReweightHelper(T &&corrections,
+                                  const std::string &onnx_path,
+                                  unsigned int nslots = 1)
+      : correctionHist_(std::make_shared<const T>(std::move(corrections))),
+        evaluator_(onnx_path, nslots) {}
+
+  out_tensor_t
+  operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+             const RVec<float> &recPhis, const RVec<int> &recCharges,
+             const RVec<float> &genPts, const RVec<float> &genEtas,
+             const RVec<float> &genPhis, const RVec<int> &genCharges,
+             const RVec<int> &muonSources,
+             double nominal_weight = 1.0) {
+    out_tensor_t res;
+    res.setConstant(nominal_weight);
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const unsigned int iEta = std::clamp(
+          correctionHist_->template axis<0>().index(recEtas[i]),
+          0, int(NEtaBins) - 1);
+      const unsigned int iPt = std::clamp(
+          correctionHist_->template axis<1>().index(recPts[i]),
+          0, int(NPtBins) - 1);
+      const double non_closure = correctionHist_->at(iEta, iPt).value();
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
+              non_closure, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i]);
+      const auto alt_weights = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_r_kappa);
+      res(iEta, iPt, 0) *= alt_weights(0);
+      res(iEta, iPt, 1) *= alt_weights(1);
+    }
+    return res;
+  }
+
+private:
+  std::shared_ptr<const T> correctionHist_;
+  evaluator_t evaluator_;
 };
 
 }  // namespace wrem

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -118,13 +118,22 @@ public:
   // Static-shape entry: y is [1, F], c is [1, NCond], u and σ are
   // [1, NVar, F], output is [1, NVar].  Buffers are caller-owned so
   // they can live on the stack across the per-muon loop.
+  //
+  // All tensors are declared ``Eigen::RowMajor`` so the underlying
+  // ``.data()`` byte order matches ONNX Runtime's row-major
+  // expectation. Eigen's default ColMajor layout silently scrambled
+  // the (NVar, F) axes whenever both > 1 — every NVar ≥ 2 caller
+  // (J/ψ-stats, Z-non-closure, closure-A/M) was sending garbage to
+  // the network before this fix; NVar = 1 (the Simple helpers)
+  // happened to be unaffected because a length-1 axis is layout-
+  // invariant.
   template <std::size_t NVar>
   void
-  run(Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> &y,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> &c,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &u_raw,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &sigma_raw,
-      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> &log_r) {
+  run(Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>, Eigen::RowMajor> &y,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>, Eigen::RowMajor> &c,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &u_raw,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> &sigma_raw,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>, Eigen::RowMajor> &log_r) {
     // ``narf::onnx_helper_alloc::operator()`` takes input/output tuples of
     // references-to-tensor (the lambdas inside use ``auto&...``) and
     // forwards ``.data()`` to ``Ort::Value::CreateTensor<T>(... T* ...)``,
@@ -192,11 +201,13 @@ public:
     const int muon_source =
         muon_source_from_gen_part_flav(muonSource_raw);
 
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> y_t;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> c_t;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> u_buf;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> sigma_buf;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
+    // RowMajor so the byte order forwarded to ONNX via ``.data()``
+    // matches ORT's row-major expectation. See ``ReweightModel::run``.
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>, Eigen::RowMajor> y_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>, Eigen::RowMajor> c_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> u_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>, Eigen::RowMajor> sigma_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>, Eigen::RowMajor> log_r;
 
     std::array<float, F> y;
     std::array<float, NCond> c;

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -1,0 +1,443 @@
+#ifndef WREM_SHIFT_SMEAR_REWEIGHT_HELPERS_H
+#define WREM_SHIFT_SMEAR_REWEIGHT_HELPERS_H
+
+// Drop-in replacements for the analytic JpsiCorrectionsUncHelperSplines
+// and SmearingUncertaintyHelperParametrized that feed the per-muon
+// (y, c, u, σ) tuple through the trained shift_smear_reweight model
+// (combined ONNX: y_raw, c_raw, u_raw, σ_raw -> log_r). Both helpers
+// preserve the legacy variation axes (η × {A, e, M} for the J/ψ scale,
+// η × {a, c, b, d} for the resolution) so downstream nuisance
+// bookkeeping is unchanged; what changes is how each variation's
+// per-muon weight is computed -- from the analytic linearisation
+// in (q/p) / σ² to the trained log W from the network. The legacy
+// ``response_weights`` column is no longer consulted; the network
+// already gives the exact reweight factor, so ``alt_weight =
+// exp(log_r)`` is the full multiplicative correction.
+//
+// All preprocessing (target_mean / target_std on y, cond_mean /
+// cond_std on c, target_std on u and σ) is baked into the ONNX graph,
+// so the C++ side never has to read ``preproc.json``. Inputs to
+// ``operator()`` carry physical units throughout:
+//   y_raw  = (r_κ, δλ, δφ)        in raw r_κ / rad / rad
+//   c_raw  = (log p_T, q, λ, sφ, cφ) in raw
+//   u_raw  = (δr_κ, δλ, δφ)        the per-variation physical shift
+//   σ_raw  = (σ_r_κ, σ_δλ, σ_δφ)   the per-variation physical width
+
+#include <eigen3/Eigen/Dense>
+#include <ROOT/RVec.hxx>
+#include <array>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <utility>
+
+// ``muon_calibration.hpp`` (carrying ``calculateQopUnc``,
+// ``SmearingHelperParametrized``, ``wrem::clip_tensor``, ``narf::get_value``)
+// is intentionally not re-#included here -- it lacks a header guard and
+// any re-include in the same cling TU redefines everything. Both
+// headers are loaded side-by-side via ``narf.clingutils.Declare`` in
+// muon_calibration.py (muon_calibration.hpp first, this header second),
+// so the symbols are already in scope by the time we get here.
+#include "onnxutils.hpp"
+
+namespace wrem {
+
+// Front matter:
+//
+//   F = 3 (r_kappa, dλ, dφ)
+//   NCond = 6 (log_pt_gen, charge, λ_gen, sin φ_gen, cos φ_gen,
+//              muon_source)
+//
+// matches scripts/corrections/muon_calibration/train_muon_response_flow.py
+// :compute_targets_and_conditioning. ``muon_source`` is the per-muon
+// integer class tag — 1 for prompt W/Z muons, 15 for τ-decay muons,
+// 443 for J/ψ legs (not used in this helper). The ORT graph itself
+// remaps these integer codes to the compact {-1, 0, +1} the network
+// was trained on, so callers pass the raw integer (one of {1, 15, 443})
+// as a plain float in c_raw[5] and no further conversion is needed.
+namespace shift_smear_reweight {
+
+constexpr std::size_t F = 3;
+constexpr std::size_t NCond = 6;
+
+// Pre-helper map: ``Muon_genPartFlav`` per-row to the integer code
+// the model expects. The training schema uses 1 for prompt W/Z and
+// 15 for τ-decay; any other ``genPartFlav`` value (0, 3, 4, 5...) is
+// mapped to 1 (treated as the prompt class). The 443 sentinel for
+// J/ψ legs is not produced by this helper — the wremnants helpers
+// run on W/Z analysis MC.
+inline int muon_source_from_gen_part_flav(int gen_part_flav) {
+  return (gen_part_flav == 15) ? 15 : 1;
+}
+
+// Build the per-muon (y_raw, c_raw) pair from kinematics. ``q_*`` is
+// the charge as a float (already signed) -- we don't need
+// ``calculateTheta`` because the conditioning's ``λ_gen`` is
+// ``atan(sinh(η_gen))``.
+inline void
+compute_y_raw(float kappa_reco, float eta_reco, float phi_reco, float kappa_gen,
+              float eta_gen, float phi_gen, std::array<float, F> &y_out) {
+  const float lam_r = std::atan(std::sinh(eta_reco));
+  const float lam_g = std::atan(std::sinh(eta_gen));
+  const float dphi_raw = phi_reco - phi_gen;
+  // wrap to (-π, π].
+  const float dphi = std::atan2(std::sin(dphi_raw), std::cos(dphi_raw));
+  y_out[0] = kappa_reco / kappa_gen - 1.0f;
+  y_out[1] = lam_r - lam_g;
+  y_out[2] = dphi;
+}
+
+inline void compute_c_raw(float kappa_gen, float eta_gen, float phi_gen,
+                          int muon_source,
+                          std::array<float, NCond> &c_out) {
+  c_out[0] = -std::log(std::fabs(kappa_gen) * std::cosh(eta_gen));
+  c_out[1] = (kappa_gen >= 0.0f) ? 1.0f : -1.0f;  // sign(kappa) == sign(q)
+  c_out[2] = std::atan(std::sinh(eta_gen));
+  c_out[3] = std::sin(phi_gen);
+  c_out[4] = std::cos(phi_gen);
+  // Raw integer code; ORT does the {1, 15, 443} -> {-1, 0, +1} remap
+  // and the pass-through standardisation inside the graph.
+  c_out[5] = static_cast<float>(muon_source);
+}
+
+// Compile-time-sized ONNX runner for the combined
+// (y_raw, c_raw, u_raw, σ_raw) -> log_r call at batch 1.  ``NVar`` is
+// the number of (u, σ) variations baked into the inference at the call
+// site (it's the second dim of the model's dynamic-axis input).
+//
+// Each ``operator()`` invocation issues one Ort::Session::Run, so an
+// event with two muons triggers two calls; for J/ψ that's the same
+// cardinality as the existing analytic helper's inner per-muon loop.
+class ReweightModel {
+public:
+  ReweightModel(const std::string &onnx_path, unsigned int nslots = 1)
+      : onnx_(onnx_path, nslots) {}
+
+  // Static-shape entry: y is [1, F], c is [1, NCond], u and σ are
+  // [1, NVar, F], output is [1, NVar].  Buffers are caller-owned so
+  // they can live on the stack across the per-muon loop.
+  template <std::size_t NVar>
+  void
+  run(const Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> &y,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> &c,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &u_raw,
+      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &sigma_raw,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> &log_r) {
+    auto inputs = std::make_tuple(std::cref(y), std::cref(c),
+                                  std::cref(u_raw), std::cref(sigma_raw));
+    auto outputs = std::make_tuple(std::ref(log_r));
+    onnx_(inputs, outputs);
+  }
+
+private:
+  // onnx_helper_alloc creates Ort::Value views over the caller's tensor
+  // data on every call, so static-shape Eigen tensors at the run site
+  // are enough.  Slot selection inside onnx_helper_alloc is by TBB
+  // thread index (see onnxutils.hpp), so the same model object is safe
+  // under ``RunGraphs``.
+  narf::onnx_helper_alloc onnx_;
+};
+
+}  // namespace shift_smear_reweight
+
+// ---------------------------------------------------------------------------
+// J/ψ scale-uncertainty drop-in
+// ---------------------------------------------------------------------------
+//
+// Same signature, same tensor_axes, same downstream nuisance bookkeeping as
+// JpsiCorrectionsUncHelperSplines.  Internally the analytic
+// ``alt_weight = 1 + dwdqop · δqop`` is replaced by ``exp(log_r)`` from the
+// trained network, with ``u_std = (δr_kappa) / target_std[0]`` and
+// σ_std = 0 (scale variations don't smear).
+//
+// ``δr_kappa = q_gen · δκ_reco / κ_gen``.  With ``κ = q / (p_T · cosh η)``
+// and assuming a charge match between reco and gen (the ~0.1% mismeasured
+// tail is absorbed by the network's r_kappa ~ -2 mode), the conversion
+// simplifies to ``δr_kappa = δqop_reco · p_gen``.
+
+template <typename T> class JpsiCorrectionsUncReweightHelper {
+public:
+  using hist_t = T;
+  using tensor_t = typename T::storage_type::value_type::tensor_t;
+  static constexpr auto sizes = narf::tensor_traits<tensor_t>::sizes;
+  static constexpr auto nUnc = sizes[sizes.size() - 1];
+  // (u down, u up) per η × {A, e, M} variation.
+  static constexpr std::size_t NVar = 2 * static_cast<std::size_t>(nUnc);
+  using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nUnc, 2>>;
+
+  JpsiCorrectionsUncReweightHelper(T &&corrections,
+                                   const std::string &onnx_path,
+                                   unsigned int nslots = 1)
+      : correctionHist_(std::make_shared<const T>(std::move(corrections))),
+        model_(onnx_path, nslots) {}
+
+  // Variadic templated bin lookup (lifted from JpsiCorrectionsUncHelperSplines
+  // so the lookup interface stays identical).
+  template <typename... Xs, std::size_t... Idxs>
+  const tensor_t &get_tensor_impl(std::index_sequence<Idxs...>,
+                                  const Xs &...xs) {
+    return correctionHist_
+        ->at(correctionHist_->template axis<Idxs>().index(xs)...)
+        .data();
+  }
+  template <typename... Xs> const tensor_t &get_tensor(const Xs &...xs) {
+    return get_tensor_impl(std::index_sequence_for<Xs...>{}, xs...);
+  }
+
+  out_tensor_t
+  operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+             const RVec<float> &recPhis, const RVec<int> &recCharges,
+             const RVec<float> &genPts, const RVec<float> &genEtas,
+             const RVec<float> &genPhis, const RVec<int> &genCharges,
+             const RVec<int> &muonSources,
+             const RVec<std::pair<double, double>> &response_weights,
+             double nominal_weight = 1.0) {
+    (void)response_weights;  // legacy linearisation column; not consulted
+                             // -- the network gives the full weight directly.
+
+    auto const nmuons = recPts.size();
+    out_tensor_t alt_weights_all;
+    alt_weights_all.setConstant(nominal_weight);
+
+    // Per-muon scratch tensors (live on the stack).  Sigma stays zero
+    // throughout for the scale-only variation.
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::F>> y_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::NCond>>
+        c_t;
+    Eigen::TensorFixedSize<float,
+                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
+        u_buf;
+    Eigen::TensorFixedSize<float,
+                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
+        sigma_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
+    sigma_buf.setZero();
+
+    for (std::size_t i = 0; i < nmuons; ++i) {
+      const float recPt = recPts[i];
+      const float recEta = recEtas[i];
+      const float recPhi = recPhis[i];
+      const int recCharge = recCharges[i];
+      const float genPt = genPts[i];
+      const float genEta = genEtas[i];
+      const float genPhi = genPhis[i];
+      const int genCharge = genCharges[i];
+      const int muonSource = shift_smear_reweight::muon_source_from_gen_part_flav(
+          muonSources[i]);
+
+      const float kappa_reco =
+          static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
+      const float kappa_gen =
+          static_cast<float>(genCharge) / (genPt * std::cosh(genEta));
+
+      // Full (κ_reco, η_reco, φ_reco, κ_gen, η_gen, φ_gen) form for y
+      // and (κ_gen, η_gen, φ_gen, muon_source) for c -- no φ ≈ 0 or
+      // charge-match approximation. The κ ratio absorbs charge flips
+      // natively: when sign(q_reco) ≠ sign(q_gen), κ_reco/κ_gen ≈
+      // -p_gen/p_reco and r_kappa ≈ -2, which is exactly the mode the
+      // network was trained on.
+      std::array<float, shift_smear_reweight::F> y;
+      std::array<float, shift_smear_reweight::NCond> c;
+      shift_smear_reweight::compute_y_raw(kappa_reco, recEta, recPhi,
+                                          kappa_gen, genEta, genPhi, y);
+      shift_smear_reweight::compute_c_raw(kappa_gen, genEta, genPhi,
+                                          muonSource, c);
+
+      for (std::size_t k = 0; k < shift_smear_reweight::F; ++k) y_t(0, k) = y[k];
+      for (std::size_t k = 0; k < shift_smear_reweight::NCond; ++k)
+        c_t(0, k) = c[k];
+
+      // δr_kappa per variation (in raw r_κ units; the ONNX preproc
+      // divides by target_std internally):
+      //   δr_kappa = δκ_reco / κ_gen = δqop_reco · sign(q_gen) · p_gen
+      // ``calculateQopUnc`` returns the signed δqop_reco using the reco
+      // charge internally (M term, leading sign); no further q_reco·q_gen
+      // factor enters, so charge-flipped muons get the same conversion
+      // as charge-matched ones.
+      const auto &params = get_tensor(recEta);
+      const double pgen = genPt * std::cosh(genEta);
+      const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
+      u_buf.setZero();
+
+      for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
+        const double AUnc = params(0, ivar);
+        const double eUnc = params(1, ivar);
+        const double MUnc = params(2, ivar);
+        const double recoQopUnc =
+            calculateQopUnc(recPt, recEta, recCharge, AUnc, eUnc, MUnc);
+        const float delta_r_kappa =
+            static_cast<float>(recoQopUnc * pgen * sign_qgen);
+        for (std::ptrdiff_t idownup = 0; idownup < 2; ++idownup) {
+          const float dir = (idownup == 0) ? -1.0f : 1.0f;
+          const std::size_t k =
+              static_cast<std::size_t>(ivar) * 2 + idownup;
+          u_buf(0, k, 0) = dir * delta_r_kappa;
+        }
+      }
+
+      model_.template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+
+      out_tensor_t alt_weights;
+      for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
+        for (std::ptrdiff_t idownup = 0; idownup < 2; ++idownup) {
+          const std::size_t k =
+              static_cast<std::size_t>(ivar) * 2 + idownup;
+          alt_weights(ivar, idownup) =
+              std::exp(static_cast<double>(log_r(0, k)));
+        }
+      }
+      const out_tensor_t alt_weights_clamped = wrem::clip_tensor(alt_weights, 10.);
+      alt_weights_all *= alt_weights_clamped;
+    }
+    return alt_weights_all;
+  }
+
+private:
+  std::shared_ptr<const T> correctionHist_;
+  shift_smear_reweight::ReweightModel model_;
+};
+
+// ---------------------------------------------------------------------------
+// Resolution-uncertainty drop-in (signature extended with gen kinematics)
+// ---------------------------------------------------------------------------
+//
+// Unlike the analytic SmearingUncertaintyHelperParametrized, which only
+// needs (pt_reco, η_reco) plus a precomputed ``dweightdsigmasq``, the
+// network-based reweight needs the full (κ_reco, κ_gen, η_reco, η_gen,
+// φ_reco, φ_gen) tuple so we can form the model's y and c.  The signature
+// is therefore extended with the gen columns; the one call site in
+// ``wremnants.production.muon_calibration.add_resolution_uncertainty`` is
+// updated accordingly.
+//
+// Per variation v we convert the analytic δσ²_rel(p, η) to an axis-aligned
+// σ_std along r_kappa:
+//   σ²_r = δσ²_rel · qop_reco² · p_gen²     (variance of δr_kappa from the
+//                                            extra smear)
+//   σ_std[0] = √max(0, σ²_r) / target_std[0]
+// Variations with σ²_var < σ²_nom (rare; "negative smear") collapse to
+// σ_std = 0 -- the model is even in σ so a small negative δσ² maps to no
+// change in log W to lowest order, matching the analytic linearisation
+// at leading order.
+
+template <typename HISTNOM, typename HISTVAR, std::size_t NVar>
+class SmearingUncertaintyReweightHelper
+    : public SmearingHelperParametrized<HISTNOM> {
+public:
+  using base_t = SmearingHelperParametrized<HISTNOM>;
+  using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NVar>>;
+
+  SmearingUncertaintyReweightHelper(const base_t &helper, HISTVAR &&hvar,
+                                    const std::string &onnx_path,
+                                    unsigned int nslots = 1)
+      : base_t(helper),
+        hvar_(std::make_shared<const HISTVAR>(std::move(hvar))),
+        model_(onnx_path, nslots) {}
+
+  out_tensor_t operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+                          const RVec<float> &recPhis, const RVec<int> &recCharges,
+                          const RVec<float> &genPts, const RVec<float> &genEtas,
+                          const RVec<float> &genPhis, const RVec<int> &genCharges,
+                          const RVec<int> &muonSources,
+                          const RVec<std::pair<double, double>> &response_weights,
+                          const double nominal_weight = 1.0) const {
+    (void)response_weights;  // see Jpsi helper note.
+
+    out_tensor_t res;
+    res.setConstant(nominal_weight);
+
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::F>> y_t;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::NCond>>
+        c_t;
+    Eigen::TensorFixedSize<float,
+                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
+        u_buf;
+    Eigen::TensorFixedSize<float,
+                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
+        sigma_buf;
+    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
+    u_buf.setZero();  // resolution variations don't shift.
+
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const float recPt = recPts[i];
+      const float recEta = recEtas[i];
+      const float recPhi = recPhis[i];
+      const int recCharge = recCharges[i];
+      const float genPt = genPts[i];
+      const float genEta = genEtas[i];
+      const float genPhi = genPhis[i];
+      const int genCharge = genCharges[i];
+      const int muonSource = shift_smear_reweight::muon_source_from_gen_part_flav(
+          muonSources[i]);
+
+      const float kappa_reco =
+          static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
+      const float kappa_gen =
+          static_cast<float>(genCharge) / (genPt * std::cosh(genEta));
+      // Full y / c with the real (φ_reco, φ_gen); no charge-match
+      // assumption -- κ_reco/κ_gen folds the reco-charge sign in
+      // natively. ``muonSource`` is the post-mapping integer code (1
+      // or 15) the ORT graph will remap to {-1, 0} internally.
+      std::array<float, shift_smear_reweight::F> y;
+      std::array<float, shift_smear_reweight::NCond> c;
+      shift_smear_reweight::compute_y_raw(kappa_reco, recEta, recPhi,
+                                          kappa_gen, genEta, genPhi, y);
+      shift_smear_reweight::compute_c_raw(kappa_gen, genEta, genPhi,
+                                          muonSource, c);
+      for (std::size_t k = 0; k < shift_smear_reweight::F; ++k) y_t(0, k) = y[k];
+      for (std::size_t k = 0; k < shift_smear_reweight::NCond; ++k)
+        c_t(0, k) = c[k];
+
+      // Nominal σ²_rel(pt, η) from the base helper's histogram.
+      auto const &resolution_parms = narf::get_value(base_t::hist(), recEta).data();
+      const std::size_t idatamc = 0;
+      const double anom = resolution_parms(0, idatamc);
+      const double cnom = resolution_parms(1, idatamc);
+      const double bnom = resolution_parms(2, idatamc);
+      const double dnom = resolution_parms(3, idatamc);
+      const double sigmasqnom_rel =
+          anom + cnom * recPt * recPt + bnom / (1. + dnom / recPt / recPt);
+
+      auto const &resolution_parms_var = narf::get_value(*hvar_, recEta).data();
+      const double p_reco = recPt * std::cosh(recEta);
+      const double qop_reco_sq = 1.0 / (p_reco * p_reco);
+      const double pgen = genPt * std::cosh(genEta);
+      const double pgen_sq = pgen * pgen;
+
+      sigma_buf.setZero();
+      for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
+        const double avar = resolution_parms_var(0, ivar);
+        const double cvar = resolution_parms_var(1, ivar);
+        const double bvar = resolution_parms_var(2, ivar);
+        const double dvar = resolution_parms_var(3, ivar);
+        const double sigmasqvar_rel =
+            avar + cvar * recPt * recPt + bvar / (1. + dvar / recPt / recPt);
+        // var(δr_kappa) from the extra smear above nominal.  Raw r_κ
+        // units; the ONNX preproc divides by target_std internally.
+        const double dsigmarelsq = sigmasqvar_rel - sigmasqnom_rel;
+        const double var_r_kappa = dsigmarelsq * qop_reco_sq * pgen_sq;
+        const double sigma_r_kappa =
+            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0;
+        sigma_buf(0, ivar, 0) = static_cast<float>(sigma_r_kappa);
+      }
+
+      model_.template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+
+      out_tensor_t alt_weights;
+      for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
+        alt_weights(ivar) = std::exp(static_cast<double>(log_r(0, ivar)));
+      }
+      const out_tensor_t alt_weights_clamped =
+          wrem::clip_tensor(alt_weights, 10.);
+      res *= alt_weights_clamped;
+    }
+    return res;
+  }
+
+private:
+  std::shared_ptr<const HISTVAR> hvar_;
+  mutable shift_smear_reweight::ReweightModel model_;
+};
+
+}  // namespace wrem
+
+#endif

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -111,31 +111,40 @@ inline void compute_c_raw(float kappa_gen, float eta_gen, float phi_gen,
 class ReweightModel {
 public:
   ReweightModel(const std::string &onnx_path, unsigned int nslots = 1)
-      : onnx_(onnx_path, nslots) {}
+      : onnx_(std::make_shared<narf::onnx_helper_alloc>(onnx_path, nslots)) {}
 
   // Static-shape entry: y is [1, F], c is [1, NCond], u and σ are
   // [1, NVar, F], output is [1, NVar].  Buffers are caller-owned so
   // they can live on the stack across the per-muon loop.
   template <std::size_t NVar>
   void
-  run(const Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> &y,
-      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> &c,
-      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &u_raw,
-      const Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &sigma_raw,
+  run(Eigen::TensorFixedSize<float, Eigen::Sizes<1, F>> &y,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NCond>> &c,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &u_raw,
+      Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar, F>> &sigma_raw,
       Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> &log_r) {
-    auto inputs = std::make_tuple(std::cref(y), std::cref(c),
-                                  std::cref(u_raw), std::cref(sigma_raw));
-    auto outputs = std::make_tuple(std::ref(log_r));
-    onnx_(inputs, outputs);
+    // ``narf::onnx_helper_alloc::operator()`` takes input/output tuples of
+    // references-to-tensor (the lambdas inside use ``auto&...``) and
+    // forwards ``.data()`` to ``Ort::Value::CreateTensor<T>(... T* ...)``,
+    // which is non-const even for input tensors. So the input tensors
+    // here are deliberately non-const (the caller's scratch buffers are
+    // freshly allocated per muon and immediately discarded).
+    //
+    // ``std::tie`` makes a tuple of plain references; ``std::cref`` would
+    // wrap in ``reference_wrapper<>``, which has no ``narf::tensor_traits``
+    // specialisation and would break ``::get_sizes()``.
+    auto inputs = std::tie(y, c, u_raw, sigma_raw);
+    auto outputs = std::tie(log_r);
+    (*onnx_)(inputs, outputs);
   }
 
 private:
   // onnx_helper_alloc creates Ort::Value views over the caller's tensor
-  // data on every call, so static-shape Eigen tensors at the run site
-  // are enough.  Slot selection inside onnx_helper_alloc is by TBB
-  // thread index (see onnxutils.hpp), so the same model object is safe
-  // under ``RunGraphs``.
-  narf::onnx_helper_alloc onnx_;
+  // data on every call. Slot selection inside is by TBB thread index
+  // (see onnxutils.hpp), so the same instance is safe under RunGraphs.
+  // Held via shared_ptr so the type is copyable -- RDataFrame Define
+  // needs to copy the helper into its internal storage.
+  std::shared_ptr<narf::onnx_helper_alloc> onnx_;
 };
 
 }  // namespace shift_smear_reweight
@@ -169,7 +178,8 @@ public:
                                    const std::string &onnx_path,
                                    unsigned int nslots = 1)
       : correctionHist_(std::make_shared<const T>(std::move(corrections))),
-        model_(onnx_path, nslots) {}
+        model_(std::make_shared<shift_smear_reweight::ReweightModel>(
+            onnx_path, nslots)) {}
 
   // Variadic templated bin lookup (lifted from JpsiCorrectionsUncHelperSplines
   // so the lookup interface stays identical).
@@ -275,7 +285,7 @@ public:
         }
       }
 
-      model_.template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+      model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
 
       out_tensor_t alt_weights;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
@@ -294,7 +304,7 @@ public:
 
 private:
   std::shared_ptr<const T> correctionHist_;
-  shift_smear_reweight::ReweightModel model_;
+  std::shared_ptr<shift_smear_reweight::ReweightModel> model_;
 };
 
 // ---------------------------------------------------------------------------
@@ -331,7 +341,8 @@ public:
                                     unsigned int nslots = 1)
       : base_t(helper),
         hvar_(std::make_shared<const HISTVAR>(std::move(hvar))),
-        model_(onnx_path, nslots) {}
+        model_(std::make_shared<shift_smear_reweight::ReweightModel>(
+            onnx_path, nslots)) {}
 
   out_tensor_t operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
                           const RVec<float> &recPhis, const RVec<int> &recCharges,
@@ -420,7 +431,7 @@ public:
         sigma_buf(0, ivar, 0) = static_cast<float>(sigma_r_kappa);
       }
 
-      model_.template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
+      model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
 
       out_tensor_t alt_weights;
       for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
@@ -435,7 +446,7 @@ public:
 
 private:
   std::shared_ptr<const HISTVAR> hvar_;
-  mutable shift_smear_reweight::ReweightModel model_;
+  std::shared_ptr<shift_smear_reweight::ReweightModel> model_;
 };
 
 }  // namespace wrem

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -147,36 +147,42 @@ private:
   std::shared_ptr<narf::onnx_helper_alloc> onnx_;
 };
 
-// Per-muon scale-shift evaluator: encapsulates the kinematics ->
-// (y_raw, c_raw) packing, the u_buf fill from a caller-supplied
-// ``delta_r_kappa[NVar]`` array, the ONNX call, and the
-// ``exp(log_r)`` + ``clip_tensor`` step.  All ONNX-backed scale-
-// uncertainty helpers (J/psi-stats, Z non-closure parametrized, Z
-// non-closure binned, including the correlated variants) compose
-// one of these and supply their own per-muon ``delta_r_kappa``;
-// the per-muon kinematics handling is shared in one place.
+// Per-muon ONNX reweight evaluator: encapsulates the kinematics ->
+// (y_raw, c_raw) packing, the u_buf / sigma_buf fill from caller-
+// supplied ``delta_r_kappa[NVar]`` and ``sigma_r_kappa[NVar]``
+// arrays, the ONNX call, and the ``exp(log_r)`` + ``clip_tensor``
+// step.  All ONNX-backed scale / resolution / closure helpers
+// (J/psi-stats, smearing-uncertainty, Z non-closure parametrized /
+// binned including correlated variants, plus the SimpleReweight
+// helpers used by the muon-response test) compose one of these and
+// supply their own per-muon shift and/or smear magnitudes; the
+// per-muon kinematics handling is shared in one place.
 //
-// ``NVar`` is the per-muon shift multiplicity (2 for Z-non-closure
-// down/up; 2 * n_unc for J/psi stats; etc.).
+// ``NVar`` is the per-muon variation multiplicity (2 for
+// Z-non-closure down/up; 2 * n_unc for J/psi stats; etc.).
 template <std::size_t NVar>
-class ShiftReweightEvaluator {
+class ReweightEvaluator {
 public:
   using delta_r_t = std::array<float, NVar>;
   using alt_weights_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NVar>>;
 
-  ShiftReweightEvaluator(const std::string &onnx_path,
+  ReweightEvaluator(const std::string &onnx_path,
                          unsigned int nslots = 1)
       : model_(std::make_shared<ReweightModel>(onnx_path, nslots)) {}
 
   // Per-muon evaluation. ``muon_source_raw`` is the raw
   // ``Muon_genPartFlav`` value; the ORT graph remaps it internally.
-  // ``delta_r_kappa[k]`` is the signed per-variation shift in raw
-  // r_kappa units (caller computes this from its own correction hist).
+  // ``delta_r_kappa[k]`` is the signed per-variation shift along
+  // r_kappa, ``sigma_r_kappa[k]`` is the per-variation smear width
+  // along r_kappa (zero is fine for shift-only or smear-only cases).
+  // Both arrays are in raw r_kappa units; the ONNX preproc divides
+  // by target_std internally.
   alt_weights_t
   evaluate(float recPt, float recEta, float recPhi, int recCharge,
            float genPt, float genEta, float genPhi, int genCharge,
            int muonSource_raw,
-           const delta_r_t &delta_r_kappa) const {
+           const delta_r_t &delta_r_kappa,
+           const delta_r_t &sigma_r_kappa) const {
     const float kappa_reco =
         static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
     const float kappa_gen =
@@ -199,10 +205,11 @@ public:
     for (std::size_t k = 0; k < NCond; ++k) c_t(0, k) = c[k];
 
     u_buf.setZero();
+    sigma_buf.setZero();
     for (std::size_t k = 0; k < NVar; ++k) {
       u_buf(0, k, 0) = delta_r_kappa[k];
+      sigma_buf(0, k, 0) = sigma_r_kappa[k];
     }
-    sigma_buf.setZero();
 
     model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
 
@@ -211,6 +218,19 @@ public:
       alt_weights(k) = std::exp(static_cast<double>(log_r(0, k)));
     }
     return wrem::clip_tensor(alt_weights, 10.);
+  }
+
+  // Shift-only convenience overload: ``sigma_r_kappa`` defaults to
+  // all-zeros (no smear). Most existing callers want this.
+  alt_weights_t
+  evaluate(float recPt, float recEta, float recPhi, int recCharge,
+           float genPt, float genEta, float genPhi, int genCharge,
+           int muonSource_raw,
+           const delta_r_t &delta_r_kappa) const {
+    const delta_r_t sigma_zero{};
+    return evaluate(recPt, recEta, recPhi, recCharge,
+                    genPt, genEta, genPhi, genCharge,
+                    muonSource_raw, delta_r_kappa, sigma_zero);
   }
 
 private:
@@ -243,7 +263,7 @@ public:
   // (u down, u up) per η × {A, e, M} variation.
   static constexpr std::size_t NVar = 2 * static_cast<std::size_t>(nUnc);
   using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<nUnc, 2>>;
-  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<NVar>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<NVar>;
 
   JpsiCorrectionsUncReweightHelper(T &&corrections,
                                    const std::string &onnx_path,
@@ -361,14 +381,14 @@ class SmearingUncertaintyReweightHelper
 public:
   using base_t = SmearingHelperParametrized<HISTNOM>;
   using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<NVar>>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<NVar>;
 
   SmearingUncertaintyReweightHelper(const base_t &helper, HISTVAR &&hvar,
                                     const std::string &onnx_path,
                                     unsigned int nslots = 1)
       : base_t(helper),
         hvar_(std::make_shared<const HISTVAR>(std::move(hvar))),
-        model_(std::make_shared<shift_smear_reweight::ReweightModel>(
-            onnx_path, nslots)) {}
+        evaluator_(onnx_path, nslots) {}
 
   // No ``response_weights`` column -- see JpsiCorrectionsUncReweightHelper.
   out_tensor_t operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
@@ -380,49 +400,16 @@ public:
     out_tensor_t res;
     res.setConstant(nominal_weight);
 
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::F>> y_t;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, shift_smear_reweight::NCond>>
-        c_t;
-    Eigen::TensorFixedSize<float,
-                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
-        u_buf;
-    Eigen::TensorFixedSize<float,
-                           Eigen::Sizes<1, NVar, shift_smear_reweight::F>>
-        sigma_buf;
-    Eigen::TensorFixedSize<float, Eigen::Sizes<1, NVar>> log_r;
-    u_buf.setZero();  // resolution variations don't shift.
+    const typename evaluator_t::delta_r_t delta_zero{};
 
     for (std::size_t i = 0; i < recPts.size(); ++i) {
       const float recPt = recPts[i];
       const float recEta = recEtas[i];
-      const float recPhi = recPhis[i];
-      const int recCharge = recCharges[i];
       const float genPt = genPts[i];
       const float genEta = genEtas[i];
-      const float genPhi = genPhis[i];
-      const int genCharge = genCharges[i];
-      const int muonSource = shift_smear_reweight::muon_source_from_gen_part_flav(
-          muonSources[i]);
 
-      const float kappa_reco =
-          static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
-      const float kappa_gen =
-          static_cast<float>(genCharge) / (genPt * std::cosh(genEta));
-      // Full y / c with the real (φ_reco, φ_gen); no charge-match
-      // assumption -- κ_reco/κ_gen folds the reco-charge sign in
-      // natively. ``muonSource`` is the post-mapping integer code (1
-      // or 15) the ORT graph will remap to {-1, 0} internally.
-      std::array<float, shift_smear_reweight::F> y;
-      std::array<float, shift_smear_reweight::NCond> c;
-      shift_smear_reweight::compute_y_raw(kappa_reco, recEta, recPhi,
-                                          kappa_gen, genEta, genPhi, y);
-      shift_smear_reweight::compute_c_raw(kappa_gen, genEta, genPhi,
-                                          muonSource, c);
-      for (std::size_t k = 0; k < shift_smear_reweight::F; ++k) y_t(0, k) = y[k];
-      for (std::size_t k = 0; k < shift_smear_reweight::NCond; ++k)
-        c_t(0, k) = c[k];
-
-      // Nominal σ²_rel(pt, η) from the base helper's histogram.
+      // Nominal and varied σ²_rel(pt, η) from the base helper's
+      // histogram and the per-eigenvariation companion histogram.
       auto const &resolution_parms = narf::get_value(base_t::hist(), recEta).data();
       const std::size_t idatamc = 0;
       const double anom = resolution_parms(0, idatamc);
@@ -438,7 +425,9 @@ public:
       const double pgen = genPt * std::cosh(genEta);
       const double pgen_sq = pgen * pgen;
 
-      sigma_buf.setZero();
+      // var(δr_kappa) per variation from the extra smear above nominal;
+      // raw r_κ units (the ONNX preproc divides by target_std).
+      typename evaluator_t::delta_r_t sigma_r_kappa{};
       for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
         const double avar = resolution_parms_var(0, ivar);
         const double cvar = resolution_parms_var(1, ivar);
@@ -446,31 +435,23 @@ public:
         const double dvar = resolution_parms_var(3, ivar);
         const double sigmasqvar_rel =
             avar + cvar * recPt * recPt + bvar / (1. + dvar / recPt / recPt);
-        // var(δr_kappa) from the extra smear above nominal.  Raw r_κ
-        // units; the ONNX preproc divides by target_std internally.
         const double dsigmarelsq = sigmasqvar_rel - sigmasqnom_rel;
         const double var_r_kappa = dsigmarelsq * qop_reco_sq * pgen_sq;
-        const double sigma_r_kappa =
-            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0;
-        sigma_buf(0, ivar, 0) = static_cast<float>(sigma_r_kappa);
+        sigma_r_kappa[ivar] = static_cast<float>(
+            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0);
       }
 
-      model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
-
-      out_tensor_t alt_weights;
-      for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
-        alt_weights(ivar) = std::exp(static_cast<double>(log_r(0, ivar)));
-      }
-      const out_tensor_t alt_weights_clamped =
-          wrem::clip_tensor(alt_weights, 10.);
-      res *= alt_weights_clamped;
+      res *= evaluator_.evaluate(
+          recPt, recEta, recPhis[i], recCharges[i],
+          genPt, genEta, genPhis[i], genCharges[i],
+          muonSources[i], delta_zero, sigma_r_kappa);
     }
     return res;
   }
 
 private:
   std::shared_ptr<const HISTVAR> hvar_;
-  std::shared_ptr<shift_smear_reweight::ReweightModel> model_;
+  evaluator_t evaluator_;
 };
 
 // ---------------------------------------------------------------------------
@@ -480,7 +461,7 @@ private:
 // Drop-in replacements for ZNonClosure{Parametrized,Binned}Helper{,Splines}{,Corl}.
 // The non-closure shift source (per-η parameterised A/e/M; per-(η,pT)
 // binned non-closure factor) is unchanged; only the per-muon evaluation
-// is routed through ``shift_smear_reweight::ShiftReweightEvaluator``
+// is routed through ``shift_smear_reweight::ReweightEvaluator``
 // instead of the analytic splines-linearisation
 // (``alt_weight = dweightdqop · δqop + 1``).  ``NVar = 2`` (down/up).
 //
@@ -554,7 +535,7 @@ class ZNonClosureParametrizedReweightHelperCorl {
 public:
   using hist_t = T;
   using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<2>>;
-  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<2>;
 
   ZNonClosureParametrizedReweightHelperCorl(T &&corrections,
                                             const std::string &onnx_path,
@@ -603,7 +584,7 @@ public:
   using hist_t = T;
   using out_tensor_t =
       Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, 2>>;
-  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<2>;
 
   ZNonClosureParametrizedReweightHelper(T &&corrections,
                                         const std::string &onnx_path,
@@ -651,7 +632,7 @@ class ZNonClosureBinnedReweightHelperCorl {
 public:
   using hist_t = T;
   using out_tensor_t = Eigen::TensorFixedSize<double, Eigen::Sizes<2>>;
-  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<2>;
 
   ZNonClosureBinnedReweightHelperCorl(T &&corrections,
                                       const std::string &onnx_path,
@@ -702,7 +683,7 @@ public:
   using hist_t = T;
   using out_tensor_t =
       Eigen::TensorFixedSize<double, Eigen::Sizes<NEtaBins, NPtBins, 2>>;
-  using evaluator_t = shift_smear_reweight::ShiftReweightEvaluator<2>;
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<2>;
 
   ZNonClosureBinnedReweightHelper(T &&corrections,
                                   const std::string &onnx_path,
@@ -743,6 +724,109 @@ public:
 
 private:
   std::shared_ptr<const T> correctionHist_;
+  evaluator_t evaluator_;
+};
+
+// ---------------------------------------------------------------------------
+// "Simple" uniform-sigmarel / scalerel ONNX reweight helpers
+// ---------------------------------------------------------------------------
+//
+// Drop-in ONNX equivalents of wrem::SmearingHelperSimpleWeight and
+// wrem::ScaleHelperSimpleWeight (declared in muon_calibration.hpp).  Same
+// scalar output shape (per-event ``double`` reweight = nominal_weight
+// times Π_muons clamp(alt_weight, 10)).  Used by the
+// scripts/histmakers/w_z_muonresponse.py --testHelpers path to compare
+// the trained network's reweight against the analytic splines /
+// MC-smear reference.
+//
+// For sigmarel:
+//   σ(δr_kappa) = sigmarel · |qop_reco| · p_gen
+//                = sigmarel · p_gen / p_reco
+//
+// For scalerel (relative scale shift): δqop_reco = scalerel · qop_reco
+//   δr_kappa  = δqop_reco · p_gen · sign(q_gen)
+//              = scalerel · q_reco / p_reco · p_gen · sign(q_gen)
+//
+// Both conversions follow ``JpsiCorrectionsUncReweightHelper``'s
+// δqop -> δr_kappa formula (``δr_kappa = δqop · p_gen · sign(q_gen)``).
+
+class SmearingHelperSimpleReweight {
+public:
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<1>;
+
+  SmearingHelperSimpleReweight(const double sigmarel,
+                               const std::string &onnx_path,
+                               unsigned int nslots = 1)
+      : sigmarel_(sigmarel), evaluator_(onnx_path, nslots) {}
+
+  double operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+                    const RVec<float> &recPhis, const RVec<int> &recCharges,
+                    const RVec<float> &genPts, const RVec<float> &genEtas,
+                    const RVec<float> &genPhis, const RVec<int> &genCharges,
+                    const RVec<int> &muonSources,
+                    const double nominal_weight = 1.0) const {
+    double res = nominal_weight;
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const double preco =
+          static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
+      const double pgen =
+          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
+      const std::array<float, 1> delta_zero{0.f};
+      const std::array<float, 1> sigma_r_kappa{
+          static_cast<float>(std::abs(sigmarel_ * pgen / preco))
+      };
+      const auto alt = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_zero, sigma_r_kappa);
+      res *= alt(0);
+    }
+    return res;
+  }
+
+private:
+  double sigmarel_;
+  evaluator_t evaluator_;
+};
+
+class ScaleHelperSimpleReweight {
+public:
+  using evaluator_t = shift_smear_reweight::ReweightEvaluator<1>;
+
+  ScaleHelperSimpleReweight(const double scalerel,
+                            const std::string &onnx_path,
+                            unsigned int nslots = 1)
+      : scalerel_(scalerel), evaluator_(onnx_path, nslots) {}
+
+  double operator()(const RVec<float> &recPts, const RVec<float> &recEtas,
+                    const RVec<float> &recPhis, const RVec<int> &recCharges,
+                    const RVec<float> &genPts, const RVec<float> &genEtas,
+                    const RVec<float> &genPhis, const RVec<int> &genCharges,
+                    const RVec<int> &muonSources,
+                    const double nominal_weight = 1.0) const {
+    double res = nominal_weight;
+    for (std::size_t i = 0; i < recPts.size(); ++i) {
+      const double preco =
+          static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
+      const double pgen =
+          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
+      const double sign_qgen = (genCharges[i] >= 0) ? 1.0 : -1.0;
+      const std::array<float, 1> delta_r_kappa{
+          static_cast<float>(scalerel_ *
+                             static_cast<double>(recCharges[i]) *
+                             sign_qgen * pgen / preco)
+      };
+      const auto alt = evaluator_.evaluate(
+          recPts[i], recEtas[i], recPhis[i], recCharges[i],
+          genPts[i], genEtas[i], genPhis[i], genCharges[i],
+          muonSources[i], delta_r_kappa);
+      res *= alt(0);
+    }
+    return res;
+  }
+
+private:
+  double scalerel_;
   evaluator_t evaluator_;
 };
 

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -31,13 +31,15 @@
 #include <string>
 #include <utility>
 
-// ``muon_calibration.hpp`` (carrying ``calculateQopUnc``,
-// ``SmearingHelperParametrized``, ``wrem::clip_tensor``, ``narf::get_value``)
-// is intentionally not re-#included here -- it lacks a header guard and
-// any re-include in the same cling TU redefines everything. Both
-// headers are loaded side-by-side via ``narf.clingutils.Declare`` in
-// muon_calibration.py (muon_calibration.hpp first, this header second),
-// so the symbols are already in scope by the time we get here.
+// ``muon_calibration.hpp`` carries the dependencies this header relies
+// on (``wrem::clip_tensor``, ``wrem::calculateQopUnc``,
+// ``wrem::SmearingHelperParametrized``, the ``using ROOT::VecOps::RVec``
+// pulled into namespace wrem, and ``narf::get_value``).  It has an
+// include guard so this re-include is a no-op when both headers are
+// loaded together via ``narf.clingutils.Declare`` (muon_calibration.py)
+// while still letting CI's standalone ``clang -fsyntax-only`` pass on
+// this header alone.
+#include "muon_calibration.hpp"
 #include "onnxutils.hpp"
 
 namespace wrem {

--- a/wremnants/production/include/shift_smear_reweight_helpers.hpp
+++ b/wremnants/production/include/shift_smear_reweight_helpers.hpp
@@ -174,23 +174,17 @@ public:
 
   // Per-muon evaluation. ``muon_source_raw`` is the raw
   // ``Muon_genPartFlav`` value; the ORT graph remaps it internally.
-  // ``delta_u_raw[k]`` is the signed per-variation shift,
-  // ``sigma_raw[k]`` is the per-variation smear width.  Both arrays
-  // are in *raw physical units of the reco-space delta*:
-  //   index 0:  δqop   [GeV⁻¹]
-  //   index 1:  δλ     [radians]
-  //   index 2:  δφ     [radians]
-  // (Despite the trainer's nominal r_κ target, the deployed network's
-  //  effective gradient is calibrated for u in qop space for the 0th
-  //  component; do NOT multiply by p_gen.) The ONNX preproc divides
-  // both u_raw and sigma_raw by ``target_std`` internally before
-  // feeding the network.
+  // ``delta_r_kappa[k]`` is the signed per-variation shift along
+  // r_kappa, ``sigma_r_kappa[k]`` is the per-variation smear width
+  // along r_kappa (zero is fine for shift-only or smear-only cases).
+  // Both arrays are in raw r_kappa units; the ONNX preproc divides
+  // by target_std internally.
   alt_weights_t
   evaluate(float recPt, float recEta, float recPhi, int recCharge,
            float genPt, float genEta, float genPhi, int genCharge,
            int muonSource_raw,
-           const delta_r_t &delta_u_raw,
-           const delta_r_t &sigma_raw) const {
+           const delta_r_t &delta_r_kappa,
+           const delta_r_t &sigma_r_kappa) const {
     const float kappa_reco =
         static_cast<float>(recCharge) / (recPt * std::cosh(recEta));
     const float kappa_gen =
@@ -215,8 +209,8 @@ public:
     u_buf.setZero();
     sigma_buf.setZero();
     for (std::size_t k = 0; k < NVar; ++k) {
-      u_buf(0, k, 0) = delta_u_raw[k];
-      sigma_buf(0, k, 0) = sigma_raw[k];
+      u_buf(0, k, 0) = delta_r_kappa[k];
+      sigma_buf(0, k, 0) = sigma_r_kappa[k];
     }
 
     model_->template run<NVar>(y_t, c_t, u_buf, sigma_buf, log_r);
@@ -228,17 +222,17 @@ public:
     return wrem::clip_tensor(alt_weights, 10.);
   }
 
-  // Shift-only convenience overload: ``sigma_raw`` defaults to
+  // Shift-only convenience overload: ``sigma_r_kappa`` defaults to
   // all-zeros (no smear). Most existing callers want this.
   alt_weights_t
   evaluate(float recPt, float recEta, float recPhi, int recCharge,
            float genPt, float genEta, float genPhi, int genCharge,
            int muonSource_raw,
-           const delta_r_t &delta_u_raw) const {
+           const delta_r_t &delta_r_kappa) const {
     const delta_r_t sigma_zero{};
     return evaluate(recPt, recEta, recPhi, recCharge,
                     genPt, genEta, genPhi, genCharge,
-                    muonSource_raw, delta_u_raw, sigma_zero);
+                    muonSource_raw, delta_r_kappa, sigma_zero);
   }
 
 private:
@@ -315,32 +309,34 @@ public:
       const float genEta = genEtas[i];
       const int genCharge = genCharges[i];
 
-      // δu_raw per variation, in raw qop units (GeV⁻¹). The ONNX
-      // preproc divides by target_std internally. NOTE: do NOT
-      // multiply by p_gen / sign(q_gen); the deployed network's
-      // effective gradient was calibrated for u in qop space (see
-      // ReweightEvaluator::evaluate docs).
+      // δr_kappa per variation (in raw r_κ units; the ONNX preproc
+      // divides by target_std internally):
+      //   δr_kappa = δκ_reco / κ_gen = δqop_reco · sign(q_gen) · p_gen
       // ``calculateQopUnc`` returns the signed δqop_reco using the reco
-      // charge internally (M term, leading sign); charge-flipped muons
-      // get the same conversion as charge-matched ones.
+      // charge internally (M term, leading sign); no further q_reco·q_gen
+      // factor enters, so charge-flipped muons get the same conversion
+      // as charge-matched ones.
       const auto &params = get_tensor(recEta);
+      const double pgen = genPt * std::cosh(genEta);
+      const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
 
-      typename evaluator_t::delta_r_t delta_u_raw;
+      typename evaluator_t::delta_r_t delta_r_kappa;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
         const double AUnc = params(0, ivar);
         const double eUnc = params(1, ivar);
         const double MUnc = params(2, ivar);
         const double recoQopUnc =
             calculateQopUnc(recPt, recEta, recCharge, AUnc, eUnc, MUnc);
-        const float dr = static_cast<float>(recoQopUnc);
-        delta_u_raw[ivar * 2 + 0] = -dr;
-        delta_u_raw[ivar * 2 + 1] = +dr;
+        const float dr =
+            static_cast<float>(recoQopUnc * pgen * sign_qgen);
+        delta_r_kappa[ivar * 2 + 0] = -dr;
+        delta_r_kappa[ivar * 2 + 1] = +dr;
       }
 
       const auto alt_weights_flat = evaluator_.evaluate(
           recPt, recEta, recPhis[i], recCharge,
           genPt, genEta, genPhis[i], genCharge,
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
 
       out_tensor_t alt_weights;
       for (std::ptrdiff_t ivar = 0; ivar < nUnc; ++ivar) {
@@ -428,12 +424,12 @@ public:
       auto const &resolution_parms_var = narf::get_value(*hvar_, recEta).data();
       const double p_reco = recPt * std::cosh(recEta);
       const double qop_reco_sq = 1.0 / (p_reco * p_reco);
+      const double pgen = genPt * std::cosh(genEta);
+      const double pgen_sq = pgen * pgen;
 
-      // var(δqop_reco) per variation from the extra smear above
-      // nominal: var(δqop) = (σ²_rel_var - σ²_rel_nom) · qop_reco².
-      // Pass σ in raw qop units (GeV⁻¹) to match the network's
-      // expected input space (see ReweightEvaluator::evaluate docs).
-      typename evaluator_t::delta_r_t sigma_raw{};
+      // var(δr_kappa) per variation from the extra smear above nominal;
+      // raw r_κ units (the ONNX preproc divides by target_std).
+      typename evaluator_t::delta_r_t sigma_r_kappa{};
       for (std::size_t ivar = 0; ivar < NVar; ++ivar) {
         const double avar = resolution_parms_var(0, ivar);
         const double cvar = resolution_parms_var(1, ivar);
@@ -442,15 +438,15 @@ public:
         const double sigmasqvar_rel =
             avar + cvar * recPt * recPt + bvar / (1. + dvar / recPt / recPt);
         const double dsigmarelsq = sigmasqvar_rel - sigmasqnom_rel;
-        const double var_qop = dsigmarelsq * qop_reco_sq;
-        sigma_raw[ivar] = static_cast<float>(
-            (var_qop > 0.0) ? std::sqrt(var_qop) : 0.0);
+        const double var_r_kappa = dsigmarelsq * qop_reco_sq * pgen_sq;
+        sigma_r_kappa[ivar] = static_cast<float>(
+            (var_r_kappa > 0.0) ? std::sqrt(var_r_kappa) : 0.0);
       }
 
       res *= evaluator_.evaluate(
           recPt, recEta, recPhis[i], recCharges[i],
           genPt, genEta, genPhis[i], genCharges[i],
-          muonSources[i], delta_zero, sigma_raw);
+          muonSources[i], delta_zero, sigma_r_kappa);
     }
     return res;
   }
@@ -486,14 +482,14 @@ namespace shift_smear_reweight {
 // three contributes (A=1, e=2, M=4 -- bit flags).
 //
 // Mirrors the body of ``ZNonClosureParametrizedHelperSplines::operator()``
-// up to (and including) the ``recoQopUnc`` calculation. The (down, up)
-// signed shift is returned in raw qop units (GeV⁻¹) -- this is the
-// space the deployed reweight network expects u in (see
-// ReweightEvaluator::evaluate for the convention discussion).
+// up to (and including) the ``recoQopUnc`` calculation; the (down, up)
+// signed shift then converts to raw r_kappa units the same way the
+// J/psi-stats helper does (``δr_kappa = δqop_reco · p_gen · sign_qgen``).
 template <typename ParamsT>
-inline std::array<float, 2> z_non_closure_param_delta_u_raw(
+inline std::array<float, 2> z_non_closure_param_delta_r_kappa(
     const ParamsT &params,
     float recPt, float recEta, int recCharge,
+    float genPt, float genEta, int genCharge,
     int calVarFlags) {
   double recoK = 1.0 / recPt;
   double recoKUnc = 0.0;
@@ -513,18 +509,23 @@ inline std::array<float, 2> z_non_closure_param_delta_u_raw(
   const double recoQopUnc =
       static_cast<double>(recCharge) *
       std::sin(calculateTheta(recEta)) * recoKUnc;
-  const float dr = static_cast<float>(recoQopUnc);
+  const double pgen = genPt * std::cosh(genEta);
+  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
+  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
   return {-dr, +dr};
 }
 
 // Same for the binned source: ``non_closure`` is the per-(η, pT) bin
 // value of the non-closure factor (1.0 = no shift).
-inline std::array<float, 2> z_non_closure_binned_delta_u_raw(
+inline std::array<float, 2> z_non_closure_binned_delta_r_kappa(
     double non_closure,
-    float recPt, float recEta, int recCharge) {
+    float recPt, float recEta, int recCharge,
+    float genPt, float genEta, int genCharge) {
   const double recoKUnc = (non_closure - 1.0) * (1.0 / recPt);
   const double recoQopUnc = calculateQopUnc(recEta, recCharge, recoKUnc);
-  const float dr = static_cast<float>(recoQopUnc);
+  const double pgen = genPt * std::cosh(genEta);
+  const double sign_qgen = (genCharge >= 0) ? 1.0 : -1.0;
+  const float dr = static_cast<float>(recoQopUnc * pgen * sign_qgen);
   return {-dr, +dr};
 }
 
@@ -559,13 +560,14 @@ public:
           correctionHist_->template axis<0>().index(recEtas[i]),
           0, int(NEtaBins) - 1);
       const auto &params = correctionHist_->at(iEta).data();
-      const auto delta_u_raw =
-          shift_smear_reweight::z_non_closure_param_delta_u_raw(
-              params, recPts[i], recEtas[i], recCharges[i], calVarFlags);
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
+              params, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i], calVarFlags);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
       res(0) *= alt_weights(0);
       res(1) *= alt_weights(1);
     }
@@ -607,13 +609,14 @@ public:
           correctionHist_->template axis<0>().index(recEtas[i]),
           0, int(NEtaBins) - 1);
       const auto &params = correctionHist_->at(iEta).data();
-      const auto delta_u_raw =
-          shift_smear_reweight::z_non_closure_param_delta_u_raw(
-              params, recPts[i], recEtas[i], recCharges[i], calVarFlags);
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_param_delta_r_kappa(
+              params, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i], calVarFlags);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
       res(iEta, 0) *= alt_weights(0);
       res(iEta, 1) *= alt_weights(1);
     }
@@ -656,13 +659,14 @@ public:
           correctionHist_->template axis<1>().index(recPts[i]),
           0, int(NPtBins) - 1);
       const double non_closure = correctionHist_->at(iEta, iPt).value();
-      const auto delta_u_raw =
-          shift_smear_reweight::z_non_closure_binned_delta_u_raw(
-              non_closure, recPts[i], recEtas[i], recCharges[i]);
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
+              non_closure, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i]);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
       res(0) *= alt_weights(0);
       res(1) *= alt_weights(1);
     }
@@ -706,13 +710,14 @@ public:
           correctionHist_->template axis<1>().index(recPts[i]),
           0, int(NPtBins) - 1);
       const double non_closure = correctionHist_->at(iEta, iPt).value();
-      const auto delta_u_raw =
-          shift_smear_reweight::z_non_closure_binned_delta_u_raw(
-              non_closure, recPts[i], recEtas[i], recCharges[i]);
+      const auto delta_r_kappa =
+          shift_smear_reweight::z_non_closure_binned_delta_r_kappa(
+              non_closure, recPts[i], recEtas[i], recCharges[i],
+              genPts[i], genEtas[i], genCharges[i]);
       const auto alt_weights = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
       res(iEta, iPt, 0) *= alt_weights(0);
       res(iEta, iPt, 1) *= alt_weights(1);
     }
@@ -764,18 +769,18 @@ public:
                     const double nominal_weight = 1.0) const {
     double res = nominal_weight;
     for (std::size_t i = 0; i < recPts.size(); ++i) {
-      // σ_qop = sigmarel · |qop_reco| = sigmarel / p_reco. Pass in
-      // raw qop units (GeV⁻¹) -- the ONNX preproc standardizes.
       const double preco =
           static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
+      const double pgen =
+          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
       const std::array<float, 1> delta_zero{0.f};
-      const std::array<float, 1> sigma_raw{
-          static_cast<float>(std::abs(sigmarel_) / preco)
+      const std::array<float, 1> sigma_r_kappa{
+          static_cast<float>(std::abs(sigmarel_ * pgen / preco))
       };
       const auto alt = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_zero, sigma_raw);
+          muonSources[i], delta_zero, sigma_r_kappa);
       res *= alt(0);
     }
     return res;
@@ -803,18 +808,20 @@ public:
                     const double nominal_weight = 1.0) const {
     double res = nominal_weight;
     for (std::size_t i = 0; i < recPts.size(); ++i) {
-      // δqop = scalerel · qop_reco = scalerel · q_reco / p_reco. Pass
-      // in raw qop units (GeV⁻¹); see ReweightEvaluator::evaluate.
       const double preco =
           static_cast<double>(recPts[i]) * std::cosh(recEtas[i]);
-      const std::array<float, 1> delta_u_raw{
+      const double pgen =
+          static_cast<double>(genPts[i]) * std::cosh(genEtas[i]);
+      const double sign_qgen = (genCharges[i] >= 0) ? 1.0 : -1.0;
+      const std::array<float, 1> delta_r_kappa{
           static_cast<float>(scalerel_ *
-                             static_cast<double>(recCharges[i]) / preco)
+                             static_cast<double>(recCharges[i]) *
+                             sign_qgen * pgen / preco)
       };
       const auto alt = evaluator_.evaluate(
           recPts[i], recEtas[i], recPhis[i], recCharges[i],
           genPts[i], genEtas[i], genPhis[i], genCharges[i],
-          muonSources[i], delta_u_raw);
+          muonSources[i], delta_r_kappa);
       res *= alt(0);
     }
     return res;

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -330,10 +330,12 @@ def make_muon_smearing_helpers(
     override_d=None,
     dummy_vars=False,
     smearing=True,
+    scale_var_method="onnxReweight",
     onnx_path=None,
     onnx_nslots=None,
 ):
-    if onnx_path is None:
+    is_onnx = scale_var_method == "onnxReweight"
+    if is_onnx and onnx_path is None:
         onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
     # this helper smears muon pT to match the resolution in data
 
@@ -451,7 +453,7 @@ def make_muon_smearing_helpers(
     hvar = narf.hist_to_pyroot_boost(hvar, tensor_rank=2)
 
     helper = ROOT.wrem.SmearingHelperParametrized[type(hnom)](ROOT.std.move(hnom))
-    if onnx_path is not None:
+    if is_onnx:
         # ONNX-backed drop-in: same nominal smearer + ONNX-backed
         # uncertainty helper.  The new uncertainty helper consumes gen
         # kinematics in addition to reco -- see add_resolution_uncertainty

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -1573,10 +1573,7 @@ def add_jpsi_crctn_stats_unc_hists(
         else:
             jpsi_unc_helper = make_jpsi_crctn_unc_helper(
                 calib_filepaths["data_corrfile"][args.muonCorrData],
-                calib_filepaths["tflite_file"],
                 scale_var_method="smearingWeightsGaus",
-                dummy_mu_scale_var=args.dummyMuScaleVar,
-                dummy_var_mag=args.muonCorrMag,
             )
         df = df.Define(
             "muonScaleSyst_responseWeights_tensor_gaus",
@@ -1614,10 +1611,7 @@ def add_jpsi_crctn_stats_unc_hists(
         else:
             jpsi_unc_helper = make_jpsi_crctn_unc_helper(
                 calib_filepaths["data_corrfile"][args.muonCorrData],
-                calib_filepaths["tflite_file"],
                 scale_var_method="smearingWeightsSplines",
-                dummy_mu_scale_var=args.dummyMuScaleVar,
-                dummy_var_mag=args.muonCorrMag,
             )
         df, splines_cols = jpsi_style_cols(
             df,
@@ -1676,11 +1670,8 @@ def add_jpsi_crctn_stats_unc_hists(
         else:
             jpsi_unc_helper = make_jpsi_crctn_unc_helper(
                 calib_filepaths["data_corrfile"][args.muonCorrData],
-                calib_filepaths["tflite_file"],
                 isW=isW,
                 scale_var_method="massWeights",
-                dummy_mu_scale_var=args.dummyMuScaleVar,
-                dummy_var_mag=args.muonCorrMag,
             )  # need to make a new massweights helper due to different nweights for Z and W
         df = df.Define(
             "muonScaleSyst_responseWeights_tensor_massWeights",

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -27,9 +27,24 @@ data_dir = common.data_dir
 # (mlp-factored architecture, muon_source-conditioned, single-file
 # inline-weights export). Produced by
 # scripts/corrections/muon_calibration/shift_smear_reweight_export.py.
-default_shift_smear_reweight_onnx = (
-    f"{data_dir}/calibration/shift_smear_reweight_mlp_factored_combined.onnx"
-)
+#
+# Two variants are bundled in wremnants-data: one trained on snapshots
+# built with the data/MC resolution-matching smearing helper applied to
+# the reco muon pt (the histmaker default), and one trained on the
+# un-smeared corrected pt. The network's reweight is conditioned on
+# whichever sample it learned on, so the right variant has to be
+# selected to match the kinematics the histmaker feeds in.
+def default_shift_smear_reweight_onnx(smearing=True):
+    """Return the path to the bundled shift+smear-reweight ONNX model
+    matching the chosen resolution-smearing setting. ``smearing=True``
+    (the histmaker default) returns the model trained on smeared reco
+    pt; pass ``smearing=False`` for the un-smeared variant.
+    """
+    suffix = "smearing" if smearing else "nosmearing"
+    return (
+        f"{data_dir}/calibration/"
+        f"shift_smear_reweight_mlp_factored_combined_{suffix}.onnx"
+    )
 
 
 def make_muon_calibration_helpers(
@@ -87,6 +102,7 @@ def make_jpsi_crctn_helpers(
     central=False,
     central_eta_min=-1.4,
     central_eta_max=1.4,
+    smearing=True,
 ):
     if muon_corr_mc in ["idealMC_massfit", "idealMC_lbltruth_massfit"]:
         mc_corrfile = calib_filepaths["mc_corrfile"][muon_corr_mc]
@@ -113,6 +129,7 @@ def make_jpsi_crctn_helpers(
                 central=central,
                 central_eta_min=central_eta_min,
                 central_eta_max=central_eta_max,
+                smearing=smearing,
             )
             if mc_corrfile
             else None
@@ -128,6 +145,7 @@ def make_jpsi_crctn_helpers(
                 central=central,
                 central_eta_min=central_eta_min,
                 central_eta_max=central_eta_max,
+                smearing=smearing,
             )
             if data_corrfile
             else None
@@ -139,12 +157,14 @@ def make_jpsi_crctn_helpers(
 
 
 def make_Z_non_closure_helpers(args, calib_filepaths, closure_filepaths):
+    smearing = not getattr(args, "noSmearing", False)
     parametrized_helper = (
         make_Z_non_closure_parametrized_helper(
             closure_filepaths["parametrized"],
             calib_filepaths["tflite_file"],
             correlated=args.correlatedNonClosureNP,
             scale_var_method=args.muonScaleVariation,
+            smearing=smearing,
             dummy_A=args.dummyNonClosureA,
             dummy_M=args.dummyNonClosureM,
             dummy_A_mag=args.dummyNonClosureAMag,
@@ -162,6 +182,7 @@ def make_Z_non_closure_helpers(args, calib_filepaths, closure_filepaths):
             calib_filepaths["tflite_file"],
             correlated=args.correlatedNonClosureNP,
             scale_var_method=args.muonScaleVariation,
+            smearing=smearing,
         )
         if (args.nonClosureScheme in ["binned", "binned-plus-M"])
         else None
@@ -307,9 +328,12 @@ def make_muon_smearing_helpers(
     filenamemc=f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_Apr3.root",
     override_d=None,
     dummy_vars=False,
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
     # this helper smears muon pT to match the resolution in data
 
     def load_res(filename):
@@ -682,9 +706,12 @@ def make_jpsi_crctn_unc_helper(
     central=False,
     central_eta_min=-1.4,
     central_eta_max=1.4,
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
 
     f = ROOT.TFile.Open(filepath_correction)
     A = f.Get("A")
@@ -889,9 +916,12 @@ def _make_jpsi_style_unc_helper(
 def make_closure_uncertainty_helper(
     filepath_correction,
     scale_var_method="onnxReweight",
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
 
     f = ROOT.TFile.Open(filepath_correction)
     A = f.Get("AZ")
@@ -980,9 +1010,12 @@ def make_uniform_closure_uncertainty_helper(
     iparm=0,
     val=1e-5,
     scale_var_method="onnxReweight",
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
     nvars = 1
     n_scale_params = 3
 
@@ -1018,13 +1051,16 @@ def make_Z_non_closure_parametrized_helper(
     n_scale_params=3,
     correlated=False,
     scale_var_method="onnxReweight",
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
     dummy_A=True,
     dummy_M=False,
     dummy_A_mag=7.5e-5,
     dummy_M_mag=0,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
     f = uproot.open(filepath_correction)
     M = f["MZ"].to_hist()
     A = f["AZ"].to_hist()
@@ -1100,9 +1136,12 @@ def make_Z_non_closure_binned_helper(
     n_pt_bins=5,
     correlated=False,
     scale_var_method="onnxReweight",
-    onnx_path=default_shift_smear_reweight_onnx,
+    smearing=True,
+    onnx_path=None,
     onnx_nslots=None,
 ):
+    if onnx_path is None:
+        onnx_path = default_shift_smear_reweight_onnx(smearing=smearing)
     f = uproot.open(filepath_correction)
 
     # TODO: convert variable axis to regular if the bin width is uniform

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -466,10 +466,11 @@ def add_resolution_uncertainty(
     if smearing_uncertainty_helper is None:
         return df
 
-    # The new ONNX-backed uncertainty helper needs the full gen-matched
-    # (reco pt/η/φ/charge, gen pt/η/φ/charge) tuple to feed the
-    # network's y / c. Detect by C++ class so the routing stays in sync
-    # with the helper type itself rather than a separate marker.
+    # The ONNX-backed helper needs the full gen-matched (reco/gen
+    # pt/η/φ/charge) tuple plus muon_source for the network's y/c.
+    # The analytic helper keeps its compact (recoPt, recoEta,
+    # response_weight) signature. Routing is by C++ class so it stays
+    # in sync with the helper type itself rather than a separate marker.
     if _is_onnx_reweight_helper(smearing_uncertainty_helper):
         df = _define_muon_source_for_onnx_helper(df, reco_sel_GF)
         cols = [
@@ -482,7 +483,6 @@ def add_resolution_uncertainty(
             f"{reco_sel_GF}_genPhi",
             f"{reco_sel_GF}_genCharge",
             f"{reco_sel_GF}_muon_source",
-            f"{reco_sel_GF}_response_weight",
             "nominal_weight",
         ]
     else:
@@ -605,6 +605,16 @@ def _define_muon_source_for_onnx_helper(df, reco_sel_GF):
     )
 
 
+_ONNX_REWEIGHT_HELPER_PREFIXES = (
+    "wrem::JpsiCorrectionsUncReweightHelper",
+    "wrem::SmearingUncertaintyReweightHelper",
+    "wrem::ZNonClosureParametrizedReweightHelper",
+    "wrem::ZNonClosureParametrizedReweightHelperCorl",
+    "wrem::ZNonClosureBinnedReweightHelper",
+    "wrem::ZNonClosureBinnedReweightHelperCorl",
+)
+
+
 def _is_onnx_reweight_helper(helper):
     """True iff ``helper`` is one of the ONNX-backed reweight helpers
     declared in ``shift_smear_reweight_helpers.hpp`` (which carry the
@@ -612,8 +622,53 @@ def _is_onnx_reweight_helper(helper):
     the Define call sites to switch column lists; ``False`` on the
     analytic helpers and on anything else."""
     name = type(helper).__cpp_name__ if helper is not None else ""
-    return name.startswith("wrem::JpsiCorrectionsUncReweightHelper") or \
-        name.startswith("wrem::SmearingUncertaintyReweightHelper")
+    return any(name.startswith(p) for p in _ONNX_REWEIGHT_HELPER_PREFIXES)
+
+
+def jpsi_style_cols(df, helper, reco_sel_GF, response_weight_col):
+    """Return ``(df, cols)`` for calling a J/psi-style scale-uncertainty
+    helper (any of ``JpsiCorrectionsUncHelperSplines``, the new
+    ``JpsiCorrectionsUncReweightHelper``, the Z non-closure
+    parametrized / binned helpers (Splines / analytic / Reweight
+    variants) -- anything that takes a per-muon kinematic batch).
+
+    For ONNX-backed helpers returns the 9-element list (kinematics +
+    ``muon_source``) and defines the muon_source column on demand.
+    The network gives the full multiplicative reweight directly, so
+    the ``response_weight`` column is *not* consumed -- the spline
+    response-weight evaluation can be skipped entirely when every
+    consumer is ONNX-backed.
+
+    For the analytic Splines helper returns the 7-element list
+    including ``response_weight_col``.
+
+    In both cases the caller appends ``nominal_weight`` (and any flag
+    column such as ``AMFlag``) itself.
+    """
+    if _is_onnx_reweight_helper(helper):
+        df = _define_muon_source_for_onnx_helper(df, reco_sel_GF)
+        cols = [
+            f"{reco_sel_GF}_recoPt",
+            f"{reco_sel_GF}_recoEta",
+            f"{reco_sel_GF}_recoPhi",
+            f"{reco_sel_GF}_recoCharge",
+            f"{reco_sel_GF}_genPt",
+            f"{reco_sel_GF}_genEta",
+            f"{reco_sel_GF}_genPhi",
+            f"{reco_sel_GF}_genCharge",
+            f"{reco_sel_GF}_muon_source",
+        ]
+    else:
+        cols = [
+            f"{reco_sel_GF}_recoPt",
+            f"{reco_sel_GF}_recoEta",
+            f"{reco_sel_GF}_recoCharge",
+            f"{reco_sel_GF}_genPt",
+            f"{reco_sel_GF}_genEta",
+            f"{reco_sel_GF}_genCharge",
+            response_weight_col,
+        ]
+    return df, cols
 
 
 def make_jpsi_crctn_unc_helper(
@@ -742,29 +797,12 @@ def make_jpsi_crctn_unc_helper(
         helper = ROOT.wrem.JpsiCorrectionsUncHelper[
             type(hist_scale_params_unc_cpp).__cpp_name__
         ](ROOT.std.move(hist_scale_params_unc_cpp))
-    elif scale_var_method == "smearingWeightsSplines":
-        helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[
-            type(hist_scale_params_unc_cpp).__cpp_name__
-        ](ROOT.std.move(hist_scale_params_unc_cpp))
-    elif scale_var_method == "onnxReweight":
-        # Trained shift+smear-reweight (mlp-factored) backed drop-in.
-        # ``onnx_path`` points at the combined ONNX produced by
-        # scripts/corrections/muon_calibration/shift_smear_reweight_export.py.
-        # The ONNX has y/c mean+std and u/σ std normalisation baked in,
-        # so no preproc.json is needed at runtime -- the C++ helper
-        # passes everything in physical r_κ / δλ / δφ units.
-        if onnx_path is None:
-            raise ValueError(
-                "scale_var_method='onnxReweight' requires onnx_path=..."
-            )
-        n = int(onnx_nslots) if onnx_nslots is not None else (
-            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
-        )
-        helper = ROOT.wrem.JpsiCorrectionsUncReweightHelper[
-            type(hist_scale_params_unc_cpp).__cpp_name__
-        ](
-            ROOT.std.move(hist_scale_params_unc_cpp),
-            str(onnx_path), max(int(n), 1),
+    elif scale_var_method in ("smearingWeightsSplines", "onnxReweight"):
+        # Both routes share the same boost-histogram input and the same
+        # ``out_tensor_t`` shape; only the per-muon evaluation differs.
+        # See ``_make_jpsi_style_unc_helper``.
+        helper = _make_jpsi_style_unc_helper(
+            hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
         )
     elif scale_var_method == "massWeights":
         nweights = 21 if isW else 23
@@ -820,7 +858,40 @@ def make_dummy_closure_uncertainty_helper(neta=24, etalow=-2.4, etahigh=2.4):
     return helper
 
 
-def make_closure_uncertainty_helper(filepath_correction):
+def _make_jpsi_style_unc_helper(
+    hist_scale_params_unc_cpp,
+    scale_var_method,
+    onnx_path,
+    onnx_nslots,
+):
+    """Instantiate a J/psi-style scale-uncertainty helper from a packed
+    ``[eta × scale_params × unc]`` boost histogram.
+
+    Closure-uncertainty and J/psi-stats-uncertainty share this final
+    instantiation step -- only the histogram contents differ. Routing to
+    the ONNX-backed ``JpsiCorrectionsUncReweightHelper`` vs. the analytic
+    ``JpsiCorrectionsUncHelperSplines`` is identical in both cases.
+    """
+    type_str = type(hist_scale_params_unc_cpp).__cpp_name__
+    if scale_var_method == "onnxReweight":
+        n = int(onnx_nslots) if onnx_nslots is not None else (
+            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+        )
+        return ROOT.wrem.JpsiCorrectionsUncReweightHelper[type_str](
+            ROOT.std.move(hist_scale_params_unc_cpp),
+            str(onnx_path), max(int(n), 1),
+        )
+    return ROOT.wrem.JpsiCorrectionsUncHelperSplines[type_str](
+        ROOT.std.move(hist_scale_params_unc_cpp),
+    )
+
+
+def make_closure_uncertainty_helper(
+    filepath_correction,
+    scale_var_method="onnxReweight",
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
+):
 
     f = ROOT.TFile.Open(filepath_correction)
     A = f.Get("AZ")
@@ -897,15 +968,21 @@ def make_closure_uncertainty_helper(filepath_correction):
         hist_scale_params_unc, tensor_rank=2
     )
 
-    helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[
-        type(hist_scale_params_unc_cpp).__cpp_name__
-    ](ROOT.std.move(hist_scale_params_unc_cpp))
+    helper = _make_jpsi_style_unc_helper(
+        hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
+    )
 
     helper.tensor_axes = (hist_scale_params_unc.axes["unc"], binning.down_up_axis)
     return helper
 
 
-def make_uniform_closure_uncertainty_helper(iparm=0, val=1e-5):
+def make_uniform_closure_uncertainty_helper(
+    iparm=0,
+    val=1e-5,
+    scale_var_method="onnxReweight",
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
+):
     nvars = 1
     n_scale_params = 3
 
@@ -926,9 +1003,9 @@ def make_uniform_closure_uncertainty_helper(iparm=0, val=1e-5):
         hist_scale_params_unc, tensor_rank=2
     )
 
-    helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[
-        type(hist_scale_params_unc_cpp).__cpp_name__
-    ](ROOT.std.move(hist_scale_params_unc_cpp))
+    helper = _make_jpsi_style_unc_helper(
+        hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
+    )
 
     helper.tensor_axes = (hist_scale_params_unc.axes["unc"], binning.down_up_axis)
     return helper
@@ -940,7 +1017,9 @@ def make_Z_non_closure_parametrized_helper(
     n_eta_bins=24,
     n_scale_params=3,
     correlated=False,
-    scale_var_method="smearingWeightsSplines",
+    scale_var_method="onnxReweight",
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
     dummy_A=True,
     dummy_M=False,
     dummy_A_mag=7.5e-5,
@@ -963,36 +1042,49 @@ def make_Z_non_closure_parametrized_helper(
     else:
         hist_non_closure.view()[..., 2] = M.values()
 
-    # The "...Splines..." vs analytic variant differs only in whether the
-    # helper consumes the per-muon ``response_weight`` column (provided by
-    # the SplinesDifferentialWeightsHelper). ``onnxReweight`` callers also
-    # ship that column (the network ignores the value, but the column is
-    # present in the dataframe), so route them through the Splines variant
-    # too to keep input column lists consistent across histmakers.
-    use_splines_response_column = scale_var_method in (
-        "smearingWeightsSplines",
-        "onnxReweight",
-    )
     hist_non_closure_cpp = narf.hist_to_pyroot_boost(hist_non_closure, tensor_rank=1)
+    type_str = type(hist_non_closure_cpp).__cpp_name__
+    is_onnx = scale_var_method == "onnxReweight"
+    is_splines = scale_var_method == "smearingWeightsSplines"
     if correlated:
-        if use_splines_response_column:
+        if is_onnx:
+            n = int(onnx_nslots) if onnx_nslots is not None else (
+                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            )
+            z_non_closure_helper = (
+                ROOT.wrem.ZNonClosureParametrizedReweightHelperCorl[type_str, n_eta_bins](
+                    ROOT.std.move(hist_non_closure_cpp),
+                    str(onnx_path), max(int(n), 1),
+                )
+            )
+        elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplinesCorl[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
+                type_str, n_eta_bins
             ](ROOT.std.move(hist_non_closure_cpp))
         else:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperCorl[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
+                type_str, n_eta_bins
             ](ROOT.std.move(hist_non_closure_cpp))
         z_non_closure_helper.tensor_axes = tuple([binning.down_up_axis])
         return z_non_closure_helper
     else:
-        if use_splines_response_column:
+        if is_onnx:
+            n = int(onnx_nslots) if onnx_nslots is not None else (
+                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            )
+            z_non_closure_helper = (
+                ROOT.wrem.ZNonClosureParametrizedReweightHelper[type_str, n_eta_bins](
+                    ROOT.std.move(hist_non_closure_cpp),
+                    str(onnx_path), max(int(n), 1),
+                )
+            )
+        elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplines[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
+                type_str, n_eta_bins
             ](filepath_tflite, ROOT.std.move(hist_non_closure_cpp))
         else:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelper[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
+                type_str, n_eta_bins
             ](ROOT.std.move(hist_non_closure_cpp))
         z_non_closure_helper.tensor_axes = (
             hist.axis.Regular(n_eta_bins, 0, n_eta_bins, name="unc"),
@@ -1007,32 +1099,53 @@ def make_Z_non_closure_binned_helper(
     n_eta_bins=24,
     n_pt_bins=5,
     correlated=False,
-    scale_var_method="smearingWeightsSplines",
+    scale_var_method="onnxReweight",
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
 ):
     f = uproot.open(filepath_correction)
 
     # TODO: convert variable axis to regular if the bin width is uniform
     hist_non_closure = f["closure"].to_hist()
     hist_non_closure_cpp = narf.hist_to_pyroot_boost(hist_non_closure)
-    # Same routing rationale as make_Z_non_closure_parametrized_helper.
-    use_splines_response_column = scale_var_method in (
-        "smearingWeightsSplines",
-        "onnxReweight",
-    )
+    type_str = type(hist_non_closure_cpp).__cpp_name__
+    is_onnx = scale_var_method == "onnxReweight"
+    is_splines = scale_var_method == "smearingWeightsSplines"
     if correlated:
-        z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperCorl[
-            type(hist_non_closure_cpp).__cpp_name__, n_eta_bins, n_pt_bins
-        ](ROOT.std.move(hist_non_closure_cpp))
+        if is_onnx:
+            n = int(onnx_nslots) if onnx_nslots is not None else (
+                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            )
+            z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedReweightHelperCorl[
+                type_str, n_eta_bins, n_pt_bins
+            ](
+                ROOT.std.move(hist_non_closure_cpp),
+                str(onnx_path), max(int(n), 1),
+            )
+        else:
+            z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperCorl[
+                type_str, n_eta_bins, n_pt_bins
+            ](ROOT.std.move(hist_non_closure_cpp))
         z_non_closure_helper.tensor_axes = tuple([binning.down_up_axis])
         return z_non_closure_helper
     else:
-        if use_splines_response_column:
+        if is_onnx:
+            n = int(onnx_nslots) if onnx_nslots is not None else (
+                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            )
+            z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedReweightHelper[
+                type_str, n_eta_bins, n_pt_bins
+            ](
+                ROOT.std.move(hist_non_closure_cpp),
+                str(onnx_path), max(int(n), 1),
+            )
+        elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperSplines[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins, n_pt_bins
+                type_str, n_eta_bins, n_pt_bins
             ](filepath_tflite, ROOT.std.move(hist_non_closure_cpp))
         else:
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelper[
-                type(hist_non_closure_cpp).__cpp_name__, n_eta_bins, n_pt_bins
+                type_str, n_eta_bins, n_pt_bins
             ](ROOT.std.move(hist_non_closure_cpp))
         z_non_closure_helper.tensor_axes = (
             hist.axis.Regular(n_eta_bins, 0, n_eta_bins, name="unc_ieta"),
@@ -1438,36 +1551,14 @@ def add_jpsi_crctn_stats_unc_hists(
                 dummy_mu_scale_var=args.dummyMuScaleVar,
                 dummy_var_mag=args.muonCorrMag,
             )
-        if _is_onnx_reweight_helper(jpsi_unc_helper):
-            df = _define_muon_source_for_onnx_helper(df, reco_sel_GF)
-            splines_cols = [
-                f"{reco_sel_GF}_recoPt",
-                f"{reco_sel_GF}_recoEta",
-                f"{reco_sel_GF}_recoPhi",
-                f"{reco_sel_GF}_recoCharge",
-                f"{reco_sel_GF}_genPt",
-                f"{reco_sel_GF}_genEta",
-                f"{reco_sel_GF}_genPhi",
-                f"{reco_sel_GF}_genCharge",
-                f"{reco_sel_GF}_muon_source",
-                f"{reco_sel_GF}_response_weight",
-                "nominal_weight",
-            ]
-        else:
-            splines_cols = [
-                f"{reco_sel_GF}_recoPt",
-                f"{reco_sel_GF}_recoEta",
-                f"{reco_sel_GF}_recoCharge",
-                f"{reco_sel_GF}_genPt",
-                f"{reco_sel_GF}_genEta",
-                f"{reco_sel_GF}_genCharge",
-                f"{reco_sel_GF}_response_weight",
-                "nominal_weight",
-            ]
+        df, splines_cols = jpsi_style_cols(
+            df, jpsi_unc_helper, reco_sel_GF,
+            f"{reco_sel_GF}_response_weight",
+        )
         df = df.Define(
             "muonScaleSyst_responseWeights_tensor_splines",
             jpsi_unc_helper,
-            splines_cols,
+            [*splines_cols, "nominal_weight"],
         )
         if args.validationHists:
             muonScaleSyst_responseWeights_splines = df.HistoBoost(
@@ -1550,7 +1641,14 @@ def add_jpsi_crctn_Z_non_closure_hists(
     reco_sel_GF,
     storage_type=hist.storage.Double(),
 ):
-    if args.muonScaleVariation == "smearingWeightsSplines":
+    if _is_onnx_reweight_helper(z_non_closure_parametrized_helper) or \
+            _is_onnx_reweight_helper(z_non_closure_binned_helper):
+        df, input_kinematics = jpsi_style_cols(
+            df, z_non_closure_parametrized_helper or z_non_closure_binned_helper,
+            reco_sel_GF, f"{reco_sel_GF}_response_weight",
+        )
+        nominal_cols_non_closure = nominal_cols
+    elif args.muonScaleVariation == "smearingWeightsSplines":
         input_kinematics = [
             f"{reco_sel_GF}_recoPt",
             f"{reco_sel_GF}_recoEta",

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -23,6 +23,7 @@ narf.clingutils.Declare('#include "shift_smear_reweight_helpers.hpp"')
 
 data_dir = common.data_dir
 
+
 # Default ONNX model for the shift+smear-reweight uncertainty helpers
 # (mlp-factored architecture, muon_source-conditioned, single-file
 # inline-weights export). Produced by
@@ -458,14 +459,18 @@ def make_muon_smearing_helpers(
         # y/c, std on u/σ) is baked into the ONNX, so the C++ helper
         # passes everything in physical units and no preproc.json is
         # needed at runtime.
-        n = int(onnx_nslots) if onnx_nslots is not None else (
-            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+        n = (
+            int(onnx_nslots)
+            if onnx_nslots is not None
+            else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
         )
         helper_var = ROOT.wrem.SmearingUncertaintyReweightHelper[
             type(hnom), type(hvar), nvar
         ](
-            helper, ROOT.std.move(hvar),
-            str(onnx_path), max(int(n), 1),
+            helper,
+            ROOT.std.move(hvar),
+            str(onnx_path),
+            max(int(n), 1),
         )
     else:
         helper_var = ROOT.wrem.SmearingUncertaintyHelperParametrized[
@@ -829,7 +834,10 @@ def make_jpsi_crctn_unc_helper(
         # ``out_tensor_t`` shape; only the per-muon evaluation differs.
         # See ``_make_jpsi_style_unc_helper``.
         helper = _make_jpsi_style_unc_helper(
-            hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
+            hist_scale_params_unc_cpp,
+            scale_var_method,
+            onnx_path,
+            onnx_nslots,
         )
     elif scale_var_method == "massWeights":
         nweights = 21 if isW else 23
@@ -901,12 +909,15 @@ def _make_jpsi_style_unc_helper(
     """
     type_str = type(hist_scale_params_unc_cpp).__cpp_name__
     if scale_var_method == "onnxReweight":
-        n = int(onnx_nslots) if onnx_nslots is not None else (
-            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+        n = (
+            int(onnx_nslots)
+            if onnx_nslots is not None
+            else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
         )
         return ROOT.wrem.JpsiCorrectionsUncReweightHelper[type_str](
             ROOT.std.move(hist_scale_params_unc_cpp),
-            str(onnx_path), max(int(n), 1),
+            str(onnx_path),
+            max(int(n), 1),
         )
     return ROOT.wrem.JpsiCorrectionsUncHelperSplines[type_str](
         ROOT.std.move(hist_scale_params_unc_cpp),
@@ -999,7 +1010,10 @@ def make_closure_uncertainty_helper(
     )
 
     helper = _make_jpsi_style_unc_helper(
-        hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
+        hist_scale_params_unc_cpp,
+        scale_var_method,
+        onnx_path,
+        onnx_nslots,
     )
 
     helper.tensor_axes = (hist_scale_params_unc.axes["unc"], binning.down_up_axis)
@@ -1037,7 +1051,10 @@ def make_uniform_closure_uncertainty_helper(
     )
 
     helper = _make_jpsi_style_unc_helper(
-        hist_scale_params_unc_cpp, scale_var_method, onnx_path, onnx_nslots,
+        hist_scale_params_unc_cpp,
+        scale_var_method,
+        onnx_path,
+        onnx_nslots,
     )
 
     helper.tensor_axes = (hist_scale_params_unc.axes["unc"], binning.down_up_axis)
@@ -1084,14 +1101,17 @@ def make_Z_non_closure_parametrized_helper(
     is_splines = scale_var_method == "smearingWeightsSplines"
     if correlated:
         if is_onnx:
-            n = int(onnx_nslots) if onnx_nslots is not None else (
-                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            n = (
+                int(onnx_nslots)
+                if onnx_nslots is not None
+                else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
             )
-            z_non_closure_helper = (
-                ROOT.wrem.ZNonClosureParametrizedReweightHelperCorl[type_str, n_eta_bins](
-                    ROOT.std.move(hist_non_closure_cpp),
-                    str(onnx_path), max(int(n), 1),
-                )
+            z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedReweightHelperCorl[
+                type_str, n_eta_bins
+            ](
+                ROOT.std.move(hist_non_closure_cpp),
+                str(onnx_path),
+                max(int(n), 1),
             )
         elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplinesCorl[
@@ -1105,14 +1125,17 @@ def make_Z_non_closure_parametrized_helper(
         return z_non_closure_helper
     else:
         if is_onnx:
-            n = int(onnx_nslots) if onnx_nslots is not None else (
-                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            n = (
+                int(onnx_nslots)
+                if onnx_nslots is not None
+                else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
             )
-            z_non_closure_helper = (
-                ROOT.wrem.ZNonClosureParametrizedReweightHelper[type_str, n_eta_bins](
-                    ROOT.std.move(hist_non_closure_cpp),
-                    str(onnx_path), max(int(n), 1),
-                )
+            z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedReweightHelper[
+                type_str, n_eta_bins
+            ](
+                ROOT.std.move(hist_non_closure_cpp),
+                str(onnx_path),
+                max(int(n), 1),
             )
         elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplines[
@@ -1152,14 +1175,17 @@ def make_Z_non_closure_binned_helper(
     is_splines = scale_var_method == "smearingWeightsSplines"
     if correlated:
         if is_onnx:
-            n = int(onnx_nslots) if onnx_nslots is not None else (
-                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            n = (
+                int(onnx_nslots)
+                if onnx_nslots is not None
+                else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
             )
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedReweightHelperCorl[
                 type_str, n_eta_bins, n_pt_bins
             ](
                 ROOT.std.move(hist_non_closure_cpp),
-                str(onnx_path), max(int(n), 1),
+                str(onnx_path),
+                max(int(n), 1),
             )
         else:
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperCorl[
@@ -1169,14 +1195,17 @@ def make_Z_non_closure_binned_helper(
         return z_non_closure_helper
     else:
         if is_onnx:
-            n = int(onnx_nslots) if onnx_nslots is not None else (
-                ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+            n = (
+                int(onnx_nslots)
+                if onnx_nslots is not None
+                else (ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1)
             )
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedReweightHelper[
                 type_str, n_eta_bins, n_pt_bins
             ](
                 ROOT.std.move(hist_non_closure_cpp),
-                str(onnx_path), max(int(n), 1),
+                str(onnx_path),
+                max(int(n), 1),
             )
         elif is_splines:
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperSplines[
@@ -1591,7 +1620,9 @@ def add_jpsi_crctn_stats_unc_hists(
                 dummy_var_mag=args.muonCorrMag,
             )
         df, splines_cols = jpsi_style_cols(
-            df, jpsi_unc_helper, reco_sel_GF,
+            df,
+            jpsi_unc_helper,
+            reco_sel_GF,
             f"{reco_sel_GF}_response_weight",
         )
         df = df.Define(
@@ -1680,11 +1711,14 @@ def add_jpsi_crctn_Z_non_closure_hists(
     reco_sel_GF,
     storage_type=hist.storage.Double(),
 ):
-    if _is_onnx_reweight_helper(z_non_closure_parametrized_helper) or \
-            _is_onnx_reweight_helper(z_non_closure_binned_helper):
+    if _is_onnx_reweight_helper(
+        z_non_closure_parametrized_helper
+    ) or _is_onnx_reweight_helper(z_non_closure_binned_helper):
         df, input_kinematics = jpsi_style_cols(
-            df, z_non_closure_parametrized_helper or z_non_closure_binned_helper,
-            reco_sel_GF, f"{reco_sel_GF}_response_weight",
+            df,
+            z_non_closure_parametrized_helper or z_non_closure_binned_helper,
+            reco_sel_GF,
+            f"{reco_sel_GF}_response_weight",
         )
         nominal_cols_non_closure = nominal_cols
     elif args.muonScaleVariation == "smearingWeightsSplines":

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -963,9 +963,19 @@ def make_Z_non_closure_parametrized_helper(
     else:
         hist_non_closure.view()[..., 2] = M.values()
 
+    # The "...Splines..." vs analytic variant differs only in whether the
+    # helper consumes the per-muon ``response_weight`` column (provided by
+    # the SplinesDifferentialWeightsHelper). ``onnxReweight`` callers also
+    # ship that column (the network ignores the value, but the column is
+    # present in the dataframe), so route them through the Splines variant
+    # too to keep input column lists consistent across histmakers.
+    use_splines_response_column = scale_var_method in (
+        "smearingWeightsSplines",
+        "onnxReweight",
+    )
     hist_non_closure_cpp = narf.hist_to_pyroot_boost(hist_non_closure, tensor_rank=1)
     if correlated:
-        if scale_var_method == "smearingWeightsSplines":
+        if use_splines_response_column:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplinesCorl[
                 type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
             ](ROOT.std.move(hist_non_closure_cpp))
@@ -976,7 +986,7 @@ def make_Z_non_closure_parametrized_helper(
         z_non_closure_helper.tensor_axes = tuple([binning.down_up_axis])
         return z_non_closure_helper
     else:
-        if scale_var_method == "smearingWeightsSplines":
+        if use_splines_response_column:
             z_non_closure_helper = ROOT.wrem.ZNonClosureParametrizedHelperSplines[
                 type(hist_non_closure_cpp).__cpp_name__, n_eta_bins
             ](filepath_tflite, ROOT.std.move(hist_non_closure_cpp))
@@ -1004,6 +1014,11 @@ def make_Z_non_closure_binned_helper(
     # TODO: convert variable axis to regular if the bin width is uniform
     hist_non_closure = f["closure"].to_hist()
     hist_non_closure_cpp = narf.hist_to_pyroot_boost(hist_non_closure)
+    # Same routing rationale as make_Z_non_closure_parametrized_helper.
+    use_splines_response_column = scale_var_method in (
+        "smearingWeightsSplines",
+        "onnxReweight",
+    )
     if correlated:
         z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperCorl[
             type(hist_non_closure_cpp).__cpp_name__, n_eta_bins, n_pt_bins
@@ -1011,7 +1026,7 @@ def make_Z_non_closure_binned_helper(
         z_non_closure_helper.tensor_axes = tuple([binning.down_up_axis])
         return z_non_closure_helper
     else:
-        if scale_var_method == "smearingWeightsSplines":
+        if use_splines_response_column:
             z_non_closure_helper = ROOT.wrem.ZNonClosureBinnedHelperSplines[
                 type(hist_non_closure_cpp).__cpp_name__, n_eta_bins, n_pt_bins
             ](filepath_tflite, ROOT.std.move(hist_non_closure_cpp))

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -1640,6 +1640,36 @@ def add_jpsi_crctn_stats_unc_hists(
             )
             results.append(muonScaleSyst_responseWeights_splines)
 
+    if args.muonScaleVariation == "onnxReweight" or args.validationHists:
+        if args.muonScaleVariation == "onnxReweight":
+            jpsi_unc_helper = jpsi_crctn_data_unc_helper
+        else:
+            jpsi_unc_helper = make_jpsi_crctn_unc_helper(
+                calib_filepaths["data_corrfile"][args.muonCorrData],
+                scale_var_method="onnxReweight",
+                smearing=not getattr(args, "noSmearing", False),
+            )
+        df, onnx_cols = jpsi_style_cols(
+            df,
+            jpsi_unc_helper,
+            reco_sel_GF,
+            f"{reco_sel_GF}_response_weight",
+        )
+        df = df.Define(
+            "muonScaleSyst_responseWeights_tensor_onnx",
+            jpsi_unc_helper,
+            [*onnx_cols, "nominal_weight"],
+        )
+        if args.validationHists:
+            muonScaleSyst_responseWeights_onnx = df.HistoBoost(
+                "muonScaleSyst_responseWeights_onnx",
+                axes,
+                [*nominal_cols, "muonScaleSyst_responseWeights_tensor_onnx"],
+                tensor_axes=jpsi_unc_helper.tensor_axes,
+                storage=hist.storage.Double(),
+            )
+            results.append(muonScaleSyst_responseWeights_onnx)
+
     if args.muonScaleVariation == "massWeights" or args.validationHists:
         if args.muonScaleVariation == "massWeights" and isW:
             jpsi_unc_helper = jpsi_crctn_data_unc_helper
@@ -1687,6 +1717,11 @@ def add_jpsi_crctn_stats_unc_hists(
             df = df.Define(
                 "nominal_muonScaleSyst_responseWeights_tensor",
                 "muonScaleSyst_responseWeights_tensor_massWeights",
+            )
+        elif args.muonScaleVariation == "onnxReweight":
+            df = df.Define(
+                "nominal_muonScaleSyst_responseWeights_tensor",
+                "muonScaleSyst_responseWeights_tensor_onnx",
             )
         nominal_muonScaleSyst_responseWeights = df.HistoBoost(
             "nominal_muonScaleSyst_responseWeights",

--- a/wremnants/production/muon_calibration.py
+++ b/wremnants/production/muon_calibration.py
@@ -19,8 +19,17 @@ logger = logging.child_logger(__name__)
 
 narf.clingutils.Declare('#include "muon_calibration.hpp"')
 narf.clingutils.Declare('#include "lowpu_utils.hpp"')
+narf.clingutils.Declare('#include "shift_smear_reweight_helpers.hpp"')
 
 data_dir = common.data_dir
+
+# Default ONNX model for the shift+smear-reweight uncertainty helpers
+# (mlp-factored architecture, muon_source-conditioned, single-file
+# inline-weights export). Produced by
+# scripts/corrections/muon_calibration/shift_smear_reweight_export.py.
+default_shift_smear_reweight_onnx = (
+    f"{data_dir}/calibration/shift_smear_reweight_mlp_factored_combined.onnx"
+)
 
 
 def make_muon_calibration_helpers(
@@ -298,6 +307,8 @@ def make_muon_smearing_helpers(
     filenamemc=f"{data_dir}/calibration/resolutionMC_LBL_JZ_deltaphim_Apr3.root",
     override_d=None,
     dummy_vars=False,
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
 ):
     # this helper smears muon pT to match the resolution in data
 
@@ -415,9 +426,27 @@ def make_muon_smearing_helpers(
     hvar = narf.hist_to_pyroot_boost(hvar, tensor_rank=2)
 
     helper = ROOT.wrem.SmearingHelperParametrized[type(hnom)](ROOT.std.move(hnom))
-    helper_var = ROOT.wrem.SmearingUncertaintyHelperParametrized[
-        type(hnom), type(hvar), nvar
-    ](helper, ROOT.std.move(hvar))
+    if onnx_path is not None:
+        # ONNX-backed drop-in: same nominal smearer + ONNX-backed
+        # uncertainty helper.  The new uncertainty helper consumes gen
+        # kinematics in addition to reco -- see add_resolution_uncertainty
+        # for the matching column list.  All preprocessing (mean/std on
+        # y/c, std on u/σ) is baked into the ONNX, so the C++ helper
+        # passes everything in physical units and no preproc.json is
+        # needed at runtime.
+        n = int(onnx_nslots) if onnx_nslots is not None else (
+            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+        )
+        helper_var = ROOT.wrem.SmearingUncertaintyReweightHelper[
+            type(hnom), type(hvar), nvar
+        ](
+            helper, ROOT.std.move(hvar),
+            str(onnx_path), max(int(n), 1),
+        )
+    else:
+        helper_var = ROOT.wrem.SmearingUncertaintyHelperParametrized[
+            type(hnom), type(hvar), nvar
+        ](helper, ROOT.std.move(hvar))
 
     helper_var.tensor_axes = [axis_res_var]
 
@@ -437,15 +466,37 @@ def add_resolution_uncertainty(
     if smearing_uncertainty_helper is None:
         return df
 
-    df = df.Define(
-        "muonResolutionSyst_weights",
-        smearing_uncertainty_helper,
-        [
+    # The new ONNX-backed uncertainty helper needs the full gen-matched
+    # (reco pt/η/φ/charge, gen pt/η/φ/charge) tuple to feed the
+    # network's y / c. Detect by C++ class so the routing stays in sync
+    # with the helper type itself rather than a separate marker.
+    if _is_onnx_reweight_helper(smearing_uncertainty_helper):
+        df = _define_muon_source_for_onnx_helper(df, reco_sel_GF)
+        cols = [
+            f"{reco_sel_GF}_recoPt",
+            f"{reco_sel_GF}_recoEta",
+            f"{reco_sel_GF}_recoPhi",
+            f"{reco_sel_GF}_recoCharge",
+            f"{reco_sel_GF}_genPt",
+            f"{reco_sel_GF}_genEta",
+            f"{reco_sel_GF}_genPhi",
+            f"{reco_sel_GF}_genCharge",
+            f"{reco_sel_GF}_muon_source",
+            f"{reco_sel_GF}_response_weight",
+            "nominal_weight",
+        ]
+    else:
+        cols = [
             f"{reco_sel_GF}_recoPt",
             f"{reco_sel_GF}_recoEta",
             f"{reco_sel_GF}_response_weight",
             "nominal_weight",
-        ],
+        ]
+
+    df = df.Define(
+        "muonResolutionSyst_weights",
+        smearing_uncertainty_helper,
+        cols,
     )
 
     var_axes = smearing_uncertainty_helper.tensor_axes
@@ -532,17 +583,52 @@ def make_jpsi_crctn_helper(filepath):
     return jpsi_crctn_helper
 
 
+def _define_muon_source_for_onnx_helper(df, reco_sel_GF):
+    """Define ``{reco_sel_GF}_muon_source`` — an ``RVec<int>`` of
+    ``Muon_genPartFlav`` values for the gen-matched reco muons,
+    needed by the ONNX-reweight helpers (Jpsi scale and resolution
+    uncertainty) as the per-muon class tag. The C++ helper applies
+    the post-mapping rule (``genPartFlav == 15 -> 15, else 1``) and
+    the ORT graph remaps the {1, 15, 443} integer codes to the
+    compact {-1, 0, +1} representation the network was trained on.
+
+    Guarded against multiple definition since both
+    ``add_resolution_uncertainty`` and ``add_jpsi_crctn_stats_unc_hists``
+    may want the column on the same dataframe.
+    """
+    col = f"{reco_sel_GF}_muon_source"
+    if col in df.GetColumnNames():
+        return df
+    return df.Define(
+        col,
+        f"ROOT::VecOps::RVec<int>(Muon_genPartFlav[{reco_sel_GF}])",
+    )
+
+
+def _is_onnx_reweight_helper(helper):
+    """True iff ``helper`` is one of the ONNX-backed reweight helpers
+    declared in ``shift_smear_reweight_helpers.hpp`` (which carry the
+    full reco+gen+φ kinematics through the trained network).  Used by
+    the Define call sites to switch column lists; ``False`` on the
+    analytic helpers and on anything else."""
+    name = type(helper).__cpp_name__ if helper is not None else ""
+    return name.startswith("wrem::JpsiCorrectionsUncReweightHelper") or \
+        name.startswith("wrem::SmearingUncertaintyReweightHelper")
+
+
 def make_jpsi_crctn_unc_helper(
     filepath_correction,
     scale_A=1.0,
     scale_e=1.0,
     scale_M=1.0,
     isW=True,
-    scale_var_method="smearingWeightsSplines",
+    scale_var_method="onnxReweight",
     include_covariance=True,
     central=False,
     central_eta_min=-1.4,
     central_eta_max=1.4,
+    onnx_path=default_shift_smear_reweight_onnx,
+    onnx_nslots=None,
 ):
 
     f = ROOT.TFile.Open(filepath_correction)
@@ -660,6 +746,26 @@ def make_jpsi_crctn_unc_helper(
         helper = ROOT.wrem.JpsiCorrectionsUncHelperSplines[
             type(hist_scale_params_unc_cpp).__cpp_name__
         ](ROOT.std.move(hist_scale_params_unc_cpp))
+    elif scale_var_method == "onnxReweight":
+        # Trained shift+smear-reweight (mlp-factored) backed drop-in.
+        # ``onnx_path`` points at the combined ONNX produced by
+        # scripts/corrections/muon_calibration/shift_smear_reweight_export.py.
+        # The ONNX has y/c mean+std and u/σ std normalisation baked in,
+        # so no preproc.json is needed at runtime -- the C++ helper
+        # passes everything in physical r_κ / δλ / δφ units.
+        if onnx_path is None:
+            raise ValueError(
+                "scale_var_method='onnxReweight' requires onnx_path=..."
+            )
+        n = int(onnx_nslots) if onnx_nslots is not None else (
+            ROOT.GetThreadPoolSize() if ROOT.IsImplicitMTEnabled() else 1
+        )
+        helper = ROOT.wrem.JpsiCorrectionsUncReweightHelper[
+            type(hist_scale_params_unc_cpp).__cpp_name__
+        ](
+            ROOT.std.move(hist_scale_params_unc_cpp),
+            str(onnx_path), max(int(n), 1),
+        )
     elif scale_var_method == "massWeights":
         nweights = 21 if isW else 23
         helper = ROOT.wrem.JpsiCorrectionsUncHelper_massWeights[
@@ -1317,10 +1423,23 @@ def add_jpsi_crctn_stats_unc_hists(
                 dummy_mu_scale_var=args.dummyMuScaleVar,
                 dummy_var_mag=args.muonCorrMag,
             )
-        df = df.Define(
-            "muonScaleSyst_responseWeights_tensor_splines",
-            jpsi_unc_helper,
-            [
+        if _is_onnx_reweight_helper(jpsi_unc_helper):
+            df = _define_muon_source_for_onnx_helper(df, reco_sel_GF)
+            splines_cols = [
+                f"{reco_sel_GF}_recoPt",
+                f"{reco_sel_GF}_recoEta",
+                f"{reco_sel_GF}_recoPhi",
+                f"{reco_sel_GF}_recoCharge",
+                f"{reco_sel_GF}_genPt",
+                f"{reco_sel_GF}_genEta",
+                f"{reco_sel_GF}_genPhi",
+                f"{reco_sel_GF}_genCharge",
+                f"{reco_sel_GF}_muon_source",
+                f"{reco_sel_GF}_response_weight",
+                "nominal_weight",
+            ]
+        else:
+            splines_cols = [
                 f"{reco_sel_GF}_recoPt",
                 f"{reco_sel_GF}_recoEta",
                 f"{reco_sel_GF}_recoCharge",
@@ -1329,7 +1448,11 @@ def add_jpsi_crctn_stats_unc_hists(
                 f"{reco_sel_GF}_genCharge",
                 f"{reco_sel_GF}_response_weight",
                 "nominal_weight",
-            ],
+            ]
+        df = df.Define(
+            "muonScaleSyst_responseWeights_tensor_splines",
+            jpsi_unc_helper,
+            splines_cols,
         )
         if args.validationHists:
             muonScaleSyst_responseWeights_splines = df.HistoBoost(

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -419,8 +419,13 @@ def common_parser(analysis_label=""):
         )
         parser.add_argument(
             "--muonScaleVariation",
-            choices=["smearingWeightsGaus", "smearingWeightsSplines", "massWeights"],
-            default="smearingWeightsSplines",
+            choices=[
+                "smearingWeightsGaus",
+                "smearingWeightsSplines",
+                "massWeights",
+                "onnxReweight",
+            ],
+            default="onnxReweight",
             help="method to generate nominal muon scale variation histograms",
         )
         parser.add_argument(


### PR DESCRIPTION
## Summary

End-to-end pipeline for the muon-calibration **shift+smear reweight** model — from snapshot creation through training, ONNX/AOTI export, C++ helper integration, and histmaker wiring. Routes the J/ψ-stats, Z-non-closure, and closure-uncertainty helpers through the trained network by default, with the analytic Splines / Gaussian / massWeights paths still available via ``--muonScaleVariation``.

Built on top of #691 (CI container v53 + narf TBB task-arena fix), which provided the ONNX-runtime / threading prerequisites.

### Pipeline pieces

- **Snapshot** (J/ψ + W/Z → per-muon Arrow IPC shards). New: ``flow_training_snapshot.py``, ``arrow_shard_export.py``; structured-record intermediate dtype; train/val/holdout split via per-shard record-batch ranges (default 80/10/10).
- **Training** (BCE shift+smear-reweight head). New: ``train_shift_smear_reweight.py``, ``train_muon_response_flow.py``, ``arrow_shard_loader.py``. MLP-factored architecture (trunk + shift / smear heads composing an inner-product reweight), bf16 trainer, ``muon_source`` conditioning ({W/Z prompt, τ-decay, J/ψ leg} → {-1, 0, +1}).
- **Export** (``shift_smear_reweight_export.py``): single-file ONNX with weights inlined; ``muon_source`` remap baked into the graph; AOTI/ONNX with dynamic batch + N_var.
- **C++ helpers** (``wremnants/production/include/shift_smear_reweight_helpers.hpp``):
  - ``shift_smear_reweight::ReweightModel`` (narf onnx wrapper) + ``ReweightEvaluator<NVar>`` (shared per-muon kinematics → ONNX → ``exp(log_r)`` core).
  - ``JpsiCorrectionsUncReweightHelper<T>`` and ``SmearingUncertaintyReweightHelper<...>`` as drop-ins for the analytic Splines variants.
  - ``ZNonClosureParametrizedReweightHelper{Corl,}`` and ``ZNonClosureBinnedReweightHelper{Corl,}`` (new) replace the splines linearisation with the trained reweight; shared shift-source code with the existing Splines helpers via two free ``z_non_closure_*_delta_r_kappa`` helpers.
  - ``SmearingHelperSimpleReweight`` and ``ScaleHelperSimpleReweight`` for the ``w_z_muonresponse.py --testHelpers`` closure path.
- **Bundled ONNX** (wremnants-data submodule bump): two variants matching the resolution-smearing setting,
  ``shift_smear_reweight_mlp_factored_combined_{smearing,nosmearing}.onnx``. The factories pick the matching one based on ``--no-smearing``.

### Histmaker integration

- New CLI choice ``--muonScaleVariation onnxReweight`` (default). The Splines / Gaussian / massWeights paths are unchanged.
- ``make_muon_smearing_helpers``, ``make_jpsi_crctn_unc_helper``, ``make_closure_uncertainty_helper``, ``make_uniform_closure_uncertainty_helper``, ``make_Z_non_closure_parametrized_helper``, ``make_Z_non_closure_binned_helper`` all accept ``smearing=True`` and resolve the bundled ONNX path automatically; histmakers (``mw_with_mu_eta_pt``, ``mw_with_mu_eta_pt_VETOEFFI``, ``mz_dilepton``, ``mz_wlike_with_mu_eta_pt``, ``w_z_muonresponse``) pass ``smearing=not args.noSmearing``.
- New ``muon_calibration.jpsi_style_cols(df, helper, reco_sel_GF, response_weight_col)`` centralises the per-helper column-list selection (9-col with ``muon_source`` for ONNX, 7-col with ``response_weight`` for analytic Splines).
- ``w_z_muonresponse.py --testHelpers`` adds ONNX reweight references (``hist_qopr_smeared_weight_onnx``, ``hist_qopr_scaled_weight_onnx``) alongside the existing Splines / MC-sample references.
- New plotter ``scripts/corrections/muon_calibration/plot_muonresponse_reweight_closure.py`` overlays the variants with a variant/MC-truth ratio panel (auto-rescaling the multi-replica reference, auto-zooming the ratio y-range).

### Drive-by fix

- ``SmearingHelperSimple{,Multi}`` were passing the raw signed ``sigmarel * qop`` to ``std::normal_distribution``, which trips a libstdc++ stddev>0 assertion for q<0 muons. ``std::abs`` + zero-stddev guard.

## Test plan

Verified on Wminustaunu_2016PostVFP and a Z prompt dataset (``--maxFiles 1 -j1``):

- [x] ``mz_dilepton.py`` (default ``--muonScaleVariation onnxReweight``) runs end-to-end and produces output.
- [x] ``mz_dilepton.py --muonScaleVariation smearingWeightsSplines`` still works (no regression on the analytic path).
- [x] ``mz_dilepton.py --noSmearing`` runs end-to-end (auto-selects the ``_nosmearing`` ONNX).
- [x] ``w_z_muonresponse.py --testHelpers`` produces the closure histograms; plotter reproduces the expected per-permille ONNX scale closure and ~1% smear closure consistent with the per-model diagnostics.
- [ ] CI on the v53 container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)