### PR TITLE
Add support for simultaneous (extended) ABCD fit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,6 +282,63 @@ jobs:
           --showNumbers --pullrange '2.1' --config wremnants/utilities/styles/styles.py --oneSidedImpacts --grouping max 
           -o $WEB_DIR/$PLOT_DIR --otherExtensions pdf png -n 50 --postfix theoryAgnosticNormVar --scaleImpacts 100
 
+  w-abcd-fit:
+    # The type of runner that the job will run on
+    runs-on: [self-hosted, linux, x64]
+    needs: [setenv, w-analysis, w-fit]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - env:
+          WREMNANTS_OUTDIR: ${{ needs.setenv.outputs.WREMNANTS_OUTDIR }}
+          WEB_DIR: ${{ needs.setenv.outputs.WEB_DIR }}
+          PLOT_DIR: ${{ needs.setenv.outputs.PLOT_DIR }}
+          LUMI_SCALE: ${{ needs.setenv.outputs.LUMI_SCALE }}
+        run: |
+          echo "WREMNANTS_OUTDIR=${WREMNANTS_OUTDIR}" >> $GITHUB_ENV
+          echo "WEB_DIR=${WEB_DIR}" >> $GITHUB_ENV
+          echo "PLOT_DIR=${PLOT_DIR}" >> $GITHUB_ENV
+          echo "LUMI_SCALE=${LUMI_SCALE}" >> $GITHUB_ENV
+          echo "HIST_FILE=${WREMNANTS_OUTDIR}/${OUTFILE_WMASS}" >> $GITHUB_ENV
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+          lfs: 'true'
+
+      - name: wmass setup lumi scale
+        if: github.event_name == 'pull_request' || github.event.schedule == '30 5 * * 1-5'
+        run: |
+          echo "LUMI_SCALE=120" >> $GITHUB_ENV
+
+      - name: wmass abcd smoothing params
+        run: >-
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/rabbit/regen_smoothing_params.py
+          -i $HIST_FILE --lumiScale $LUMI_SCALE -o ${WREMNANTS_OUTDIR}/simultaneousABCD
+
+      - name: wmass abcd rabbit setup
+        run: >-
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/rabbit/setupRabbit.py -i $HIST_FILE
+          --lumiScale $LUMI_SCALE -o ${WREMNANTS_OUTDIR}/simultaneousABCD --fitvar eta-pt-charge-relIso-mt --fakeEstimation none
+
+      - name: wmass abcd rabbit fit
+        run: >-
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py
+          '$WREMNANTS_OUTDIR/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/WMass.hdf5'
+          --paramModel SmoothExtendedABCDIsoMT 'params:$WREMNANTS_OUTDIR/simultaneousABCD/params.hdf5' Fake ch0
+          -t -1 --doImpacts -o '$WREMNANTS_OUTDIR/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/'
+
+      - name: wmass abcd impacts comparison
+        run: >-
+          scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_plot_pulls_and_impacts.py
+          ${WREMNANTS_OUTDIR}/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/fitresults.hdf5
+          -r ${WREMNANTS_OUTDIR}/WMass_eta_pt_charge/fitresults.hdf5
+          --name simultaneousABCD --refName nominal
+          --showNumbers --oneSidedImpacts --grouping max --config wremnants/utilities/styles/styles.py
+          -o $WEB_DIR/$PLOT_DIR --otherExtensions pdf png -n 50 --postfix simultaneousABCD --scaleImpacts 100
+          --title CMS --subtitle Preliminary
+
   w-bsm:
     # The type of runner that the job will run on
     runs-on: [self-hosted, linux, x64]
@@ -1613,7 +1670,7 @@ jobs:
 
   copy-clean:
     runs-on: [self-hosted, linux, x64]
-    needs: [setenv, w-analysis, w-fit, w-plotting, w-bsm, lowpu-w, lowpu-z, lowpu-combined-unfolding, wlike, wlike-plotting, dilepton-mll, alphas-z-histmaker, alphas-z-reco, dilepton, dilepton-unfolding, dilepton-plotting, gen, alphas-z-unfolding, alphas-z-gen-fit, combined-fit]
+    needs: [setenv, w-analysis, w-fit, w-abcd-fit, w-plotting, w-bsm, lowpu-w, lowpu-z, lowpu-combined-unfolding, wlike, wlike-plotting, dilepton-mll, alphas-z-histmaker, alphas-z-reco, dilepton, dilepton-unfolding, dilepton-plotting, gen, alphas-z-unfolding, alphas-z-gen-fit, combined-fit]
     if: always()
     steps:
       - env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,7 +255,7 @@ jobs:
         run: >- 
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py 
           '$WREMNANTS_OUTDIR/WMass_eta_pt_charge/WMass.hdf5'
-          -t -1 --doImpacts -o '$WREMNANTS_OUTDIR/WMass_eta_pt_charge/'
+          -t -1 --doImpacts --globalImpacts -o '$WREMNANTS_OUTDIR/WMass_eta_pt_charge/'
 
       - name: wmass rabbit impacts
         run: >-
@@ -327,14 +327,14 @@ jobs:
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_fit.py
           '$WREMNANTS_OUTDIR/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/WMass.hdf5'
           --paramModel SmoothExtendedABCDIsoMT 'params:$WREMNANTS_OUTDIR/simultaneousABCD/params.hdf5' Fake ch0
-          -t -1 --doImpacts -o '$WREMNANTS_OUTDIR/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/'
+          -t -1 --doImpacts --globalImpacts -o '$WREMNANTS_OUTDIR/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/'
 
       - name: wmass abcd impacts comparison
         run: >-
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run.sh rabbit_plot_pulls_and_impacts.py
           ${WREMNANTS_OUTDIR}/simultaneousABCD/WMass_eta_pt_charge_relIso_mt/fitresults.hdf5
           -r ${WREMNANTS_OUTDIR}/WMass_eta_pt_charge/fitresults.hdf5
-          --name simultaneousABCD --refName nominal
+          --name simultaneousABCD --refName nominal --impactType global
           --showNumbers --oneSidedImpacts --grouping max --config wremnants/utilities/styles/styles.py
           -o $WEB_DIR/$PLOT_DIR --otherExtensions pdf png -n 50 --postfix simultaneousABCD --scaleImpacts 100
           --title CMS --subtitle Preliminary

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -311,13 +311,13 @@ axis_mtCat = hist.axis.Variable(
     ),
     name="mt",
     underflow=False,
-    overflow=True,
+    overflow=False,
 )
 axis_isoCat = hist.axis.Variable(
     binning.get_binning_fakes_relIso(high_iso_bins=False),
     name="relIso",
     underflow=False,
-    overflow=True,
+    overflow=False,
 )
 axes_abcd = [axis_mtCat, axis_isoCat]
 

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -236,17 +236,14 @@ if args.addAxisSignUt:
     )
 
 # for isoMt region validation and related tests
-# use very high upper edge as a proxy for infinity (cannot exploit overflow bins in the fit)
-# can probably use numpy infinity, but this is compatible with the root conversion
-# FIXME: now we can probably use overflow bins in the fit
 axis_mtCat = hist.axis.Variable(
-    [0, int(args.mtCut / 2.0), args.mtCut, 1000],
+    [0, int(args.mtCut / 2.0), args.mtCut, np.inf],
     name="mt",
     underflow=False,
     overflow=False,
 )
 axis_isoCat = hist.axis.Variable(
-    [0, 0.15, 0.3, 100], name="relIso", underflow=False, overflow=False
+    [0, 0.15, 0.3, np.inf], name="relIso", underflow=False, overflow=False
 )
 
 if args.addIsoMtAxes:

--- a/scripts/rabbit/regen_smoothing_params.py
+++ b/scripts/rabbit/regen_smoothing_params.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Dump per-region smoothing polynomial coefficients for SmoothExtendedABCD.
+
+Refit the linearized smoothing polynomial from a nominal fake histogram and
+save the per-region polynomial coefficients in the SmoothExtendedABCD
+power-series basis.  The output can be loaded as initial parameter values in a
+rabbit fit via ``params:PATH`` in the ``--paramModel SmoothExtendedABCDIsoMT``
+CLI token.
+
+Typical use::
+
+    python scripts/rabbit/regen_smoothing_params.py \\
+        -i mw_with_mu_eta_pt_scetlib_dyturbo.hdf5 \\
+        -o /path/to/params.hdf5
+"""
+
+import os
+
+import h5py
+import numpy as np
+
+from wremnants.postprocessing.datagroups.datagroups import Datagroups
+from wremnants.postprocessing.histselections import FakeSelectorSimpleABCD
+from wremnants.postprocessing.regression import Regressor
+from wremnants.utilities import common, parsing
+from wums import ioutils, logging, output_tools
+
+logger = logging.child_logger(__name__)
+
+
+def make_parser():
+    parser = parsing.base_parser()
+    parser.description = __doc__
+    parser.add_argument(
+        "-i",
+        "--inputFile",
+        required=True,
+        type=str,
+        help="Input HDF5 histogram file (output of a histmaker).",
+    )
+    parser.add_argument(
+        "-o",
+        "--outpath",
+        required=True,
+        type=str,
+        help="Output path for the params HDF5 file (.hdf5 appended if missing).",
+    )
+    parser.add_argument(
+        "--inputBaseName",
+        default="nominal",
+        type=str,
+        help="Name of the nominal histogram inside the input file.",
+    )
+    parser.add_argument(
+        "--fakerateAxes",
+        nargs="+",
+        default=["eta", "pt", "charge"],
+        help="Axes for the fakerate binning.",
+    )
+    parser.add_argument(
+        "--fakeEstimation",
+        type=str,
+        default="extended1D",
+        choices=["simple", "extrapolate", "extended1D", "extended2D"],
+        help="Fake estimation mode (must match what will be used in setupRabbit).",
+    )
+    parser.add_argument(
+        "--fakeSmoothingMode",
+        type=str,
+        default="full",
+        choices=FakeSelectorSimpleABCD.smoothing_modes,
+        help="Smoothing mode for fake estimate.",
+    )
+    parser.add_argument(
+        "--fakeSmoothingOrder",
+        type=int,
+        default=3,
+        help="Polynomial order for the spectrum smoothing.",
+    )
+    parser.add_argument(
+        "--fakeSmoothingPolynomial",
+        type=str,
+        default="chebyshev",
+        choices=Regressor.polynomials,
+        help="Polynomial type for the spectrum smoothing.",
+    )
+    parser.add_argument(
+        "--excludeProcGroups",
+        type=str,
+        nargs="*",
+        default=["QCD"],
+        help="Process groups to exclude when building Datagroups.",
+    )
+    parser.add_argument(
+        "--filterProcGroups",
+        type=str,
+        nargs="*",
+        default=None,
+        help="If set, keep only these process groups when building Datagroups.",
+    )
+    return parser
+
+
+def dump_smoothing_params(
+    outpath, fakeselector, datagroups, inputBaseName, meta_data_dict=None, postfix=""
+):
+    """
+    Re-fit the linearized smoothing polynomial for the nominal fake histogram
+    (without the region reduction step) and save the per-region polynomial
+    coefficients in the SmoothExtendedABCD power-series basis to *outpath*.
+
+    The saved array has shape (5 * n_outer * (order+1),) with the layout
+    [A_params, B_params, C_params, Ax_params, Bx_params], matching the
+    internal layout expected by SmoothExtendedABCD as initial_params.
+
+    Flat ABCD index ordering for the 5 regions with signal_region=False
+    (FakeSelector1DExtendedABCD, with flow=True, after y-axis flip so tight iso is last):
+        0=Ax (low mt, fail iso), 1=Bx (low mt, pass iso),
+        2=A  (mid mt, fail iso), 3=B  (mid mt, pass iso),
+                                 4=C  (signal mt, fail iso)  ← application region, rabbit's free parameter
+    Note: signal_region=False drops flat index 5 = D (signal mt, pass iso = signal
+    region), which is rabbit's predicted region.
+
+    Histselections ↔ SmoothExtendedABCD model name mapping:
+        histsel "application region" (signal mt + fail iso) = C_model (free)
+        histsel "signal region"      (signal mt + pass iso) = D_model (predicted)
+
+    Mapping to model order [A=0, B=1, C=2, Ax=3, Bx=4]:
+        model_A  ← sideband flat 2
+        model_B  ← sideband flat 3
+        model_C  ← sideband flat 4
+        model_Ax ← sideband flat 0
+        model_Bx ← sideband flat 1
+    """
+    g = datagroups.fakeName
+    # Build the combined fake histogram (data - prompt MC) the same way the normal
+    # histogram loading does, but without applying the histselector.
+    datagroups.loadHistsForDatagroups(
+        inputBaseName, syst="", procsToRead=[g], label="_dump_tmp", applySelection=False
+    )
+    h_fakes = datagroups.groups[g].hists["_dump_tmp"]
+
+    # Single call with signal_region=False: returns 5 regions [Ax=0, Bx=1, A=2, B=3, C=4]
+    # The dropped 6th flat element (D = signal mt + pass iso) is the predicted region.
+    fakeselector.calculate_fullABCD_smoothed(h_fakes, signal_region=False)
+    if not hasattr(fakeselector, "_params_before_reduce"):
+        raise RuntimeError(
+            "dump_smoothing_params: _params_before_reduce not found on fakeselector. "
+            "Ensure fakeSmoothingMode='full' is used."
+        )
+    # Shape: (*outer_dims, 5, order+1) — indices [Ax=0, Bx=1, A=2, B=3, C=4]
+    params_5d = fakeselector._params_before_reduce.copy()
+
+    reg = fakeselector.spectrum_regressor
+    order = reg.order
+
+    # Flatten outer dims → (n_outer_flat, n_abcd, order+1)
+    outer_shape = params_5d.shape[:-2]
+    n_outer_flat = int(np.prod(outer_shape))
+    params_5d_flat = params_5d.reshape(n_outer_flat, 5, order + 1)
+
+    # Assemble the 5 model regions in model order [A, B, C, Ax, Bx]
+    # A ← flat 2, B ← flat 3, C ← flat 4, Ax ← flat 0, Bx ← flat 1
+    params_model = np.stack(
+        [
+            params_5d_flat[:, 2, :],  # A  (mid mt, fail iso)
+            params_5d_flat[:, 3, :],  # B  (mid mt, pass iso)
+            params_5d_flat[:, 4, :],  # C  (signal mt, fail iso) = application region
+            params_5d_flat[:, 0, :],  # Ax (low mt, fail iso)
+            params_5d_flat[:, 1, :],  # Bx (low mt, pass iso)
+        ],
+        axis=1,
+    )  # (n_outer, 5, order+1)
+
+    # The regressor was fit with polynomial=chebyshev, normalised x to [-1,1]
+    # via x_cheby = 2*(x - center)/(max-min).
+    # The SmoothExtendedABCD model uses a power-series basis normalised to [0,1]
+    # via x_norm = (x - x_min)/(x_max - x_min).
+    # Conversion: evaluate the Chebyshev polynomial at the model's x_norm points
+    # and refit with the power-series Vandermonde.
+    smooth_ax = h_fakes.axes[fakeselector.smoothing_axis_name]
+    x_centers = np.array(smooth_ax.centers)
+    bin_widths = np.array(smooth_ax.widths)
+    x_min_model = float(x_centers.min())
+    x_max_model = float(x_centers.max())
+    x_norm = (
+        (x_centers - x_min_model) / (x_max_model - x_min_model)
+        if x_max_model > x_min_model
+        else np.zeros_like(x_centers)
+    )
+
+    # Transform x_centers to the regressor's Chebyshev domain [-1, 1]
+    x_cheby = reg.transform_x(x_centers)  # shape (n_smooth,)
+
+    # Evaluate Chebyshev polynomials T_k at x_cheby: shape (n_smooth, order+1)
+    n_smooth = len(x_cheby)
+    T = np.zeros((n_smooth, order + 1))
+    T[:, 0] = 1.0
+    if order >= 1:
+        T[:, 1] = x_cheby
+    for k in range(2, order + 1):
+        T[:, k] = 2.0 * x_cheby * T[:, k - 1] - T[:, k - 2]
+
+    # Evaluate regressor log-rate at each pt bin: (n_outer, 5, n_smooth)
+    log_rate = np.einsum("oak,sk->oas", params_model, T)
+
+    # The regressor fits log(data_yield / bin_width).
+    # The model (with mc = ones) predicts yield = exp(-q), so:
+    #   q(x) = -log(data_yield) = -(log_rate + log(bin_width))
+    log_yield = log_rate + np.log(bin_widths)  # broadcast over (n_outer, 5, n_smooth)
+    target = -log_yield  # q values to represent as a power series
+
+    # Build power-series Vandermonde for x_norm: shape (n_smooth, order+1)
+    V = np.column_stack([x_norm**k for k in range(order + 1)])
+
+    # Solve V @ q_coeffs = target for each (outer, abcd) in least-squares sense
+    target_mat = target.transpose(2, 0, 1).reshape(n_smooth, n_outer_flat * 5)
+    q_mat = np.linalg.lstsq(V, target_mat, rcond=None)[0]  # (order+1, n_outer*5)
+    q_model = q_mat.T.reshape(n_outer_flat, 5, order + 1)  # (n_outer, 5, order+1)
+
+    # Flatten to model's layout [A_block, B_block, C_block, Ax_block, Bx_block]
+    # Each block: n_outer × (order+1) in C-order
+    params_out = q_model.transpose(1, 0, 2).reshape(-1)  # (5 * n_outer * (order+1),)
+    if outpath and not os.path.isdir(outpath):
+        os.makedirs(outpath)
+
+    outfile = f"{outpath}/params"
+    if postfix:
+        outfile += f"_{postfix}"
+
+    outfile += ".hdf5"
+
+    with h5py.File(outfile, mode="w") as f:
+        f.create_dataset("params", data=params_out)
+        f.create_dataset("order", data=np.array(order))
+        f.create_dataset(
+            "smoothing_axis_name",
+            data=np.array(fakeselector.smoothing_axis_name, dtype=h5py.string_dtype()),
+        )
+        f.create_dataset("n_outer", data=np.array(n_outer_flat))
+        f.create_dataset("outer_shape", data=np.array(outer_shape, dtype="int64"))
+        if meta_data_dict is not None:
+            ioutils.pickle_dump_h5py("meta", meta_data_dict, f)
+
+    logger.info(
+        f"Saved smoothing initial params to {outfile}  "
+        f"(shape {params_out.shape}, n_outer={n_outer_flat}, n_abcd=5, order={order})"
+    )
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+    logging.setup_logger(__file__, args.verbose, args.noColorLogger)
+
+    dg = Datagroups(
+        args.inputFile,
+        excludeGroups=args.excludeProcGroups if args.excludeProcGroups else None,
+        filterGroups=args.filterProcGroups if args.filterProcGroups else None,
+    )
+
+    dg.fakerate_axes = args.fakerateAxes
+    dg.set_histselectors(
+        dg.getNames(),
+        args.inputBaseName,
+        mode=args.fakeEstimation,
+        smoothing_mode=args.fakeSmoothingMode,
+        smoothingOrderSpectrum=args.fakeSmoothingOrder,
+        smoothingPolynomialSpectrum=args.fakeSmoothingPolynomial,
+        mcCorr=None,
+        integrate_x=True,
+        forceGlobalScaleFakes=False,
+        abcdExplicitAxisEdges={},
+        fakeTransferAxis="",
+        fakeTransferCorrFileName=None,
+        histAxesRemovedBeforeFakes=[],
+    )
+
+    fakeselector = dg.groups[dg.fakeName].histselector
+    logger.info(f"fakeselector type: {type(fakeselector).__name__}")
+
+    meta_data_dict = {
+        "meta_info": output_tools.make_meta_info_dict(
+            args=args,
+            wd=common.base_dir,
+        ),
+        "meta_info_input": dg.getMetaInfo(),
+    }
+
+    dump_smoothing_params(
+        args.outpath,
+        fakeselector,
+        dg,
+        args.inputBaseName,
+        meta_data_dict=meta_data_dict,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rabbit/regen_smoothing_params.py
+++ b/scripts/rabbit/regen_smoothing_params.py
@@ -105,13 +105,22 @@ def dump_smoothing_params(
     outpath, fakeselector, datagroups, inputBaseName, meta_data_dict=None, postfix=""
 ):
     """
-    Re-fit the linearized smoothing polynomial for the nominal fake histogram
-    (without the region reduction step) and save the per-region polynomial
-    coefficients in the SmoothExtendedABCD power-series basis to *outpath*.
+    Dump the per-region Chebyshev polynomial coefficients of the nominal fake
+    histogram smoothing fit, in the layout expected by SmoothExtendedABCD as
+    ``initial_params``.
+
+    Both the WRemnants spectrum regressor and SmoothExtendedABCD now use the
+    same Chebyshev basis (T_k of the first kind, with x̃ ∈ [-1, 1] via the
+    axis edges), so the regressor coefficients are passed through directly,
+    with a projection of ``log(bin_width)`` added so the exported coefficients
+    predict yields per bin, not rates per unit of the smoothing axis (the
+    regressor fits ``log(data_rate) = log(data_yield / bin_width)``). In the
+    simultaneous (extended)ABCD fit the nonprompt process is filled with
+    ``OnesSelector``, so ``mc_template = 1`` and the polynomial must carry the
+    full absolute scale; the Chebyshev intercept (T_0) is therefore kept.
 
     The saved array has shape (5 * n_outer * (order+1),) with the layout
-    [A_params, B_params, C_params, Ax_params, Bx_params], matching the
-    internal layout expected by SmoothExtendedABCD as initial_params.
+    [A_params, B_params, C_params, Ax_params, Bx_params].
 
     Flat ABCD index ordering for the 5 regions with signal_region=False
     (FakeSelector1DExtendedABCD, with flow=True, after y-axis flip so tight iso is last):
@@ -172,28 +181,17 @@ def dump_smoothing_params(
         axis=1,
     )  # (n_outer, 5, order+1)
 
-    # The regressor was fit with polynomial=chebyshev, normalised x to [-1,1]
-    # via x_cheby = 2*(x - center)/(max-min).
-    # The SmoothExtendedABCD model uses a power-series basis normalised to [0,1]
-    # via x_norm = (x - x_min)/(x_max - x_min).
-    # Conversion: evaluate the Chebyshev polynomial at the model's x_norm points
-    # and refit with the power-series Vandermonde.
+    # Both bases now agree (Chebyshev T_k, x̃ ∈ [-1, 1] via the axis edges).
+    # The regressor fits log(data_rate) = log(data_yield / bin_width); the model
+    # evaluates yield = exp(poly) * mc. With mc = 1 (OnesSelector in the
+    # simultaneous ABCD fit) the target coefficients are those of
+    # log(data_yield) = log_rate + log(bin_width). The log(bin_width)
+    # contribution is projected onto the Chebyshev basis and added.
     smooth_ax = h_fakes.axes[fakeselector.smoothing_axis_name]
-    x_centers = np.array(smooth_ax.centers)
     bin_widths = np.array(smooth_ax.widths)
-    x_min_model = float(x_centers.min())
-    x_max_model = float(x_centers.max())
-    x_norm = (
-        (x_centers - x_min_model) / (x_max_model - x_min_model)
-        if x_max_model > x_min_model
-        else np.zeros_like(x_centers)
-    )
-
-    # Transform x_centers to the regressor's Chebyshev domain [-1, 1]
-    x_cheby = reg.transform_x(x_centers)  # shape (n_smooth,)
-
-    # Evaluate Chebyshev polynomials T_k at x_cheby: shape (n_smooth, order+1)
+    x_cheby = reg.transform_x(np.array(smooth_ax.centers))
     n_smooth = len(x_cheby)
+
     T = np.zeros((n_smooth, order + 1))
     T[:, 0] = 1.0
     if order >= 1:
@@ -201,22 +199,10 @@ def dump_smoothing_params(
     for k in range(2, order + 1):
         T[:, k] = 2.0 * x_cheby * T[:, k - 1] - T[:, k - 2]
 
-    # Evaluate regressor log-rate at each pt bin: (n_outer, 5, n_smooth)
-    log_rate = np.einsum("oak,sk->oas", params_model, T)
+    # Chebyshev coefficients of log(bin_width) on the smoothing grid, shape (order+1,)
+    log_bw_coeffs = np.linalg.lstsq(T, np.log(bin_widths), rcond=None)[0]
 
-    # The regressor fits log(data_yield / bin_width).
-    # The model (with mc = ones) predicts yield = exp(-q), so:
-    #   q(x) = -log(data_yield) = -(log_rate + log(bin_width))
-    log_yield = log_rate + np.log(bin_widths)  # broadcast over (n_outer, 5, n_smooth)
-    target = -log_yield  # q values to represent as a power series
-
-    # Build power-series Vandermonde for x_norm: shape (n_smooth, order+1)
-    V = np.column_stack([x_norm**k for k in range(order + 1)])
-
-    # Solve V @ q_coeffs = target for each (outer, abcd) in least-squares sense
-    target_mat = target.transpose(2, 0, 1).reshape(n_smooth, n_outer_flat * 5)
-    q_mat = np.linalg.lstsq(V, target_mat, rcond=None)[0]  # (order+1, n_outer*5)
-    q_model = q_mat.T.reshape(n_outer_flat, 5, order + 1)  # (n_outer, 5, order+1)
+    q_model = params_model + log_bw_coeffs[np.newaxis, np.newaxis, :]
 
     # Flatten to model's layout [A_block, B_block, C_block, Ax_block, Bx_block]
     # Each block: n_outer × (order+1) in C-order

--- a/scripts/rabbit/regen_smoothing_params.py
+++ b/scripts/rabbit/regen_smoothing_params.py
@@ -85,6 +85,12 @@ def make_parser():
         help="Polynomial type for the spectrum smoothing.",
     )
     parser.add_argument(
+        "--lumiScale",
+        type=float,
+        default=1.0,
+        help="Rescale equivalent luminosity by this value (must match the value used in setupRabbit).",
+    )
+    parser.add_argument(
         "--excludeProcGroups",
         type=str,
         nargs="*",
@@ -245,6 +251,7 @@ def main():
         filterGroups=args.filterProcGroups if args.filterProcGroups else None,
     )
 
+    dg.lumiScale = args.lumiScale
     dg.fakerate_axes = args.fakerateAxes
     dg.set_histselectors(
         dg.getNames(),

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -1393,50 +1393,37 @@ def setup(
         datagroups.fakeName = args.qcdProcessName
 
     if wmass and not datagroups.xnorm:
-        if args.fakeEstimation not in [None, "none"]:
-            abcdExplicitAxisEdges = {}
-            if len(args.ABCDedgesByAxis):
-                for item in args.ABCDedgesByAxis:
-                    ax_name, ax_edges = item.split("=")
-                    abcdExplicitAxisEdges[ax_name] = [
-                        float(x) for x in ax_edges.split(",")
-                    ]
+        abcdExplicitAxisEdges = {}
+        if len(args.ABCDedgesByAxis):
+            for item in args.ABCDedgesByAxis:
+                ax_name, ax_edges = item.split("=")
+                abcdExplicitAxisEdges[ax_name] = [float(x) for x in ax_edges.split(",")]
 
-            datagroups.fakerate_axes = args.fakerateAxes
-            # datagroups.fakeTransferAxis = args.fakeTransferAxis if args.fakeTransferAxis in args.fakerateAxes else ""
-            # datagroups.fakeTransferCorrFileName = args.fakeTransferCorrFileName
-            histselector_kwargs = dict(
-                mode=args.fakeEstimation,
-                smoothing_mode=args.fakeSmoothingMode,
-                smoothingOrderSpectrum=args.fakeSmoothingOrder,
-                smoothingPolynomialSpectrum=args.fakeSmoothingPolynomial,
-                mcCorr=args.fakeMCCorr,
-                integrate_x="mt" not in fitvar,
-                forceGlobalScaleFakes=args.forceGlobalScaleFakes,
-                abcdExplicitAxisEdges=abcdExplicitAxisEdges,
-                fakeTransferAxis=(
-                    args.fakeTransferAxis
-                    if args.fakeTransferAxis in args.fakerateAxes
-                    else ""
-                ),
-                fakeTransferCorrFileName=args.fakeTransferCorrFileName,
-                histAxesRemovedBeforeFakes=(
-                    [str(x[0].split(":")[0]) for x in args.presel]
-                    if args.presel
-                    else []
-                ),
-            )
-            datagroups.set_histselectors(
-                datagroups.getNames(), inputBaseName, **histselector_kwargs
-            )
-        else:
-            from wremnants.postprocessing import histselections as sel
-
-            g = datagroups.fakeName
-            members = datagroups.groups[g].members[:]
-            if len(members) == 0:
-                raise RuntimeError(f"No member found for group {g}")
-            datagroups.groups[g].histselector = sel.OnesSelector()
+        datagroups.fakerate_axes = args.fakerateAxes
+        # datagroups.fakeTransferAxis = args.fakeTransferAxis if args.fakeTransferAxis in args.fakerateAxes else ""
+        # datagroups.fakeTransferCorrFileName = args.fakeTransferCorrFileName
+        histselector_kwargs = dict(
+            mode=args.fakeEstimation,
+            smoothing_mode=args.fakeSmoothingMode,
+            smoothingOrderSpectrum=args.fakeSmoothingOrder,
+            smoothingPolynomialSpectrum=args.fakeSmoothingPolynomial,
+            mcCorr=args.fakeMCCorr,
+            integrate_x="mt" not in fitvar,
+            forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+            abcdExplicitAxisEdges=abcdExplicitAxisEdges,
+            fakeTransferAxis=(
+                args.fakeTransferAxis
+                if args.fakeTransferAxis in args.fakerateAxes
+                else ""
+            ),
+            fakeTransferCorrFileName=args.fakeTransferCorrFileName,
+            histAxesRemovedBeforeFakes=(
+                [str(x[0].split(":")[0]) for x in args.presel] if args.presel else []
+            ),
+        )
+        datagroups.set_histselectors(
+            datagroups.getNames(), inputBaseName, **histselector_kwargs
+        )
 
     logger.debug(f"Making datacards with these processes: {datagroups.getProcesses()}")
 
@@ -1467,6 +1454,7 @@ def setup(
 
     passSystToFakes = (
         wmass
+        and args.fakeEstimation not in ["none"]
         and not (datagroups.xnorm or args.skipSignalSystOnFakes)
         and datagroups.fakeName != "QCD"
         and (excludeGroup != None and datagroups.fakeName not in excludeGroup)
@@ -2065,14 +2053,28 @@ def setup(
                 norm=abs(args.logNormalWtaunu),
             )
 
-        if args.logNormalFake > 0.0 and datagroups.fakeName in datagroups.groups.keys():
+        if (
+            args.logNormalFake > 0.0
+            and datagroups.fakeName in datagroups.groups.keys()
+            and args.fakeEstimation != "none"
+        ):
+            # In the simultaneous (extended)ABCD fit (OnesSelector) the
+            # per-region polynomial coefficients are unconstrained, so a global
+            # log-normal on the fake process is fully degenerate with shifting
+            # each region's T_0 and carries no information.
             if "fakenorm" in args.decorrSystByVar and decorr_syst_var in fitvar:
                 datagroups.addSystematic(
-                    name=f"CMS_{datagroups.fakeName}",
+                    name=f"{datagroups.fakeName}Param0",
                     processes=[datagroups.fakeName],
-                    groups=["Fake", "experiment", "expNoLumi", "expNoCalib"],
+                    groups=[
+                        f"{datagroups.fakeName}Param0",
+                        "Fake",
+                        "experiment",
+                        "expNoLumi",
+                        "expNoCalib",
+                    ],
                     passToFakes=False,
-                    baseName=f"CMS_{datagroups.fakeName}_",
+                    baseName=f"{datagroups.fakeName}Param0_",
                     systAxes=[f"{decorr_syst_var}_", "downUpVar"],
                     labelsByAxis=[decorr_syst_var, "downUpVar"],
                     actionRequiresNomi=True,
@@ -2086,9 +2088,15 @@ def setup(
                 )
             else:
                 datagroups.addNormSystematic(
-                    name=f"CMS_{datagroups.fakeName}",
+                    name=f"{datagroups.fakeName}Param0",
                     processes=[datagroups.fakeName],
-                    groups=["Fake", "experiment", "expNoLumi", "expNoCalib"],
+                    groups=[
+                        f"{datagroups.fakeName}Param0",
+                        "Fake",
+                        "experiment",
+                        "expNoLumi",
+                        "expNoCalib",
+                    ],
                     passToFakes=False,
                     norm=args.logNormalFake,
                 )
@@ -2121,6 +2129,7 @@ def setup(
         (datagroups.fakeName != "QCD" and args.qcdProcessName != "QCD")
         and datagroups.fakeName in datagroups.groups.keys()
         and not datagroups.xnorm
+        and args.fakeEstimation not in ["none"]
         and (
             args.fakeSmoothingMode != "binned"
             or (args.fakeEstimation in ["extrapolate"] and "mt" in fitvar)
@@ -2356,6 +2365,69 @@ def setup(
                     systAxes=["downUpVar"],
                     labelsByAxis=["downUpVar"],
                 )
+
+    if (
+        args.fakeEstimation == "none"
+        and datagroups.fakeName in datagroups.groups.keys()
+        and not datagroups.xnorm
+    ):
+        # OnesSelector path: rabbit's per-region polynomial provides the shape;
+        # vary the k-th Chebyshev coefficient by reweighting the signal-region
+        # slice of the flat-ones template by exp(mag * T_k(pt_norm)).
+        onesselector = datagroups.groups[datagroups.fakeName].histselector
+
+        def fake_nonclosure_ones(
+            h,
+            *args,
+            param_idx=1,
+            variation_size=0.1,
+            order=2,
+            fakeselector=None,
+            **kwargs,
+        ):
+            if args:
+                raise TypeError(f"Unexpected positional arguments: {args}")
+            params = np.zeros(order + 1)
+            params[param_idx] = variation_size
+            fakeselector.external_params = params
+            hvar = fakeselector.get_hist(h, **kwargs)
+            fakeselector.external_params = None
+            hvar = hist.Hist(
+                *hvar.axes,
+                hist.axis.Integer(0, 1, name="var", underflow=False, overflow=False),
+                storage=hist.storage.Double(),
+                data=hvar.values(flow=True)[..., np.newaxis],
+            )
+            return hvar
+
+        # idx=0: signal-region norm uncertainty (T_0 = 1), magnitude = log(1.05)
+        # to match the historical 5% log-normal on the fake process.
+        for idx, mag in [(0, np.log(1.05)), (1, 0.1), (2, 0.1)]:
+            subgroup = f"{datagroups.fakeName}Param{idx}"
+            datagroups.addSystematic(
+                inputBaseName,
+                groups=[
+                    subgroup,
+                    "Fake",
+                    "experiment",
+                    "expNoLumi",
+                    "expNoCalib",
+                ],
+                name=subgroup,
+                baseName=subgroup,
+                processes=datagroups.fakeName,
+                noConstraint=False,
+                mirror=True,
+                scale=1,
+                applySelection=False,
+                action=fake_nonclosure_ones,
+                actionArgs=dict(
+                    param_idx=idx,
+                    variation_size=mag,
+                    fakeselector=onesselector,
+                ),
+                systAxes=["var"],
+            )
 
     if not args.noEfficiencyUnc:
 

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -577,7 +577,15 @@ def make_parser(parser=None, argv=None):
         type=str,
         help="Set the mode for the fake estimation",
         default="extended1D",
-        choices=["mc", "closure", "simple", "extrapolate", "extended1D", "extended2D"],
+        choices=[
+            "none",
+            "mc",
+            "closure",
+            "simple",
+            "extrapolate",
+            "extended1D",
+            "extended2D",
+        ],
     )
     parser.add_argument(
         "--forceGlobalScaleFakes",
@@ -1384,38 +1392,51 @@ def setup(
     if args.qcdProcessName:
         datagroups.fakeName = args.qcdProcessName
 
-    abcdExplicitAxisEdges = {}
-    if len(args.ABCDedgesByAxis):
-        for item in args.ABCDedgesByAxis:
-            ax_name, ax_edges = item.split("=")
-            abcdExplicitAxisEdges[ax_name] = [float(x) for x in ax_edges.split(",")]
-
     if wmass and not datagroups.xnorm:
-        datagroups.fakerate_axes = args.fakerateAxes
-        # datagroups.fakeTransferAxis = args.fakeTransferAxis if args.fakeTransferAxis in args.fakerateAxes else ""
-        # datagroups.fakeTransferCorrFileName = args.fakeTransferCorrFileName
-        histselector_kwargs = dict(
-            mode=args.fakeEstimation,
-            smoothing_mode=args.fakeSmoothingMode,
-            smoothingOrderSpectrum=args.fakeSmoothingOrder,
-            smoothingPolynomialSpectrum=args.fakeSmoothingPolynomial,
-            mcCorr=args.fakeMCCorr,
-            integrate_x="mt" not in fitvar,
-            forceGlobalScaleFakes=args.forceGlobalScaleFakes,
-            abcdExplicitAxisEdges=abcdExplicitAxisEdges,
-            fakeTransferAxis=(
-                args.fakeTransferAxis
-                if args.fakeTransferAxis in args.fakerateAxes
-                else ""
-            ),
-            fakeTransferCorrFileName=args.fakeTransferCorrFileName,
-            histAxesRemovedBeforeFakes=(
-                [str(x[0].split(":")[0]) for x in args.presel] if args.presel else []
-            ),
-        )
-        datagroups.set_histselectors(
-            datagroups.getNames(), inputBaseName, **histselector_kwargs
-        )
+        if args.fakeEstimation not in [None, "none"]:
+            abcdExplicitAxisEdges = {}
+            if len(args.ABCDedgesByAxis):
+                for item in args.ABCDedgesByAxis:
+                    ax_name, ax_edges = item.split("=")
+                    abcdExplicitAxisEdges[ax_name] = [
+                        float(x) for x in ax_edges.split(",")
+                    ]
+
+            datagroups.fakerate_axes = args.fakerateAxes
+            # datagroups.fakeTransferAxis = args.fakeTransferAxis if args.fakeTransferAxis in args.fakerateAxes else ""
+            # datagroups.fakeTransferCorrFileName = args.fakeTransferCorrFileName
+            histselector_kwargs = dict(
+                mode=args.fakeEstimation,
+                smoothing_mode=args.fakeSmoothingMode,
+                smoothingOrderSpectrum=args.fakeSmoothingOrder,
+                smoothingPolynomialSpectrum=args.fakeSmoothingPolynomial,
+                mcCorr=args.fakeMCCorr,
+                integrate_x="mt" not in fitvar,
+                forceGlobalScaleFakes=args.forceGlobalScaleFakes,
+                abcdExplicitAxisEdges=abcdExplicitAxisEdges,
+                fakeTransferAxis=(
+                    args.fakeTransferAxis
+                    if args.fakeTransferAxis in args.fakerateAxes
+                    else ""
+                ),
+                fakeTransferCorrFileName=args.fakeTransferCorrFileName,
+                histAxesRemovedBeforeFakes=(
+                    [str(x[0].split(":")[0]) for x in args.presel]
+                    if args.presel
+                    else []
+                ),
+            )
+            datagroups.set_histselectors(
+                datagroups.getNames(), inputBaseName, **histselector_kwargs
+            )
+        else:
+            from wremnants.postprocessing import histselections as sel
+
+            g = datagroups.fakeName
+            members = datagroups.groups[g].members[:]
+            if len(members) == 0:
+                raise RuntimeError(f"No member found for group {g}")
+            datagroups.groups[g].histselector = sel.OnesSelector()
 
     logger.debug(f"Making datacards with these processes: {datagroups.getProcesses()}")
 

--- a/wremnants/postprocessing/datagroups/datagroups.py
+++ b/wremnants/postprocessing/datagroups/datagroups.py
@@ -301,6 +301,18 @@ class Datagroups(object):
                 "histselectors only implemented for single lepton (with fakes)"
             )
             return  # histselectors only implemented for single lepton (with fakes)
+
+        if mode in ["none", None]:
+            g = self.fakeName
+            members = self.groups[g].members[:]
+            if len(members) == 0:
+                raise RuntimeError(f"No member found for group {g}")
+            base_member = members[0].name
+            h = self.results[base_member]["output"][histToRead].get()
+            self.groups[g].histselector = sel.OnesSelector(h)
+
+            return
+
         auxiliary_info = {"ABCDmode": mode}
         signalselector = sel.SignalSelectorABCD
         scale = 1

--- a/wremnants/postprocessing/datagroups/datagroups.py
+++ b/wremnants/postprocessing/datagroups/datagroups.py
@@ -309,8 +309,11 @@ class Datagroups(object):
                 raise RuntimeError(f"No member found for group {g}")
             base_member = members[0].name
             h = self.results[base_member]["output"][histToRead].get()
-            self.groups[g].histselector = sel.OnesSelector(h)
-
+            if forceGlobalScaleFakes is not None:
+                scale = forceGlobalScaleFakes
+            else:
+                scale = 0.85
+            self.groups[g].histselector = sel.OnesSelector(h, global_scalefactor=scale)
             return
 
         auxiliary_info = {"ABCDmode": mode}

--- a/wremnants/postprocessing/histselections.py
+++ b/wremnants/postprocessing/histselections.py
@@ -246,11 +246,18 @@ class HistselectorABCD(object):
         self.smoothing_axis_min = edges[0]
         self.smoothing_axis_max = edges[-1]
 
-    def get_selection_edges(self, axis_name, upper_bound=False, hist_axis_edges=None):
+    def get_selection_edges(self, axis_name, upper_bound=False, hist_axis=None):
         # returns edges from pass to fail regions [x0, x1, x2, x3] e.g. x=[x0,x1], dx=[x1,x2], d2x=[x2,x3]
         if axis_name in self.abcd_thresholds:
             ts = self.abcd_thresholds[axis_name]
-            if hist_axis_edges is not None:
+            if hist_axis is not None:
+                hist_axis_edges = list(hist_axis.edges)
+                # treat underflow / overflow as explicit edge with +/- np.inf
+                if hist_axis.traits.overflow:
+                    hist_axis_edges.append(np.inf)
+                if hist_axis.traits.underflow:
+                    hist_axis_edges.insert(0, -np.inf)
+
                 if len(ts) == len(hist_axis_edges):
                     # consistent number of edges: take them from axis
                     ts = [x for x in hist_axis_edges]
@@ -258,23 +265,18 @@ class HistselectorABCD(object):
                         f"ABCD method: using edges {ts} for axis {axis_name}"
                     )
                 elif len(ts) < len(hist_axis_edges):
-                    if all(tsi in hist_axis_edges for i, tsi in enumerate(ts)):
+                    if all(tsi in hist_axis_edges for tsi in ts):
                         # more edges in axis, but default ones are a subset: keep edges from default
                         logger.warning(
                             f"ABCD method: using subset of edges {ts} for axis {axis_name}, out of {hist_axis_edges}"
                         )
                     else:
-                        logger.warning(
-                            f"Axis {axis_name} has inconsistent edges ({hist_axis_edges}): expected {ts}"
-                        )
-                        logger.warning(
-                            f"Please, explicitly provide the edges to be used for ABCD method."
-                        )
-                        raise RuntimeError(
-                            f"Inconsistent edges for ABCD method with axis {axis_name}."
-                        )
+                        raise RuntimeError(f"""
+                            Axis {axis_name} has inconsistent edges ({hist_axis_edges}): expected {ts}.
+                            Please, explicitly provide the edges to use for ABCD method.
+                            """)
                 else:
-                    if all(xi in ts for i, xi in enumerate(hist_axis_edges)):
+                    if all(xi in ts for xi in hist_axis_edges):
                         # less edges in axis, but subset of default ones: use them filling remaining elements with None
                         ts = [x for x in hist_axis_edges]
                         ts.extend([None] * (len(ts) - len(hist_axis_edges)))
@@ -283,15 +285,10 @@ class HistselectorABCD(object):
                         )
                     else:
                         # less edges in axis but also inconsistent: request the user to explicitly provide what to use
-                        logger.warning(
-                            f"ABCD method: axis {axis_name} has less edges ({hist_axis_edges}) than expected ({ts})"
-                        )
-                        logger.warning(
-                            f"and inconsistent too. Please, explicitly provide the edges to use"
-                        )
-                        raise RuntimeError(
-                            f"Inconsistent edges for ABCD method with axis {axis_name}."
-                        )
+                        raise RuntimeError(f"""
+                            Axis {axis_name} has less edges ({hist_axis_edges}) than expected ({ts}) and inconsistent too. 
+                            Please, explicitly provide the edges to use for ABCD method.
+                            """)
 
             if axis_name in ["mt", "pt"]:
                 # low: failing, high: passing, no upper bound
@@ -357,7 +354,7 @@ class HistselectorABCD(object):
             self.sel_dx = 0
         else:
             x0, x1, x2, x3 = self.get_selection_edges(
-                self.name_x, hist_axis_edges=self.axis_x.edges
+                self.name_x, hist_axis=self.axis_x
             )
             s = hist.tag.Slicer()
             do = hist.sum if self.integrate_x else None
@@ -378,7 +375,7 @@ class HistselectorABCD(object):
             y0, y1, y2, y3 = self.get_selection_edges(
                 self.name_y,
                 upper_bound=self.upper_bound_y,
-                hist_axis_edges=self.axis_y.edges,
+                hist_axis=self.axis_y,
             )
             s = hist.tag.Slicer()
             self.sel_y = (
@@ -1342,9 +1339,7 @@ class FakeSelector1DExtendedABCD(FakeSelectorSimpleABCD):
 
     # set slices object for selection of sideband regions
     def set_selections_x(self, integrate_x=True):
-        x0, x1, x2, x3 = self.get_selection_edges(
-            self.name_x, hist_axis_edges=self.axis_x.edges
-        )
+        x0, x1, x2, x3 = self.get_selection_edges(self.name_x, hist_axis=self.axis_x)
         s = hist.tag.Slicer()
         do = hist.sum if integrate_x else None
         self.sel_x = (
@@ -1618,7 +1613,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
         y0, y1, y2, y3 = self.get_selection_edges(
             self.name_y,
             upper_bound=self.upper_bound_y,
-            hist_axis_edges=self.axis_y.edges,
+            hist_axis=self.axis_y,
         )
         s = hist.tag.Slicer()
         self.sel_y = (

--- a/wremnants/postprocessing/histselections.py
+++ b/wremnants/postprocessing/histselections.py
@@ -1552,13 +1552,15 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
                 # min and max (in application region) for transformation of bernstain polynomials into interval [0,1]
                 axis_x_min = h[{self.name_x: self.sel_x}].axes[self.name_x].edges[0]
                 if self.name_x == "mt":
-                    # mt does not have an upper bound, cap at 100
+                    # mt may extend to infinity; use the last finite edge for the regressor
                     edges = (
                         self.rebin_x
                         if self.rebin_x is not None
                         else h.axes[self.name_x].edges
                     )
-                    axis_x_max = extend_edges(h.axes[self.name_x].traits, edges)[-1]
+                    all_edges = extend_edges(h.axes[self.name_x].traits, edges)
+                    finite_edges = all_edges[np.isfinite(all_edges)]
+                    axis_x_max = finite_edges[-1] if len(finite_edges) > 0 else 100.0
                 elif self.name_x in ["iso", "relIso", "relJetLeptonDiff", "dxy"]:
                     # iso and dxy have a finite lower and upper bound in the application region
                     axis_x_max = self.abcd_thresholds[self.name_x][1]

--- a/wremnants/postprocessing/histselections.py
+++ b/wremnants/postprocessing/histselections.py
@@ -152,9 +152,9 @@ class HistselectorABCD(object):
         # or if abcdExplicitAxisEdges is provided from outside
         self.abcd_thresholds = {
             "pt": [26, 28, 30],
-            "mt": [0, 40] if self.ABCDmode == "simple" else [0, 20, 40],
+            "mt": [0, 40, np.inf] if self.ABCDmode == "simple" else [0, 20, 40, np.inf],
             "iso": [0, 4, 8, 12],
-            "relIso": [0, 0.15, 0.3, 0.45],
+            "relIso": [0, 0.15, np.inf],
             "relJetLeptonDiff": [0, 0.2, 0.35, 0.5],
             "dxy": [0, 0.01, 0.02, 0.03],
         }
@@ -401,6 +401,23 @@ class SignalSelectorABCD(HistselectorABCD):
     # signal region selection
     def get_hist(self, h, is_nominal=False):
         return self.get_hist_passX_passY(h)
+
+
+class OnesSelector(object):
+    """
+    Don't actually select anything, just set the values of the histogram to ones
+    This is e.g. to perform the ABCD method in the simultaneous fit of all regions to data
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    # signal region selection
+    def get_hist(self, h, is_nominal=False):
+        h_new = h.copy()
+        h_new.values()[...] = np.ones_like(h.values())
+        h_new.variances()[...] = np.zeros_like(h.values())
+        return h_new
 
 
 class FakeSelectorSimpleABCD(HistselectorABCD):
@@ -810,6 +827,11 @@ class FakeSelectorSimpleABCD(HistselectorABCD):
         regressor.solve(x, y, w)
 
         logger.debug("Reduce is " + str(reduce))
+
+        # Always save params before (optional) reduction so the dump can access
+        # per-region polynomial coefficients for both signal_region=False and
+        # signal_region=True calls.
+        self._params_before_reduce = regressor.params.copy()
 
         if reduce:
             # add up parameters from smoothing of individual sideband regions

--- a/wremnants/postprocessing/histselections.py
+++ b/wremnants/postprocessing/histselections.py
@@ -154,7 +154,7 @@ class HistselectorABCD(object):
             "pt": [26, 28, 30],
             "mt": [0, 40, np.inf] if self.ABCDmode == "simple" else [0, 20, 40, np.inf],
             "iso": [0, 4, 8, 12],
-            "relIso": [0, 0.15, np.inf],
+            "relIso": [0, 0.15, 0.3, np.inf],
             "relJetLeptonDiff": [0, 0.2, 0.35, 0.5],
             "dxy": [0, 0.01, 0.02, 0.03],
         }
@@ -404,7 +404,7 @@ class OnesSelector(HistselectorABCD):
     """
     Flat-ones fake template for the simultaneous (extended)ABCD fit, where the
     rabbit model carries the absolute scale and per-region polynomial shape.
-    The (sel_x, sel_y) signal-region slice is scaled by 0.85 as a closure-test
+    The (sel_x, sel_y) signal-region slice is scaled by 'global_scalefactor' as a closure-test
     correction.
 
     Setting ``external_params`` to a Chebyshev coefficient vector before calling
@@ -415,9 +415,16 @@ class OnesSelector(HistselectorABCD):
     with FakeSelector*ExtendedABCD.
     """
 
-    def __init__(self, h, *args, **kwargs):
+    def __init__(
+        self,
+        h,
+        *args,
+        global_scalefactor=1,  # apply global correction factor on prediction
+        **kwargs,
+    ):
         super().__init__(h, *args, **kwargs)
         self.external_params = None
+        self.global_scalefactor = global_scalefactor
 
     @staticmethod
     def _uhi_to_numpy(sel, axis):
@@ -464,8 +471,8 @@ class OnesSelector(HistselectorABCD):
         h_new = h.copy()
         h_new.values()[...] = 1.0
         h_new.variances()[...] = 0.0
-        # Closure-test correction: scale the signal region template by 0.85.
-        h_new.values()[self._signal_region_slice(h_new)] = 0.85
+        # Closure-test correction: scale the signal region template.
+        h_new.values()[self._signal_region_slice(h_new)] = self.global_scalefactor
         self._apply_cheb_reweight(h_new)
         return h_new
 
@@ -1629,8 +1636,7 @@ class FakeSelector2DExtendedABCD(FakeSelector1DExtendedABCD):
                         else h.axes[self.name_x].edges
                     )
                     all_edges = extend_edges(h.axes[self.name_x].traits, edges)
-                    finite_edges = all_edges[np.isfinite(all_edges)]
-                    axis_x_max = finite_edges[-1] if len(finite_edges) > 0 else 100.0
+                    axis_x_max = all_edges[np.isfinite(all_edges)][-1]
                 elif self.name_x in ["iso", "relIso", "relJetLeptonDiff", "dxy"]:
                     # iso and dxy have a finite lower and upper bound in the application region
                     axis_x_max = self.abcd_thresholds[self.name_x][1]

--- a/wremnants/postprocessing/histselections.py
+++ b/wremnants/postprocessing/histselections.py
@@ -400,20 +400,73 @@ class SignalSelectorABCD(HistselectorABCD):
         return self.get_hist_passX_passY(h)
 
 
-class OnesSelector(object):
+class OnesSelector(HistselectorABCD):
     """
-    Don't actually select anything, just set the values of the histogram to ones
-    This is e.g. to perform the ABCD method in the simultaneous fit of all regions to data
+    Flat-ones fake template for the simultaneous (extended)ABCD fit, where the
+    rabbit model carries the absolute scale and per-region polynomial shape.
+    The (sel_x, sel_y) signal-region slice is scaled by 0.85 as a closure-test
+    correction.
+
+    Setting ``external_params`` to a Chebyshev coefficient vector before calling
+    ``get_hist`` reweights the signal-region slice by
+    ``exp(sum_k p_k T_k(x_norm))`` along the smoothing axis on top of the
+    nominal scale, so a single non-zero coefficient produces a Param_k
+    systematic shape analogous to the polynomial-coefficient variations used
+    with FakeSelector*ExtendedABCD.
     """
 
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, h, *args, **kwargs):
+        super().__init__(h, *args, **kwargs)
+        self.external_params = None
+
+    @staticmethod
+    def _uhi_to_numpy(sel, axis):
+        # hist UHI uses imaginary numbers for axis coordinates and hist.sum as
+        # a step to collapse the axis; numpy understands neither.
+        if isinstance(sel, slice):
+            start, stop = sel.start, sel.stop
+            if isinstance(start, complex):
+                start = axis.index(start.imag)
+            if isinstance(stop, complex):
+                stop = axis.index(stop.imag)
+            return slice(start, stop)
+        if isinstance(sel, complex):
+            return axis.index(sel.imag)
+        return sel
+
+    def _signal_region_slice(self, h):
+        sl = [slice(None)] * h.ndim
+        for name, sel in [(self.name_x, self.sel_x), (self.name_y, self.sel_y)]:
+            i = h.axes.name.index(name)
+            sl[i] = self._uhi_to_numpy(sel, h.axes[i])
+        return tuple(sl)
+
+    def _apply_cheb_reweight(self, h):
+        if self.external_params is None or not np.any(self.external_params):
+            return
+        edges = h.axes[self.smoothing_axis_name].edges
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        x_norm = (
+            2
+            * (centers - self.smoothing_axis_min)
+            / (self.smoothing_axis_max - self.smoothing_axis_min)
+            - 1
+        )
+        weight = np.exp(np.polynomial.chebyshev.chebval(x_norm, self.external_params))
+        sm_idx = h.axes.name.index(self.smoothing_axis_name)
+        bcast = [1] * h.ndim
+        bcast[sm_idx] = -1
+        sl = self._signal_region_slice(h)
+        h.values()[sl] *= weight.reshape(bcast)
 
     # signal region selection
     def get_hist(self, h, is_nominal=False):
         h_new = h.copy()
-        h_new.values()[...] = np.ones_like(h.values())
-        h_new.variances()[...] = np.zeros_like(h.values())
+        h_new.values()[...] = 1.0
+        h_new.variances()[...] = 0.0
+        # Closure-test correction: scale the signal region template by 0.85.
+        h_new.values()[self._signal_region_slice(h_new)] = 0.85
+        self._apply_cheb_reweight(h_new)
         return h_new
 
 

--- a/wremnants/utilities/binning.py
+++ b/wremnants/utilities/binning.py
@@ -536,7 +536,7 @@ axis_passMT = hist.axis.Boolean(name=passMTName)
 # axes with only a few bins for beyond simple ABCD methods
 axis_isoCat = hist.axis.Variable([0, 4, 8], name="iso", underflow=False, overflow=True)
 axis_relIsoCat = hist.axis.Variable(
-    [0, 0.15, 0.3], name="relIso", underflow=False, overflow=True
+    [0, 0.15, 0.3, np.inf], name="relIso", underflow=False, overflow=False
 )
 
 
@@ -578,6 +578,8 @@ def get_binning_fakes_mt(mt_cut=40, high_mt_bins=False, fine_mt_binning=False):
         edges = np.append(
             edges, np.linspace(mt_cut + step, end, int((end - mt_cut) / step))
         )
+    # last bin captures everything above the highest finite edge (no overflow needed)
+    edges = np.append(edges, np.inf)
     return edges
 
 
@@ -586,6 +588,8 @@ def get_binning_fakes_relIso(high_iso_bins=False):
     if high_iso_bins:
         # needed for extended 2D method
         edges.append(0.3)
+    # last bin captures everything above the highest finite edge (no overflow needed)
+    edges.append(np.inf)
     return edges
 
 


### PR DESCRIPTION
Split out of #661.

This PR adds support for performing the (extended) ABCD fake estimation simultaneously within the rabbit fit, instead of computing the fake prediction beforehand:

- **Simultaneous (extended) ABCD fit** (`setupRabbit.py`): with `--fakeEstimation none`, the unsmoothed fake-control regions are passed to rabbit and the fake group uses the new `OnesSelector`, letting the ABCD estimation happen inside the fit.
- **`scripts/rabbit/regen_smoothing_params.py`** (new): regenerates the fake smoothing parameters from a fit result, saving them directly in the Chebyshev basis.
- **np.inf-edged ABCD axes**: the mt/relIso categorization axes now explicitly capture `[edge, inf)` instead of relying on histogram overflow, and `histselections.py` treats underflow/overflow as +/- np.inf, so rabbit can include the outer bins in the fit.
- **Systematic variations on fakes** for the simultaneous fit.

- **CI**: new `w-abcd-fit` job (after `w-fit`) regenerates the smoothing params, sets up the tensor with `--fakeEstimation none`, runs the fit with the `SmoothExtendedABCDIsoMT` param model, and plots the mW impacts compared to the nominal fit.

The rabbit-side support is already contained in the rabbit version pinned on main; no submodule update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

