### PR TITLE
ci: bump high-stats NTHREADS to 128 and pass --noHessian to ZMassDilepton externalPostfit step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
       - name: setup 1:1 data:mc events
         if: github.event_name != 'pull_request' && github.event.schedule != '30 5 * * 1-5'
         run: |
-          echo "NTHREADS=64" >> $GITHUB_ENV
+          echo "NTHREADS=128" >> $GITHUB_ENV
           echo "MAX_FILES=-2" >> $GITHUB_ENV
           echo "LUMI_SCALE=1" >> $GITHUB_ENV
           echo "NOMINAL_FAKE_SMOOTHING=full" >> $GITHUB_ENV
@@ -1304,9 +1304,9 @@ jobs:
 
       - name: dilepton ptll from wlike
         run: >-
-          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py 
-          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors 
-          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py
+          $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ZMassDilepton.hdf5 --saveHists --saveHistsPerProcess --computeHistErrors
+          --externalPostfit $WREMNANTS_OUTDIR/ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB --noHessian
           -o $WREMNANTS_OUTDIR/ZMassDilepton_ptll/ --postfix from_ZMassWLike_eta_pt_charge --pseudoData uncorr
 
       - name: dilepton ptll from wlike postfit


### PR DESCRIPTION
## Summary

Two independent CI fixes for the high-stats workflow.

### 1. `NTHREADS` 64 → 128 in the high-stats `setenv` branch

The `setup 1:1 data:mc events` branch (high-stats path, triggered by `workflow_dispatch` or any non-`30 5 * * 1-5` schedule) was timing out steps at `NTHREADS=64`. Bump to 128 to fit comfortably under the per-step time budget. PR/reference runs (the other two branches in `setenv`) are unaffected.

### 2. `--noHessian` on the `dilepton ptll from wlike` rabbit_fit step

The high-stats CI repeatably fails `dilepton-plotting` at the step that invokes `rabbit_fit.py` with `--externalPostfit ZMassWLike_eta_pt_charge/fitresults_uncorr.hdf5 --externalPostfitResult uncorr --noPostfitProfileBB`. The fit results file is written successfully, then `rabbit_fit.py:302` unconditionally calls `edmval_cov(grad, hess)` on the local loss Hessian at the externally-supplied (non-stationary) point, and Cholesky fails with `4-th leading minor of the array is not positive definite`. Off-minimum, the local Hessian is generically indefinite; this isn't a numerical bug.

`rabbit_fit.py` already has `--noHessian` (line 298 gates exactly this block) — passing it skips the EDM + covariance computation while still saving all the histograms and writing `fitresults_from_ZMassWLike_eta_pt_charge.hdf5`. The downstream `rabbit_plot_hists.py` step reads from there and the externally-loaded postfit's own covariance, neither of which depends on the indefinite local Hessian.

Reproduced in the most recent high-stats run (https://github.com/WMass/WRemnants/actions/runs/26352296494) and the preceding one (`muon_reweight_test` on 2026-05-23, ID 26327021423) — same `4-th leading minor` failure, both pre-existing the muon_reweight branch changes.

## Test plan

- [ ] CI on this PR (PR-mode path is unaffected by either change).
- [ ] Trigger high-stats workflow_dispatch on this branch and confirm `dilepton-plotting` passes and the previously timed-out steps finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)