### PR TITLE
scripts/ci: bump container wmassdevrolling v53 -> v57

### DIFF
--- a/scripts/ci/run_with_singularity.sh
+++ b/scripts/ci/run_with_singularity.sh
@@ -6,7 +6,7 @@ fi
 if [[ -d /ceph ]]; then
     export APPTAINER_BIND="${APPTAINER_BIND},/ceph"
 fi
-CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v53
+CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v57
 
 # Kerberos cache setup
 # Assuming kinit was already done on the host!


### PR DESCRIPTION
Bump the singularity/apptainer container tag used in the CI scripts from `v53` to `v57`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

There is a comprehensive update to system and python packages, as well as the update from Root 6.40.00-rc1 to 6.40.00 plus a few small adjustments of packages to support ML workflows.