### PR TITLE
Apply PDF and MiNNLO theory uncertainties via correction hists by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -820,7 +820,7 @@ jobs:
       - name: wlike rabbit setup
         run: >-
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/rabbit/setupRabbit.py 
-          -i $HIST_FILE --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --pseudoData uncorr
+          -i $HIST_FILE --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --pseudoData uncorr --pdfUncFromUncorr
 
       - name: wlike rabbit fit asimov
         run: >- 
@@ -1054,8 +1054,7 @@ jobs:
           mkdir -p $ALPHAS_OUTDIR
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/rabbit/setupRabbit.py \
             -i $ALPHAS_HIST_FILE --fitvar "$ALPHAS_FITVAR" --lumiScale $LUMI_SCALE --realData \
-            -o $ALPHAS_OUTDIR --noi alphaS --npUnc LatticeEigvars --pdfUncFromCorr \
-            --axlim ptll 0j 44j
+            -o $ALPHAS_OUTDIR --noi alphaS --npUnc LatticeEigvars --axlim ptll 0j 44j
 
       - name: alphaS Z reco fit (${{ matrix.mode }})
         run: >-
@@ -1478,7 +1477,7 @@ jobs:
   #           --fitvar "ptll-yll-cosThetaStarll_quantile-phiStarll_quantile" "eta-pt-charge" \
   #           --lumiScale $LUMI_SCALE $LUMI_SCALE \
   #           -o $ALPHAS_OUTDIR --noi alphaS wmass --postfix reco \
-  #           --npUnc LatticeEigvars --pdfUncFromCorr
+  #           --npUnc LatticeEigvars
 
   #     - name: alphaS WZ reco fit
   #       run: >-
@@ -1527,7 +1526,7 @@ jobs:
             --genAxes "ptVGen-absYVGen-helicitySig" \
             --scaleNormXsecHistYields "0.05" --allowNegativeExpectation \
             --realData --systematicType normal --postfix unfolding \
-            --npUnc LatticeEigvars --pdfUncFromCorr \
+            --npUnc LatticeEigvars \
             --rebin 2 2 # this is for CI only! needed for max_files=100
 
       - name: alphaS Z unfolding fit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -820,7 +820,7 @@ jobs:
       - name: wlike rabbit setup
         run: >-
           scripts/ci/run_with_singularity.sh scripts/ci/setup_and_run_python.sh scripts/rabbit/setupRabbit.py 
-          -i $HIST_FILE --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --pseudoData uncorr --pdfUncFromUncorr
+          -i $HIST_FILE --lumiScale $LUMI_SCALE -o $WREMNANTS_OUTDIR --pseudoData uncorr --pdfUncFromWeights
 
       - name: wlike rabbit fit asimov
         run: >- 

--- a/scripts/corrections/make_theory_corr.py
+++ b/scripts/corrections/make_theory_corr.py
@@ -373,12 +373,18 @@ def main():
         minnloh = hh.rebinHist(
             minnloh,
             args.integrateAxis,
-            minnloh.axes[args.integrateAxis].edges[np.array((0, -1))],
+            [
+                minnloh.axes[args.integrateAxis].edges[0],
+                minnloh.axes[args.integrateAxis].edges[-1],
+            ],
         )
         numh = hh.rebinHist(
             numh,
             args.integrateAxis,
-            numh.axes[args.integrateAxis].edges[np.array((0, -1))],
+            [
+                numh.axes[args.integrateAxis].edges[0],
+                numh.axes[args.integrateAxis].edges[-1],
+            ],
         )
 
     corrh_unc, minnloh, numh = theory_corrections.make_corr_from_ratio(
@@ -523,7 +529,9 @@ def main():
                             ],
                             [
                                 "MiNNLO",
-                                generator.replace("_", " ").replace("FineBins ", ""),
+                                args.generator.replace("_", " ").replace(
+                                    "FineBins ", ""
+                                ),
                             ],
                             colors=["orange", "mediumpurple"],
                             linestyles=[
@@ -541,7 +549,7 @@ def main():
                             binwnorm=1.0,
                             baseline=True,
                             extra_text=extra_text,
-                            extra_text_loc=(0.5, 0.7) if varm == "qT" else (0.1, 0.2),
+                            extra_text_loc=(0.3, 0.7) if varm == "qT" else (0.1, 0.2),
                         )
                         plot_name = f"{varm}_{generator}_MiNNLO_{proc}{suffix}"
                         plot_tools.save_pdf_and_png(outdir, plot_name)

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -725,14 +725,19 @@ def make_parser(parser=None, argv=None):
         help="Scale the PDF hessian uncertainties by this factor (by default take the value in the pdfInfo map)",
     )
     parser.add_argument(
-        "--pdfUncFromCorr",
+        "--pdfUncFromUncorr",
         action="store_true",
-        help="Take PDF uncertainty from correction hist (requires having run that correction)",
+        help="Take PDF uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
     )
     parser.add_argument(
         "--asUncFromUncorr",
         action="store_true",
         help="Take alpha_S uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
+    )
+    parser.add_argument(
+        "--minnloUncFromUncorr",
+        action="store_true",
+        help="Take minnlo muR-muF uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
     )
     parser.add_argument(
         "--scaleMinnloScale",
@@ -1866,8 +1871,9 @@ def setup(
             np_model=args.npUnc,
             tnp_scale=args.scaleTNP,
             mirror_tnp=False,
-            pdf_from_corr=args.pdfUncFromCorr,
+            pdf_from_corr=not args.pdfUncFromUncorr,
             as_from_corr=not args.asUncFromUncorr,
+            minnlo_from_corr=not args.minnloUncFromUncorr,
             scale_pdf_unc=args.scalePdf,
             scale_np_lambda4=args.scaleNPLambda4,
             samples=theorySystSamples,
@@ -1876,6 +1882,7 @@ def setup(
             from_hels=not args.noTheoryCorrsViaHelicities,
             theory_symmetrize=args.symmetrizeTheoryUnc,
             pdf_symmetrize=args.symmetrizePdfUnc,
+            helicity_fit_unc=args.helicityFitTheoryUnc,
         )
 
         theory_helper.add_pdf_alphas_variation(
@@ -1887,9 +1894,7 @@ def setup(
         )
 
         if not stat_only and not args.noTheoryUnc:
-            theory_helper.add_all_theory_unc(
-                helicity_fit_unc=args.helicityFitTheoryUnc,
-            )
+            theory_helper.add_all_theory_unc()
 
     if stat_only:
         # print a card with only mass weights

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -735,11 +735,6 @@ def make_parser(parser=None, argv=None):
         help="Take alpha_S uncertainty from the MiNNLO event weights (by default it reads it from the theory-correction/helicity-smoothed hist, but requires having run that correction)",
     )
     parser.add_argument(
-        "--minnloUncFromWeights",
-        action="store_true",
-        help="Take minnlo muR-muF uncertainty from the MiNNLO event weights (by default it reads it from the theory-correction/helicity-smoothed hist, but requires having run that correction)",
-    )
-    parser.add_argument(
         "--scaleMinnloScale",
         default=1.0,
         type=float,
@@ -1108,7 +1103,9 @@ def make_parser(parser=None, argv=None):
     parser.add_argument(
         "--noTheoryCorrsViaHelicities",
         action="store_true",
-        help="Don't use theory correction histograms produced via smoothing through helicites.",
+        help="Don't use theory correction histograms produced via smoothing through helicities. "
+        "Affects the PDF, alpha_S, quark-mass and MiNNLO muR/muF uncertainties: with this flag they "
+        "are taken from the raw MiNNLO event weights instead of the helicity-decomposed (ByHelicity) hists.",
     )
     parser.add_argument(
         "--breitwignerWMassWeights",
@@ -1873,7 +1870,6 @@ def setup(
             mirror_tnp=False,
             pdf_from_corr=not args.pdfUncFromWeights,
             as_from_corr=not args.asUncFromWeights,
-            minnlo_from_corr=not args.minnloUncFromWeights,
             scale_pdf_unc=args.scalePdf,
             scale_np_lambda4=args.scaleNPLambda4,
             samples=theorySystSamples,

--- a/scripts/rabbit/setupRabbit.py
+++ b/scripts/rabbit/setupRabbit.py
@@ -725,19 +725,19 @@ def make_parser(parser=None, argv=None):
         help="Scale the PDF hessian uncertainties by this factor (by default take the value in the pdfInfo map)",
     )
     parser.add_argument(
-        "--pdfUncFromUncorr",
+        "--pdfUncFromWeights",
         action="store_true",
-        help="Take PDF uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
+        help="Take PDF uncertainty from the MiNNLO event weights (by default it reads it from the theory-correction/helicity-smoothed hist, but requires having run that correction)",
     )
     parser.add_argument(
-        "--asUncFromUncorr",
+        "--asUncFromWeights",
         action="store_true",
-        help="Take alpha_S uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
+        help="Take alpha_S uncertainty from the MiNNLO event weights (by default it reads it from the theory-correction/helicity-smoothed hist, but requires having run that correction)",
     )
     parser.add_argument(
-        "--minnloUncFromUncorr",
+        "--minnloUncFromWeights",
         action="store_true",
-        help="Take minnlo muR-muF uncertainty from uncorrected hist (by default it reads it from the correction hist, but requires having run that correction)",
+        help="Take minnlo muR-muF uncertainty from the MiNNLO event weights (by default it reads it from the theory-correction/helicity-smoothed hist, but requires having run that correction)",
     )
     parser.add_argument(
         "--scaleMinnloScale",
@@ -1871,9 +1871,9 @@ def setup(
             np_model=args.npUnc,
             tnp_scale=args.scaleTNP,
             mirror_tnp=False,
-            pdf_from_corr=not args.pdfUncFromUncorr,
-            as_from_corr=not args.asUncFromUncorr,
-            minnlo_from_corr=not args.minnloUncFromUncorr,
+            pdf_from_corr=not args.pdfUncFromWeights,
+            as_from_corr=not args.asUncFromWeights,
+            minnlo_from_corr=not args.minnloUncFromWeights,
             scale_pdf_unc=args.scalePdf,
             scale_np_lambda4=args.scaleNPLambda4,
             samples=theorySystSamples,

--- a/wremnants/postprocessing/rabbit_theory_helper.py
+++ b/wremnants/postprocessing/rabbit_theory_helper.py
@@ -74,7 +74,7 @@ class TheoryHelper(object):
 
         self.datagroups = datagroups
         corr_hists = self.datagroups.args_from_metadata("theoryCorr")
-        self.corr_hist_name = (corr_hists[0] + "_Corr") if corr_hists else None
+        self.corr_hist_name = (corr_hists[0] + "_Corr") if corr_hists else ""
 
         self.syst_ax = "vars"
         self.corr_hist = None
@@ -111,6 +111,7 @@ class TheoryHelper(object):
         mirror_tnp=True,
         as_from_corr=True,
         pdf_from_corr=False,
+        minnlo_from_corr=True,
         pdf_operation=None,
         samples=[],
         scale_pdf_unc=-1.0,
@@ -120,6 +121,7 @@ class TheoryHelper(object):
         from_hels=False,
         theory_symmetrize="quadratic",
         pdf_symmetrize="quadratic",
+        helicity_fit_unc=False,
     ):
 
         self.set_resum_unc_type(resumUnc)
@@ -131,12 +133,13 @@ class TheoryHelper(object):
         self.tnp_scale = tnp_scale
         self.mirror_tnp = mirror_tnp
         self.pdf_from_corr = pdf_from_corr
-        self.as_from_corr = pdf_from_corr or as_from_corr
+        self.as_from_corr = as_from_corr
+        self.minnlo_from_corr = minnlo_from_corr
         self.pdf_operation = pdf_operation
         self.scale_pdf_unc = scale_pdf_unc
         self.scale_np_lambda4 = scale_np_lambda4
         self.samples = samples
-        self.helicity_fit_unc = False
+        self.helicity_fit_unc = helicity_fit_unc
         self.minnlo_scale = minnlo_scale
         self.from_hels = from_hels
 
@@ -144,10 +147,10 @@ class TheoryHelper(object):
         self.theory_symmetrize = convert_none(theory_symmetrize)
         self.pdf_symmetrize = convert_none(pdf_symmetrize)
 
-    def add_all_theory_unc(self, helicity_fit_unc=False):
-        self.helicity_fit_unc = helicity_fit_unc
+    def add_all_theory_unc(self):
         self.add_nonpert_unc(model=self.np_model)
         self.add_resum_unc(scale=self.tnp_scale)
+        self.add_fixed_order_unc()
         if "nnlojet" in self.corr_hist_name:
             self.add_stat_unc()
         # additional uncertainty for effect of shower and intrinsic kt on angular coeffs
@@ -258,6 +261,7 @@ class TheoryHelper(object):
                     transition=self.transitionUnc,
                 )
 
+    def add_fixed_order_unc(self):
         if self.minnlo_unc and self.minnlo_unc not in ["none", None]:
             # sigma_-1 uncertainty is covered by scetlib-dyturbo uncertainties if they are used
             helicities_to_exclude = None if self.resumUnc == "minnlo" else [-1]
@@ -270,7 +274,7 @@ class TheoryHelper(object):
                         # orthogonality of chebychev polynomials means that there is no
                         # double counting with fully correlated uncertainty
                         scale_inclusive = 1.0
-                    else:
+                    elif "Pt" in self.minnlo_unc:
                         fine_pt_binning = binning.ptV_binning[::2]
                         nptfine = len(fine_pt_binning) - 1
                         scale_inclusive = np.sqrt((nptfine - 1) / nptfine)
@@ -283,6 +287,8 @@ class TheoryHelper(object):
                             scale=self.minnlo_scale,
                             symmetrize=self.theory_symmetrize,
                         )
+                    else:
+                        scale_inclusive = 1.0
 
                     self.add_minnlo_scale_uncertainty(
                         sample_group,
@@ -297,7 +303,6 @@ class TheoryHelper(object):
         self,
         sample_group,
         extra_name="",
-        use_hel_hist=True,
         rebin_pt=None,
         helicities_to_exclude=None,
         pt_min=None,
@@ -310,49 +315,44 @@ class TheoryHelper(object):
             )
             return
 
-        helicity = "Helicity" in self.minnlo_unc
-        pt_binned = "Pt" in self.minnlo_unc
-        scale_hist = (
-            "qcdScale" if not (helicity or use_hel_hist) else "qcdScaleByHelicity"
-        )
-        if "helicity" in scale_hist.lower():
-            use_hel_hist = True
+        group_name = f"QCDscale{self.sample_label(sample_group)}"
+        base_name = f"{group_name}{extra_name}"
 
-        # All possible syst_axes
+        pt_binned = "Pt" in self.minnlo_unc
         # TODO: Move the axes to common and refer to axis_chargeVgen etc by their name attribute, not just
         # assuming the name is unchanged
         obs = self.datagroups.fit_axes
         pt_ax = "ptVgen" if "ptVgen" not in obs else "ptVgenAlt"
 
-        syst_axes = [pt_ax, "vars"]
-        syst_ax_labels = ["PtV", "var"]
-        format_with_values = ["edges", "center"]
+        if self.minnlo_from_corr:
+            scale_hist = "qcdScaleByHelicity"
 
-        group_name = f"QCDscale{self.sample_label(sample_group)}"
-        base_name = f"{group_name}{extra_name}"
+            syst_axes = ["vars"]
+            syst_ax_labels = ["var"]
 
-        skip_entries = []
-        preop_map = {}
+            skip_entries = []
+            # skip nominal
+            skip_entries.append({"vars": "nominal"})
+            # skip pythia shower and kt variations since they are handled elsewhere
+            skip_entries.append({"vars": "pythia_shower_kt"})
 
-        # skip nominal
-        skip_entries.append({"vars": "nominal"})
+            # All possible syst_axes
+            syst_axes = [pt_ax, *syst_axes]
+            syst_ax_labels = ["PtV", *syst_ax_labels]
+            format_with_values = ["edges", "center"]
 
-        # skip pythia shower and kt variations since they are handled elsewhere
-        skip_entries.append({"vars": "pythia_shower_kt"})
-
-        if helicities_to_exclude:
-            for helicity in helicities_to_exclude:
-                skip_entries.append({"vars": f"helicity_{helicity}_Down"})
-                skip_entries.append({"vars": f"helicity_{helicity}_Up"})
+            if helicities_to_exclude:
+                for helicity in helicities_to_exclude:
+                    skip_entries.append({"vars": f"helicity_{helicity}_Down"})
+                    skip_entries.append({"vars": f"helicity_{helicity}_Up"})
+        else:
+            scale_hist = "qcdScale"
 
         # NOTE: The map needs to be keyed on the base procs not the group names, which is
         # admittedly a bit nasty
         expanded_samples = self.datagroups.getProcGroupNames([sample_group])
         logger.debug(f"using {scale_hist} histogram for QCD scale systematics")
         logger.debug(f"expanded_samples: {expanded_samples}")
-
-        preop_map = {}
-        preop_args = {}
 
         if pt_binned:
             signal_samples = self.datagroups.procGroups["signal_samples"]
@@ -386,29 +386,34 @@ class TheoryHelper(object):
                 pt_idx = np.argmax(binning >= pt_min)
                 skip_entries.extend([{pt_ax: complex(0, x)} for x in binning[:pt_idx]])
 
-            func = (
+            preop = (
                 syst_tools.gen_hist_to_variations
                 if pt_ax == "ptVgenAlt"
                 else syst_tools.hist_to_variations
             )
-            preop_map = {proc: func for proc in expanded_samples}
-            preop_args["gen_axes"] = [pt_ax]
-            preop_args["rebin_axes"] = [pt_ax]
-            preop_args["rebin_edges"] = [binning]
+
+            preop_args = {
+                "gen_axes": [pt_ax],
+                "rebin_axes": [pt_ax],
+                "rebin_edges": [binning],
+            }
             if pt_ax == "ptVgenAlt":
                 preop_args["gen_obs"] = ["ptVgen"]
+        else:
+            preop = None
+            preop_args = {}
 
         # Skip MiNNLO unc.
-        if self.resumUnc and not (pt_binned or helicity):
+        if self.resumUnc and not (pt_binned or "Helicity" in self.minnlo_unc):
             logger.warning(
                 "Without pT or helicity splitting, only the SCETlib uncertainty will be applied!"
             )
-        else:
+        elif self.minnlo_from_corr:
             # FIXME Maybe put W and Z nuisances in the same group
             group_name += f"MiNNLO"
             self.datagroups.addSystematic(
                 scale_hist,
-                preOpMap=preop_map,
+                preOp=preop,
                 preOpArgs=preop_args,
                 symmetrize=symmetrize,
                 processes=[sample_group],
@@ -429,6 +434,40 @@ class TheoryHelper(object):
                 scale=scale,
                 name=base_name,  # Needed to allow it to be called multiple times
             )
+        else:
+            # vary muR or muF one at a time
+            for var, other in [["muRfact", "muFfact"], ["muFfact", "muRfact"]]:
+                group_name += f"MiNNLO"
+                self.datagroups.addSystematic(
+                    scale_hist,
+                    preOp=lambda h, *args, **kwargs: (
+                        preop(h[{other: 1}], *args, **kwargs)
+                        if preop
+                        else h[{other: 1}]
+                    ),
+                    preOpArgs=preop_args,
+                    symmetrize=symmetrize,
+                    processes=[sample_group],
+                    groups=[
+                        group_name,
+                        "QCDscale",
+                        "angularCoeffs",
+                        "theory",
+                        "theory_qcd",
+                    ],
+                    splitGroup={},
+                    systAxes=[var],
+                    systNameReplace=[
+                        [f"{var}0p5", f"{var}Down"],
+                        [f"{var}2", f"{var}Up"],
+                    ],
+                    skipEntries=[{var: 1}],
+                    baseName=base_name + "_",
+                    formatWithValue=["center"],
+                    passToFakes=self.propagate_to_fakes,
+                    scale=scale,
+                    name=base_name,  # Needed to allow it to be called multiple times
+                )
 
     def add_helicity_shower_kt_uncertainty(self):
         # select the proper variation and project over gen pt unless it is one of the fit variables

--- a/wremnants/postprocessing/rabbit_theory_helper.py
+++ b/wremnants/postprocessing/rabbit_theory_helper.py
@@ -117,7 +117,6 @@ class TheoryHelper(object):
         mirror_tnp=True,
         as_from_corr=True,
         pdf_from_corr=False,
-        minnlo_from_corr=True,
         pdf_operation=None,
         samples=[],
         scale_pdf_unc=-1.0,
@@ -140,7 +139,6 @@ class TheoryHelper(object):
         self.mirror_tnp = mirror_tnp
         self.pdf_from_corr = pdf_from_corr
         self.as_from_corr = as_from_corr
-        self.minnlo_from_corr = minnlo_from_corr
         self.pdf_operation = pdf_operation
         self.scale_pdf_unc = scale_pdf_unc
         self.scale_np_lambda4 = scale_np_lambda4
@@ -330,7 +328,10 @@ class TheoryHelper(object):
         obs = self.datagroups.fit_axes
         pt_ax = "ptVgen" if "ptVgen" not in obs else "ptVgenAlt"
 
-        if self.minnlo_from_corr:
+        # from_hels selects the helicity-smoothed scale hist, which carries the
+        # muR/muF variations decomposed by helicity (UL + each A_i); otherwise use
+        # the raw MiNNLO event-weight grid and vary muR/muF one at a time below.
+        if self.from_hels:
             scale_hist = "qcdScaleByHelicity"
 
             syst_axes = ["vars"]
@@ -414,7 +415,7 @@ class TheoryHelper(object):
             logger.warning(
                 "Without pT or helicity splitting, only the SCETlib uncertainty will be applied!"
             )
-        elif self.minnlo_from_corr:
+        elif self.from_hels:
             # FIXME Maybe put W and Z nuisances in the same group
             group_name += f"MiNNLO"
             self.datagroups.addSystematic(

--- a/wremnants/postprocessing/syst_tools.py
+++ b/wremnants/postprocessing/syst_tools.py
@@ -902,6 +902,9 @@ def hist_to_variations(
         # all the axes have already been projected out, nothing else to do
         return hist_in
 
+    if "vars" not in hist_in.axes.name:
+        return hist_in
+
     nom_hist = hist_in[{"vars": 0}]
     nom_hist_sum = nom_hist[gen_sum_expr]
 

--- a/wremnants/production/theory_corrections.py
+++ b/wremnants/production/theory_corrections.py
@@ -1082,7 +1082,7 @@ def make_helicity_smoothing_helpers(
                 )
             )
 
-        if "pdf" in corrs:
+        if len(pdfs) > 0 and "pdf" in corrs:
             helicity_smoothing_helpers_procs[proc]["pdf"] = (
                 make_pdfs_uncertainties_helper_by_helicity(
                     proc=proc,
@@ -1105,7 +1105,7 @@ def make_helicity_smoothing_helpers(
                     as_vars=as_vars,
                 )
             )
-        if "pdf_central" in corrs:
+        if len(pdfs) > 0 and "pdf_central" in corrs:
             helicity_smoothing_helpers_procs[proc]["pdf_central"] = (
                 make_uncertainty_helper_by_helicity(
                     proc=proc,

--- a/wremnants/utilities/io_tools/input_tools.py
+++ b/wremnants/utilities/io_tools/input_tools.py
@@ -332,6 +332,12 @@ def read_dyturbo_hist(
 
     hists = []
     for fn in filenames:
+
+        if "-mur0p5-" in fn.split("/")[-1]:
+            fn = fn.replace("-mur0p5-", "-murH-")
+        if "-muf0p5-" in fn.split("/")[-1]:
+            fn = fn.replace("-muf0p5-", "-mufH-")
+
         expandedf = fn.split("+")
 
         hs = []
@@ -671,13 +677,16 @@ def read_matched_scetlib_hist(
         def translate_slice(ax, s):
             if not isinstance(s, slice):
                 return s
+            # values(flow=True) prepends the underflow bin (if present), so shift
+            # axis-coordinate indices by ax.traits.underflow to address real bins.
+            uflow = int(ax.traits.underflow)
             start = (
-                int(ax.index(s.start.imag) + s.start.real)
+                int(ax.index(s.start.imag) + s.start.real + uflow)
                 if isinstance(s.start, complex)
                 else s.start
             )
             stop = (
-                int(ax.index(s.stop.imag) + s.stop.real + 1)
+                int(ax.index(s.stop.imag) + s.stop.real + uflow)
                 if isinstance(s.stop, complex)
                 else s.stop
             )


### PR DESCRIPTION
Split out from the total-phase-space PR (#661): this isolates the change that makes the PDF and MiNNLO muR/muF theory uncertainties be taken from the theory **correction / helicity-smoothed histograms** by default, so the nominal configuration needs no extra CL args.

## What changes
- **Default flip:** the PDF uncertainty is now read from the theory-correction (helicity-smoothed) hist by default. Opt out with new flags to read it from the raw MiNNLO event weights instead:
  - `--pdfUncFromWeights`
  - `--asUncFromWeights` (renamed from `--asUncFromUncorr`; alpha_S was already from-corr by default)
- **MiNNLO muR/muF source:** the helicity-smoothed (`qcdScaleByHelicity`) vs raw-event-weight (`qcdScale`) choice for the MiNNLO muR/muF scale uncertainty now follows the existing `--noTheoryCorrsViaHelicities` flag. An earlier iteration of this PR added a separate `--minnloUncFromWeights`, but it selected the same `qcdScaleByHelicity` hist already governed by `--noTheoryCorrsViaHelicities`, so it was redundant and has been dropped — `--noTheoryCorrsViaHelicities` is now the single switch for the helicity-smoothing layer across the PDF, alpha_S, quark-mass and MiNNLO muR/muF uncertainties.
- Naming: the previous `Corr`/`Uncorr` wording collided with the usual MiNNLO(uncorr) vs SCETlib+DYturbo(corr) meaning — both options here are MiNNLO-based — so the opt-out flags are named after the event-weights source. This also avoids clashing with the existing `--noTheoryCorrsViaHelicities` flag.
- Refactor `TheoryHelper`: extract `add_fixed_order_unc`, restructure `add_minnlo_scale_uncertainty`, move `helicity_fit_unc` into `configure()`.
- CI workflow updated to keep the wlike and alphaS fits at their intended behavior (`--pdfUncFromWeights` on wlike; drop now-redundant `--pdfUncFromCorr` on alphaS).

## Effect
The only default-behavior change for the standard fit is the **PDF default flip**, which produces the small differences seen in the wmass impacts during PR validation. The wlike impacts are unchanged (PDF behavior preserved via the explicit flag). The MiNNLO and alpha_S defaults are functionally unchanged.

## Merge order
Should be merged **before** #661. The same from-corr changes currently live on the total-phase-space branch and are byte-identical, so they deduplicate cleanly once this is in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
