### PR TITLE
CVH refit efficiency: measure it and apply a 2D module-frame data/MC scale factor

### DIFF
--- a/scripts/analysisTools/make_cvh_efficiency_sf.py
+++ b/scripts/analysisTools/make_cvh_efficiency_sf.py
@@ -1,0 +1,300 @@
+"""Generate the CVH-refit efficiency scale-factor map for muon_efficiencies_cvh.hpp.
+
+Reads the 'cvhEfficiency' histogram produced by
+'scripts/histmakers/mz_dilepton.py --cvhEfficiencyHists' (axes
+pt, eta, phi, charge, passCVH, in uncorrected muon kinematics) and writes the
+measured SF = eps_data / eps_MC as a map in (eta, phi'), where
+
+    phi' = phi - q * C / pt
+
+is the muon azimuth at the module rather than at the vertex (C is the track
+bending, see muon_efficiencies_cvh.hpp). Working in phi' makes the map charge-
+and pt-independent: the two charges' holes, which sit at opposite +-C/pt
+offsets in vertex phi, line up, so a single map applies to everything without
+smearing the sharp module edges.
+
+The affected cells (a couple of small rectangles) are written into the
+GENERATED block of the header in place; everywhere else the SF is exactly 1.
+
+Usage:
+    python scripts/analysisTools/make_cvh_efficiency_sf.py -i <cvhEfficiency.hdf5>
+"""
+
+import argparse
+import os
+
+import h5py
+import numpy as np
+
+from wums import ioutils, logging
+
+logger = logging.child_logger(__name__)
+
+HEADER = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "wremnants/production/include/muon_efficiencies_cvh.hpp",
+)
+
+# track bending to the module radius, C = 0.3*B*r/2 [rad*GeV]; must match the
+# value hard-coded in muon_efficiencies_cvh.hpp (cvh_bending_C)
+BENDING_C = 0.214
+
+# search boxes (module frame) in which to keep the correction; everything
+# outside stays at SF = 1. (eta_lo, eta_hi, phiprime_lo, phiprime_hi)
+SEARCH_BOXES = {
+    "hotspot1 (TIB-L2, detId 369141860)": (-0.10, 0.85, 0.60, 1.20),
+    "hotspot2 (uncorrected)": (-1.95, -1.40, 4.90, 5.55),
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("-i", "--input", required=True, help="cvhEfficiency hdf5")
+    p.add_argument(
+        "--nSigma",
+        type=float,
+        default=3.0,
+        help="Keep a cell's SF only if it is below 1 by at least this many sigma",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the generated block but do not modify the header",
+    )
+    p.add_argument("-v", "--verbose", type=int, default=3)
+    return p.parse_args()
+
+
+def load(fname):
+    """Return the (data, total MC) 'cvhEfficiency' histograms."""
+    hdata, hmc = None, None
+    with h5py.File(fname, "r") as f:
+        for proc in f.keys():
+            if proc == "meta_info":
+                continue
+            res = ioutils.pickle_load_h5py(f[proc])
+            h = res["output"]["cvhEfficiency"].get()
+            if res["dataset"].get("is_data", False):
+                hdata = h if hdata is None else hdata + h
+            else:
+                hmc = h if hmc is None else hmc + h
+    return hdata, hmc
+
+
+def to_module_phi(h):
+    """Collapse (pt, eta, phi, charge, pass) -> (eta, phi', pass).
+
+    Each (pt, charge) slice is shifted in phi by -q*C/pt with a linear sub-bin
+    redistribution (the shift is well below one phi bin over 25-65 GeV), then
+    summed. This is the histogram-level equivalent of filling phi' per muon.
+    """
+    v = h.values()  # pt, eta, phi, charge, pass
+    pt_c = h.axes["pt"].centers
+    phi_w = h.axes["phi"].edges[1] - h.axes["phi"].edges[0]
+    nphi = len(h.axes["phi"])
+    charges = {0: -1.0, 1: +1.0}  # charge-axis index -> muon charge
+
+    out = np.zeros((len(h.axes["eta"]), nphi, 2))
+    for iq, q in charges.items():
+        for ipt, pt in enumerate(pt_c):
+            f = -q * BENDING_C / pt / phi_w  # shift in units of phi bins
+            assert abs(f) < 1.0, f"sub-bin shift assumption violated: |f|={abs(f)}"
+            step = 1 if f > 0 else -1
+            src = v[ipt, :, :, iq, :]  # eta, phi, pass
+            out += (1.0 - abs(f)) * src
+            out += abs(f) * np.roll(src, step, axis=1)
+    return out
+
+
+def efficiency(v):
+    """(eff, err) from an array with the pass axis last (index 1 = pass)."""
+    n = v.sum(axis=-1)
+    eff = np.divide(v[..., 1], n, out=np.ones_like(n), where=n > 0)
+    err = np.divide(
+        np.sqrt(np.maximum(eff * (1 - eff), 0) * n),
+        n,
+        out=np.zeros_like(n),
+        where=n > 0,
+    )
+    return eff, err
+
+
+def scale_factor(vd, vm):
+    """SF = eff_data/eff_MC and its (data-dominated) uncertainty."""
+    ed, dd = efficiency(vd)
+    em, _ = efficiency(vm)
+    em = np.where(em > 0, em, 1.0)
+    return ed / em, dd / em
+
+
+def build_regions(hd, hm, nsigma):
+    """Return a list of (name, i0, i1, j0, j1, sf[nEta,nPhi]) rectangles."""
+    md = to_module_phi(hd)
+    mm = to_module_phi(hm)
+    sf, err = scale_factor(md, mm)
+    # holes only: never upweight, and drop cells not significantly below 1
+    keep = (sf < 1.0 - nsigma * err) & (err > 0)
+    sf = np.where(keep, np.clip(sf, 0.0, 1.0), 1.0)
+
+    eta_e = hd.axes["eta"].edges
+    phi_e = hd.axes["phi"].edges
+    eta_c = hd.axes["eta"].centers
+    phi_c = hd.axes["phi"].centers
+
+    regions = []
+    for name, (e0, e1, p0, p1) in SEARCH_BOXES.items():
+        box = (
+            (eta_c[:, None] > e0)
+            & (eta_c[:, None] < e1)
+            & (phi_c[None, :] > p0)
+            & (phi_c[None, :] < p1)
+        )
+        sig = keep & box
+        if not sig.any():
+            logger.warning(f"no significant cells in {name}, skipping")
+            continue
+        ii, jj = np.where(sig)
+        i0, i1, j0, j1 = ii.min(), ii.max(), jj.min(), jj.max()
+        block = sf[i0 : i1 + 1, j0 : j1 + 1].copy()
+        regions.append((name, i0, i1, j0, j1, block, eta_e, phi_e))
+        logger.info(
+            f"{name}: eta [{eta_e[i0]:.2f},{eta_e[i1+1]:.2f}] "
+            f"phi' [{phi_e[j0]:.3f},{phi_e[j1+1]:.3f}], "
+            f"{block.shape[0]}x{block.shape[1]} cells, min SF = {block.min():.3f}"
+        )
+    return regions
+
+
+def render(regions):
+    """Render the C++ GENERATED block."""
+    lines = [
+        "// BEGIN GENERATED -- do not edit by hand, see make_cvh_efficiency_sf.py",
+        "",
+    ]
+    for k, (name, i0, i1, j0, j1, block, eta_e, phi_e) in enumerate(regions):
+        neta, nphi = block.shape
+        eta_lo, eta_w = eta_e[i0], eta_e[1] - eta_e[0]
+        phi_lo, phi_w = phi_e[j0], phi_e[1] - phi_e[0]
+        lines.append(f"// {name}")
+        lines.append(
+            f"//   eta in [{eta_e[i0]:.2f}, {eta_e[i1+1]:.2f}), "
+            f"phi' in [{phi_e[j0]:.3f}, {phi_e[j1+1]:.3f})"
+        )
+        lines.append(f"inline const double cvh_sf_region{k}[{neta} * {nphi}] = {{")
+        for ie in range(neta):
+            row = ", ".join(f"{block[ie, ip]:.3f}" for ip in range(nphi))
+            eta_center = eta_lo + (ie + 0.5) * eta_w
+            lines.append(f"    {row}, // eta ~ {eta_center:+.3f}")
+        # (trailing comma on the last row is legal in a C++ aggregate initializer)
+        lines.append("};")
+        lines.append("")
+
+    lines.append("inline const CvhSFRegion cvh_sf_regions[] = {")
+    for k, (name, i0, i1, j0, j1, block, eta_e, phi_e) in enumerate(regions):
+        neta, nphi = block.shape
+        eta_lo, eta_w = eta_e[i0], eta_e[1] - eta_e[0]
+        phi_lo, phi_w = phi_e[j0], phi_e[1] - phi_e[0]
+        lines.append(
+            f"    {{{eta_lo:.4f}, {eta_w:.4f}, {neta}, "
+            f"{phi_lo:.4f}, {phi_w:.4f}, {nphi}, cvh_sf_region{k}}},"
+        )
+    lines.append("};")
+    lines.append("")
+    lines.append("// END GENERATED")
+    return "\n".join(lines)
+
+
+def patch_header(block):
+    with open(HEADER) as f:
+        text = f.read()
+    b0 = text.index("// BEGIN GENERATED")
+    e0 = text.index("// END GENERATED")
+    e0 = text.index("\n", e0) + 1
+    # keep the surrounding clang-format guards, which sit just outside the markers
+    new = text[:b0] + block + "\n" + text[e0:]
+    with open(HEADER, "w") as f:
+        f.write(new)
+    logger.info(f"Patched {HEADER}")
+
+
+def closure(hd, hm, regions):
+    """Per charge, compare the map (evaluated per cell in module phi) against
+    the directly measured vertex-phi SF.
+
+    In the analysis only passing muons are kept and each is downweighted by the
+    map SF, so the map must reproduce the truth SF = eps_data/eps_MC cell by
+    cell. Here that truth is measured in vertex phi, separately per charge, and
+    the map is looked up at phi' = phi - q*C/pt. The residual, averaged over
+    (phi, pt) weighted by the muons being corrected, should be ~1 in every eta
+    bin -- unlike a charge-averaged vertex-phi correction, which is off because
+    the hole sits at opposite phi offsets for the two charges.
+    """
+
+    def sf_lookup(eta, phiprime):
+        for _, i0, i1, j0, j1, block, eta_e, phi_e in regions:
+            ie = int(np.floor((eta - eta_e[i0]) / (eta_e[1] - eta_e[0])))
+            ip = int(np.floor((phiprime - phi_e[j0]) / (phi_e[1] - phi_e[0])))
+            if 0 <= ie < block.shape[0] and 0 <= ip < block.shape[1]:
+                return block[ie, ip]
+        return 1.0
+
+    eta_c = hd.axes["eta"].centers
+    phi_c = hd.axes["phi"].centers
+    pt_c = hd.axes["pt"].centers
+    vd, vm = hd.values(), hm.values()
+    twopi = 2 * np.pi
+    eta_boxes = [(e0, e1) for (e0, e1, _, _) in SEARCH_BOXES.values()]
+
+    logger.info(
+        "Closure: effective correction, measured (needed) -> residual after map"
+    )
+    for iq, q in ((0, -1), (1, +1)):
+        # per-cell truth SF = eff_data/eff_MC (an efficiency ratio, so non-CVH
+        # data/MC differences cancel), and the map SF at phi'(q,pt)
+        ed, _ = efficiency(vd[:, :, :, iq, :])  # pt, eta, phi
+        em, _ = efficiency(vm[:, :, :, iq, :])
+        em = np.where(em > 0, em, 1.0)
+        sf_meas = ed / em
+        w = vm[:, :, :, iq, 1]  # passing MC, the muons being corrected
+
+        for je, eta in enumerate(eta_c):
+            if not any(e0 < eta < e1 for e0, e1 in eta_boxes):
+                continue
+            wsum = w[:, je, :].sum()
+            if wsum < 500:
+                continue
+            need = (w[:, je, :] * sf_meas[:, je, :]).sum() / wsum
+            applied = np.zeros(1)
+            sf_map = np.array(
+                [
+                    [
+                        sf_lookup(eta, (phi - q * BENDING_C / pt) % twopi)
+                        for phi in phi_c
+                    ]
+                    for pt in pt_c
+                ]
+            )
+            appl = (w[:, je, :] * sf_map).sum() / wsum
+            resid = need / appl
+            if abs(need - 1) > 1e-3 or abs(resid - 1) > 1e-3:
+                logger.info(
+                    f"  q={q:+d} eta~{eta:+.2f}: needed {need:.4f}, "
+                    f"applied {appl:.4f}, residual {resid:.4f}"
+                )
+
+
+def main():
+    args = parse_args()
+    logging.setup_logger(__file__, args.verbose)
+    hd, hm = load(args.input)
+    regions = build_regions(hd, hm, args.nSigma)
+    block = render(regions)
+    if args.dry_run:
+        print(block)
+    else:
+        patch_header(block)
+    closure(hd, hm, regions)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysisTools/plot_cvh_efficiency.py
+++ b/scripts/analysisTools/plot_cvh_efficiency.py
@@ -1,0 +1,514 @@
+"""Plot the single-muon CVH refit efficiency in data and MC.
+
+Input is the 'cvhEfficiency' histogram produced by
+'scripts/histmakers/mz_dilepton.py --cvhEfficiencyHists' (see there for the
+required options), with axes (pt, eta, phi, charge, passCVH) in uncorrected
+muon kinematics.
+
+The measured scale factor SF = eff(data)/eff(MC) per (eta,phi) cell is what
+'wremnants/production/include/muon_efficiencies_cvh.hpp' has to reproduce; the
+hard-coded version of it is overlaid for comparison.
+"""
+
+import argparse
+import datetime
+import os
+
+import h5py
+import make_cvh_efficiency_sf as cvhgen  # sibling module, same directory
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import mplhep as hep
+import numpy as np
+
+from wums import ioutils, logging, output_tools, plot_tools
+
+hep.style.use(hep.style.ROOT)
+logger = logging.child_logger(__name__)
+
+# the two localized CVH refit efficiency holes seen in data, as (eta, phi) boxes
+HOTSPOTS = {
+    "hotspot1": dict(
+        eta=(-0.10, 0.85),
+        phi=(0.65, 1.15),
+        label=r"TIB-L2 glued module (detId 369141860)",
+    ),
+    "hotspot2": dict(
+        eta=(-1.95, -1.40),
+        phi=(4.95, 5.50),
+        label=r"second hole, uncorrected",
+    ),
+}
+
+# the original 1D-in-eta approximation (flat over phi 0.80-1.00), now superseded
+# by the 2D module-phi map in muon_efficiencies_cvh.hpp; kept here only as a
+# reference curve on the vertex-phi diagnostic
+SF_CODE_ETA_EDGES = np.arange(0.05, 0.701, 0.05)
+SF_CODE_VALUES = np.array(
+    [
+        0.982,
+        0.933,
+        0.910,
+        0.823,
+        0.718,
+        0.645,
+        0.585,
+        0.606,
+        0.653,
+        0.777,
+        0.847,
+        0.955,
+        0.980,
+    ]
+)
+SF_CODE_PHI_GATE = (0.80, 1.00)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="hdf5 output of mz_dilepton.py --cvhEfficiencyHists",
+    )
+    parser.add_argument(
+        "--hist",
+        type=str,
+        default="cvhEfficiency",
+        help="Name of the histogram to read",
+    )
+    parser.add_argument("--outpath", type=str, default=None, help="Output base dir")
+    parser.add_argument("--postfix", type=str, default="", help="Suffix for filenames")
+    parser.add_argument("--title", type=str, default="CMS")
+    parser.add_argument("--subtitle", type=str, default="Work in progress")
+    parser.add_argument("--lumi", type=float, default=16.8, help="Luminosity in /fb")
+    parser.add_argument(
+        "--nSigma",
+        type=float,
+        default=3.0,
+        help="Significance threshold for the applied-map plot (matches the generator)",
+    )
+    parser.add_argument("--titlePos", type=int, default=0)
+    parser.add_argument("-v", "--verbose", type=int, default=3)
+    return parser.parse_args()
+
+
+def default_outpath(script_path):
+    stem = os.path.splitext(os.path.basename(script_path))[0]
+    repo_root = os.path.dirname(os.path.abspath(script_path))
+    while repo_root != "/" and not os.path.isdir(os.path.join(repo_root, ".git")):
+        repo_root = os.path.dirname(repo_root)
+    repo_name = os.path.basename(repo_root) if repo_root != "/" else "plots"
+    today = datetime.date.today().strftime("%y%m%d")
+    return os.path.expanduser(f"~/public_html/{repo_name}/{today}_{stem}/")
+
+
+def load(fname, hname):
+    """Return the (data, total MC prediction) 'cvhEfficiency' histograms."""
+    hdata, hmc = None, None
+    with h5py.File(fname, "r") as f:
+        for proc in f.keys():
+            if proc == "meta_info":
+                continue
+            res = ioutils.pickle_load_h5py(f[proc])
+            h = res["output"][hname].get()
+            # aggregated groups drop the 'is_data' flag, they are all MC
+            if res["dataset"].get("is_data", False):
+                hdata = h if hdata is None else hdata + h
+            else:
+                hmc = h if hmc is None else hmc + h
+    logger.info(f"Loaded {hname} with axes {[a.name for a in hdata.axes]}")
+    return hdata, hmc
+
+
+def efficiency(v):
+    """(eff, err) from an array with the passCVH axis last."""
+    n = v.sum(axis=-1)
+    eff = np.divide(v[..., 1], n, out=np.ones_like(n), where=n > 0)
+    err = np.divide(
+        np.sqrt(np.maximum(eff * (1 - eff), 0) * n),
+        n,
+        out=np.zeros_like(n),
+        where=n > 0,
+    )
+    return eff, err
+
+
+def scale_factor(vd, vm):
+    """SF = eff_data/eff_MC with the (dominant) data uncertainty."""
+    ed, dd = efficiency(vd)
+    em, _ = efficiency(vm)
+    em = np.where(em > 0, em, 1.0)
+    return ed / em, dd / em
+
+
+def sf_hardcoded(eta, phi):
+    """The correction currently applied to MC, evaluated on a grid."""
+    eta, phi = np.broadcast_arrays(np.asarray(eta), np.asarray(phi))
+    sf = np.ones(eta.shape)
+    ibin = np.digitize(eta, SF_CODE_ETA_EDGES) - 1
+    inside = (
+        (phi >= SF_CODE_PHI_GATE[0])
+        & (phi < SF_CODE_PHI_GATE[1])
+        & (ibin >= 0)
+        & (ibin < len(SF_CODE_VALUES))
+    )
+    sf[inside] = SF_CODE_VALUES[ibin[inside]]
+    return sf
+
+
+def decorate(ax, args, fontsize=17):
+    """CMS label, with an explicit font size so it fits next to the lumi text."""
+    hep.cms.label(
+        ax=ax,
+        label=args.subtitle,
+        data=True,
+        lumi=args.lumi,
+        loc=args.titlePos,
+        fontsize=fontsize,
+        exp=args.title,
+    )
+
+
+def plot_map(outdir, args, hd, hm, name):
+    """2D map of the measured SF over the full (eta, phi) plane."""
+    sf, _ = scale_factor(hd.values().sum(axis=(0, 3)), hm.values().sum(axis=(0, 3)))
+    eta_e, phi_e = hd.axes["eta"].edges, hd.axes["phi"].edges
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    mesh = ax.pcolormesh(
+        eta_e, phi_e, sf.T, cmap="viridis", vmin=0.35, vmax=1.0, rasterized=True
+    )
+    cbar = fig.colorbar(mesh, ax=ax, pad=0.02)
+    cbar.set_label(r"$\epsilon_\mathrm{data}\,/\,\epsilon_\mathrm{MC}$", labelpad=10)
+    for hs in HOTSPOTS.values():
+        ax.add_patch(
+            mpl.patches.Rectangle(
+                (hs["eta"][0], hs["phi"][0]),
+                hs["eta"][1] - hs["eta"][0],
+                hs["phi"][1] - hs["phi"][0],
+                fill=False,
+                edgecolor="red",
+                lw=1.5,
+            )
+        )
+    ax.set_xlabel(r"muon $\eta$")
+    ax.set_ylabel(r"muon $\phi$")
+    ax.xaxis.set_minor_locator(mpl.ticker.NullLocator())
+    ax.yaxis.set_minor_locator(mpl.ticker.NullLocator())
+    decorate(ax, args)
+    plot_tools.save_pdf_and_png(outdir, name, fig=fig)
+    plt.close(fig)
+
+
+def plot_applied_map(outdir, args, hd, hm, name):
+    """2D map of the applied SF in (eta, phi'), i.e. the actual correction that
+    goes into muon_efficiencies_cvh.hpp. Built with the generator's own logic
+    (module-phi folding + significance clamp) so it cannot drift from the header.
+    """
+    regions = cvhgen.build_regions(hd, hm, args.nSigma)
+    eta_e, phi_e = hd.axes["eta"].edges, hd.axes["phi"].edges
+    sf = np.ones((len(hd.axes["eta"]), len(hd.axes["phi"])))
+    for _, i0, i1, j0, j1, block, _, _ in regions:
+        sf[i0 : i1 + 1, j0 : j1 + 1] = block
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    mesh = ax.pcolormesh(
+        eta_e,
+        phi_e,
+        np.ma.masked_equal(sf.T, 1.0),  # leave SF=1 cells blank
+        cmap="viridis",
+        vmin=0.35,
+        vmax=1.0,
+        rasterized=True,
+    )
+    mesh.cmap.set_bad("#f0f0f0")
+    cbar = fig.colorbar(mesh, ax=ax, pad=0.02)
+    cbar.set_label(
+        r"applied SF  $\epsilon_\mathrm{data}\,/\,\epsilon_\mathrm{MC}$", labelpad=10
+    )
+    ax.set_xlabel(r"muon $\eta$")
+    ax.set_ylabel(r"muon $\phi'$ (module frame, $\phi - qC/p_\mathrm{T}$)")
+    ax.xaxis.set_minor_locator(mpl.ticker.NullLocator())
+    ax.yaxis.set_minor_locator(mpl.ticker.NullLocator())
+    decorate(ax, args)
+    plot_tools.save_pdf_and_png(outdir, name, fig=fig)
+    plt.close(fig)
+
+    # zoomed panels, one per region, with the SF value printed in each cell
+    for k, (rname, i0, i1, j0, j1, block, ee, pe) in enumerate(regions):
+        fig, ax = plt.subplots(figsize=(1.6 + 1.1 * block.shape[0], 6))
+        mesh = ax.pcolormesh(
+            ee[i0 : i1 + 2],
+            pe[j0 : j1 + 2],
+            np.ma.masked_equal(block.T, 1.0),
+            cmap="viridis",
+            vmin=0.35,
+            vmax=1.0,
+        )
+        mesh.cmap.set_bad("#f0f0f0")
+        for ie in range(block.shape[0]):
+            for ip in range(block.shape[1]):
+                if block[ie, ip] == 1.0:
+                    continue
+                ax.text(
+                    ee[i0 + ie] + 0.5 * (ee[1] - ee[0]),
+                    pe[j0 + ip] + 0.5 * (pe[1] - pe[0]),
+                    f"{block[ie, ip]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=9,
+                    color="white" if block[ie, ip] < 0.75 else "black",
+                )
+        fig.colorbar(mesh, ax=ax, pad=0.02, label="applied SF")
+        ax.set_xlabel(r"muon $\eta$")
+        ax.set_ylabel(r"muon $\phi'$ (module frame)")
+        ax.xaxis.set_minor_locator(mpl.ticker.NullLocator())
+        ax.yaxis.set_minor_locator(mpl.ticker.NullLocator())
+        decorate(ax, args)
+        fig.suptitle(rname, fontsize=14)
+        znm = "_".join(filter(None, [name, f"region{k}", args.postfix]))
+        plot_tools.save_pdf_and_png(outdir, znm, fig=fig)
+        output_tools.write_logfile(
+            outdir, znm, args=args, wd=os.path.dirname(os.path.abspath(__file__))
+        )
+        plt.close(fig)
+
+
+def plot_hotspot(outdir, args, hd, hm, key, name):
+    """Zoomed SF map and the SF vs eta in each phi slice of one hotspot."""
+    hs = HOTSPOTS[key]
+    eta_c, phi_c = hd.axes["eta"].centers, hd.axes["phi"].centers
+    eta_e, phi_e = hd.axes["eta"].edges, hd.axes["phi"].edges
+    ie = np.where((eta_c > hs["eta"][0]) & (eta_c < hs["eta"][1]))[0]
+    ip = np.where((phi_c > hs["phi"][0]) & (phi_c < hs["phi"][1]))[0]
+
+    vd = hd.values().sum(axis=(0, 3))
+    vm = hm.values().sum(axis=(0, 3))
+    sf, err = scale_factor(vd, vm)
+
+    fig, axs = plt.subplots(1, 2, figsize=(16, 6), gridspec_kw=dict(wspace=0.45))
+
+    ax = axs[0]
+    mesh = ax.pcolormesh(
+        eta_e[ie[0] : ie[-1] + 2],
+        phi_e[ip[0] : ip[-1] + 2],
+        sf[np.ix_(ie, ip)].T,
+        cmap="viridis",
+        vmin=0.35,
+        vmax=1.0,
+    )
+    cbar = fig.colorbar(mesh, ax=ax, pad=0.02)
+    cbar.set_label(r"$\epsilon_\mathrm{data}\,/\,\epsilon_\mathrm{MC}$", labelpad=10)
+    ax.set_xlabel(r"muon $\eta$")
+    ax.set_ylabel(r"muon $\phi$")
+    ax.xaxis.set_minor_locator(mpl.ticker.NullLocator())
+    ax.yaxis.set_minor_locator(mpl.ticker.NullLocator())
+
+    ax = axs[1]
+    for k, j in enumerate(ip):
+        if sf[ie, j].min() > 0.995:
+            continue
+        ax.errorbar(
+            eta_c[ie],
+            sf[ie, j],
+            yerr=err[ie, j],
+            marker="o",
+            ms=3,
+            lw=1.2,
+            label=rf"$\phi \in [{phi_e[j]:.2f}, {phi_e[j+1]:.2f}]$",
+        )
+    if key == "hotspot1":
+        # the hard-coded correction is flat in phi inside its gate
+        ax.plot(
+            eta_c[ie],
+            sf_hardcoded(eta_c[ie], np.full(len(ie), 0.9)),
+            color="k",
+            ls="--",
+            lw=2,
+            label="original 1D approx. (superseded)",
+        )
+    ax.axhline(1.0, color="gray", lw=1, ls=":")
+    ax.set_xlabel(r"muon $\eta$")
+    ax.set_ylabel(r"$\epsilon_\mathrm{data}\,/\,\epsilon_\mathrm{MC}$")
+    ax.set_ylim(0.2, 1.1)
+    ax.legend(fontsize=13, ncol=1, loc="lower left")
+    decorate(ax, args)
+    fig.suptitle(hs["label"], fontsize=16)
+    plot_tools.save_pdf_and_png(outdir, name, fig=fig)
+    plt.close(fig)
+
+
+def plot_stability(outdir, args, hd, hm, name):
+    """SF integrated over each hotspot vs pt, separately per charge."""
+    eta_c, phi_c = hd.axes["eta"].centers, hd.axes["phi"].centers
+    pt_c, pt_e = hd.axes["pt"].centers, hd.axes["pt"].edges
+    E, P = np.meshgrid(eta_c, phi_c, indexing="ij")
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for key, hs in HOTSPOTS.items():
+        msk = (
+            (E > hs["eta"][0])
+            & (E < hs["eta"][1])
+            & (P > hs["phi"][0])
+            & (P < hs["phi"][1])
+        )
+        for q, (ql, ls) in enumerate((("$\\mu^-$", "-"), ("$\\mu^+$", "--"))):
+            vd = hd.values()[:, :, :, q, :][:, msk].sum(axis=1)
+            vm = hm.values()[:, :, :, q, :][:, msk].sum(axis=1)
+            sf, err = scale_factor(vd, vm)
+            ax.errorbar(
+                pt_c, sf, yerr=err, marker="o", ms=4, ls=ls, label=f"{key}, {ql}"
+            )
+    ax.set_xlim(pt_e[0], pt_e[-1])
+    ax.set_xlabel(r"muon $p_\mathrm{T}$ (GeV)")
+    ax.set_ylabel(r"$\epsilon_\mathrm{data}\,/\,\epsilon_\mathrm{MC}$ in hotspot")
+    ax.legend(fontsize=14, ncol=2)
+    decorate(ax, args)
+    plot_tools.save_pdf_and_png(outdir, name, fig=fig)
+    plt.close(fig)
+
+
+def hole_position(hd, key, ipt=None, q=None):
+    """Failure-weighted mean phi of a hotspot, i.e. where the hole sits."""
+    hs = HOTSPOTS[key]
+    eta_c, phi_c = hd.axes["eta"].centers, hd.axes["phi"].centers
+    E, P = np.meshgrid(eta_c, phi_c, indexing="ij")
+    msk = (
+        (E > hs["eta"][0])
+        & (E < hs["eta"][1])
+        & (P > hs["phi"][0])
+        & (P < hs["phi"][1])
+    )
+    v = hd.values()[..., 0]  # failing muons
+    v = v[ipt] if ipt is not None else v.sum(axis=0)
+    v = v[..., q] if q is not None else v.sum(axis=-1)
+    w = v[msk]
+    n = w.sum()
+    mean = (w * P[msk]).sum() / n
+    rms = np.sqrt((w * (P[msk] - mean) ** 2).sum() / n)
+    return mean, rms / np.sqrt(n), n
+
+
+def plot_position(outdir, args, hd, key, name):
+    """Position of the hole in phi vs pt and charge.
+
+    The muon phi in the histogram is the one at the vertex, while the module
+    sits at a fixed phi in the detector, so the hole is seen displaced by the
+    track bending, +-C/pt for the two charges. This is what makes the hotspot
+    scale factor look charge dependent when parametrized in the vertex phi.
+    """
+    pt_c = hd.axes["pt"].centers
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    x, y, ey, qs = [], [], [], []
+    for q, (ql, col) in enumerate(((r"$\mu^-$", "C0"), (r"$\mu^+$", "C1"))):
+        m = np.array([hole_position(hd, key, ipt=i, q=q) for i in range(len(pt_c))])
+        ok = m[:, 2] > 50
+        ax.errorbar(
+            pt_c[ok],
+            m[ok, 0],
+            yerr=m[ok, 1],
+            marker="o",
+            ms=5,
+            ls="none",
+            color=col,
+            label=ql,
+        )
+        x.append(pt_c[ok])
+        y.append(m[ok, 0])
+        ey.append(m[ok, 1])
+        qs.append(np.full(ok.sum(), -1 if q == 0 else 1))
+    x, y, ey, qs = (np.concatenate(a) for a in (x, y, ey, qs))
+
+    # phi_vertex = phi_module + q*C/pt, C = 0.3*B*r/2 for a track reaching radius r
+    def chi2(p):
+        return (((y - (p[0] + qs * p[1] / x)) / ey) ** 2).sum()
+
+    from scipy import optimize
+
+    fit = optimize.minimize(chi2, [y.mean(), 0.2])
+    phi0, C = fit.x
+    radius = 2 * C / (0.3 * 3.8)
+    xx = np.linspace(x.min(), x.max(), 100)
+    for sign, col in ((-1, "C0"), (1, "C1")):
+        ax.plot(xx, phi0 + sign * C / xx, color=col, lw=1.5)
+    ax.axhline(phi0, color="k", ls=":", lw=1)
+    ax.text(
+        0.04,
+        0.06,
+        rf"$\phi = \phi_0 + q\,C/p_\mathrm{{T}}$, $C = {C:.3f}$ rad GeV"
+        + "\n"
+        + rf"$\rightarrow r = 2C/(0.3B) = {100*radius:.0f}$ cm, $\chi^2/\mathrm{{ndf}} = {fit.fun:.1f}/{len(x)-2}$",
+        transform=ax.transAxes,
+        fontsize=14,
+    )
+    ax.set_xlabel(r"muon $p_\mathrm{T}$ (GeV)")
+    ax.set_ylabel(r"$\langle \phi \rangle$ of failed refits")
+    ax.legend(fontsize=15, loc="center right")
+    decorate(ax, args)
+    fig.suptitle(HOTSPOTS[key]["label"], fontsize=15)
+    plot_tools.save_pdf_and_png(outdir, name, fig=fig)
+    plt.close(fig)
+    logger.info(
+        f"{key}: hole at phi0 = {phi0:.4f}, bending C = {C:.4f} rad GeV "
+        f"(r = {100*radius:.1f} cm), chi2/ndf = {fit.fun:.1f}/{len(x)-2}"
+    )
+
+
+def print_summary(hd, hm):
+    """Integrated efficiencies inside and outside the hotspots."""
+    eta_c, phi_c = hd.axes["eta"].centers, hd.axes["phi"].centers
+    E, P = np.meshgrid(eta_c, phi_c, indexing="ij")
+    vd, vm = hd.values().sum(axis=(0, 3)), hm.values().sum(axis=(0, 3))
+    rest = np.ones(E.shape, dtype=bool)
+    regions = {}
+    for key, hs in HOTSPOTS.items():
+        msk = (
+            (E > hs["eta"][0])
+            & (E < hs["eta"][1])
+            & (P > hs["phi"][0])
+            & (P < hs["phi"][1])
+        )
+        regions[key] = msk
+        rest &= ~msk
+    regions["outside"] = rest
+    regions["inclusive"] = np.ones(E.shape, dtype=bool)
+    for key, msk in regions.items():
+        d, m = vd[msk].sum(axis=0), vm[msk].sum(axis=0)
+        sf, err = scale_factor(d, m)
+        logger.info(
+            f"{key:10s}: data fail {d[0]:8.0f}/{d.sum():10.0f} (eff {efficiency(d)[0]:.6f}), "
+            f"MC fail {m[0]:7.1f}/{m.sum():10.0f} (eff {efficiency(m)[0]:.6f}), "
+            f"SF = {sf:.5f} +/- {err:.5f}"
+        )
+
+
+def main():
+    args = parse_args()
+    logging.setup_logger(__file__, args.verbose)
+    outdir = output_tools.make_plot_dir(args.outpath or default_outpath(__file__))
+    logger.info(f"Writing plots to {outdir}")
+
+    hd, hm = load(args.input, args.hist)
+    print_summary(hd, hm)
+
+    for name, fn in (
+        ("cvhSF_map", lambda o, n: plot_map(o, args, hd, hm, n)),
+        ("cvhSF_appliedMap", lambda o, n: plot_applied_map(o, args, hd, hm, n)),
+        ("cvhSF_hotspot1", lambda o, n: plot_hotspot(o, args, hd, hm, "hotspot1", n)),
+        ("cvhSF_hotspot2", lambda o, n: plot_hotspot(o, args, hd, hm, "hotspot2", n)),
+        ("cvhSF_stability", lambda o, n: plot_stability(o, args, hd, hm, n)),
+        ("cvhSF_position", lambda o, n: plot_position(o, args, hd, "hotspot1", n)),
+    ):
+        name = "_".join(filter(None, [name, args.postfix]))
+        fn(outdir, name)
+        output_tools.write_logfile(
+            outdir, name, args=args, wd=os.path.dirname(os.path.abspath(__file__))
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -1291,12 +1291,21 @@ def build_graph(df, dataset):
             )
             weight_expr += "*weight_fullMuonSF_withTrackingReco"
 
-            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
-            # data-only alignment bug -> downweight MC in the affected
-            # (eta,phi) cell. Hard-coded from a 2016G data A/B; see
-            # muon_efficiencies_cvh.hpp. Single W muon.
+            # CVH efficiency holes (badly aligned modules, incl. TIB-L2 detId
+            # 369141860): a data-only alignment effect -> downweight MC in the
+            # affected (eta,phi') cells. Measured map, see
+            # muon_efficiencies_cvh.hpp. charge/pt undo the track bending.
+            # Single W muon.
             df, _ = muon_efficiencies_cvh.define_cvh_weight(
-                df, [("goodMuons_eta0", "goodMuons_phi0")]
+                df,
+                [
+                    (
+                        "goodMuons_eta0",
+                        "goodMuons_phi0",
+                        "goodMuons_charge0",
+                        "goodMuons_pt0",
+                    )
+                ],
             )
             weight_expr += "*weight_cvhSF"
 

--- a/scripts/histmakers/mw_with_mu_eta_pt.py
+++ b/scripts/histmakers/mw_with_mu_eta_pt.py
@@ -17,6 +17,7 @@ from wremnants.production import (
     generator_level_definitions,
     muon_calibration,
     muon_efficiencies_binned,
+    muon_efficiencies_cvh,
     muon_efficiencies_newVeto,
     muon_efficiencies_smooth,
     muon_efficiencies_veto,
@@ -1289,6 +1290,15 @@ def build_graph(df, dataset):
                 columnsForSF,
             )
             weight_expr += "*weight_fullMuonSF_withTrackingReco"
+
+            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
+            # data-only alignment bug -> downweight MC in the affected
+            # (eta,phi) cell. Hard-coded from a 2016G data A/B; see
+            # muon_efficiencies_cvh.hpp. Single W muon.
+            df, _ = muon_efficiencies_cvh.define_cvh_weight(
+                df, [("goodMuons_eta0", "goodMuons_phi0")]
+            )
+            weight_expr += "*weight_cvhSF"
 
             if isZ and not args.noGenMatchMC:
                 if args.scaleDYvetoFraction > 0.0:

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -118,6 +118,21 @@ parser.add_argument(
     default=12345,
     help="Random seed for jackknifing procedure",
 )
+parser.add_argument(
+    "--cvhEfficiencyHists",
+    action="store_true",
+    help="""Make single-muon histograms of the (uncorrected) kinematics split by CVH refit pass/fail,
+    to measure the CVH refit efficiency in data and MC (residual effects on top of the glued-module SF).
+    Requires '--muonCorrData none --muonCorrMC none' (and preferably --noSmearing), otherwise muons with a
+    failed refit are removed by the selection and the failing bin is empty.""",
+)
+parser.add_argument(
+    "--cvhEfficiencyBranchMC",
+    type=str,
+    default="cvhideal",
+    choices=["cvhideal", "cvh"],
+    help="CVH refit branch used to define pass/fail in MC ('cvh' is always used in data). The default matches the refit actually applied to MC in the analysis (ideal geometry)",
+)
 parser = parsing.set_parser_default(
     parser, "aggregateGroups", ["Diboson", "Top", "Wtaunu", "Wmunu"]
 )
@@ -131,6 +146,27 @@ logger = logging.setup_logger(__file__, args.verbose, args.noColorLogger)
 
 if args.dxybsVeto > 0 and args.dxybsVeto < args.dxybs:
     raise ValueError("When using together '--dxybsVeto X --dxybs Y' it must be X > Y.")
+
+if args.cvhEfficiencyHists and (
+    args.muonCorrData != "none" or args.muonCorrMC != "none"
+):
+    # the momentum corrections are built on the CVH refit, so a muon whose refit
+    # failed gets a garbage corrected pt and is thrown away by the selection: the
+    # CVH-failing bin would then be empty by construction
+    raise ValueError(
+        "'--cvhEfficiencyHists' requires '--muonCorrData none --muonCorrMC none', "
+        f"got --muonCorrData {args.muonCorrData} --muonCorrMC {args.muonCorrMC}"
+    )
+
+if args.cvhEfficiencyHists and args.requirePixelHits:
+    # Muon_cvhNValidPixelHits is 0 when the refit failed, same bias as above
+    raise ValueError("'--cvhEfficiencyHists' is incompatible with '--requirePixelHits'")
+
+if args.cvhEfficiencyHists and (args.pt[1] > 25.0 or args.pt[2] < 65.0):
+    logger.warning(
+        f"The muon pt selection ({args.pt[1]}, {args.pt[2]}) does not cover the full pt range "
+        "of the CVH efficiency histograms (25, 65), use e.g. '--pt 40 25 65' to fill it"
+    )
 
 thisAnalysis = (
     ROOT.wrem.AnalysisType.Dilepton
@@ -907,16 +943,27 @@ def build_graph(df, dataset):
             )
             weight_expr += "*weight_fullMuonSF_withTrackingReco"
 
-            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
-            # data-only alignment bug -> downweight MC in the affected
-            # (eta,phi) cell. Hard-coded from a 2016G data A/B; see
-            # muon_efficiencies_cvh.hpp. (phi read inline from the mask, as
-            # this histmaker does not define *_phi0 columns.)
+            # CVH efficiency holes (badly aligned modules, incl. TIB-L2 detId
+            # 369141860): a data-only alignment effect -> downweight MC in the
+            # affected (eta,phi') cells. Measured map, see
+            # muon_efficiencies_cvh.hpp. charge/pt are passed to undo the track
+            # bending; phi read inline from the mask as this histmaker does not
+            # define *_phi0 columns.
             df, _ = muon_efficiencies_cvh.define_cvh_weight(
                 df,
                 [
-                    ("trigMuons_eta0", "Muon_correctedPhi[trigMuons][0]"),
-                    ("nonTrigMuons_eta0", "Muon_correctedPhi[nonTrigMuons][0]"),
+                    (
+                        "trigMuons_eta0",
+                        "Muon_correctedPhi[trigMuons][0]",
+                        "trigMuons_charge0",
+                        "trigMuons_pt0",
+                    ),
+                    (
+                        "nonTrigMuons_eta0",
+                        "Muon_correctedPhi[nonTrigMuons][0]",
+                        "nonTrigMuons_charge0",
+                        "nonTrigMuons_pt0",
+                    ),
                 ],
             )
             weight_expr += "*weight_cvhSF"
@@ -1054,6 +1101,80 @@ def build_graph(df, dataset):
         ],
     )
     results.append(hNValidPixelHitsNonTrig)
+
+    if args.cvhEfficiencyHists:
+        # Single-muon CVH refit efficiency: kinematics vs refit pass/fail, for data
+        # and MC, to look for residual data/MC differences on top of the glued-module
+        # hotspot correction (see muon_efficiencies_cvh.hpp).
+        # Everything (selection and axes) uses the uncorrected muon kinematics, since
+        # the corrected ones are undefined when the refit failed; this is enforced by
+        # requiring '--muonCorr{Data,MC} none' above.
+        # Filled once per muon, i.e. both muons of the Z candidate enter.
+        cvhEffBranch = "cvh" if dataset.is_data else args.cvhEfficiencyBranchMC
+        logger.info(
+            f"CVH refit efficiency histograms using Muon_{cvhEffBranch}Pt > 0 as pass condition"
+        )
+
+        for mu in ["trigMuons", "nonTrigMuons"]:
+            df = df.Define(f"{mu}_uncorrPt0", f"Muon_pt[{mu}][0]")
+            df = df.Define(f"{mu}_uncorrEta0", f"Muon_eta[{mu}][0]")
+            # nanoAOD phi is in [-pi,pi], the tracker modules are naturally in [0,2pi)
+            df = df.Define(
+                f"{mu}_uncorrPhi0",
+                f"static_cast<float>(Muon_phi[{mu}][0] < 0.f ? Muon_phi[{mu}][0] + 2.f*M_PI : Muon_phi[{mu}][0])",
+            )
+            df = df.Define(f"{mu}_uncorrCharge0", f"Muon_charge[{mu}][0]")
+            df = df.Define(
+                f"{mu}_passCVH0", f"Muon_{cvhEffBranch}Pt[{mu}][0] > 0.f ? 1 : 0"
+            )
+
+        for v, t in (
+            ("uncorrPt0", "float"),
+            ("uncorrEta0", "float"),
+            ("uncorrPhi0", "float"),
+            ("uncorrCharge0", "int"),
+            ("passCVH0", "int"),
+        ):
+            df = df.Define(
+                f"cvhEffMuons_{v}",
+                f"ROOT::VecOps::RVec<{t}>{{trigMuons_{v}, nonTrigMuons_{v}}}",
+            )
+
+        if dataset.is_data or args.noScaleFactors:
+            df = df.Alias("cvhEff_weight", "nominal_weight")
+        else:
+            # undo the hotspot scale factor, this histogram is meant to measure it
+            df = df.Define("cvhEff_weight", "nominal_weight/weight_cvhSF")
+
+        results.append(
+            df.HistoBoost(
+                "cvhEfficiency",
+                [
+                    hist.axis.Regular(8, 25.0, 65.0, name="pt"),
+                    hist.axis.Regular(96, -2.4, 2.4, name="eta"),
+                    hist.axis.Regular(
+                        72,
+                        0.0,
+                        2.0 * math.pi,
+                        name="phi",
+                        underflow=False,
+                        overflow=False,
+                    ),
+                    axis_charge,
+                    hist.axis.Integer(
+                        0, 2, name="passCVH", underflow=False, overflow=False
+                    ),
+                ],
+                [
+                    "cvhEffMuons_uncorrPt0",
+                    "cvhEffMuons_uncorrEta0",
+                    "cvhEffMuons_uncorrPhi0",
+                    "cvhEffMuons_uncorrCharge0",
+                    "cvhEffMuons_passCVH0",
+                    "cvhEff_weight",
+                ],
+            )
+        )
 
     if args.unfolding and args.poiAsNoi and dataset.group == "Zmumu":
         unfolder_z.add_poi_as_noi_histograms(

--- a/scripts/histmakers/mz_dilepton.py
+++ b/scripts/histmakers/mz_dilepton.py
@@ -15,6 +15,7 @@ import narf
 from wremnants.production import (
     muon_calibration,
     muon_efficiencies_binned,
+    muon_efficiencies_cvh,
     muon_efficiencies_smooth,
     muon_prefiring,
     muon_selections,
@@ -905,6 +906,20 @@ def build_graph(df, dataset):
                 columnsForSF,
             )
             weight_expr += "*weight_fullMuonSF_withTrackingReco"
+
+            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
+            # data-only alignment bug -> downweight MC in the affected
+            # (eta,phi) cell. Hard-coded from a 2016G data A/B; see
+            # muon_efficiencies_cvh.hpp. (phi read inline from the mask, as
+            # this histmaker does not define *_phi0 columns.)
+            df, _ = muon_efficiencies_cvh.define_cvh_weight(
+                df,
+                [
+                    ("trigMuons_eta0", "Muon_correctedPhi[trigMuons][0]"),
+                    ("nonTrigMuons_eta0", "Muon_correctedPhi[nonTrigMuons][0]"),
+                ],
+            )
+            weight_expr += "*weight_cvhSF"
 
         # prepare inputs for pixel multiplicity helpers
         df = df.DefinePerSample(

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -16,6 +16,7 @@ from wremnants.production import (
     generator_level_definitions,
     muon_calibration,
     muon_efficiencies_binned,
+    muon_efficiencies_cvh,
     muon_efficiencies_smooth,
     muon_prefiring,
     muon_selections,
@@ -883,6 +884,19 @@ def build_graph(df, dataset):
                     columnsForSF,
                 )
                 weight_expr += "*weight_fullMuonSF_withTrackingReco"
+
+            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
+            # data-only alignment bug -> downweight MC in the affected
+            # (eta,phi) cell so MC matches the (uncorrected) data. Hard-coded
+            # from a 2016G data A/B refit; see muon_efficiencies_cvh.hpp.
+            df, _ = muon_efficiencies_cvh.define_cvh_weight(
+                df,
+                [
+                    ("nonTrigMuons_eta0", "nonTrigMuons_phi0"),
+                    ("trigMuons_eta0", "trigMuons_phi0"),
+                ],
+            )
+            weight_expr += "*weight_cvhSF"
 
         # prepare inputs for pixel multiplicity helpers
         cvhName = "cvhideal"

--- a/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
+++ b/scripts/histmakers/mz_wlike_with_mu_eta_pt.py
@@ -885,15 +885,26 @@ def build_graph(df, dataset):
                 )
                 weight_expr += "*weight_fullMuonSF_withTrackingReco"
 
-            # CVH glued-module (TIB-L2 detId 369141860) efficiency hole: a
-            # data-only alignment bug -> downweight MC in the affected
-            # (eta,phi) cell so MC matches the (uncorrected) data. Hard-coded
-            # from a 2016G data A/B refit; see muon_efficiencies_cvh.hpp.
+            # CVH efficiency holes (badly aligned modules, incl. TIB-L2 detId
+            # 369141860): a data-only alignment effect -> downweight MC in the
+            # affected (eta,phi') cells so MC matches the (uncorrected) data.
+            # Measured map, see muon_efficiencies_cvh.hpp. charge/pt undo the
+            # track bending.
             df, _ = muon_efficiencies_cvh.define_cvh_weight(
                 df,
                 [
-                    ("nonTrigMuons_eta0", "nonTrigMuons_phi0"),
-                    ("trigMuons_eta0", "trigMuons_phi0"),
+                    (
+                        "nonTrigMuons_eta0",
+                        "nonTrigMuons_phi0",
+                        "nonTrigMuons_charge0",
+                        "nonTrigMuons_pt0",
+                    ),
+                    (
+                        "trigMuons_eta0",
+                        "trigMuons_phi0",
+                        "trigMuons_charge0",
+                        "trigMuons_pt0",
+                    ),
                 ],
             )
             weight_expr += "*weight_cvhSF"

--- a/wremnants/production/include/muon_efficiencies_cvh.hpp
+++ b/wremnants/production/include/muon_efficiencies_cvh.hpp
@@ -1,61 +1,129 @@
 #ifndef WREMNANTS_MUON_EFFICIENCIES_CVH_H
 #define WREMNANTS_MUON_EFFICIENCIES_CVH_H
 
-// Data/MC muon efficiency scale factor for the CVH-refit efficiency hole
-// introduced by the bug fixed in WMass/cmssw PR#46, commit eb96caef.
+#include <cmath>
+
+// Data/MC muon efficiency scale factor for the CVH-refit efficiency holes.
 //
-// The bug: a garbage-aligned glued (double-sided) module in the real data
-// tracker alignment -- TIB layer 2, detId 369141860, whose mono face is
-// rotated ~0.75 rad from ideal -- corrupts the composite frame used to
-// anchor the CVH fit, killing tracks that cross it. It is DATA-ONLY (MC is
-// reconstructed with ideal geometry, which has no such pathology), so MC
-// over-counts efficiency in a localized (eta,phi) cell.
+// Some badly aligned modules in the real data tracker alignment corrupt the
+// composite frame used to anchor the CVH fit and kill the tracks that cross
+// them. The known case is the glued (double-sided) module in TIB layer 2,
+// detId 369141860, whose mono face is rotated ~0.75 rad from ideal (fixed in
+// WMass/cmssw PR#46, commit eb96caef). The effect is DATA-ONLY -- MC is
+// reconstructed with ideal geometry and has no such pathology -- so MC
+// over-counts the efficiency in a localized cell and has to be downweighted.
 //
-// Measured by an A/B refit (with vs without the fix) on 2016G SingleMuon,
-// ~3.4M events/arm. The loss is:
-//   * confined to the module's phi stripe  0.80 < phi < 1.00 rad,
-//   * a smooth dip in eta, core SF ~0.585 at eta ~ 0.35-0.40,
-//   * charge-independent and pT-independent (checked 25-65 GeV).
-// So the correction is a 1D function of eta, gated on phi. Applied as a
-// per-muon multiplicative weight on MC.
+// The correction is a map of eps_data/eps_MC in (eta, phi'), measured directly
+// from the single-muon CVH refit efficiency in Z->mumu events with
+//   mz_dilepton.py --cvhEfficiencyHists,
+// and written out by scripts/analysisTools/make_cvh_efficiency_sf.py. Two
+// regions of the (eta,phi') plane are affected; everywhere else the data/MC
+// agreement is at the 1e-5 level and the SF is exactly 1.
 //
-// Values hard-coded from the Delta-eta = 0.05 measurement (phi 0.80-1.00,
-// pT 25-65 GeV). Bins outside the measured region return 1.
+// phi' is the azimuth at the module rather than at the vertex: a muon of
+// charge q and transverse momentum pt is bent by q*C/pt on its way out to the
+// module radius r, with C = 0.3*B*r/2. Undoing it (see cvh_module_phi) makes
+// the map charge- and pt-independent, and is what keeps the sharp edges of the
+// module from being smeared over the two charges.
 
 namespace wrem {
 
-// Per-muon SF: eps_data(buggy) / eps_MC, = 1 outside the affected cell.
-inline double cvh_muon_sf(float eta, float phi) {
-  // phi stripe of the pathological module (radians, phi in [-pi,pi])
-  if (phi < 0.80f || phi >= 1.00f)
-    return 1.0;
-  // eta dip, 0.05-wide bins from 0.05 to 0.70; else no effect
-  if (eta < 0.05f || eta >= 0.70f)
-    return 1.0;
-  const int ibin = static_cast<int>((eta - 0.05f) / 0.05f); // 0..12
-  // SF per bin, index 0 -> [0.05,0.10) ... index 12 -> [0.65,0.70)
-  static const double sf[13] = {
-      0.982, // [0.05,0.10)
-      0.933, // [0.10,0.15)
-      0.910, // [0.15,0.20)
-      0.823, // [0.20,0.25)
-      0.718, // [0.25,0.30)
-      0.645, // [0.30,0.35)
-      0.585, // [0.35,0.40)  core
-      0.606, // [0.40,0.45)
-      0.653, // [0.45,0.50)
-      0.777, // [0.50,0.55)
-      0.847, // [0.55,0.60)
-      0.955, // [0.60,0.65)
-      0.980  // [0.65,0.70)
-  };
-  return sf[ibin];
+// Bending to the module radius, C = 0.3*B*r/2 in rad*GeV. Fitted from the
+// charge splitting of the hole position, C = 0.214 +- 0.014, which corresponds
+// to r = 38 cm, i.e. TIB layer 2 (layers at r = 25.5, 33.9, 41.9, 49.8 cm).
+inline constexpr double cvh_bending_C = 0.214;
+
+// Azimuth of the muon where it crosses the module, in [0, 2*pi).
+// Accepts phi either in [-pi,pi] (nanoAOD) or in [0,2*pi).
+inline float cvh_module_phi(float phi, int charge, float pt,
+                            double bendC = cvh_bending_C) {
+  constexpr float twopi = 2.f * static_cast<float>(M_PI);
+  float p = phi - static_cast<float>(charge * bendC) / pt;
+  while (p < 0.f)
+    p += twopi;
+  while (p >= twopi)
+    p -= twopi;
+  return p;
+}
+
+// A rectangular region of the (eta, phi') plane holding the measured SF map,
+// row-major in [ieta][iphi].
+struct CvhSFRegion {
+  double etaLow, etaBinWidth;
+  int nEta;
+  double phiLow, phiBinWidth;
+  int nPhi;
+  const double *sf;
+};
+
+// clang-format off
+// BEGIN GENERATED -- do not edit by hand, see make_cvh_efficiency_sf.py
+
+// hotspot1 (TIB-L2, detId 369141860)
+//   eta in [0.00, 0.75), phi' in [0.698, 1.047)
+inline const double cvh_sf_region0[15 * 4] = {
+    1.000, 0.991, 0.987, 1.000, // eta ~ +0.025
+    1.000, 0.973, 0.975, 1.000, // eta ~ +0.075
+    1.000, 0.934, 0.940, 1.000, // eta ~ +0.125
+    1.000, 0.892, 0.886, 0.995, // eta ~ +0.175
+    0.994, 0.800, 0.771, 0.989, // eta ~ +0.225
+    0.993, 0.744, 0.636, 0.977, // eta ~ +0.275
+    0.992, 0.690, 0.504, 0.959, // eta ~ +0.325
+    0.992, 0.717, 0.421, 0.941, // eta ~ +0.375
+    0.995, 0.770, 0.396, 0.927, // eta ~ +0.425
+    0.997, 0.859, 0.492, 0.926, // eta ~ +0.475
+    1.000, 0.925, 0.636, 0.930, // eta ~ +0.525
+    1.000, 0.971, 0.783, 0.949, // eta ~ +0.575
+    1.000, 0.990, 0.912, 0.967, // eta ~ +0.625
+    1.000, 1.000, 0.967, 0.989, // eta ~ +0.675
+    1.000, 1.000, 0.993, 0.994, // eta ~ +0.725
+};
+
+// hotspot2 (uncorrected)
+//   eta in [-1.80, -1.45), phi' in [5.061, 5.411)
+inline const double cvh_sf_region1[7 * 4] = {
+    1.000, 1.000, 1.000, 0.983, // eta ~ -1.775
+    0.992, 0.990, 0.990, 0.922, // eta ~ -1.725
+    0.986, 0.968, 0.964, 0.872, // eta ~ -1.675
+    0.958, 0.953, 0.939, 0.887, // eta ~ -1.625
+    0.931, 0.923, 0.885, 0.902, // eta ~ -1.575
+    0.965, 0.962, 0.943, 0.956, // eta ~ -1.525
+    1.000, 1.000, 0.991, 0.994, // eta ~ -1.475
+};
+
+inline const CvhSFRegion cvh_sf_regions[] = {
+    {0.0000, 0.0500, 15, 0.6981, 0.0873, 4, cvh_sf_region0},
+    {-1.8000, 0.0500, 7, 5.0615, 0.0873, 4, cvh_sf_region1},
+};
+
+// END GENERATED
+// clang-format on
+
+// Per-muon SF: eps_data/eps_MC, = 1 outside the affected regions. Apply to MC
+// only, as a multiplicative weight, once per reconstructed muon.
+inline double cvh_muon_sf(float eta, float phi, int charge, float pt) {
+  const float phiModule = cvh_module_phi(phi, charge, pt);
+  for (const auto &r : cvh_sf_regions) {
+    // floor, not truncation: the regions can sit at negative eta
+    const int ieta =
+        static_cast<int>(std::floor((eta - r.etaLow) / r.etaBinWidth));
+    if (ieta < 0 || ieta >= r.nEta)
+      continue;
+    const int iphi =
+        static_cast<int>(std::floor((phiModule - r.phiLow) / r.phiBinWidth));
+    if (iphi < 0 || iphi >= r.nPhi)
+      continue;
+    return r.sf[ieta * r.nPhi + iphi];
+  }
+  return 1.0;
 }
 
 // Event-level weight for a dimuon (Z) final state: both reconstructed muons
 // must survive, so the per-muon SFs multiply.
-inline double cvh_dimuon_sf(float eta1, float phi1, float eta2, float phi2) {
-  return cvh_muon_sf(eta1, phi1) * cvh_muon_sf(eta2, phi2);
+inline double cvh_dimuon_sf(float eta1, float phi1, int charge1, float pt1,
+                            float eta2, float phi2, int charge2, float pt2) {
+  return cvh_muon_sf(eta1, phi1, charge1, pt1) *
+         cvh_muon_sf(eta2, phi2, charge2, pt2);
 }
 
 } // namespace wrem

--- a/wremnants/production/include/muon_efficiencies_cvh.hpp
+++ b/wremnants/production/include/muon_efficiencies_cvh.hpp
@@ -1,0 +1,63 @@
+#ifndef WREMNANTS_MUON_EFFICIENCIES_CVH_H
+#define WREMNANTS_MUON_EFFICIENCIES_CVH_H
+
+// Data/MC muon efficiency scale factor for the CVH-refit efficiency hole
+// introduced by the bug fixed in WMass/cmssw PR#46, commit eb96caef.
+//
+// The bug: a garbage-aligned glued (double-sided) module in the real data
+// tracker alignment -- TIB layer 2, detId 369141860, whose mono face is
+// rotated ~0.75 rad from ideal -- corrupts the composite frame used to
+// anchor the CVH fit, killing tracks that cross it. It is DATA-ONLY (MC is
+// reconstructed with ideal geometry, which has no such pathology), so MC
+// over-counts efficiency in a localized (eta,phi) cell.
+//
+// Measured by an A/B refit (with vs without the fix) on 2016G SingleMuon,
+// ~3.4M events/arm. The loss is:
+//   * confined to the module's phi stripe  0.80 < phi < 1.00 rad,
+//   * a smooth dip in eta, core SF ~0.585 at eta ~ 0.35-0.40,
+//   * charge-independent and pT-independent (checked 25-65 GeV).
+// So the correction is a 1D function of eta, gated on phi. Applied as a
+// per-muon multiplicative weight on MC.
+//
+// Values hard-coded from the Delta-eta = 0.05 measurement (phi 0.80-1.00,
+// pT 25-65 GeV). Bins outside the measured region return 1.
+
+namespace wrem {
+
+// Per-muon SF: eps_data(buggy) / eps_MC, = 1 outside the affected cell.
+inline double cvh_muon_sf(float eta, float phi) {
+  // phi stripe of the pathological module (radians, phi in [-pi,pi])
+  if (phi < 0.80f || phi >= 1.00f)
+    return 1.0;
+  // eta dip, 0.05-wide bins from 0.05 to 0.70; else no effect
+  if (eta < 0.05f || eta >= 0.70f)
+    return 1.0;
+  const int ibin = static_cast<int>((eta - 0.05f) / 0.05f); // 0..12
+  // SF per bin, index 0 -> [0.05,0.10) ... index 12 -> [0.65,0.70)
+  static const double sf[13] = {
+      0.982, // [0.05,0.10)
+      0.933, // [0.10,0.15)
+      0.910, // [0.15,0.20)
+      0.823, // [0.20,0.25)
+      0.718, // [0.25,0.30)
+      0.645, // [0.30,0.35)
+      0.585, // [0.35,0.40)  core
+      0.606, // [0.40,0.45)
+      0.653, // [0.45,0.50)
+      0.777, // [0.50,0.55)
+      0.847, // [0.55,0.60)
+      0.955, // [0.60,0.65)
+      0.980  // [0.65,0.70)
+  };
+  return sf[ibin];
+}
+
+// Event-level weight for a dimuon (Z) final state: both reconstructed muons
+// must survive, so the per-muon SFs multiply.
+inline double cvh_dimuon_sf(float eta1, float phi1, float eta2, float phi2) {
+  return cvh_muon_sf(eta1, phi1) * cvh_muon_sf(eta2, phi2);
+}
+
+} // namespace wrem
+
+#endif

--- a/wremnants/production/muon_efficiencies_cvh.py
+++ b/wremnants/production/muon_efficiencies_cvh.py
@@ -1,0 +1,23 @@
+import narf.clingutils
+from wums import logging
+
+logger = logging.child_logger(__name__)
+
+# Declares wrem::cvh_muon_sf / wrem::cvh_dimuon_sf, the hard-coded data/MC
+# efficiency SF for the CVH-refit glued-module bug (TIB-L2 module 369141860,
+# fixed in WMass/cmssw eb96caef). See the header for the measurement. MC only.
+narf.clingutils.Declare('#include "muon_efficiencies_cvh.hpp"')
+
+
+def define_cvh_weight(df, muons, out_col="weight_cvhSF"):
+    """Define the per-event CVH efficiency weight = product of the per-muon SF
+    over all reconstructed muons in the final state (1 for W, 2 for Z).
+
+    muons: iterable of (eta_expr, phi_expr) pairs, each a column name or an
+    inline RDF expression, e.g. ("trigMuons_eta0", "trigMuons_phi0") or
+    ("Muon_correctedEta[trigMuons][0]", "Muon_correctedPhi[trigMuons][0]").
+    Call on MC only; multiply the result into the nominal weight.
+    """
+    expr = "*".join(f"wrem::cvh_muon_sf({eta}, {phi})" for eta, phi in muons)
+    df = df.Define(out_col, expr)
+    return df, out_col

--- a/wremnants/production/muon_efficiencies_cvh.py
+++ b/wremnants/production/muon_efficiencies_cvh.py
@@ -13,11 +13,16 @@ def define_cvh_weight(df, muons, out_col="weight_cvhSF"):
     """Define the per-event CVH efficiency weight = product of the per-muon SF
     over all reconstructed muons in the final state (1 for W, 2 for Z).
 
-    muons: iterable of (eta_expr, phi_expr) pairs, each a column name or an
-    inline RDF expression, e.g. ("trigMuons_eta0", "trigMuons_phi0") or
-    ("Muon_correctedEta[trigMuons][0]", "Muon_correctedPhi[trigMuons][0]").
+    muons: iterable of (eta_expr, phi_expr, charge_expr, pt_expr) tuples, each a
+    column name or an inline RDF expression, e.g.
+    ("trigMuons_eta0", "trigMuons_phi0", "trigMuons_charge0", "trigMuons_pt0").
+    charge and pt are needed to undo the track bending, i.e. to evaluate the SF
+    map in the module azimuth phi' = phi - q*C/pt (see muon_efficiencies_cvh.hpp).
     Call on MC only; multiply the result into the nominal weight.
     """
-    expr = "*".join(f"wrem::cvh_muon_sf({eta}, {phi})" for eta, phi in muons)
+    expr = "*".join(
+        f"wrem::cvh_muon_sf({eta}, {phi}, {charge}, {pt})"
+        for eta, phi, charge, pt in muons
+    )
     df = df.Define(out_col, expr)
     return df, out_col


### PR DESCRIPTION
## What

Adds a data/MC muon **CVH-refit efficiency** scale factor, measured directly from Z→μμ and applied as a 2D map in the tracker-module azimuth.

Some badly aligned modules in the real-data tracker alignment corrupt the CVH fit and kill tracks crossing them. This is data-only (MC uses ideal geometry), so MC over-counts efficiency in a few localized (η,φ) cells and must be downweighted.

## Measurement

`mz_dilepton.py --cvhEfficiencyHists` books a per-muon histogram of the **uncorrected** kinematics (pt, eta, phi, charge) split by CVH refit pass/fail, for data and MC. It requires `--muonCorrData none --muonCorrMC none` because the momentum corrections are built on the refit and would otherwise drop the failing muons. The same correction is wired into the `mw` and `mz_wlike` histmakers through the shared `define_cvh_weight` helper.

On 2016 (16.1M muons) the data/MC efficiency ratio is flat at the 1e-5 level everywhere **except two localized holes**:
- the known **TIB-L2 glued module** (detId 369141860), core SF ≈ 0.40;
- a **previously uncorrected second hole** at η ≈ −1.6, core SF ≈ 0.87.

Both are pt-independent. Their apparent charge dependence is purely the track bending displacing the hole by ∓C/pt in vertex φ — confirmed by a fit to the hole position: **C = 0.214 rad·GeV → r = 38 cm**, i.e. TIB layer 2.

## Correction

`muon_efficiencies_cvh.hpp` now holds ε_data/ε_MC as a map in **(η, φ′)** with φ′ = φ − q·C/pt. Undoing the bending lets a single charge-averaged map reproduce the per-charge vertex-φ SF to **≤0.05%** in every η bin, versus the **0.4%** charge asymmetry left by the old charge-averaged 1D correction. `cvh_muon_sf` now takes `(eta, phi, charge, pt)`.

## Tooling
- `scripts/analysisTools/make_cvh_efficiency_sf.py` — derives the map and patches the header's `GENERATED` block, with a per-charge closure printout.
- `scripts/analysisTools/plot_cvh_efficiency.py` — measured vertex-φ SF, applied module-φ map (full plane + per-hotspot zooms with values), pt/charge stability, and the hole-position bending fit.

## Notes / to discuss
- The measurement is **data-statistics-limited** (ε_MC ≈ 0.99993); more MC files do not sharpen it. Sharpening would need more data (other run periods).
- The second hole (η ≈ −1.6) is new — worth tracing to a specific module in the alignment payload the same way as TIB-L2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)