### PR TITLE
Rename smoothing helper for clarity and add option to disable them

### DIFF
--- a/scripts/histmakers/mw_lowPU.py
+++ b/scripts/histmakers/mw_lowPU.py
@@ -138,11 +138,13 @@ columns_fakerate = [
     "transverseMass",
 ]  ## was transverseMass
 
-theory_helpers_procs = theory_corrections.make_theory_helpers(
+helicity_smoothing_helpers_procs = theory_corrections.make_helicity_smoothing_helpers(
     args.pdfs, args.theoryCorr
 )
-axis_ptVgen = theory_helpers_procs["W"]["qcdScale"].hist.axes["ptVgen"]
-axis_chargeVgen = theory_helpers_procs["W"]["qcdScale"].hist.axes["chargeVgen"]
+axis_ptVgen = helicity_smoothing_helpers_procs["W"]["qcdScale"].hist.axes["ptVgen"]
+axis_chargeVgen = helicity_smoothing_helpers_procs["W"]["qcdScale"].hist.axes[
+    "chargeVgen"
+]
 
 groups_to_aggregate = args.aggregateGroups
 
@@ -190,9 +192,9 @@ def build_graph(df, dataset):
     results = []
     isQCDMC = dataset.group == "QCD"
 
-    theory_helpers = None
+    helicity_smoothing_helpers = None
     if dataset.name in samples.vprocs:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -246,7 +248,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     [a for a in unfolding_axes[level] if a.name != "acceptance"],
                     [c for c in unfolding_cols[level] if c != f"{level}_acceptance"],
                     base_name=level,
@@ -416,7 +418,11 @@ def build_graph(df, dataset):
 
         df = df.Define("exp_weight", "SFMC")
         df = theory_corrections.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
     else:
         df = df.DefinePerSample("nominal_weight", "1.0")
@@ -524,7 +530,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     a,
                     c,
                     base_name=n,

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -448,9 +448,14 @@ if args.unfolding:
             args.fitresult, channel="ch1_masked"
         )
 
-theory_helpers_procs = theory_corrections.make_theory_helpers(
-    args.pdfs, args.theoryCorr, procs=["Z", "W"]
-)
+if args.skipByHelicityCorrection:
+    helicity_smoothing_helpers_procs = (
+        theory_corrections.make_helicity_smoothing_helpers(
+            args.pdfs, args.theoryCorr, procs=["Z", "W"]
+        )
+    )
+else:
+    helicity_smoothing_helpers_procs = {}
 
 if args.theoryAgnostic:
     theoryAgnostic_axes, theoryAgnostic_cols = binning.get_theoryAgnostic_axes(
@@ -734,9 +739,10 @@ def build_graph(df, dataset):
         hist.storage.Double()
     )  # turn off sum weight square for systematic histograms
 
-    theory_helpers = {}
-    if isWorZ:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+    if dataset.name[0] in helicity_smoothing_helpers_procs.keys():
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
+    else:
+        helicity_smoothing_helpers = {}
 
     # disable auxiliary histograms when unfolding to reduce memory consumptions, or when doing the original theory agnostic without --poiAsNoi
     auxiliary_histograms = True
@@ -836,7 +842,7 @@ def build_graph(df, dataset):
             args,
             dataset.name,
             corr_helpers,
-            theory_helpers,
+            helicity_smoothing_helpers,
             [],
             [],
             base_name="gen",
@@ -893,7 +899,7 @@ def build_graph(df, dataset):
                         args,
                         dataset.name,
                         corr_helpers,
-                        theory_helpers,
+                        helicity_smoothing_helpers,
                         [a for a in unfolding_axes[level] if a.name != "acceptance"],
                         [
                             c
@@ -914,7 +920,7 @@ def build_graph(df, dataset):
                         args,
                         dataset.name,
                         corr_helpers,
-                        theory_helpers,
+                        helicity_smoothing_helpers,
                         [a for a in unfolding_axes[level] if a.name != "acceptance"],
                         [
                             c
@@ -931,7 +937,7 @@ def build_graph(df, dataset):
         elif dataset.name == "Zmumu_2016PostVFP":
             if args.unfolding and dataset.name == "Zmumu_2016PostVFP":
                 df = unfolder_z.add_gen_histograms(
-                    args, df, results, dataset, corr_helpers, theory_helpers
+                    args, df, results, dataset, corr_helpers, helicity_smoothing_helpers
                 )
 
                 if not unfolder_z.poi_as_noi:
@@ -1342,7 +1348,11 @@ def build_graph(df, dataset):
         logger.debug(f"Exp weight defined: {weight_expr}")
         df = df.Define("exp_weight", weight_expr)
         df = theory_corrections.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
 
         if (
@@ -2352,7 +2362,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                theory_helpers,
+                helicity_smoothing_helpers,
                 axes,
                 cols,
                 for_wmass=True,

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -449,13 +449,13 @@ if args.unfolding:
         )
 
 if args.skipByHelicityCorrection:
+    helicity_smoothing_helpers_procs = {}
+else:
     helicity_smoothing_helpers_procs = (
         theory_corrections.make_helicity_smoothing_helpers(
             args.pdfs, args.theoryCorr, procs=["Z", "W"]
         )
     )
-else:
-    helicity_smoothing_helpers_procs = {}
 
 if args.theoryAgnostic:
     theoryAgnostic_axes, theoryAgnostic_cols = binning.get_theoryAgnostic_axes(
@@ -739,7 +739,7 @@ def build_graph(df, dataset):
         hist.storage.Double()
     )  # turn off sum weight square for systematic histograms
 
-    if dataset.name[0] in helicity_smoothing_helpers_procs.keys():
+    if isWorZ and dataset.name[0] in helicity_smoothing_helpers_procs.keys():
         helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
     else:
         helicity_smoothing_helpers = {}

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -366,6 +366,8 @@ muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = 
 )
 
 if args.skipByHelicityCorrection:
+    helicity_smoothing_helpers_procs = {}
+else:
     procs = [
         p
         for p, grp in (("W", samples.wprocs), ("Z", samples.zprocs))
@@ -376,8 +378,6 @@ if args.skipByHelicityCorrection:
             args.pdfs, args.theoryCorr, procs=procs
         )
     )
-else:
-    helicity_smoothing_helpers_procs = {}
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:
@@ -541,7 +541,7 @@ def build_graph(df, dataset):
     isZ = dataset.name in samples.zprocs
     isWorZ = isW or isZ
 
-    if dataset.name[0] in helicity_smoothing_helpers_procs.keys():
+    if isWorZ and dataset.name[0] in helicity_smoothing_helpers_procs.keys():
         helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
     else:
         helicity_smoothing_helpers = {}

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -364,14 +364,20 @@ if args.unfolding:
 muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = (
     muon_prefiring.make_muon_prefiring_helpers(era=era)
 )
-procs = [
-    p
-    for p, grp in (("W", samples.wprocs), ("Z", samples.zprocs))
-    if any(d.name in grp for d in datasets)
-]
-theory_helpers_procs = theory_corrections.make_theory_helpers(
-    args.pdfs, args.theoryCorr, procs=procs
-)
+
+if args.skipByHelicityCorrection:
+    procs = [
+        p
+        for p, grp in (("W", samples.wprocs), ("Z", samples.zprocs))
+        if any(d.name in grp for d in datasets)
+    ]
+    helicity_smoothing_helpers_procs = (
+        theory_corrections.make_helicity_smoothing_helpers(
+            args.pdfs, args.theoryCorr, procs=procs
+        )
+    )
+else:
+    helicity_smoothing_helpers_procs = {}
 
 # extra axes which can be used to label tensor_axes
 if args.binnedScaleFactors:
@@ -535,9 +541,10 @@ def build_graph(df, dataset):
     isZ = dataset.name in samples.zprocs
     isWorZ = isW or isZ
 
-    theory_helpers = {}
-    if isWorZ:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+    if dataset.name[0] in helicity_smoothing_helpers_procs.keys():
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
+    else:
+        helicity_smoothing_helpers = {}
 
     cvh_helper = data_calibration_helper if dataset.is_data else mc_calibration_helper
     jpsi_helper = data_jpsi_crctn_helper if dataset.is_data else mc_jpsi_crctn_helper
@@ -580,7 +587,12 @@ def build_graph(df, dataset):
 
     if args.unfolding and dataset.group == "Zmumu":
         df = unfolder_z.add_gen_histograms(
-            args, df, results, dataset, corr_helpers, theory_helpers=theory_helpers
+            args,
+            df,
+            results,
+            dataset,
+            corr_helpers,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
 
         if not unfolder_z.poi_as_noi:
@@ -601,7 +613,11 @@ def build_graph(df, dataset):
         df_gen = df
         df_gen = df_gen.DefinePerSample("exp_weight", "1.0")
         df_gen = theory_corrections.define_theory_weights_and_corrs(
-            df_gen, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df_gen,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
 
         for obs in auxiliary_gen_axes:
@@ -616,7 +632,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                theory_helpers,
+                helicity_smoothing_helpers,
                 [all_axes[obs]],
                 [obs],
                 base_name=f"gen_{obs}",
@@ -931,7 +947,11 @@ def build_graph(df, dataset):
         logger.debug(f"Experimental weight defined: {weight_expr}")
         df = df.Define("exp_weight", weight_expr)
         df = theory_corrections.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
 
         results.append(
@@ -1069,7 +1089,7 @@ def build_graph(df, dataset):
                         args,
                         dataset.name,
                         corr_helpers,
-                        theory_helpers,
+                        helicity_smoothing_helpers,
                         obs_axes,
                         obs,
                         base_name=obs_name,
@@ -1091,7 +1111,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     [all_axes[obs]],
                     [obs],
                     base_name=f"nominal_{obs}",
@@ -1292,7 +1312,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                theory_helpers,
+                helicity_smoothing_helpers,
                 axes,
                 cols,
                 for_wmass=False,

--- a/scripts/histmakers/mz_lowPU.py
+++ b/scripts/histmakers/mz_lowPU.py
@@ -103,11 +103,13 @@ axis_wlike_met = hist.axis.Regular(200, 0, 200, name="WlikeMET")
 axes_mt = [axis_mt]
 cols_mt = ["transverseMass"]
 
-theory_helpers_procs = theory_corrections.make_theory_helpers(
+helicity_smoothing_helpers_procs = theory_corrections.make_helicity_smoothing_helpers(
     args.pdfs, args.theoryCorr
 )
-axis_ptVgen = theory_helpers_procs["Z"]["qcdScale"].hist.axes["ptVgen"]
-axis_chargeVgen = theory_helpers_procs["Z"]["qcdScale"].hist.axes["chargeVgen"]
+axis_ptVgen = helicity_smoothing_helpers_procs["Z"]["qcdScale"].hist.axes["ptVgen"]
+axis_chargeVgen = helicity_smoothing_helpers_procs["Z"]["qcdScale"].hist.axes[
+    "chargeVgen"
+]
 
 if args.unfolding:
 
@@ -151,9 +153,9 @@ def build_graph(df, dataset):
 
     results = []
 
-    theory_helpers = None
+    helicity_smoothing_helpers = None
     if dataset.name in samples.vprocs:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -168,7 +170,7 @@ def build_graph(df, dataset):
 
     if args.unfolding and dataset.group == base_group:
         df = unfolder_z.add_gen_histograms(
-            args, df, results, dataset, corr_helpers, theory_helpers
+            args, df, results, dataset, corr_helpers, helicity_smoothing_helpers
         )
 
         if not unfolder_z.poi_as_noi:
@@ -356,7 +358,11 @@ def build_graph(df, dataset):
 
         df = df.Define("exp_weight", "SFMC")
         df = theory_corrections.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
     else:
         df = df.DefinePerSample("nominal_weight", "1.0")
@@ -539,7 +545,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     a,
                     c,
                     base_name=n,

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -310,7 +310,7 @@ muon_prefiring_helper, muon_prefiring_helper_stat, muon_prefiring_helper_syst = 
     muon_prefiring.make_muon_prefiring_helpers(era=era)
 )
 
-theory_helpers_procs = theory_corrections.make_theory_helpers(
+helicity_smoothing_helpers_procs = theory_corrections.make_helicity_smoothing_helpers(
     args.pdfs, args.theoryCorr, corrs=["qcdScale", "alphaS", "pdf"]
 )
 
@@ -477,9 +477,9 @@ def build_graph(df, dataset):
     isZ = dataset.name in samples.zprocs
     isWorZ = isW or isZ
 
-    theory_helpers = None
+    helicity_smoothing_helpers = None
     if isWorZ:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
 
     if dataset.is_data:
         df = df.DefinePerSample("weight", "1.0")
@@ -603,7 +603,7 @@ def build_graph(df, dataset):
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     [a for a in unfolding_axes[level] if a.name != "acceptance"],
                     [c for c in unfolding_cols[level] if c != f"{level}_acceptance"],
                     base_name=level,
@@ -939,7 +939,11 @@ def build_graph(df, dataset):
         logger.debug(f"Exp weight defined: {weight_expr}")
         df = df.Define("exp_weight", weight_expr)
         df = theory_corrections.define_theory_weights_and_corrs(
-            df, dataset.name, corr_helpers, args, theory_helpers=theory_helpers
+            df,
+            dataset.name,
+            corr_helpers,
+            args,
+            helicity_smoothing_helpers=helicity_smoothing_helpers,
         )
 
     results.append(
@@ -1467,7 +1471,7 @@ def build_graph(df, dataset):
                 args,
                 dataset.name,
                 corr_helpers,
-                theory_helpers,
+                helicity_smoothing_helpers,
                 axes,
                 cols,
                 for_wmass=False,

--- a/scripts/histmakers/w_z_gen_dists.py
+++ b/scripts/histmakers/w_z_gen_dists.py
@@ -192,7 +192,7 @@ if args.helicity and args.propagatePDFstoHelicity:
     corrs.append("qcdScale")
 if args.centralBosonPDFWeight:
     corrs.append("pdf_central")
-theory_helpers_procs = theory_corrections.make_theory_helpers(
+helicity_smoothing_helpers_procs = theory_corrections.make_helicity_smoothing_helpers(
     args.pdfs, args.theoryCorr, procs=["Z", "W"], corrs=corrs
 )
 
@@ -215,9 +215,9 @@ def build_graph(df, dataset):
     ]  # in samples.zprocs
 
     if isW or isZ:
-        theory_helpers = theory_helpers_procs[dataset.name[0]]
+        helicity_smoothing_helpers = helicity_smoothing_helpers_procs[dataset.name[0]]
     else:
-        theory_helpers = {}
+        helicity_smoothing_helpers = {}
 
     theoryAgnostic_axes, _ = binning.get_theoryAgnostic_axes(
         ptV_flow=True, absYV_flow=True, wlike="Z" in dataset.name
@@ -316,7 +316,7 @@ def build_graph(df, dataset):
     df = df.Define("isEvenEvent", "event % 2 == 0")
 
     df = theory_corrections.define_theory_weights_and_corrs(
-        df, dataset.name, corr_helpers, args, theory_helpers
+        df, dataset.name, corr_helpers, args, helicity_smoothing_helpers
     )
 
     if isZ or dataset.group in [
@@ -957,7 +957,7 @@ def build_graph(df, dataset):
             args,
             dataset.name,
             corr_helpers,
-            theory_helpers,
+            helicity_smoothing_helpers,
             nominal_axes,
             nominal_cols,
             base_name="nominal_gen",

--- a/wremnants/production/systematics.py
+++ b/wremnants/production/systematics.py
@@ -1347,7 +1347,7 @@ def add_theory_hists(
     args,
     dataset_name,
     corr_helpers,
-    theory_helpers,
+    helicity_smoothing_helpers,
     axes,
     cols,
     base_name="nominal",
@@ -1418,21 +1418,21 @@ def add_theory_hists(
 
     if for_wmass or isZ:
 
-        if theory_helpers.get("qcdScale") is not None:
+        if helicity_smoothing_helpers.get("qcdScale") is not None:
             logger.debug(f"Make QCD scale histograms for {dataset_name}")
             # there is no W backgrounds for the Wlike, make QCD scale histograms only for Z
             # should probably remove the charge here, because the Z only has a single charge and the pt distribution does not depend on which charged lepton is selected
             add_qcdScaleByHelicityUnc_hist(
                 results,
                 df,
-                theory_helpers.get("qcdScale"),
+                helicity_smoothing_helpers.get("qcdScale"),
                 scale_axes,
                 scale_cols,
                 **info,
             )
 
-        if theory_helpers.get("pdf") is not None:
-            pdf_helpers = theory_helpers.get("pdf")
+        if helicity_smoothing_helpers.get("pdf") is not None:
+            pdf_helpers = helicity_smoothing_helpers.get("pdf")
             for pdf in args.pdfs:
                 pdf_name = theory_utils.pdfMap[pdf]["name"]
                 if pdf_name not in pdf_helpers.keys():
@@ -1453,7 +1453,7 @@ def add_theory_hists(
                     cols,
                     **info,
                 )
-        for pdf_name, pdf_from_corr_helper in theory_helpers.get(
+        for pdf_name, pdf_from_corr_helper in helicity_smoothing_helpers.get(
             "pdf_from_corr", {}
         ).items():
             logger.debug(
@@ -1470,7 +1470,7 @@ def add_theory_hists(
                 **info,
             )
 
-        for k, v in theory_helpers.get("alphaS", {}).items():
+        for k, v in helicity_smoothing_helpers.get("alphaS", {}).items():
             logger.debug(
                 f"Make alphaS uncertainty by helicity histogram for {dataset_name} and alphaS from correction {k}"
             )

--- a/wremnants/production/theory_corrections.py
+++ b/wremnants/production/theory_corrections.py
@@ -405,7 +405,9 @@ def define_pdf_columns(df, dataset_name, pdfs, noAltUnc):
     return df
 
 
-def define_central_pdf_weight_from_helicities(df, dataset_name, pdf, theory_helpers):
+def define_central_pdf_weight_from_helicities(
+    df, dataset_name, pdf, helicity_smoothing_helpers
+):
 
     logger.info("Using PDF weights from helicities for the central PDF weight")
     pdf_name = theory_utils.pdfMap[pdf]["name"]
@@ -415,7 +417,7 @@ def define_central_pdf_weight_from_helicities(df, dataset_name, pdf, theory_help
         df = df.DefinePerSample("unity", "1.")
     df = df.Define(
         tensorName,
-        theory_helpers["pdf_central"],
+        helicity_smoothing_helpers["pdf_central"],
         [
             "massVgen",
             "absYVgen",
@@ -455,7 +457,9 @@ def define_central_pdf_weight(df, dataset_name, pdf):
     )
 
 
-def define_theory_weights_and_corrs(df, dataset_name, helpers, args, theory_helpers={}):
+def define_theory_weights_and_corrs(
+    df, dataset_name, helpers, args, helicity_smoothing_helpers={}
+):
     if "LHEPart_status" in df.GetColumnNames():
         df = generator_level_definitions.define_lhe_vars(df)
 
@@ -480,15 +484,15 @@ def define_theory_weights_and_corrs(df, dataset_name, helpers, args, theory_help
 
     df = df.DefinePerSample("theory_weight_truncate", "10.")
     if (
-        theory_helpers
-        and "pdf_central" in theory_helpers.keys()
-        and theory_helpers["pdf_central"] is not None
+        helicity_smoothing_helpers
+        and "pdf_central" in helicity_smoothing_helpers.keys()
+        and helicity_smoothing_helpers["pdf_central"] is not None
     ):
         df = define_central_pdf_weight_from_helicities(
             df,
             dataset_name,
             args.pdfs[0] if len(args.pdfs) >= 1 else None,
-            theory_helpers,
+            helicity_smoothing_helpers,
         )
     else:  # if no boson-parametrized weights are available
         df = define_central_pdf_weight(
@@ -1058,19 +1062,19 @@ def make_corr_by_helicity(
     return corr_coeffs
 
 
-def make_theory_helpers(
+def make_helicity_smoothing_helpers(
     pdfs,
     theory_corr=[],
     procs=["Z", "W"],
     corrs=["qcdScale", "pdf", "pdf_from_corr", "alphaS", "pdf_central"],
 ):
 
-    theory_helpers_procs = {p: {} for p in procs}
+    helicity_smoothing_helpers_procs = {p: {} for p in procs}
 
-    for proc in theory_helpers_procs.keys():
+    for proc in helicity_smoothing_helpers_procs.keys():
 
         if "qcdScale" in corrs:
-            theory_helpers_procs[proc]["qcdScale"] = (
+            helicity_smoothing_helpers_procs[proc]["qcdScale"] = (
                 make_qcd_uncertainty_helper_by_helicity(
                     is_z=proc == "Z",
                     rebin_ptVgen=False,
@@ -1079,7 +1083,7 @@ def make_theory_helpers(
             )
 
         if "pdf" in corrs:
-            theory_helpers_procs[proc]["pdf"] = (
+            helicity_smoothing_helpers_procs[proc]["pdf"] = (
                 make_pdfs_uncertainties_helper_by_helicity(
                     proc=proc,
                     pdfs=pdfs,
@@ -1087,7 +1091,7 @@ def make_theory_helpers(
             )
         if "pdf_from_corr" in corrs:
             pdf_from_corrs = [x + "_Corr" for x in theory_corr if "pdfvar" in x]
-            theory_helpers_procs[proc]["pdf_from_corr"] = (
+            helicity_smoothing_helpers_procs[proc]["pdf_from_corr"] = (
                 make_pdfs_from_corrs_uncertainties_helper_by_helicity(
                     proc=proc,
                     pdfs_from_corrs=pdf_from_corrs,
@@ -1095,14 +1099,14 @@ def make_theory_helpers(
             )
         if "alphaS" in corrs:
             as_vars = [x + "_Corr" for x in theory_corr if "pdfas" in x]
-            theory_helpers_procs[proc]["alphaS"] = (
+            helicity_smoothing_helpers_procs[proc]["alphaS"] = (
                 make_alphaS_uncertainties_helper_by_helicity(
                     proc=proc,
                     as_vars=as_vars,
                 )
             )
         if "pdf_central" in corrs:
-            theory_helpers_procs[proc]["pdf_central"] = (
+            helicity_smoothing_helpers_procs[proc]["pdf_central"] = (
                 make_uncertainty_helper_by_helicity(
                     proc=proc,
                     nom=theory_utils.pdfMap[pdfs[0]]["name"],
@@ -1113,7 +1117,7 @@ def make_theory_helpers(
                 )
             )
 
-    return theory_helpers_procs
+    return helicity_smoothing_helpers_procs
 
 
 def make_qcd_uncertainty_helper_by_helicity(

--- a/wremnants/production/unfolding_tools.py
+++ b/wremnants/production/unfolding_tools.py
@@ -182,7 +182,7 @@ def add_xnorm_histograms(
     args,
     dataset_name,
     corr_helpers,
-    theory_helpers,
+    helicity_smoothing_helpers,
     unfolding_axes,
     unfolding_cols,
     base_name="xnorm",
@@ -193,7 +193,11 @@ def add_xnorm_histograms(
     df_xnorm = df_xnorm.DefinePerSample("exp_weight", "1.0")
 
     df_xnorm = theory_corrections.define_theory_weights_and_corrs(
-        df_xnorm, dataset_name, corr_helpers, args, theory_helpers=theory_helpers
+        df_xnorm,
+        dataset_name,
+        corr_helpers,
+        args,
+        helicity_smoothing_helpers=helicity_smoothing_helpers,
     )
 
     df_xnorm = df_xnorm.Define("xnorm", "0.5")
@@ -231,7 +235,7 @@ def add_xnorm_histograms(
         args,
         dataset_name,
         corr_helpers,
-        theory_helpers,
+        helicity_smoothing_helpers,
         xnorm_axes,
         xnorm_cols,
         base_name=base_name,
@@ -436,7 +440,7 @@ class UnfolderZ:
         )
 
     def add_gen_histograms(
-        self, args, df, results, dataset, corr_helpers, theory_helpers={}
+        self, args, df, results, dataset, corr_helpers, helicity_smoothing_helpers={}
     ):
         df = define_gen_level(
             df, dataset.name, self.unfolding_levels, mode=self.analysis_label
@@ -463,7 +467,7 @@ class UnfolderZ:
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     [a for a in self.unfolding_axes[level] if a.name != "acceptance"],
                     [
                         c
@@ -506,7 +510,7 @@ class UnfolderZ:
                     args,
                     dataset.name,
                     corr_helpers,
-                    theory_helpers,
+                    helicity_smoothing_helpers,
                     [a for a in self.unfolding_axes[level] if a.name != "acceptance"],
                     [
                         c

--- a/wremnants/utilities/parsing.py
+++ b/wremnants/utilities/parsing.py
@@ -204,9 +204,14 @@ def common_parser(analysis_label=""):
         help="Add EW theory corrections without modifying the default theoryCorr list. Will be appended to args.theoryCorr",
     )
     parser.add_argument(
+        "--skipByHelicityCorrection",
+        action="store_true",
+        help="Apply the QCD corrections and uncertainties from MiNNLO event weights, otherwise use by-helicity reweighting",
+    )
+    parser.add_argument(
         "--skipHelicity",
         action="store_true",
-        help="Skip the qcdScaleByHelicity histogram (it can be huge)",
+        help="Skip the qcdScaleByHelicity histogram production (it can be huge)",
     )
     parser.add_argument(
         "--noRecoil", action="store_true", help="Don't apply recoil correction"


### PR DESCRIPTION
- Previously there was in addition to "args.theoryCorr" and "theory_corrs" also "theory_helpers" which was too generic and confusing. renaming them to "helicity_smoothing_helpers" is more explicit and clear. 
- This PR also adds an option to disable these smoothing helper correction but they keep enabled by default so the result in the CI should not change