### PR TITLE
Bump container to v67 (xrootd OpenSSL 3 fix)

### DIFF
--- a/scripts/ci/run_with_singularity.sh
+++ b/scripts/ci/run_with_singularity.sh
@@ -6,7 +6,7 @@ fi
 if [[ -d /ceph ]]; then
     export APPTAINER_BIND="${APPTAINER_BIND},/ceph"
 fi
-CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v61
+CONTAINER=/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/bendavid/cmswmassdocker/wmassdevrolling\:v67
 
 # Kerberos cache setup
 # Assuming kinit was already done on the host!

--- a/scripts/plotting/makePdfUncPlot.py
+++ b/scripts/plotting/makePdfUncPlot.py
@@ -5,7 +5,7 @@ import os
 import h5py
 import hist
 import numpy as np
-from matplotlib import cm
+from matplotlib import colormaps
 
 from wremnants.postprocessing import pdf_tools
 from wremnants.utilities import theory_utils
@@ -112,7 +112,7 @@ for dataset in args.datasets:
         pdfInfo[pdf]["scale"] if "scale" in pdfInfo[pdf] else 1.0 for pdf in args.pdfs
     ]
     names = [[pdfName + r" $\pm1\sigma$", "", ""] for pdfName in pdfNames]
-    cmap = cm.get_cmap("tab10")
+    cmap = colormaps["tab10"]
     colors = [[cmap(i)] * 3 for i in range(len(args.pdfs))]
 
     if "unrolled_gen_hel" in args.obs:

--- a/scripts/plotting/makeScetlibComparisons.py
+++ b/scripts/plotting/makeScetlibComparisons.py
@@ -3,7 +3,7 @@ import pickle
 
 import hist
 import lz4.frame
-from matplotlib import cm
+from matplotlib import colormaps
 
 from wremnants.production import helicity_utils
 from wremnants.utilities import parsing
@@ -217,7 +217,7 @@ if not args.scetlib_files:
         {"massVgen": s[0 : x.axes["massVgen"].size : hist.sum]}
     ]
 
-cmap = cm.get_cmap("tab10")
+cmap = colormaps["tab10"]
 lookup["minnlo"]["colors"] = ["red"] + [
     cmap(i) for i in range(len(args.minnlo_files) - 1)
 ]

--- a/wremnants/utilities/styles/styles.py
+++ b/wremnants/utilities/styles/styles.py
@@ -1,6 +1,6 @@
 import copy
 
-import matplotlib.cm as cm
+from matplotlib import colormaps
 
 from wums import boostHistHelpers as hh
 from wums import logging
@@ -818,7 +818,7 @@ def get_labels_colors_procs_sorted(procs):
         "Rare",
     ][::-1]
 
-    cmap = cm.get_cmap("tab10")
+    cmap = colormaps["tab10"]
 
     procs = sorted(
         procs, key=lambda x: procs_sort.index(x) if x in procs_sort else len(procs_sort)


### PR DESCRIPTION
## Summary

Bumps the apptainer/singularity container pin in `run_with_singularity.sh` to `wmassdevrolling:v67`.

v67 rebuilds the pip-installed `xrootd` against the container's **system OpenSSL 3** instead of vendoring its own **OpenSSL 1.1.1**. Previously, importing `XRootD.client` (used for EOS directory listing in `dataset_tools.py`) loaded pyxrootd's bundled OpenSSL 1.1.1, which — sharing the `libXrdCl` soname and via ROOT/cppyy's `RTLD_GLOBAL` — collided with pyarrow's OpenSSL 3 symbols and **segfaulted during the krb5 authentication handshake** when loading samples from EOS over xrootd.

In v67, `xrootd.libs/` no longer bundles any crypto and pyxrootd's `libXrdSeckrb5` links the system `libcrypto.so.3` / `libkrb5.so.3` / `libk5crypto.so.3`, so the whole process runs on a single consistent OpenSSL 3 and the clash is gone at the source.

## Verification

On v67, with the existing python `XRootD.client` usage:
- `w_z_gen_dists.py` books files from EOS with no segfault (the exact path that crashed on v66).
- End-to-end: `import hist` (-> pyarrow/OpenSSL 3) + `import XRootD.client` + list + open + read 113,400 events all succeed.
- pyxrootd is loaded, yet the only `libcrypto` mapped in the process is the system `libcrypto.so.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)